### PR TITLE
Document our backend API definitions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,30 +118,44 @@ GET endpoints:
 ```
 GET /v1/namespaces/<namespace>/pipeline
 Get all Tekton Pipelines
+Returns HTTP code 200 and a list of Pipelines in the given namespace
+Returns HTTP code 404 if an error occurred getting the Pipeline list
 
 GET /v1/namespaces/<namespace>/pipeline/<pipeline-name>
 Get a Tekton Pipeline by name
+Returns HTTP code 200 and the given pipeline in the given namespace if found
+Returns HTTP code 404 if an error occurred getting the Pipeline
 
 GET /v1/namespaces/<namespace>/pipelinerun
 Get all Tekton PipelineRuns, also supports '?repository=https://gitserver/foo/bar' querying
+Returns HTTP code 200 and a list of PipelineRuns, optionally matching the above query, in the given namespace
+Returns HTTP code 404 if an error occurred getting the PipelineRun list
 
 GET /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>
 Get a Tekton PipelineRun by name
+Returns HTTP code 200 and the given PipelineRun in the given namespace
+Returns HTTP code 404 if an error occurred getting the PipelineRun
 
 GET /v1/namespaces/<namespace>/task
 Get all Tekton tasks
+Returns HTTP code 200 and a list of Tasks in the given namespace 
+Returns HTTP code 404 if an error occurred getting the Task list
 
 GET /v1/namespaces/<namespace>/task/<task-name>
 Get a Tekton Task by name
 
 GET /v1/namespaces/<namespace>/taskrun
 Get all Tekton TaskRuns
+Returns HTTP code 200 and a list of TaskRuns in the given namespace 
+Returns HTTP code 404 if an error occurred getting the TaskRun list
 
 GET /v1/namespaces/<namespace>/taskrun/<taskrun-name>
 Get a Tekton TaskRun by name
 
 GET /v1/namespaces/<namespace>/pipelineresource
 Get all Tekton PipelineResources
+Returns HTTP code 200 and a list of PipelineResources in the given namespace 
+Returns HTTP code 404 if an error occurred getting the PipelineRun list
 
 GET /v1/namespaces/<namespace>/pipelineresource/<pipelineresource-name>
 Get a Tekton PipelineResource by name
@@ -153,7 +167,7 @@ GET /v1/namespaces/<namespace>/taskrunlog/<taskrun-name>
 Get the logs for a TaskRun by name- get log of <taskrun-name> taskrun
 
 GET /v1/namespaces/<namespace>/credentials
-Get all credentials by name
+Get all credentials by name in the given namespace
 
 GET /v1/namespaces/<namespace>/credentials/<id>
 Get a credential by ID

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,30 +116,54 @@ The backend API offers the following endpoints at `/v1/namespaces/<namespace>`:
 
 GET endpoints:
 ```
-GET /v1/namespaces/<namespace>/pipeline                                  - get all pipelines
-GET /v1/namespaces/<namespace>/pipeline/<pipeline-name>                  - get <pipeline-name> pipeline
+GET /v1/namespaces/<namespace>/pipeline
+Get all Tekton Pipelines
 
-GET /v1/namespaces/<namespace>/pipelinerun                               - get all pipelineruns, also supports '?repository=https://gitserver/foo/bar' querying
-GET /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>            - get <pipelinerun-name> pipelinerun
+GET /v1/namespaces/<namespace>/pipeline/<pipeline-name>
+Get a Tekton Pipeline by name
 
-GET /v1/namespaces/<namespace>/task                                      - get all tasks
-GET /v1/namespaces/<namespace>/task/<task-name>                          - get <task-name> task
+GET /v1/namespaces/<namespace>/pipelinerun
+Get all Tekton PipelineRuns, also supports '?repository=https://gitserver/foo/bar' querying
 
-GET /v1/namespaces/<namespace>/taskrun                                   - get all taskruns
-GET /v1/namespaces/<namespace>/taskrun/<taskrun-name>                    - get <taskrun-name> taskrun
+GET /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>
+Get a Tekton PipelineRun by name
 
