### PR TITLE
Add OWNERS file with a list of approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+# See https://github.com/kubernetes/test-infra/tree/master/prow/plugins/approve/approvers.
+# It supports a list of approvers and reviewers and their github names must be provided.
+
+approvers:
+- a-roberts
+- alangreene
+- akihikokuroda
+- carolynmabbott
+- dibbles
+- jessm12
+- mnuttall
+- ncskier
+- skaegi
+- steveodonovan
+- vtereso


### PR DESCRIPTION
This is for https://github.com/tektoncd/dashboard/issues/28.

I know each person here from working on the dashboard before the move to open source (🎉) and can vouch for them being good reviewers that know our codebase. There is a mixture here of frontend and backend developers.

I've used https://github.com/kubernetes/test-infra/tree/master/prow/plugins/approve/approvers as a reference and it looks like `approvers` is all we need. Also for reference, here is the OWNERS file for tektoncd/pipeline: https://github.com/tektoncd/pipeline/blob/master/OWNERS - we have no alumni yet!

@alangreene @akihikokuroda @carolynmabbott @dibbles @jessm12 @mnuttall @ncskier @skaegi @steveodonovan @vtereso FYI