### PR TITLE
Update front end to handle change in taskrunlog response format

### DIFF
--- a/src/components/Log/Log.js
+++ b/src/components/Log/Log.js
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/* eslint-disable react/no-array-index-key */
 import React, { Component } from 'react';
 import { SkeletonText } from 'carbon-components-react';
 
@@ -34,7 +35,7 @@ class Log extends Component {
   }
 
   render() {
-    const { loading, log } = this.props;
+    const { loading, logs } = this.props;
 
     return (
       <pre className="log">
@@ -43,7 +44,7 @@ class Log extends Component {
         ) : (
           <>
             <Ansi className="log-content" linkify>
-              {log}
+              {logs.join('\n')}
             </Ansi>
             {this.logTrailer()}
           </>
@@ -54,7 +55,7 @@ class Log extends Component {
 }
 
 Log.defaultProps = {
-  log: 'No log available',
+  logs: ['No log available'],
   trailers: {
     Completed: 'Step completed',
     Error: 'Step failed'

--- a/src/components/Log/Log.stories.js
+++ b/src/components/Log/Log.stories.js
@@ -20,6 +20,6 @@ const ansiLog = '\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: 
 storiesOf('Log', module)
   .add('default', () => <Log />)
   .add('loading', () => <Log loading />)
-  .add('completed', () => <Log log="A log message" status="Completed" />)
-  .add('failed', () => <Log log="A log message" status="Error" />)
-  .add('ansi codes', () => <Log log={ansiLog} />);
+  .add('completed', () => <Log logs={['A log message']} status="Completed" />)
+  .add('failed', () => <Log logs={['A log message']} status="Error" />)
+  .add('ansi codes', () => <Log logs={[ansiLog]} />);

--- a/src/components/Log/Log.test.js
+++ b/src/components/Log/Log.test.js
@@ -21,7 +21,7 @@ it('Log renders default content', () => {
 });
 
 it('Log renders the provided content', () => {
-  const { queryByText } = render(<Log log="testing" />);
+  const { queryByText } = render(<Log logs={['testing']} />);
   expect(queryByText(/testing/i)).toBeTruthy();
 });
 
@@ -31,6 +31,6 @@ it('Log renders trailer', () => {
 });
 
 it('Log renders loading state', () => {
-  const { queryByText } = render(<Log loading log="testing" />);
+  const { queryByText } = render(<Log loading logs={['testing']} />);
   expect(queryByText(/testing/i)).toBeFalsy();
 });

--- a/src/components/StepDetails/StepDetails.js
+++ b/src/components/StepDetails/StepDetails.js
@@ -23,7 +23,7 @@ import './StepDetails.scss';
 
 const StepDetails = props => {
   const { definition, reason, status, stepName, stepStatus, taskRun } = props;
-  const { pod, taskRunName } = taskRun;
+  const { taskRunName } = taskRun;
 
   return (
     <div className="step-details">
@@ -35,7 +35,7 @@ const StepDetails = props => {
       />
       <Tabs>
         <Tab className="details-tab" label="Logs">
-          <Log pod={pod} taskRunName={taskRunName} />
+          <Log key={stepName} stepName={stepName} taskRunName={taskRunName} />
         </Tab>
         <Tab className="details-tab" label="Status">
           <StepStatus status={stepStatus} />

--- a/src/containers/Log/Log.js
+++ b/src/containers/Log/Log.js
@@ -17,34 +17,43 @@ import Log from '../../components/Log';
 import { getTaskRunLog } from '../../api';
 
 class LogContainer extends Component {
-  state = { log: null };
+  state = { logs: [] };
 
   componentDidMount() {
     this.loadLog();
   }
 
   componentDidUpdate(prevProps) {
-    const { taskRunName } = this.props;
-    if (taskRunName !== prevProps.taskRunName) {
+    const { stepName, taskRunName } = this.props;
+    if (
+      taskRunName !== prevProps.taskRunName ||
+      stepName !== prevProps.stepName
+    ) {
       this.loadLog();
     }
   }
 
   async loadLog() {
-    const { taskRunName } = this.props;
+    const { stepName, taskRunName } = this.props;
     if (taskRunName) {
       try {
-        const log = await getTaskRunLog(taskRunName);
-        this.setState({ log });
+        const logs = await getTaskRunLog(taskRunName);
+        const buildStepName = `build-step-${stepName}`;
+        const stepLog =
+          (logs.StepContainers &&
+            logs.StepContainers.find(l => l.Name === buildStepName)) ||
+          {};
+        this.setState({ logs: stepLog.Logs || undefined });
       } catch {
-        this.setState({ log: 'Unable to fetch log' });
+        this.setState({ logs: ['Unable to fetch log'] });
       }
     }
   }
 
   render() {
-    const { log } = this.state;
-    return <Log log={log} />;
+    const { stepName } = this.props;
+    const { logs } = this.state;
+    return <Log logs={logs} stepName={stepName} />;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/tektoncd/dashboard/issues/16

Update front end code to handle changed log response format for TaskRun / Step:
- from `String`
- to `{ ..., StepContainers: [{ Name: ..., Logs: [String]}] }`