-GET /v1/namespaces/<namespace>/pipelineresource                          - get all pipelineresources
-GET /v1/namespaces/<namespace>/pipelineresource/<pipelineresource-name>  - get <pipelineresource-name> pipelineresource
+GET /v1/namespaces/<namespace>/task
+Get all Tekton tasks
 
-GET /v1/namespaces/<namespace>/log/<pod-name>                            - get log of <pod-name> pod
-GET /v1/namespaces/<namespace>/taskrunlog/<taskrun-name>                 - get log of <taskrun-name> taskrun
+GET /v1/namespaces/<namespace>/task/<task-name>
+Get a Tekton Task by name
 
-GET /v1/namespaces/<namespace>/credentials                               - get all credentials
-GET /v1/namespaces/<namespace>/credentials/<id>                          - get credential <id>
+GET /v1/namespaces/<namespace>/taskrun
+Get all Tekton TaskRuns
 
-GET /v1/websocket/logs                                                   - WIP, get websocket stream of logs
+GET /v1/namespaces/<namespace>/taskrun/<taskrun-name>
+Get a Tekton TaskRun by name
 
-GET /v1/namespaces/<namespace>/knative/installstatus                     - get install status of a Knative resource group -> the request body should contain the resource group to check for. Shorthand values are accepted for Knative serving and eventing-sources: use ("component": "serving" or "eventing-sources"). Any Kubernetes group can be used too, for example: `extensions/v1beta1`
+GET /v1/namespaces/<namespace>/pipelineresource
+Get all Tekton PipelineResources
+
+GET /v1/namespaces/<namespace>/pipelineresource/<pipelineresource-name>
+Get a Tekton PipelineResource by name
+
+GET /v1/namespaces/<namespace>/log/<pod-name>
+Get the logs for a Pod by name
+
+GET /v1/namespaces/<namespace>/taskrunlog/<taskrun-name>
+Get the logs for a TaskRun by name- get log of <taskrun-name> taskrun
+
+GET /v1/namespaces/<namespace>/credentials
+Get all credentials by name
+
+GET /v1/namespaces/<namespace>/credentials/<id>
+Get a credential by ID
+
+GET /v1/websocket/logs
+WIP, get a websocket stream of logs
+
+GET /v1/namespaces/<namespace>/knative/installstatus                     
+Get the install status of a Knative resource group .
+The request body should contain the resource group to check for. Shorthand values are accepted for Knative serving and eventing-sources: use ("component": "serving" or "eventing-sources"). Any Kubernetes group can be used too, for example: `extensions/v1beta1`
 
 Returns HTTP code 204 if the component is installed (any Kubernetes resource can be provided)
 Returns HTTP code 400 if a bad request is sent
@@ -149,14 +173,20 @@ Note that a check of the resource definition being registered is performed: not 
 
 POST endpoint:
 ```
-POST /v1/namespaces/<namespace>/credentials                              - create new credential    -> request body must contain id, username, password, and type ('accesstoken' or 'userpass')
+POST /v1/namespaces/<namespace>/credentials
+Create a new credential
+Request body must contain id, username, password, and type ('accesstoken' or 'userpass')
 ```
 
 PUT endpoints:
 ```
-PUT /v1/namespaces/<namespace>/credentials/<id>                          - update credential <id>       -> request body must contain username, password, and type ('accesstoken' or 'userpass')
+PUT /v1/namespaces/<namespace>/credentials/<id>                          
+Update credential by ID
+Request body must contain username, password, and type ('accesstoken' or 'userpass')
 
-PUT /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>            - update pipelinerun status    -> request body must contain desired status ("status: "PipelineRunCancelled" to cancel a running one). 
+PUT /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>
+Update pipelinerun status
+Request body must contain desired status ("status": "PipelineRunCancelled" to cancel a running one). 
 
 Returns HTTP code 204 if the PipelineRun was cancelled successfully (no contents are provided in the response)
 Returns HTTP code 400 if a bad request was used
@@ -167,5 +197,6 @@ Returns HTTP code 500 if the PipelineRun could not be stopped (an error has occu
 
 DELETE endpoint:
 ```
