### PR TITLE
Address go-lint problems, readiness/health probe log message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 FROM golang:1.12-alpine as builder
 USER root
 RUN apk add curl git

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -219,6 +219,20 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:f9f144aab0a32f55fcfa49f2b64461affa903cdb8db918b89770668d852a13a1"
+  name = "github.com/tektoncd/dashboard"
+  packages = [
+    "pkg/broadcaster",
+    "pkg/endpoints",
+    "pkg/logging",
+    "pkg/utils",
+    "pkg/websocket",
+  ]
+  pruneopts = "UT"
+  revision = "ecc9da8a0c1d069cc89eddc21fbd1c7f948f8a6a"
+
+[[projects]]
+  branch = "master"
   digest = "1:aff35c0379f09633e57e10fcd3a00e7563a2669c668e184fe3e2f94a5915f028"
   name = "github.com/tektoncd/pipeline"
   packages = [
@@ -599,6 +613,11 @@
   input-imports = [
     "github.com/emicklei/go-restful",
     "github.com/gorilla/websocket",
+    "github.com/tektoncd/dashboard/pkg/broadcaster",
+    "github.com/tektoncd/dashboard/pkg/endpoints",
+    "github.com/tektoncd/dashboard/pkg/logging",
+    "github.com/tektoncd/dashboard/pkg/utils",
+    "github.com/tektoncd/dashboard/pkg/websocket",
     "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1",
     "github.com/tektoncd/pipeline/pkg/client/clientset/versioned",
     "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake",

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (
@@ -36,7 +37,7 @@ func main() {
 		cfg, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		logging.Log.Errorf("Error building kubeconfig from %s: %s", kubeconfig, err.Error())
+		logging.Log.Errorf("error building kubeconfig from %s: %s", kubeconfig, err.Error())
 	}
 
 	port := ":8080"
@@ -51,14 +52,14 @@ func main() {
 
 	pipelineClient, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		logging.Log.Errorf("Error building pipeline clientset: %s", err.Error())
+		logging.Log.Errorf("error building pipeline clientset: %s", err.Error())
 	} else {
 		logging.Log.Info("Got a pipeline client")
 	}
 
 	k8sClient, err := k8sclientset.NewForConfig(cfg)
 	if err != nil {
-		logging.Log.Errorf("Error building k8s clientset: %s", err.Error())
+		logging.Log.Errorf("error building k8s clientset: %s", err.Error())
 	} else {
 		logging.Log.Info("Got a k8s client")
 	}

--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package broadcaster
 
 import (

--- a/pkg/endpoints/credentials_test.go
+++ b/pkg/endpoints/credentials_test.go
@@ -35,22 +35,22 @@ func TestCredentials(t *testing.T) {
 	// Initialize test data
 	expectCreds := []credential{}
 	accessTokenCred := credential{
-		Id:          "credentialaccesstoken",
+		ID:          "credentialaccesstoken",
 		Username:    "personal-access-token",
 		Password:    "passwordaccesstoken",
 		Description: "access token credential",
 		Type:        "accesstoken",
-		Url: map[string]string{
+		URL: map[string]string{
 			"tekton.dev/git-0": "https://github.com",
 		},
 	}
 	userPassCred := credential{
-		Id:          "credentialuserpass",
+		ID:          "credentialuserpass",
 		Username:    "usernameuserpass",
 		Password:    "passworduserpass",
 		Description: "user password credential",
 		Type:        "userpass",
-		Url: map[string]string{
+		URL: map[string]string{
 			"tekton.dev/docker-0": "https://gcr.io",
 		},
 	}
@@ -110,7 +110,7 @@ func TestCredentials(t *testing.T) {
 
 	// DELETE credential accesstoken
 	t.Log("DELETE credential 'credentialaccesstoken' when it exists")
-	deleteCredentialTest(namespace, accessTokenCred.Id, "", r, t)
+	deleteCredentialTest(namespace, accessTokenCred.ID, "", r, t)
 
 	// READ ALL credentials when there is only the userpass credential
 	t.Log("READ all credentials when there is only 'credentialuserpass' ('credentialaccesstoken' was just deleted)")
@@ -121,7 +121,7 @@ func TestCredentials(t *testing.T) {
 
 	// DELETE credential userpass
 	t.Log("DELETE credential 'credentialuserpass' when it exists")
-	deleteCredentialTest(namespace, userPassCred.Id, "", r, t)
+	deleteCredentialTest(namespace, userPassCred.ID, "", r, t)
 
 	// READ ALL credentials when there are none
 	t.Log("READ all credentials when there are none ('credentialuserpass' was just deleted)")
@@ -141,56 +141,56 @@ func TestCredentialsErrors(t *testing.T) {
 	expectError := ""
 	invalidCreds := []credential{}
 
-	// (ERROR) CREATE and UPDATE invalid credentials missing username, password, id, url or type ('accesstoken' or 'userpass')
+	// (ERROR) CREATE and UPDATE invalid credentials missing username, password, ID, URL or type ('accesstoken' or 'userpass')
 	invalidCreds = []credential{
 		credential{
 			Username:    "personal-access-token",
-			Password:    "passwordaccesstoken",
+			Password:    "passordaccesstoken",
 			Description: "access token credential",
 			Type:        "accesstoken",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
 			Type:        "accesstoken",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Description: "access token credential",
 			Type:        "accesstoken",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
 			Type:        "bogustype",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
@@ -198,6 +198,7 @@ func TestCredentialsErrors(t *testing.T) {
 		},
 	}
 	for _, invalidCred := range invalidCreds {
+		// Must match error message exactly in the verify function, careful if you change fields
 		expectError = fmt.Sprintf("Error: username, password, id, url and type ('accesstoken' or 'userpass') must all be supplied.")
 		createCredentialTest(namespace, invalidCred, expectError, r, t)
 		updateCredentialTest(namespace, invalidCred, expectError, r, t)
@@ -205,18 +206,18 @@ func TestCredentialsErrors(t *testing.T) {
 
 	invalidCreds = []credential{
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
 			Type:        "accesstoken",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/gitaa-0": "https://github.com",
 			},
 		},
 	}
 	for _, invalidCred := range invalidCreds {
-		expectError = fmt.Sprintf("Error: url key must start with \"tekton.dev/docker-\" or \"tekton.dev/get-\" invalid url: tekton.dev/gitaa-0")
+		expectError = fmt.Sprintf("Error: URL key must start with \"tekton.dev/docker-\" or \"tekton.dev/get-\" invalid URL: tekton.dev/gitaa-0")
 		createCredentialTest(namespace, invalidCred, expectError, r, t)
 		updateCredentialTest(namespace, invalidCred, expectError, r, t)
 	}
@@ -226,12 +227,12 @@ func TestCredentialsErrors(t *testing.T) {
 	// (ERROR) READ, UPDATE, and DELETE credentials that do not exist
 	invalidCreds = []credential{
 		credential{
-			Id:          "credentialaccesstoken",
+			ID:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
 			Type:        "accesstoken",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
@@ -240,29 +241,29 @@ func TestCredentialsErrors(t *testing.T) {
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
 			Type:        "accesstoken",
-			Url: map[string]string{
+			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},
 		},
 	}
 	for _, invalidCred := range invalidCreds {
-		expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCred.Id)
+		expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCred.ID)
 		readCredentialTest(namespace, invalidCred, expectError, r, t)
-		deleteCredentialTest(namespace, invalidCred.Id, expectError, r, t)
+		deleteCredentialTest(namespace, invalidCred.ID, expectError, r, t)
 	}
-	expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCreds[0].Id)
+	expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCreds[0].ID)
 	updateCredentialTest(namespace, invalidCreds[0], expectError, r, t)
 
 	// (ERROR) CREATE, READ, UPDATE, and DELETE credentials in a namespace that does not exist
 	bogusNamespace := "bogusnamespace"
 	expectError = fmt.Sprintf("Namespace provided does not exist: '%s'.", bogusNamespace)
 	cred := credential{
-		Id:          "credentialaccesstoken",
+		ID:          "credentialaccesstoken",
 		Username:    "personal-access-token",
 		Password:    "passwordaccesstoken",
 		Description: "access token credential",
 		Type:        "accesstoken",
-		Url: map[string]string{
+		URL: map[string]string{
 			"tekton.dev/git-0": "https://github.com",
 		},
 	}
@@ -270,13 +271,13 @@ func TestCredentialsErrors(t *testing.T) {
 	readAllCredentialsTest(bogusNamespace, []credential{cred}, expectError, r, t)
 	readCredentialTest(bogusNamespace, cred, expectError, r, t)
 	updateCredentialTest(bogusNamespace, cred, expectError, r, t)
-	deleteCredentialTest(bogusNamespace, cred.Id, expectError, r, t)
+	deleteCredentialTest(bogusNamespace, cred.ID, expectError, r, t)
 }
 
 /*
  * CREATE credential test
  * To function properly, [cred] must have the following fields:
- *  - id
+ *  - ID
  *  - username
  *  - password
  *  - type (must have the value 'accesstoken' or 'userpass')
@@ -285,7 +286,8 @@ func createCredentialTest(namespace string, cred credential, expectError string,
 	t.Logf("CREATE credential %+v", cred)
 	// Create dummy rest api request and response
 	jsonBody, _ := json.Marshal(cred)
-	httpReq := dummyHttpRequest("POST", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/", bytes.NewBuffer(jsonBody))
+	t.Logf("json body for create cred test: %s", jsonBody)
+	httpReq := dummyHTTPRequest("POST", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/", bytes.NewBuffer(jsonBody))
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -300,23 +302,23 @@ func createCredentialTest(namespace string, cred credential, expectError string,
 	}
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, cred.Id), cred, t)
+	testCredential(r.getK8sCredential(namespace, cred.ID), cred, t)
 }
 
 /*
  * READ ALL credentials test
  * To function properly, [expectCreds] must have the same number of credentials as there are in the system
- * and they must be in the correct order (alphabetical by id field)
+ * and they must be in the correct order (alphabetical by ID field)
  */
 func readAllCredentialsTest(namespace string, expectCreds []credential, expectError string, r *Resource, t *testing.T) {
 	t.Logf("READ all credentials. Expecting: %+v", expectCreds)
-	// Create dummy rest api request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/", nil)
+	// Create dummy REST API request and response
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/", nil)
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
-	// Test get all credentials
+	// Test to get all credentials
 	r.getAllCredentials(req, resp)
 
 	// Look for password "********"
@@ -337,22 +339,22 @@ func readAllCredentialsTest(namespace string, expectCreds []credential, expectEr
 		expectCreds[i].Password = credPasswords[i]
 	}
 
-	// Verify agains K8s client
+	// Verify against K8s client
 	testCredentials(r.getK8sCredentials(namespace), expectCreds, t)
-	t.Logf("READ all credentials 3. Expecting: %+v", expectCreds)
+	t.Logf("Done in READ all credentials. Expecting: %+v", expectCreds)
 }
 
 /*
  * READ credential test
- * To function properly, [expectCred] must have the "id" field
+ * To function properly, [expectCred] must have the "ID" field
  */
 func readCredentialTest(namespace string, expectCred credential, expectError string, r *Resource, t *testing.T) {
-	t.Logf("READ credential %s", expectCred.Id)
+	t.Logf("READ credential %s", expectCred.ID)
 	// Create dummy rest api request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+expectCred.Id, nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+expectCred.ID, nil)
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = expectCred.Id
+	params["id"] = expectCred.ID
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -372,13 +374,13 @@ func readCredentialTest(namespace string, expectCred credential, expectError str
 	expectCred.Password = expectCredPassword
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, expectCred.Id), expectCred, t)
+	testCredential(r.getK8sCredential(namespace, expectCred.ID), expectCred, t)
 }
 
 /*
  * UPDATE credential test
  * To function properly, [cred] must have the following fields:
- *  - id
+ *  - ID
  *  - username
  *  - password
  *  - type (must have the value 'accesstoken' or 'userpass')
@@ -387,10 +389,10 @@ func updateCredentialTest(namespace string, cred credential, expectError string,
 	t.Logf("UPDATE credential %+v", cred)
 	// Create dummy rest api request and response
 	jsonBody, _ := json.Marshal(cred)
-	httpReq := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+cred.Id, bytes.NewBuffer(jsonBody))
+	httpReq := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+cred.ID, bytes.NewBuffer(jsonBody))
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = cred.Id
+	params["id"] = cred.ID
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -404,19 +406,19 @@ func updateCredentialTest(namespace string, cred credential, expectError string,
 	}
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, cred.Id), cred, t)
+	testCredential(r.getK8sCredential(namespace, cred.ID), cred, t)
 }
 
 /*
  * DELETE credential test
  */
-func deleteCredentialTest(namespace string, credId string, expectError string, r *Resource, t *testing.T) {
-	t.Logf("DELETE credential %s", credId)
+func deleteCredentialTest(namespace string, credID string, expectError string, r *Resource, t *testing.T) {
+	t.Logf("DELETE credential %s", credID)
 	// Create dummy rest api request and response
-	httpReq := dummyHttpRequest("DELETE", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+credId, nil)
+	httpReq := dummyHTTPRequest("DELETE", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+credID, nil)
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = credId
+	params["id"] = credID
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -430,7 +432,7 @@ func deleteCredentialTest(namespace string, credId string, expectError string, r
 	}
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, credId), credential{}, t)
+	testCredential(r.getK8sCredential(namespace, credID), credential{}, t)
 }
 
 /*
@@ -442,29 +444,29 @@ func deleteCredentialTest(namespace string, credId string, expectError string, r
 func testParseResponse(body *bytes.Buffer, result interface{}, expectError string, t *testing.T) bool {
 	b, err := ioutil.ReadAll(body)
 	if err != nil {
-		t.Errorf("ERROR reading response body: %s", err.Error())
+		t.Errorf("FAIL: ERROR - reading response body: %s", err.Error())
 		return false
 	}
 	err = json.Unmarshal(b, result)
 	if err != nil {
 		resultError := string(b)
 		if resultError != expectError {
-			t.Errorf("ERROR: Error message == '%s', want '%s'", resultError, expectError)
+			t.Errorf("FAIL: ERROR - Error message == '%s', want '%s', body: %s", resultError, expectError, body)
 		}
 		return false
 	}
 	if expectError != "" {
-		t.Errorf("ERROR: Result == %+v, want error message '%s'", result, expectError)
+		t.Errorf("FAIL: ERROR - Result == %+v, want error message '%s'", result, expectError)
 	}
 	return true
 }
 
-// Compare two lists of credentials
+// Compares two lists of credentials
 func testCredentials(result []credential, expectResult []credential, t *testing.T) {
-	t.Logf("log result creds: %+v\n", result)
-	t.Logf("log expect creds: %+v\n", expectResult)
+	t.Logf("Resulting credentials: %+v\n", result)
+	t.Logf("Expected credentials: %+v\n", expectResult)
 	if len(result) != len(expectResult) {
-		t.Errorf("ERROR: Result == %+v, want %+v, different number of credentials", result, expectResult)
+		t.Errorf("FAIL: result == %+v, want %+v, different number of credentials", result, expectResult)
 	}
 	for i := range expectResult {
 		expectCred := expectResult[i]
@@ -475,31 +477,31 @@ func testCredentials(result []credential, expectResult []credential, t *testing.
 
 // Compare two credentials
 func testCredential(resultCred credential, expectCred credential, t *testing.T) {
-	t.Logf("log result cred: %+v\n", resultCred)
-	t.Logf("log expect cred: %+v\n", expectCred)
+	t.Logf("Resulting credential: %+v\n", resultCred)
+	t.Logf("Expected credential: %+v\n", expectCred)
 	// Result credential might have more fields than the expected one
-	if resultCred.Id != expectCred.Id ||
+	if resultCred.ID != expectCred.ID ||
 		resultCred.Username != expectCred.Username ||
 		resultCred.Password != expectCred.Password ||
 		resultCred.Description != expectCred.Description ||
 		resultCred.Type != expectCred.Type {
-		t.Errorf("ERROR: Result == %+v, want %+v", resultCred, expectCred)
+		t.Errorf("FAIL: result == %+v, want %+v", resultCred, expectCred)
 	}
-	for key, _ := range expectCred.Url {
-		if _, ok := resultCred.Url[key]; !ok || resultCred.Url[key] != expectCred.Url[key] {
-			t.Errorf("ERROR: Result == %+v, want %+v for key %s", resultCred.Url, expectCred.Url, key)
+	for key := range expectCred.URL {
+		if _, ok := resultCred.URL[key]; !ok || resultCred.URL[key] != expectCred.URL[key] {
+			t.Errorf("FAIL: result == %+v, want %+v for key %s", resultCred.URL, expectCred.URL, key)
 		}
 	}
 }
 
 // Get all K8s client secrets with selector LABEL_SELECTOR
 func (r Resource) getK8sCredentials(namespace string) (credentials []credential) {
-	secrets, err := r.K8sClient.CoreV1().Secrets(namespace).List(metav1.ListOptions{LabelSelector: "restknative=true"})
+	secrets, err := r.K8sClient.CoreV1().Secrets(namespace).List(metav1.ListOptions{LabelSelector: "tektondashboard=true"})
 	if err != nil {
 		return
 	}
 	for _, secret := range secrets.Items {
-		credentials = append(credentials, secretToJson(&secret))
+		credentials = append(credentials, secretToJSON(&secret))
 	}
 	return credentials
 }
@@ -510,18 +512,18 @@ func (r Resource) getK8sCredential(namespace string, name string) (credential cr
 	if err != nil {
 		return
 	}
-	return secretToJson(secret)
+	return secretToJSON(secret)
 }
 
 // Convert K8s secret struct into credential struct
-func secretToJson(secret *corev1.Secret) credential {
+func secretToJSON(secret *corev1.Secret) credential {
 	cred := credential{
-		Id:              secret.GetName(),
+		ID:              secret.GetName(),
 		Username:        string(secret.Data["username"]),
 		Password:        string(secret.Data["password"]),
 		Description:     string(secret.Data["description"]),
 		Type:            string(secret.Data["type"]),
-		Url:             secret.ObjectMeta.Annotations,
+		URL:             secret.ObjectMeta.Annotations,
 		ResourceVersion: secret.GetResourceVersion(),
 	}
 	return cred

--- a/pkg/endpoints/health.go
+++ b/pkg/endpoints/health.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoints
 
 import (

--- a/pkg/endpoints/health_test.go
+++ b/pkg/endpoints/health_test.go
@@ -21,7 +21,7 @@ import (
 func TestHealthEndpointPresent(t *testing.T) {
 	r := dummyResource()
 	httpWriter := httptest.NewRecorder()
-	bodyRequest := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/health", nil)
+	bodyRequest := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/health", nil)
 	bodyRestful := dummyRestfulRequest(bodyRequest, "ns1", "")
 	resp := dummyRestfulResponse(httpWriter)
 	r.checkHealth(bodyRestful, resp)

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoints
 
 import (
@@ -64,6 +65,7 @@ type PipelineRunUpdateBody struct {
 	STATUS string `json:"status"`
 }
 
+// TaskRunLog - represents a task run's logs (including logs for containers)
 type TaskRunLog struct {
 	PodName string
 	// Containers correlating to Task step definitions
@@ -73,6 +75,7 @@ type TaskRunLog struct {
 	InitContainers []LogContainer
 }
 
+// LogContainer - represents the logs for a given container
 type LogContainer struct {
 	Name string
 	Logs []string
@@ -118,9 +121,8 @@ func (r Resource) getPipelineImpl(name, namespace string) (v1alpha1.Pipeline, er
 	if err != nil {
 		logging.Log.Errorf("could not retrieve the pipeline called %s in namespace %s", name, namespace)
 		return *pipeline, err
-	} else {
-		logging.Log.Debugf("Found the pipeline definition OK")
 	}
+	logging.Log.Debug("Found the pipeline definition OK")
 	return *pipeline, nil
 }
 
@@ -489,9 +491,8 @@ func (r Resource) updatePipelineRun(request *restful.Request, response *restful.
 	if err != nil || pipelineRun == nil {
 		utils.RespondError(response, err, http.StatusNotFound)
 		return
-	} else {
-		logging.Log.Debug("Found the PipelineRun ok")
 	}
+	logging.Log.Debug("Found the PipelineRun ok")
 
 	// We've found the PipelineRun at this stage
 
@@ -525,9 +526,8 @@ func (r Resource) updatePipelineRun(request *restful.Request, response *restful.
 			logging.Log.Errorf("error updating PipelineRun status: %s", err)
 			utils.RespondError(response, err, http.StatusInternalServerError)
 			return
-		} else {
-			logging.Log.Debugf("PipelineRun status updated OK to %s", pipelineRun.Spec.Status)
 		}
+		logging.Log.Debugf("PipelineRun status updated OK to %s", pipelineRun.Spec.Status)
 	} else {
 		errorMsg := fmt.Sprintf("error: Status was already set to %s", desiredStatus)
 		logging.Log.Error(errorMsg)

--- a/pkg/endpoints/pipeline_test.go
+++ b/pkg/endpoints/pipeline_test.go
@@ -64,7 +64,7 @@ func TestTask(t *testing.T) {
 
 	// Test getAllTasks function
 	// Sample request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/task/", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/task/", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -89,7 +89,7 @@ func TestTask(t *testing.T) {
 
 	// Test getTask function
 	// Sample request and response
-	httpReq = dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/task/Task2", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/task/Task2", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "Task2")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -148,7 +148,7 @@ func TestPipeline(t *testing.T) {
 
 	// Test getAllPipelines function
 	// Sample request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipeline/", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipeline/", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -173,7 +173,7 @@ func TestPipeline(t *testing.T) {
 
 	// Test getPipeline function
 	// Sample request and response
-	httpReq = dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipeline/Pipeline2", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipeline/Pipeline2", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "Pipeline2")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -232,7 +232,7 @@ func TestTaskRun(t *testing.T) {
 
 	// Test getAllTaskRuns function
 	// Sample request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun/", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun/", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -257,7 +257,7 @@ func TestTaskRun(t *testing.T) {
 
 	// Test getTaskRun function
 	// Sample request and response
-	httpReq = dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun/TaskRun2", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun/TaskRun2", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "TaskRun2")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -329,7 +329,7 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getAllPipelineRuns function
 	// Sample request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -354,7 +354,7 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getAllPipelineRuns function with query
 	// Sample request and response
-	httpReq = dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?repository=http://github.com/foo/bar", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?repository=http://github.com/foo/bar", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -376,7 +376,7 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getPipelineRun function
 	// Sample request and response
-	httpReq = dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun2", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun2", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "PipelineRun2")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -526,7 +526,7 @@ func TestTaskRunLog(t *testing.T) {
 
 	// Test getAllPipelineRuns function
 	// Sample request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrunlog/TaskRun1", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrunlog/TaskRun1", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "TaskRun1")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -740,7 +740,7 @@ func TestPipelineRunLog(t *testing.T) {
 
 	// Test getAllPipelineRuns function
 	// Sample request and response
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerlog/PipelineRun1", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerlog/PipelineRun1", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "PipelineRun1")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -844,7 +844,7 @@ func TestPipelineRunUpdateBadRequest(t *testing.T) {
 	httpWriter := httptest.NewRecorder()
 
 	badRequestBody := strings.NewReader(`{"notstatus" : "foo"}`)
-	badRequest := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", badRequestBody)
+	badRequest := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", badRequestBody)
 	badRequestRestful := dummyRestfulRequest(badRequest, "ns1", "PipelineRun1")
 	resp := dummyRestfulResponse(httpWriter)
 	r.updatePipelineRun(badRequestRestful, resp)
@@ -867,7 +867,7 @@ func TestPipelineRunUpdateNotFoundByName(t *testing.T) {
 	httpWriter := httptest.NewRecorder()
 
 	notFoundBody := strings.NewReader(`{"status" : "foo"}`)
-	notFoundRequest := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/IDoNotExist", notFoundBody)
+	notFoundRequest := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/IDoNotExist", notFoundBody)
 	notFoundRestfulRequest := dummyRestfulRequest(notFoundRequest, "ns1", "IDoNotExist")
 	resp := dummyRestfulResponse(httpWriter)
 	r.updatePipelineRun(notFoundRestfulRequest, resp)
@@ -954,7 +954,7 @@ func TestPipelineRunUpdateNotFoundByNamespace(t *testing.T) {
 	httpWriter := httptest.NewRecorder()
 
 	notFoundBody := strings.NewReader(`{"status" : "foo"}`)
-	notFoundRequest := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/notns1/pipelinerun/PipelineRun1", notFoundBody)
+	notFoundRequest := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/notns1/pipelinerun/PipelineRun1", notFoundBody)
 	notFoundRestfulRequest := dummyRestfulRequest(notFoundRequest, "notns1", "PipelineRun1")
 	resp := dummyRestfulResponse(httpWriter)
 	r.updatePipelineRun(notFoundRestfulRequest, resp)
@@ -1040,7 +1040,7 @@ func TestPipelineRunUpdateAllGood(t *testing.T) {
 	httpWriter := httptest.NewRecorder()
 
 	goodRequestBody := strings.NewReader(`{"status" : "PipelineRunCancelled"}`)
-	goodRequest := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", goodRequestBody)
+	goodRequest := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", goodRequestBody)
 	goodRequestRestful := dummyRestfulRequest(goodRequest, "ns1", "PipelineRun1")
 	resp := dummyRestfulResponse(httpWriter)
 	r.updatePipelineRun(goodRequestRestful, resp)
@@ -1124,7 +1124,7 @@ func TestPipelineRunUpdateStatusAlreadySet412(t *testing.T) {
 
 	statusCancelBody := strings.NewReader(`{"status": "PipelineRunCancelled"}`)
 
-	statusCancelRequest := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", statusCancelBody)
+	statusCancelRequest := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", statusCancelBody)
 	statusCancelRestful := dummyRestfulRequest(statusCancelRequest, "ns1", "PipelineRun1")
 	resp := dummyRestfulResponse(httpWriter)
 	r.updatePipelineRun(statusCancelRestful, resp)
@@ -1136,7 +1136,7 @@ func TestPipelineRunUpdateStatusAlreadySet412(t *testing.T) {
 	// It's already set to be cancelled, so doing it again should give us a 412 response (pre-condition failed)
 
 	anotherCancelBody := strings.NewReader(`{"status": "PipelineRunCancelled"}`)
-	duplicatedStatusSet := dummyHttpRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", anotherCancelBody)
+	duplicatedStatusSet := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/PipelineRun1", anotherCancelBody)
 	duplicatedStatusSetRestful := dummyRestfulRequest(duplicatedStatusSet, "ns1", "PipelineRun1")
 	resp = dummyRestfulResponse(httpWriter)
 	r.updatePipelineRun(duplicatedStatusSetRestful, resp)

--- a/pkg/endpoints/test-utils.go
+++ b/pkg/endpoints/test-utils.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoints
 
 import (
@@ -31,7 +32,7 @@ func dummyClientset() *fakeclientset.Clientset {
 	return result
 }
 
-func dummyHttpRequest(method string, url string, body io.Reader) *http.Request {
+func dummyHTTPRequest(method string, url string, body io.Reader) *http.Request {
 	httpReq, _ := http.NewRequest(method, url, body)
 	httpReq.Header.Set("Content-Type", "application/json")
 	return httpReq

--- a/pkg/endpoints/utils.go
+++ b/pkg/endpoints/utils.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoints
 
 import (
@@ -19,13 +20,13 @@ import (
 	k8sclientset "k8s.io/client-go/kubernetes"
 )
 
-// Store all types here that are reused throughout files
+// Resource - stores all types here that are reused throughout files
 type Resource struct {
 	PipelineClient versioned.Interface
 	K8sClient      k8sclientset.Interface
 }
 
-// RegisterPipeline
+// RegisterEndpoints - this registers our actual endpoints!
 func (r Resource) RegisterEndpoints(container *restful.Container) {
 	wsv1 := new(restful.WebService)
 	wsv1.
@@ -34,6 +35,7 @@ func (r Resource) RegisterEndpoints(container *restful.Container) {
 		Produces(restful.MIME_JSON)
 
 	logging.Log.Info("Adding v1, and API for pipelines")
+
 	wsv1.Route(wsv1.GET("/{namespace}/pipeline").To(r.getAllPipelines))
 	wsv1.Route(wsv1.GET("/{namespace}/pipeline/{name}").To(r.getPipeline))
 
@@ -65,6 +67,7 @@ func (r Resource) RegisterEndpoints(container *restful.Container) {
 	container.Add(wsv1)
 }
 
+// RegisterWebsocket - this registers a websocket with which we can send log information to
 func (r Resource) RegisterWebsocket(container *restful.Container) {
 	logging.Log.Info("Adding API for websocket")
 	wsv2 := new(restful.WebService)
@@ -77,6 +80,7 @@ func (r Resource) RegisterWebsocket(container *restful.Container) {
 	container.Add(wsv2)
 }
 
+// RegisterHealthProbes - this registers the /health endpoint
 func (r Resource) RegisterHealthProbes(container *restful.Container) {
 	logging.Log.Info("Adding API for health")
 	wsv3 := new(restful.WebService)
@@ -90,8 +94,9 @@ func (r Resource) RegisterHealthProbes(container *restful.Container) {
 	container.Add(wsv3)
 }
 
+// RegisterReadinessProbes - this registers the /readiness endpoint
 func (r Resource) RegisterReadinessProbes(container *restful.Container) {
-	logging.Log.Info("Adding API for health")
+	logging.Log.Info("Adding API for readiness")
 	wsv4 := new(restful.WebService)
 	wsv4.
 		Path("/readiness").

--- a/pkg/endpoints/websocket.go
+++ b/pkg/endpoints/websocket.go
@@ -10,12 +10,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoints
 
 import (
 	restful "github.com/emicklei/go-restful"
-	logging "github.com/tektoncd/dashboard/pkg/logging"
 	broadcaster "github.com/tektoncd/dashboard/pkg/broadcaster"
+	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"github.com/tektoncd/dashboard/pkg/websocket"
 )
 

--- a/pkg/endpoints/websocket_test.go
+++ b/pkg/endpoints/websocket_test.go
@@ -195,7 +195,7 @@ func (r Resource) createTestPipelineRun(name, resourceVersion string) {
 // Util to update pipelinerun
 func (r Resource) updateTestPipelineRun(name, newResourceVersion string) {
 
-	httpReq := dummyHttpRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/"+name, nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/"+name, nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package logging
 
 import (
@@ -17,6 +18,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// Log is our logger for use elsewhere
 var Log = loggerInit()
 
 func loggerInit() *zap.SugaredLogger {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package utils
 
 import (


### PR DESCRIPTION
This should be an easy one, imported the project and noticed this in my Vscode environment with go-lint, this was bugging me and it's trivial stuff really (very basic implementation and test code changes) and we had an incorrect print for the readiness/health checks.

I've also modified the secret label to be **tektondashboard** instead of **restknative**.

For testing I ran this with a Dockerfile_test that we're going to add with a new PR coming up shortly.

Only internal field names have changed.

For convenience the test Dockerfile is as follows:

```
FROM golang:1.10 (should this be 1.12?)
USER root
RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x /usr/local/bin/dep
WORKDIR /go/src/github.com/tektoncd/dashboard/
COPY . .
#RUN dep ensure
RUN dep ensure -vendor-only
WORKDIR /go/src/github.com/tektoncd/dashboard/pkg/endpoints
RUN CGO_ENABLED=0 NAMESPACE=default GOOS=linux go test -v
```

Credits to @vtereso too for spotting the label to change too 😄 