### PR TITLE
Fix context root code to handle dev mode

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -13,9 +13,17 @@ limitations under the License.
 
 import { deleteRequest, get, post, put } from './comms';
 
-const { href, hash } = window.location;
-const baseURL = href.replace(hash, '');
-const apiRoot = `${baseURL}/api`;
+export function getAPIRoot() {
+  const apiPrefix = 'api';
+  const { href, hash } = window.location;
+  let baseURL = href.replace(hash, '');
+  if (!baseURL.endsWith('/')) {
+    baseURL += '/';
+  }
+  return `${baseURL}${apiPrefix}`;
+}
+
+const apiRoot = getAPIRoot();
 
 export function getAPI(type, id = '', namespace = 'default') {
   return [

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -20,6 +20,7 @@ import {
   createPipelineRun,
   deleteCredential,
   getAPI,
+  getAPIRoot,
   getCredential,
   getCredentials,
   getPipeline,
@@ -36,6 +37,20 @@ import {
   getTasks,
   updateCredential
 } from '.';
+
+beforeEach(jest.resetAllMocks);
+
+describe('getAPIRoot', () => {
+  it('handles base URL with trailing slash', () => {
+    window.history.pushState({}, 'Title', '/path/#hash');
+    expect(getAPIRoot()).toContain('/path/api');
+  });
+
+  it('handles base URL without trailing slash', () => {
+    window.history.pushState({}, 'Title', '/path#hash');
+    expect(getAPIRoot()).toContain('/path/api');
+  });
+});
 
 describe('getAPI', () => {
   it('returns a URI containing the given type', () => {


### PR DESCRIPTION
Fixes https://github.com/tektoncd/dashboard/issues/15

Ensure the code to handle variable context roots also works when running the front end locally in dev mode (webpack-dev-server) at `/`