-DELETE /v1/namespaces/<namespace>/credentials/<id>                       - delete credential <id>
+DELETE /v1/namespaces/<namespace>/credentials/<id>
+Delete a credential by ID
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,3 +109,63 @@ To look at the dashboard logs, run:
 ```shell
 kubectl logs -l app=tekton-dashboard
 ```
+
+## API definitions
+
+The backend API offers the following endpoints at `/v1/namespaces/<namespace>`:
+
+GET endpoints:
+```
+GET /v1/namespaces/<namespace>/pipeline                                  - get all pipelines
+GET /v1/namespaces/<namespace>/pipeline/<pipeline-name>                  - get <pipeline-name> pipeline
+
+GET /v1/namespaces/<namespace>/pipelinerun                               - get all pipelineruns, also supports '?repository=https://gitserver/foo/bar' querying
+GET /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>            - get <pipelinerun-name> pipelinerun
+
+GET /v1/namespaces/<namespace>/task                                      - get all tasks
+GET /v1/namespaces/<namespace>/task/<task-name>                          - get <task-name> task
+
+GET /v1/namespaces/<namespace>/taskrun                                   - get all taskruns
+GET /v1/namespaces/<namespace>/taskrun/<taskrun-name>                    - get <taskrun-name> taskrun
+
+GET /v1/namespaces/<namespace>/pipelineresource                          - get all pipelineresources
+GET /v1/namespaces/<namespace>/pipelineresource/<pipelineresource-name>  - get <pipelineresource-name> pipelineresource
+
+GET /v1/namespaces/<namespace>/log/<pod-name>                            - get log of <pod-name> pod
+GET /v1/namespaces/<namespace>/taskrunlog/<taskrun-name>                 - get log of <taskrun-name> taskrun
+
+GET /v1/namespaces/<namespace>/credentials                               - get all credentials
+GET /v1/namespaces/<namespace>/credentials/<id>                          - get credential <id>
+
+GET /v1/websocket/logs                                                   - WIP, get websocket stream of logs
+
+GET /v1/namespaces/<namespace>/knative/installstatus                     - get install status of a Knative resource group -> the request body should contain the resource group to check for. Shorthand values are accepted for Knative serving and eventing-sources: use ("component": "serving" or "eventing-sources"). Any Kubernetes group can be used too, for example: `extensions/v1beta1`
+
+Returns HTTP code 204 if the component is installed (any Kubernetes resource can be provided)
+Returns HTTP code 400 if a bad request is sent
+Returns HTTP code 417 (expectation failed) if the resource is not registered
+Note that a check of the resource definition being registered is performed: not that pods are running and healthy.
+```
+
+POST endpoint:
+```
+POST /v1/namespaces/<namespace>/credentials                              - create new credential    -> request body must contain id, username, password, and type ('accesstoken' or 'userpass')
+```
+
+PUT endpoints:
+```
+PUT /v1/namespaces/<namespace>/credentials/<id>                          - update credential <id>       -> request body must contain username, password, and type ('accesstoken' or 'userpass')
+
+PUT /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>            - update pipelinerun status    -> request body must contain desired status ("status: "PipelineRunCancelled" to cancel a running one). 
+
+Returns HTTP code 204 if the PipelineRun was cancelled successfully (no contents are provided in the response)
+Returns HTTP code 400 if a bad request was used
+Returns HTTP code 404 if the requested PipelineRun could not be found 
+Returns HTTP code 412 if the status was already set to that
+Returns HTTP code 500 if the PipelineRun could not be stopped (an error has occurred when updating the PipelineRun)
+```
+
+DELETE endpoint:
+```
+DELETE /v1/namespaces/<namespace>/credentials/<id>                       - delete credential <id>
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,6 +143,8 @@ Returns HTTP code 404 if an error occurred getting the Task list
 
 GET /v1/namespaces/<namespace>/task/<task-name>
 Get a Tekton Task by name
+Returns HTTP code 200 and the given Task in the given namespace if found
+Returns HTTP code 404 if an error occurred getting the TaskRun 
 
 GET /v1/namespaces/<namespace>/taskrun
 Get all Tekton TaskRuns
@@ -151,37 +153,88 @@ Returns HTTP code 404 if an error occurred getting the TaskRun list
 
 GET /v1/namespaces/<namespace>/taskrun/<taskrun-name>
 Get a Tekton TaskRun by name
+Returns HTTP code 200 and the given TaskRun in the given namespace if found
+Returns HTTP code 404 if an error occurred getting the TaskRun 
 
 GET /v1/namespaces/<namespace>/pipelineresource
 Get all Tekton PipelineResources
 Returns HTTP code 200 and a list of PipelineResources in the given namespace 
-Returns HTTP code 404 if an error occurred getting the PipelineRun list
+Returns HTTP code 404 if an error occurred getting the PipelineResource list
 
 GET /v1/namespaces/<namespace>/pipelineresource/<pipelineresource-name>
 Get a Tekton PipelineResource by name
+Returns HTTP code 200 and the given PipelineResource in the given namespace if found
+Returns HTTP code 404 if an error occurred getting the PipelineResource 
 
 GET /v1/namespaces/<namespace>/log/<pod-name>
 Get the logs for a Pod by name
+Returns HTTP code 200 and the pod's logs in the given namespace if found
+Returns HTTP code 404 if an error occurred getting the logs or no pod was found by name in the given namespace
 
 GET /v1/namespaces/<namespace>/taskrunlog/<taskrun-name>
-Get the logs for a TaskRun by name- get log of <taskrun-name> taskrun
+Get the logs for a TaskRun by name-
+Returns HTTP code 200 and the logs from a TaskRun
+
+Example payload response:
+
+{
+ "PodName": "run-pipeline0-pipeline0-task-bk48w-pod-0fd388",
+ "Steps": [
+  {
+   "ContainerName": "build-step-git-source-pipeline0-git-source-lqzds",
+   "Logs": [
+    "{\"level\":\"warn\",\"ts\":1554153223.112332,\"logger\":\"fallback-logger\",\"caller\":\"logging/config.go:65\",\"msg\":\"Fetch GitHub commit ID from kodata failed: \\\"ref: refs/heads/master\\\" is not a valid GitHub commit ID\"}",
+    "{\"level\":\"info\",\"ts\":1554153223.7619479,\"logger\":\"fallback-logger\",\"caller\":\"git-init/main.go:100\",\"msg\":\"Successfully cloned \\\"https://github.com/ncskier/tekton-pipeline-config\\\" @ \\\"master\\\" in path \\\"/workspace/git-source\\\"\"}"
+   ]
+  },
+  {
+   "ContainerName": "build-step-kubectl-apply",
+   "Logs": [
+    "task.tekton.dev/build-push created",
+    "task.tekton.dev/deploy-simple-kubectl-task created",
+    "pipeline.tekton.dev/simple-pipeline created"
+   ]
+  },
+  {
+   "ContainerName": "nop",
+   "Logs": [
+    "Build successful"
+   ]
+  },
+  {
+   "ContainerName": "build-step-credential-initializer-ml54v",
+   "Logs": [
+    "{\"level\":\"warn\",\"ts\":1554153217.318807,\"logger\":\"fallback-logger\",\"caller\":\"logging/config.go:65\",\"msg\":\"Fetch GitHub commit ID from kodata failed: \\\"ref: refs/heads/master\\\" is not a valid GitHub commit ID\"}",
+    "{\"level\":\"info\",\"ts\":1554153217.3199604,\"logger\":\"fallback-logger\",\"caller\":\"creds-init/main.go:40\",\"msg\":\"Credentials initialized.\"}"
+   ]
+  },
+  {
+   "ContainerName": "build-step-place-tools",
+   "Logs": null
+  }
+ ]
+}
+
+Returns HTTP code 404 if an error occurred getting the logs or TaskRun pod was found by name in the given namespace
 
 GET /v1/namespaces/<namespace>/credentials
 Get all credentials by name in the given namespace
+Returns HTTP code 503 if an error occurred getting the credentials
+Returns HTTP code 200 and the given credential as a Kubernetes secret in the given namespace with a blanked out password if found, otherwise an empty list is returned
 
 GET /v1/namespaces/<namespace>/credentials/<id>
 Get a credential by ID
-
-GET /v1/websocket/logs
-WIP, get a websocket stream of logs
+Returns HTTP code 503 if an error occurred getting the credential
+Returns HTTP code 200 and the given credential as a Kubernetes secret in the given namespace with a blanked out password, otherwise an empty list is returned
 
 GET /v1/namespaces/<namespace>/knative/installstatus                     
-Get the install status of a Knative resource group .
+Get the install status of a Knative resource group.
 The request body should contain the resource group to check for. Shorthand values are accepted for Knative serving and eventing-sources: use ("component": "serving" or "eventing-sources"). Any Kubernetes group can be used too, for example: `extensions/v1beta1`
 
 Returns HTTP code 204 if the component is installed (any Kubernetes resource can be provided)
 Returns HTTP code 400 if a bad request is sent
 Returns HTTP code 417 (expectation failed) if the resource is not registered
+
 Note that a check of the resource definition being registered is performed: not that pods are running and healthy.
 ```
 
