### PR TITLE
correct image name

### DIFF
--- a/install/tekton-dashboard-deployment.yaml
+++ b/install/tekton-dashboard-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: tekton-dashboard
-        image: "CHANGE_ME:latest"
+        image: "CHANGE_ME/back-end:latest"
         imagePullPolicy: Always
         ports:
         - containerPort: 9097


### PR DESCRIPTION
correct image name
The back-end is missing in the tekton-dashboard-deployment.yaml file.