@@ -190,6 +243,7 @@ POST endpoint:
 POST /v1/namespaces/<namespace>/credentials
 Create a new credential
 Request body must contain id, username, password, and type ('accesstoken' or 'userpass')
+
 ```
 
 PUT endpoints:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,9 +112,11 @@ kubectl logs -l app=tekton-dashboard
 
 ## API definitions
 
-The backend API offers the following endpoints at `/v1/namespaces/<namespace>`:
+The backend API provides the following endpoints at `/v1/namespaces/<namespace>`:
 
-GET endpoints:
+__GET endpoints__
+
+__Pipelines__
 ```
 GET /v1/namespaces/<namespace>/pipeline
 Get all Tekton Pipelines
@@ -125,7 +127,10 @@ GET /v1/namespaces/<namespace>/pipeline/<pipeline-name>
 Get a Tekton Pipeline by name
 Returns HTTP code 200 and the given pipeline in the given namespace if found
 Returns HTTP code 404 if an error occurred getting the Pipeline
+```
 
+__PipelineRuns__
+```
 GET /v1/namespaces/<namespace>/pipelinerun
 Get all Tekton PipelineRuns, also supports '?repository=https://gitserver/foo/bar' querying
 Returns HTTP code 200 and a list of PipelineRuns, optionally matching the above query, in the given namespace
@@ -135,7 +140,10 @@ GET /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>
 Get a Tekton PipelineRun by name
 Returns HTTP code 200 and the given PipelineRun in the given namespace
 Returns HTTP code 404 if an error occurred getting the PipelineRun
+```
 
+__Tasks__
+```
 GET /v1/namespaces/<namespace>/task
 Get all Tekton tasks
 Returns HTTP code 200 and a list of Tasks in the given namespace 
@@ -145,7 +153,10 @@ GET /v1/namespaces/<namespace>/task/<task-name>
 Get a Tekton Task by name
 Returns HTTP code 200 and the given Task in the given namespace if found
 Returns HTTP code 404 if an error occurred getting the TaskRun 
+```
 
+__TaskRuns__
+```
 GET /v1/namespaces/<namespace>/taskrun
 Get all Tekton TaskRuns
 Returns HTTP code 200 and a list of TaskRuns in the given namespace 
@@ -155,7 +166,10 @@ GET /v1/namespaces/<namespace>/taskrun/<taskrun-name>
 Get a Tekton TaskRun by name
 Returns HTTP code 200 and the given TaskRun in the given namespace if found
 Returns HTTP code 404 if an error occurred getting the TaskRun 
+```
 
+__PipelineResources__
+```
 GET /v1/namespaces/<namespace>/pipelineresource
 Get all Tekton PipelineResources
 Returns HTTP code 200 and a list of PipelineResources in the given namespace 
@@ -165,7 +179,10 @@ GET /v1/namespaces/<namespace>/pipelineresource/<pipelineresource-name>
 Get a Tekton PipelineResource by name
 Returns HTTP code 200 and the given PipelineResource in the given namespace if found
 Returns HTTP code 404 if an error occurred getting the PipelineResource 
+```
 
+__Logs__
+```
 GET /v1/namespaces/<namespace>/log/<pod-name>
 Get the logs for a Pod by name
 Returns HTTP code 200 and the pod's logs in the given namespace if found
@@ -216,7 +233,10 @@ Example payload response:
 }
 
 Returns HTTP code 404 if an error occurred getting the logs or TaskRun pod was found by name in the given namespace
+```
 
+__Credentials__
+```
 GET /v1/namespaces/<namespace>/credentials
 Get all credentials by name in the given namespace
 Returns HTTP code 500 if an error occurred getting the credentials
@@ -227,7 +247,10 @@ Get a credential by ID
 Returns HTTP code 400 if the credential does not exist by name or an invalid namespace was provided
 Returns HTTP code 500 if an error occurred getting the credential
 Returns HTTP code 200 and the given credential as a Kubernetes secret in the given namespace with a blanked out password, otherwise an empty list is returned
+```
 
+__Knative__
+```
 GET /v1/namespaces/<namespace>/knative/installstatus                     
 Get the install status of a Knative resource group.
 The request body should contain the resource group to check for. Shorthand values are accepted for Knative serving and eventing-sources: use ("component": "serving" or "eventing-sources"). Any Kubernetes group can be used too, for example: `extensions/v1beta1`
@@ -237,10 +260,11 @@ Returns HTTP code 400 if a bad request is sent
 Returns HTTP code 417 (expectation failed) if the resource is not registered
 
 Note that a check of the resource definition being registered is performed: not that pods are running and healthy.
-
 ```
 
-POST endpoint:
+__POST endpoints__
+
+__Credentials__
 ```
 POST /v1/namespaces/<namespace>/credentials
 Create a new credential
@@ -255,7 +279,7 @@ Example POST (non-trivial as it involves the URL map):
 
 {
     "id": "mysecretname",
-    "username": "a-roberts",
+    "username": "myusername",
     "password": "mypassword",
     "type": "userpass",
     "description": "my secret for github",
@@ -263,14 +287,19 @@ Example POST (non-trivial as it involves the URL map):
 }
 ```
 
-PUT endpoints:
+__PUT endpoints__
+
+__Credentials__
 ```
 PUT /v1/namespaces/<namespace>/credentials/<id>                          
 Update credential by ID
 Request body must contain id, username, password, type ('accesstoken' or 'userpass'), description and the URL that the credential will be used for (e.g. the Git server)
 Returns HTTP code 200 and nothing else if the credential was updated OK
 Returns HTTP code 400 if a bad request was provided or if an error occurs updating the credential
+```
 
+__PipelineRuns__
+```
 PUT /v1/namespaces/<namespace>/pipelinerun/<pipelinerun-name>
 Update pipelinerun status
 Request body must contain desired status ("status": "PipelineRunCancelled" to cancel a running one). 
@@ -282,7 +311,9 @@ Returns HTTP code 412 if the status was already set to that
 Returns HTTP code 500 if the PipelineRun could not be stopped (an error has occurred when updating the PipelineRun)
 ```
 
-DELETE endpoint:
+__DELETE endpoints__
+
+__Credentials__
 ```
 DELETE /v1/namespaces/<namespace>/credentials/<id>
 Delete a credential by ID


### PR DESCRIPTION
Here's what I have so far (I'm done with work for this week and want to share some progress). This is for https://github.com/tektoncd/dashboard/issues/41. 

As @AlanGreene suggested [here](https://github.com/tektoncd/dashboard/issues/42) it would be awesome to have a swagger/openapi spec. It would be very cool to autogenerate these using swagger and https://github.com/go-swagger/go-swagger looks to be suitable.

I'd like to flesh this out by adding **all** response codes next for each API.