### PR TITLE
Restful routes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -270,7 +270,7 @@ POST /v1/namespaces/<namespace>/credentials
 Create a new credential
 Request body must contain id, username, password, type ('accesstoken' or 'userpass'), description and the URL that the credential will be used for (e.g. the Git server)
 
-Returns HTTP code 200 if the credential was created OK
+Returns HTTP code 201 if the credential was created OK and sets the 'Content-Location' header
 Returns HTTP code 400 if a bad request was provided
 Returns HTTP code 406 if no body is provided
 Returns HTTP code 500 if an error occurred creating the credential
@@ -294,7 +294,7 @@ __Credentials__
 PUT /v1/namespaces/<namespace>/credentials/<id>                          
 Update credential by ID
 Request body must contain id, username, password, type ('accesstoken' or 'userpass'), description and the URL that the credential will be used for (e.g. the Git server)
-Returns HTTP code 200 and nothing else if the credential was updated OK
+Returns HTTP code 201 if the credential was updated OK and sets the 'Content-Location' header
 Returns HTTP code 400 if a bad request was provided or if an error occurs updating the credential
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -294,7 +294,7 @@ __Credentials__
 PUT /v1/namespaces/<namespace>/credentials/<id>                          
 Update credential by ID
 Request body must contain id, username, password, type ('accesstoken' or 'userpass'), description and the URL that the credential will be used for (e.g. the Git server)
-Returns HTTP code 201 if the credential was updated OK and sets the 'Content-Location' header
+Returns HTTP code 204 if the credential was updated OK (no contents are provided in the response)
 Returns HTTP code 400 if a bad request was provided or if an error occurs updating the credential
 ```
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,238 +2,195 @@
 
 
 [[projects]]
-  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:4407e93a89da65e7f7e51768c1a4b20ba035e463f78b3027b791dd4f29174ced"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log",
+    "log"
   ]
-  pruneopts = "UT"
   revision = "b9bbc5664f49b6deec52393bd68f39830687a347"
   version = "v2.9.3"
 
 [[projects]]
-  digest = "1:f1f2bd73c025d24c3b93abf6364bccb802cf2fdedaa44360804c67800e8fab8d"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
-  pruneopts = "UT"
   revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
   version = "v4.1.0"
 
 [[projects]]
-  digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:4d02824a56d268f74a6b6fdd944b20b58a77c3d70e81008b3ee0c4f1a6777340"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = "UT"
   revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
   version = "v1.2.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:239c4c7fd2159585454003d9be7207167970194216193a8a210b8d29576f19c9"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "UT"
   revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
   name = "github.com/google/btree"
   packages = ["."]
-  pruneopts = "UT"
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value",
+    "cmp/internal/value"
   ]
-  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "UT"
   revision = "f140a6486e521aad38f5917de355cbf147cc0496"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "UT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
   name = "github.com/gorilla/websocket"
   packages = ["."]
-  pruneopts = "UT"
   revision = "66b9c49e59c6c48f0ffce28c2d8b8a5678502c6d"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b4395b2a4566c24459af3d04009b39cc21762fc77ec7bf7a1aa905c91e8f018d"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache",
+    "diskcache"
   ]
-  pruneopts = "UT"
   revision = "3befbb6ad0cc97d4c25d851e9528915809e1a22f"
 
 [[projects]]
-  digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "UT"
   revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
   version = "v0.5.1"
 
 [[projects]]
-  digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "UT"
   revision = "7c29201646fa3de8506f701213473dd407f19646"
   version = "v0.3.7"
 
 [[projects]]
-  digest = "1:f5a2051c55d05548d2d4fd23d244027b59fbd943217df8aa3b5e170ac2fd6e1b"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
   version = "v1.1.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:58dc2abfa0d3901dde142cd636abf13d495f37c125564390c7a5791d1fa29e80"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
     "apis/duck",
     "apis/duck/v1alpha1",
-    "kmp",
+    "kmp"
   ]
-  pruneopts = "UT"
   revision = "28cfa161499b88cc5a71cfb7cf8a59fc34bff3d3"
 
 [[projects]]
   branch = "master"
-  digest = "1:fc2b04b0069d6b10bdef96d278fe20c345794009685ed3c8c7f1a6dc023eefec"
   name = "github.com/mattbaird/jsonpatch"
   packages = ["."]
-  pruneopts = "UT"
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
-  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = "UT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
-  pruneopts = "UT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
-  digest = "1:0e7775ebbcf00d8dd28ac663614af924411c868dca3d5aa762af0fae3808d852"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
-  pruneopts = "UT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:f9f144aab0a32f55fcfa49f2b64461affa903cdb8db918b89770668d852a13a1"
   name = "github.com/tektoncd/dashboard"
   packages = [
     "pkg/broadcaster",
     "pkg/endpoints",
     "pkg/logging",
     "pkg/utils",
-    "pkg/websocket",
+    "pkg/websocket"
   ]
-  pruneopts = "UT"
   revision = "ecc9da8a0c1d069cc89eddc21fbd1c7f948f8a6a"
 
 [[projects]]
   branch = "master"
-  digest = "1:aff35c0379f09633e57e10fcd3a00e7563a2669c668e184fe3e2f94a5915f028"
   name = "github.com/tektoncd/pipeline"
   packages = [
     "pkg/apis/pipeline",
@@ -250,29 +207,23 @@
     "pkg/client/listers/pipeline/v1alpha1",
     "pkg/list",
     "pkg/names",
-    "pkg/templating",
+    "pkg/templating"
   ]
-  pruneopts = "UT"
   revision = "c463f1230adc340ee96c02c60f074fff83240210"
 
 [[projects]]
-  digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
   name = "go.uber.org/atomic"
   packages = ["."]
-  pruneopts = "UT"
   revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
   version = "v1.3.2"
 
 [[projects]]
-  digest = "1:60bf2a5e347af463c42ed31a493d817f8a72f102543060ed992754e689805d1a"
   name = "go.uber.org/multierr"
   packages = ["."]
-  pruneopts = "UT"
   revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:c52caf7bd44f92e54627a31b85baf06a68333a196b3d8d241480a774733dcf8b"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -280,23 +231,19 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
-    "zapcore",
+    "zapcore"
   ]
-  pruneopts = "UT"
   revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
   version = "v1.9.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:bbe51412d9915d64ffaa96b51d409e070665efc5194fcf145c4a27d4133107a4"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = "UT"
   revision = "38d8ce5564a5b71b2e3a00553993f1b9a7ae852f"
 
 [[projects]]
   branch = "master"
-  digest = "1:c745644c88df7496196bf316dd0e813f1908215ff29e96622c2fc194f21bac0c"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -304,35 +251,29 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna",
+    "idna"
   ]
-  pruneopts = "UT"
   revision = "eb5bcb51f2a31c7d5141d810b70815c05d9c9146"
 
 [[projects]]
   branch = "master"
-  digest = "1:9927d6aceb89d188e21485f42a7a254e67e6fdcf4260aba375fe18e3c300dfb4"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal",
+    "internal"
   ]
-  pruneopts = "UT"
   revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
 
 [[projects]]
   branch = "master"
-  digest = "1:503f66aac79cb9135d73679c7fa3e95a6fad82a3da399c505ea282b50ff03723"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "UT"
   revision = "4b34438f7a67ee5f45cc6132e2bad873a20324e9"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -348,22 +289,18 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "UT"
   revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
-  digest = "1:6eb6e3b6d9fffb62958cf7f7d88dbbe1dd6839436b0802e194c590667a40412a"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -372,30 +309,24 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = "UT"
   revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:faf52d216e0d651ee48a5ee8fb43f818a6c36bf4246282a5e30b8985da5581ff"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -428,14 +359,12 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "UT"
   revision = "145d52631d00cbfe68490d19ae4f0f501fd31a95"
   version = "kubernetes-1.12.6"
 
 [[projects]]
-  digest = "1:94babe94a374f3367bc9606841879a72591bef89a7370751b0cc3957f0d8c804"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -483,14 +412,12 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "UT"
   revision = "01f179d85dbce0f2e0e4351a92394b38694b7cae"
   version = "kubernetes-1.12.6"
 
 [[projects]]
-  digest = "1:38b619740b74c3596fce093a1f6cf70245259797538454662ff3973067a80e2b"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -585,53 +512,26 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/retry",
+    "util/retry"
   ]
-  pruneopts = "UT"
   revision = "78295b709ec6fa5be12e35892477a326dea2b5d3"
   version = "kubernetes-1.12.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:22abb5d4204ab1a0dcc9cda64906a31c43965ff5159e8b9f766c9d2a162dbed5"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  pruneopts = "UT"
   revision = "94e1e7b7574c44c4c0f2007de6fe617e259191f3"
 
 [[projects]]
   branch = "master"
-  digest = "1:e1fc4a624e8497252148125a50cec64b416d69ef69afc2244498e0c9b73060d5"
   name = "k8s.io/sample-controller"
   packages = ["pkg/signals"]
-  pruneopts = "UT"
   revision = "ef739b027d6ca5a347fdba88dec315e56ee14b2e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/emicklei/go-restful",
-    "github.com/gorilla/websocket",
-    "github.com/tektoncd/dashboard/pkg/broadcaster",
-    "github.com/tektoncd/dashboard/pkg/endpoints",
-    "github.com/tektoncd/dashboard/pkg/logging",
-    "github.com/tektoncd/dashboard/pkg/utils",
-    "github.com/tektoncd/dashboard/pkg/websocket",
-    "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1",
-    "github.com/tektoncd/pipeline/pkg/client/clientset/versioned",
-    "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake",
-    "github.com/tektoncd/pipeline/pkg/client/informers/externalversions",
-    "go.uber.org/zap",
-    "k8s.io/api/core/v1",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/kubernetes/fake",
-    "k8s.io/client-go/rest",
-    "k8s.io/client-go/tools/cache",
-    "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/sample-controller/pkg/signals",
-  ]
+  inputs-digest = "52b8a6d95fec414aaa0086a16165a3b7d01dbfa130037f98a9e1ccc03c3fc324"
   solver-name = "gps-cdcl"
   solver-version = 1
-

--- a/pkg/endpoints/credentials.go
+++ b/pkg/endpoints/credentials.go
@@ -147,7 +147,7 @@ func (r Resource) createCredential(request *restful.Request, response *restful.R
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusBadRequest)
 		return
 	}
-	writeResponseLocation(request,response)
+	writeResponseLocation(request,response,cred.Id)
 }
 
 /* API route for updating a given credential
@@ -197,7 +197,7 @@ func (r Resource) updateCredential(request *restful.Request, response *restful.R
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusBadRequest)
 		return
 	}
-	writeResponseLocation(request,response)
+	writeResponseLocation(request,response,cred.Id)
 }
 
 /* API route for creating a given credential

--- a/pkg/endpoints/credentials.go
+++ b/pkg/endpoints/credentials.go
@@ -116,7 +116,6 @@ func (r Resource) getCredential(request *restful.Request, response *restful.Resp
  *  - type (must have the value 'accesstoken' or 'userpass')
  */
 func (r Resource) createCredential(request *restful.Request, response *restful.Response) {
-	logging.Log.Info("CREATE CREDENTIAL")
 	// Get path parameter
 	requestNamespace := request.PathParameter("namespace")
 	// Get query parameters

--- a/pkg/endpoints/credentials.go
+++ b/pkg/endpoints/credentials.go
@@ -26,7 +26,7 @@ import (
 )
 
 type credential struct {
-	ID              string            `json:"id"`
+	Name             string           `json:"name"`
 	Username        string            `json:"username"`
 	Password        string            `json:"password"`
 	Description     string            `json:"description"`
@@ -35,9 +35,14 @@ type credential struct {
 	URL             map[string]string `json:"url"`
 }
 
-var labelSelector = "tektondashboard=true" // must have format "<key>=<value>"
 var typeAccessToken = "accesstoken"
 var typeUserPass = "userpass"
+
+const (
+	dashboardKey string = "tekton-dashboard"
+	dashboardValue string = "true"
+	dashboardLabelSelector string = dashboardKey+"="+dashboardValue // must have format "<key>=<value>"
+)
 
 /* API route for getting all credentials in a given namespace
  * Required path parameters:
@@ -53,7 +58,7 @@ func (r Resource) getAllCredentials(request *restful.Request, response *restful.
 	}
 
 	// Get secrets from the resource K8sClient
-	secrets, err := r.K8sClient.CoreV1().Secrets(requestNamespace).List(metav1.ListOptions{LabelSelector: labelSelector})
+	secrets, err := r.K8sClient.CoreV1().Secrets(requestNamespace).List(metav1.ListOptions{LabelSelector: dashboardLabelSelector})
 	if err != nil {
 		errorMessage := fmt.Sprintf("Error getting secrets from K8sClient: %s.", err.Error())
 		response.WriteErrorString(http.StatusInternalServerError, errorMessage)
@@ -80,19 +85,19 @@ func (r Resource) getAllCredentials(request *restful.Request, response *restful.
 func (r Resource) getCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameters
 	requestNamespace := request.PathParameter("namespace")
-	requestID := request.PathParameter("id")
+	requestName := request.PathParameter("name")
 
 	// Verify namespace exists
 	if !r.verifyNamespaceExists(requestNamespace, response) {
 		return
 	}
 	// Verify secret exists
-	if !r.verifySecretExists(requestID, requestNamespace, response) {
+	if !r.verifySecretExists(requestName, requestNamespace, response) {
 		return
 	}
 
 	// Get secret from the resource K8sClient
-	secret, err := r.K8sClient.CoreV1().Secrets(requestNamespace).Get(requestID, metav1.GetOptions{})
+	secret, err := r.K8sClient.CoreV1().Secrets(requestNamespace).Get(requestName, metav1.GetOptions{})
 	if err != nil {
 		errorMessage := fmt.Sprintf("Error getting secret from K8sClient: %s.", err.Error())
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusInternalServerError)
@@ -147,7 +152,7 @@ func (r Resource) createCredential(request *restful.Request, response *restful.R
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusBadRequest)
 		return
 	}
-	writeResponseLocation(request,response,cred.ID)
+	writeResponseLocation(request,response,cred.Name)
 }
 
 /* API route for updating a given credential
@@ -163,13 +168,13 @@ func (r Resource) createCredential(request *restful.Request, response *restful.R
 func (r Resource) updateCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameters
 	requestNamespace := request.PathParameter("namespace")
-	requestID := request.PathParameter("id")
+	requestName := request.PathParameter("name")
 	// Get query parameters
 	cred := credential{}
 	if err := getQueryEntity(&cred, request, response); err != nil {
 		return
 	}
-	cred.ID = requestID
+	cred.Name = requestName
 
 	// Verify required query parameters are in cred
 	if !r.verifyCredentialParameters(cred, response) {
@@ -181,7 +186,7 @@ func (r Resource) updateCredential(request *restful.Request, response *restful.R
 		return
 	}
 	// Verify secret exists
-	if !r.verifySecretExists(requestID, requestNamespace, response) {
+	if !r.verifySecretExists(requestName, requestNamespace, response) {
 		return
 	}
 
@@ -197,7 +202,7 @@ func (r Resource) updateCredential(request *restful.Request, response *restful.R
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusBadRequest)
 		return
 	}
-	writeResponseLocation(request,response,cred.ID)
+	response.WriteHeader(204)
 }
 
 /* API route for creating a given credential
@@ -208,19 +213,19 @@ func (r Resource) updateCredential(request *restful.Request, response *restful.R
 func (r Resource) deleteCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameters
 	requestNamespace := request.PathParameter("namespace")
-	requestID := request.PathParameter("id")
+	requestName := request.PathParameter("name")
 
 	// Verify namespace exists
 	if !r.verifyNamespaceExists(requestNamespace, response) {
 		return
 	}
 	// Verify secret exists
-	if !r.verifySecretExists(requestID, requestNamespace, response) {
+	if !r.verifySecretExists(requestName, requestNamespace, response) {
 		return
 	}
 
 	// Get secret from the resource K8sClient
-	err := r.K8sClient.CoreV1().Secrets(requestNamespace).Delete(requestID, &metav1.DeleteOptions{})
+	err := r.K8sClient.CoreV1().Secrets(requestNamespace).Delete(requestName, &metav1.DeleteOptions{})
 	if err != nil {
 		errorMessage := fmt.Sprintf("Error deleting secret from K8sClient: %s.", err.Error())
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusInternalServerError)
@@ -268,13 +273,13 @@ func (r Resource) verifySecretExists(secretName string, namespace string, respon
  *  - Type (must have the value 'accesstoken' or 'userpass')
  */
 func (r Resource) verifyCredentialParameters(cred credential, response *restful.Response) bool {
-	if cred.ID == "" ||
+	if cred.Name == "" ||
 		cred.Username == "" ||
 		cred.Password == "" ||
 		cred.URL == nil ||
 		(cred.Type != typeAccessToken && cred.Type != typeUserPass) {
 
-		errorMessage := fmt.Sprintf("Error: username, password, id, url and type ('%s' or '%s') must all be supplied.", typeAccessToken, typeUserPass)
+		errorMessage := fmt.Sprintf("Error: username, password, name, url and type ('%s' or '%s') must all be supplied.", typeAccessToken, typeUserPass)
 		utils.RespondErrorMessage(response, errorMessage, http.StatusBadRequest)
 		return false
 	}
@@ -302,7 +307,7 @@ func getQueryEntity(entityPointer interface{}, request *restful.Request, respons
 // Convert K8s secret struct into credential struct
 func secretToCredential(secret *corev1.Secret, mask bool) credential {
 	cred := credential{
-		ID:              secret.GetName(),
+		Name:              secret.GetName(),
 		Username:        string(secret.Data["username"]),
 		Password:        string(secret.Data["password"]),
 		Description:     string(secret.Data["description"]),
@@ -321,7 +326,7 @@ func credentialToSecret(cred credential, namespace string, response *restful.Res
 	// Create new secret struct
 	secret := corev1.Secret{}
 	secret.SetNamespace(namespace)
-	secret.SetName(cred.ID)
+	secret.SetName(cred.Name)
 	secret.Type = corev1.SecretTypeBasicAuth
 	secret.Data = make(map[string][]byte)
 	secret.Data["username"] = []byte(cred.Username)
@@ -330,17 +335,9 @@ func credentialToSecret(cred credential, namespace string, response *restful.Res
 	secret.Data["type"] = []byte(cred.Type)
 	secret.ObjectMeta.Annotations = cred.URL
 
-	// Add label
-	keyValue := strings.Split(labelSelector, "=")
-	if len(keyValue) != 2 {
-		errorMessage := "Error setting label for secret"
-		utils.RespondErrorMessage(response, errorMessage, http.StatusInternalServerError)
-		return nil, false
+	labels := map[string]string {
+		dashboardKey: dashboardValue,
 	}
-	key := keyValue[0]
-	value := keyValue[1]
-	labels := make(map[string]string)
-	labels[key] = value
 	secret.SetLabels(labels)
 
 	// Return secret

--- a/pkg/endpoints/credentials.go
+++ b/pkg/endpoints/credentials.go
@@ -116,6 +116,7 @@ func (r Resource) getCredential(request *restful.Request, response *restful.Resp
  *  - type (must have the value 'accesstoken' or 'userpass')
  */
 func (r Resource) createCredential(request *restful.Request, response *restful.Response) {
+	logging.Log.Info("CREATE CREDENTIAL")
 	// Get path parameter
 	requestNamespace := request.PathParameter("namespace")
 	// Get query parameters
@@ -146,7 +147,7 @@ func (r Resource) createCredential(request *restful.Request, response *restful.R
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusBadRequest)
 		return
 	}
-	setContentLocation(request,response)
+	writeResponseLocation(request,response)
 }
 
 /* API route for updating a given credential
@@ -196,7 +197,7 @@ func (r Resource) updateCredential(request *restful.Request, response *restful.R
 		utils.RespondErrorAndMessage(response, err, errorMessage, http.StatusBadRequest)
 		return
 	}
-	setContentLocation(request,response)
+	writeResponseLocation(request,response)
 }
 
 /* API route for creating a given credential

--- a/pkg/endpoints/credentials.go
+++ b/pkg/endpoints/credentials.go
@@ -26,7 +26,7 @@ import (
 )
 
 type credential struct {
-	Name             string           `json:"name"`
+	Name            string            `json:"name"`
 	Username        string            `json:"username"`
 	Password        string            `json:"password"`
 	Description     string            `json:"description"`
@@ -79,8 +79,8 @@ func (r Resource) getAllCredentials(request *restful.Request, response *restful.
 
 /* API route for getting a given credential by name in a given namespace
  * Required path parameters:
- *  - namespace
- *  - id
+ *  - Namespace
+ *  - Name
  */
 func (r Resource) getCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameters
@@ -116,10 +116,10 @@ func (r Resource) getCredential(request *restful.Request, response *restful.Resp
  * Required path parameters:
  *  - namespace
  * Required query parameters:
- *  - id
- *  - username
- *  - password
- *  - type (must have the value 'accesstoken' or 'userpass')
+ *  - Name
+ *  - Username
+ *  - Password
+ *  - Type (must have the value 'accesstoken' or 'userpass')
  */
 func (r Resource) createCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameter
@@ -156,14 +156,14 @@ func (r Resource) createCredential(request *restful.Request, response *restful.R
 }
 
 /* API route for updating a given credential
- * Cannot update the id field
+ * Cannot update the Name field
  * Required path parameters:
- *  - namespace
- *  - id
+ *  - Namespace
+ *  - Name
  * Required query parameters:
- *  - username
- *  - password
- *  - type (must have the value 'accesstoken' or 'userpass')
+ *  - Username
+ *  - Password
+ *  - Type (must have the value 'accesstoken' or 'userpass')
  */
 func (r Resource) updateCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameters
@@ -207,8 +207,8 @@ func (r Resource) updateCredential(request *restful.Request, response *restful.R
 
 /* API route for creating a given credential
  * Required path parameters:
- *  - namespace
- *  - id
+ *  - Namespace
+ *  - Name
  */
 func (r Resource) deleteCredential(request *restful.Request, response *restful.Response) {
 	// Get path parameters
@@ -267,7 +267,7 @@ func (r Resource) verifySecretExists(secretName string, namespace string, respon
 
 /* Verify required parameters are in credential struct
  * Required parameters:
- *  - Id
+ *  - Name
  *  - Username
  *  - Password
  *  - Type (must have the value 'accesstoken' or 'userpass')
@@ -279,7 +279,7 @@ func (r Resource) verifyCredentialParameters(cred credential, response *restful.
 		cred.URL == nil ||
 		(cred.Type != typeAccessToken && cred.Type != typeUserPass) {
 
-		errorMessage := fmt.Sprintf("Error: username, password, name, url and type ('%s' or '%s') must all be supplied.", typeAccessToken, typeUserPass)
+		errorMessage := fmt.Sprintf("Error: Username, Password, Name, URL and Type ('%s' or '%s') must all be supplied.", typeAccessToken, typeUserPass)
 		utils.RespondErrorMessage(response, errorMessage, http.StatusBadRequest)
 		return false
 	}

--- a/pkg/endpoints/credentials_test.go
+++ b/pkg/endpoints/credentials_test.go
@@ -36,7 +36,7 @@ func TestCredentials(t *testing.T) {
 	// Initialize test data
 	expectCreds := []credential{}
 	accessTokenCred := credential{
-		ID:          "credentialaccesstoken",
+		Name:          "credentialaccesstoken",
 		Username:    "personal-access-token",
 		Password:    "passwordaccesstoken",
 		Description: "access token credential",
@@ -46,7 +46,7 @@ func TestCredentials(t *testing.T) {
 		},
 	}
 	userPassCred := credential{
-		ID:          "credentialuserpass",
+		Name:          "credentialuserpass",
 		Username:    "usernameuserpass",
 		Password:    "passworduserpass",
 		Description: "user password credential",
@@ -111,7 +111,7 @@ func TestCredentials(t *testing.T) {
 
 	// DELETE credential accesstoken
 	t.Log("DELETE credential 'credentialaccesstoken' when it exists")
-	deleteCredentialTest(namespace, accessTokenCred.ID, "", r, t)
+	deleteCredentialTest(namespace, accessTokenCred.Name, "", r, t)
 
 	// READ ALL credentials when there is only the userpass credential
 	t.Log("READ all credentials when there is only 'credentialuserpass' ('credentialaccesstoken' was just deleted)")
@@ -122,7 +122,7 @@ func TestCredentials(t *testing.T) {
 
 	// DELETE credential userpass
 	t.Log("DELETE credential 'credentialuserpass' when it exists")
-	deleteCredentialTest(namespace, userPassCred.ID, "", r, t)
+	deleteCredentialTest(namespace, userPassCred.Name, "", r, t)
 
 	// READ ALL credentials when there are none
 	t.Log("READ all credentials when there are none ('credentialuserpass' was just deleted)")
@@ -139,10 +139,10 @@ func TestCredentialsErrors(t *testing.T) {
 	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 	// Initialize test data
-	expectError := ""
-	invalidCreds := []credential{}
+	var expectError string
+	var invalidCreds []credential
 
-	// (ERROR) CREATE and UPDATE invalid credentials missing username, password, ID, URL or type ('accesstoken' or 'userpass')
+	// (ERROR) CREATE and UPDATE invalid credentials missing Username, Password, Name, URL or invalid type (NOT 'accesstoken' or 'userpass')
 	invalidCreds = []credential{
 		credential{
 			Username:    "personal-access-token",
@@ -154,7 +154,7 @@ func TestCredentialsErrors(t *testing.T) {
 			},
 		},
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
 			Type:        "accesstoken",
@@ -163,7 +163,7 @@ func TestCredentialsErrors(t *testing.T) {
 			},
 		},
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Description: "access token credential",
 			Type:        "accesstoken",
@@ -172,7 +172,7 @@ func TestCredentialsErrors(t *testing.T) {
 			},
 		},
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
@@ -181,7 +181,7 @@ func TestCredentialsErrors(t *testing.T) {
 			},
 		},
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
@@ -191,7 +191,7 @@ func TestCredentialsErrors(t *testing.T) {
 			},
 		},
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
@@ -200,14 +200,14 @@ func TestCredentialsErrors(t *testing.T) {
 	}
 	for _, invalidCred := range invalidCreds {
 		// Must match error message exactly in the verify function, careful if you change fields
-		expectError = fmt.Sprintf("Error: username, password, id, url and type ('accesstoken' or 'userpass') must all be supplied.")
+		expectError = "Error: username, password, id, url and type ('accesstoken' or 'userpass') must all be supplied."
 		createCredentialTest(namespace, invalidCred, expectError, r, t)
 		updateCredentialTest(namespace, invalidCred, expectError, r, t)
 	}
 
 	invalidCreds = []credential{
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
@@ -228,7 +228,7 @@ func TestCredentialsErrors(t *testing.T) {
 	// (ERROR) READ, UPDATE, and DELETE credentials that do not exist
 	invalidCreds = []credential{
 		credential{
-			ID:          "credentialaccesstoken",
+			Name:          "credentialaccesstoken",
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",
@@ -248,18 +248,18 @@ func TestCredentialsErrors(t *testing.T) {
 		},
 	}
 	for _, invalidCred := range invalidCreds {
-		expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCred.ID)
+		expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCred.Name)
 		readCredentialTest(namespace, invalidCred, expectError, r, t)
-		deleteCredentialTest(namespace, invalidCred.ID, expectError, r, t)
+		deleteCredentialTest(namespace, invalidCred.Name, expectError, r, t)
 	}
-	expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCreds[0].ID)
+	expectError = fmt.Sprintf("Error getting secret from K8sClient: '%s'.", invalidCreds[0].Name)
 	updateCredentialTest(namespace, invalidCreds[0], expectError, r, t)
 
 	// (ERROR) CREATE, READ, UPDATE, and DELETE credentials in a namespace that does not exist
 	bogusNamespace := "bogusnamespace"
 	expectError = fmt.Sprintf("Namespace provided does not exist: '%s'.", bogusNamespace)
 	cred := credential{
-		ID:          "credentialaccesstoken",
+		Name:          "credentialaccesstoken",
 		Username:    "personal-access-token",
 		Password:    "passwordaccesstoken",
 		Description: "access token credential",
@@ -272,13 +272,13 @@ func TestCredentialsErrors(t *testing.T) {
 	readAllCredentialsTest(bogusNamespace, []credential{cred}, expectError, r, t)
 	readCredentialTest(bogusNamespace, cred, expectError, r, t)
 	updateCredentialTest(bogusNamespace, cred, expectError, r, t)
-	deleteCredentialTest(bogusNamespace, cred.ID, expectError, r, t)
+	deleteCredentialTest(bogusNamespace, cred.Name, expectError, r, t)
 }
 
 /*
  * CREATE credential test
  * To function properly, [cred] must have the following fields:
- *  - ID
+ *  - Name
  *  - username
  *  - password
  *  - type (must have the value 'accesstoken' or 'userpass')
@@ -303,13 +303,13 @@ func createCredentialTest(namespace string, cred credential, expectError string,
 	}
 
 	// Verify against K8s client
-	testCredential(r.getK8sCredential(namespace, cred.ID), cred, t)
+	testCredential(r.getK8sCredential(namespace, cred.Name), cred, t)
 }
 
 /*
  * READ ALL credentials test
  * To function properly, [expectCreds] must have the same number of credentials as there are in the system
- * and they must be in the correct order (alphabetical by ID field)
+ * and they must be in the correct order (alphabetical by Name field)
  */
 func readAllCredentialsTest(namespace string, expectCreds []credential, expectError string, r *Resource, t *testing.T) {
 	t.Logf("READ all credentials. Expecting: %+v", expectCreds)
@@ -347,15 +347,15 @@ func readAllCredentialsTest(namespace string, expectCreds []credential, expectEr
 
 /*
  * READ credential test
- * To function properly, [expectCred] must have the "ID" field
+ * To function properly, [expectCred] must have the "Name" field
  */
 func readCredentialTest(namespace string, expectCred credential, expectError string, r *Resource, t *testing.T) {
-	t.Logf("READ credential %s", expectCred.ID)
+	t.Logf("READ credential %s", expectCred.Name)
 	// Create dummy rest api request and response
-	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+expectCred.ID, nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+expectCred.Name, nil)
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = expectCred.ID
+	params["id"] = expectCred.Name
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -375,25 +375,25 @@ func readCredentialTest(namespace string, expectCred credential, expectError str
 	expectCred.Password = expectCredPassword
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, expectCred.ID), expectCred, t)
+	testCredential(r.getK8sCredential(namespace, expectCred.Name), expectCred, t)
 }
 
 /*
  * UPDATE credential test
  * To function properly, [cred] must have the following fields:
- *  - ID
- *  - username
- *  - password
- *  - type (must have the value 'accesstoken' or 'userpass')
+ *  - Name
+ *  - Username
+ *  - Password
+ *  - Type (must have the value 'accesstoken' or 'userpass')
  */
 func updateCredentialTest(namespace string, cred credential, expectError string, r *Resource, t *testing.T) {
 	t.Logf("UPDATE credential %+v", cred)
 	// Create dummy rest api request and response
 	jsonBody, _ := json.Marshal(cred)
-	httpReq := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+cred.ID, bytes.NewBuffer(jsonBody))
+	httpReq := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+cred.Name, bytes.NewBuffer(jsonBody))
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = cred.ID
+	params["id"] = cred.Name
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -407,19 +407,19 @@ func updateCredentialTest(namespace string, cred credential, expectError string,
 	}
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, cred.ID), cred, t)
+	testCredential(r.getK8sCredential(namespace, cred.Name), cred, t)
 }
 
 /*
  * DELETE credential test
  */
-func deleteCredentialTest(namespace string, credID string, expectError string, r *Resource, t *testing.T) {
-	t.Logf("DELETE credential %s", credID)
+func deleteCredentialTest(namespace string, credName string, expectError string, r *Resource, t *testing.T) {
+	t.Logf("DELETE credential %s", credName)
 	// Create dummy rest api request and response
-	httpReq := dummyHTTPRequest("DELETE", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+credID, nil)
+	httpReq := dummyHTTPRequest("DELETE", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+credName, nil)
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = credID
+	params["name"] = credName
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -433,7 +433,7 @@ func deleteCredentialTest(namespace string, credID string, expectError string, r
 	}
 
 	// Verify agains K8s client
-	testCredential(r.getK8sCredential(namespace, credID), credential{}, t)
+	testCredential(r.getK8sCredential(namespace, credName), credential{}, t)
 }
 
 /*
@@ -483,7 +483,7 @@ func testCredential(resultCred credential, expectCred credential, t *testing.T) 
 
 // Get all K8s client secrets with selector LABEL_SELECTOR
 func (r Resource) getK8sCredentials(namespace string) (credentials []credential) {
-	secrets, err := r.K8sClient.CoreV1().Secrets(namespace).List(metav1.ListOptions{LabelSelector: "tektondashboard=true"})
+	secrets, err := r.K8sClient.CoreV1().Secrets(namespace).List(metav1.ListOptions{LabelSelector: dashboardLabelSelector})
 	if err != nil {
 		return
 	}

--- a/pkg/endpoints/credentials_test.go
+++ b/pkg/endpoints/credentials_test.go
@@ -200,7 +200,7 @@ func TestCredentialsErrors(t *testing.T) {
 	}
 	for _, invalidCred := range invalidCreds {
 		// Must match error message exactly in the verify function, careful if you change fields
-		expectError = "Error: username, password, id, url and type ('accesstoken' or 'userpass') must all be supplied."
+		expectError = "Error: Username, Password, Name, URL and Type ('accesstoken' or 'userpass') must all be supplied."
 		createCredentialTest(namespace, invalidCred, expectError, r, t)
 		updateCredentialTest(namespace, invalidCred, expectError, r, t)
 	}
@@ -355,7 +355,7 @@ func readCredentialTest(namespace string, expectCred credential, expectError str
 	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+expectCred.Name, nil)
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = expectCred.Name
+	params["name"] = expectCred.Name
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 
@@ -393,7 +393,7 @@ func updateCredentialTest(namespace string, cred credential, expectError string,
 	httpReq := dummyHTTPRequest("PUT", "http://wwww.dummy.com:8383/v1/namespaces/"+namespace+"/credentials/"+cred.Name, bytes.NewBuffer(jsonBody))
 	req := dummyRestfulRequest(httpReq, namespace, "")
 	params := req.PathParameters()
-	params["id"] = cred.Name
+	params["name"] = cred.Name
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
 

--- a/pkg/endpoints/router.go
+++ b/pkg/endpoints/router.go
@@ -53,10 +53,10 @@ func (r Resource) RegisterEndpoints(container *restful.Container) {
 	wsv1.Route(wsv1.GET("/{namespace}/pipelinerunlog/{name}").To(r.getPipelineRunLog))
 
 	wsv1.Route(wsv1.GET("/{namespace}/credential").To(r.getAllCredentials))
-	wsv1.Route(wsv1.GET("/{namespace}/credential/{id}").To(r.getCredential))
+	wsv1.Route(wsv1.GET("/{namespace}/credential/{name}").To(r.getCredential))
 	wsv1.Route(wsv1.POST("/{namespace}/credential").To(r.createCredential))
-	wsv1.Route(wsv1.PUT("/{namespace}/credential/{id}").To(r.updateCredential))
-	wsv1.Route(wsv1.DELETE("/{namespace}/credential/{id}").To(r.deleteCredential))
+	wsv1.Route(wsv1.PUT("/{namespace}/credential/{name}").To(r.updateCredential))
+	wsv1.Route(wsv1.DELETE("/{namespace}/credential/{name}").To(r.deleteCredential))
 
 	container.Add(wsv1)
 }

--- a/pkg/endpoints/router.go
+++ b/pkg/endpoints/router.go
@@ -98,7 +98,7 @@ func (r Resource) RegisterReadinessProbes(container *restful.Container) {
 	container.Add(wsv4)
 }
 
-// Write Content-Location header within PUT/POST methods and set StatusCode to 201
+// Write Content-Location header within POST methods and set StatusCode to 201
 // Headers MUST be set before writing to body (if any) to succeed
 func writeResponseLocation(request *restful.Request, response *restful.Response, identifier string) {
 	location := request.Request.URL.Path

--- a/pkg/endpoints/routes_test.go
+++ b/pkg/endpoints/routes_test.go
@@ -46,15 +46,16 @@ func TestMain(m *testing.M) {
 
 	// Remove all Put methods that do not have a corresponding POST
 	// Cannot update what can not be created
-	postMap := make(map[string]struct{})
+	checkMap := make(map[string]struct{})
 	for _, route := range methodMap[http.MethodPost] {
-		postMap[route] = struct{}{}
+		// Add identifier like PUT routes
+		checkMap[route+"/fake"] = struct{}{}
 	}
 
 	oldPutRoutes := methodMap[http.MethodPut]
 	var newPutRoutes []string
 	for _, route := range oldPutRoutes {
-		if _, ok := postMap[route]; ok {
+		if _, ok := checkMap[route]; ok {
 			newPutRoutes = append(newPutRoutes, route)
 		}
 	}

--- a/pkg/endpoints/routes_test.go
+++ b/pkg/endpoints/routes_test.go
@@ -1,0 +1,146 @@
+package endpoints 
+
+import (
+	"os"
+	"bytes"
+	"strings"
+	"testing"
+	"regexp"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	restful "github.com/emicklei/go-restful"
+)
+
+
+var server *httptest.Server
+var routeMap = make(map[string][]string) // k, v := HTTP_METHOD, []route
+// Temporary measure as not all GET routes have corresponding POST, but the reverse is true
+// After POST/PUT, populate this map with 'Content-Location' values to check for object
+var getRoutesMap = make(map[string][]string) // k, v := HTTP_METHOD, []route
+
+// Set up
+func TestMain(m *testing.M) {
+	wsContainer := restful.NewContainer()
+
+	resource := dummyResource()
+	resource.RegisterEndpoints(wsContainer)
+	resource.RegisterWebsocket(wsContainer)
+	resource.RegisterHealthProbes(wsContainer)
+	resource.RegisterReadinessProbes(wsContainer)
+
+	regex := regexp.MustCompile("{[^}]*}")
+	for _, ws := range wsContainer.RegisteredWebServices() {
+		for _, r := range ws.Routes() {
+			// /{namespace}/pipeline/{name} -> /fake/pipeline/fake
+			// This replacement makes the following assumption:
+			// The below tests should only create one instance of particular CRDs where the identifier is also "fake"
+			fakeRoute := regex.ReplaceAllLiteralString(r.Path,"fake")
+			routeMap[r.Method] = append(routeMap[r.Method], fakeRoute)
+		}
+	}
+
+	server = httptest.NewServer(wsContainer)
+	os.Exit(m.Run())
+}
+
+
+func Test201Url(t *testing.T) {
+	// POST ROUTES:
+	// Make requests for all existing POST routes (POST data to get Content-Location header)
+	makeRequests(t,routeMap,http.MethodPost)
+	// Gets are against individual resources, identifier populated above
+	makeRequests(t,getRoutesMap,http.MethodGet)
+
+	// Reset
+	getRoutesMap = make(map[string][]string)
+
+	// PUT ROUTES:
+	// Make requests for all existing PUT routes (PUT "updates" data to the same values as POST to get Content-Location header)
+	makeRequests(t,routeMap,http.MethodPut)
+	// Gets are against individual resources, identifier populated above
+	makeRequests(t,getRoutesMap,http.MethodGet)
+}
+
+// routeMap overrides global variable
+func makeRequests(t *testing.T, routeMap map[string][]string, httpMethod string) {
+	// Supported HTTP methods
+	switch httpMethod {
+	case http.MethodGet:
+	case http.MethodPost:
+	case http.MethodPut:
+	default:
+		t.Errorf("%s not supported",httpMethod)
+	}
+
+	for _, route := range routeMap[httpMethod] {
+		t.Logf("%s method: %s",httpMethod,route)
+		var resourceType string
+		switch httpMethod {
+		case http.MethodPost:
+			resourceIndex := strings.LastIndex(route,"/") + 1
+			resourceType = route[resourceIndex:]
+		case http.MethodGet:
+			fallthrough
+		case http.MethodPut:
+			lastIndex := strings.LastIndex(route,"/")
+			secondLastIndex := strings.LastIndex(route[:lastIndex],"/")
+			resourceType = route[secondLastIndex+1:lastIndex]
+		}
+		var requestBody *bytes.Reader
+		if isDataMethod(httpMethod) {
+			resource := fakeCRD(t,resourceType)
+			if resource == nil {
+				continue
+			}
+			b, err := json.Marshal(&resource)
+			if err != nil {
+				t.Error("Failed to marshal resource type:",resourceType)
+				continue
+			}
+			requestBody = bytes.NewReader(b)
+		}
+		request := httptest.NewRequest(httpMethod,server.URL+route,requestBody)
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Error("Response error from server:",err)
+			continue
+		}
+		if isDataMethod(httpMethod) {
+			if response.StatusCode != 201 {
+				t.Error("Status code not set to 201")
+			}
+			contentLocation, ok := response.Header["Content-Location"]
+			if !ok {
+				t.Errorf("Content-Location header not provided in %s method for resource type: %s",httpMethod,resourceType)
+			} else {
+				// We specify a single Content-Location, only grab first index
+				getRoutesMap[http.MethodGet] = append(getRoutesMap[http.MethodGet], contentLocation[0])
+			}
+		}
+	}
+}
+
+func isDataMethod(httpMethod string) bool {
+	return httpMethod == http.MethodPost || httpMethod == http.MethodPut
+}
+
+func fakeCRD(t *testing.T, crdType string) interface{} {
+	switch crdType {
+	case "credential":
+		return &credential{
+			Id:          "credentialaccesstoken",
+			Username:    "personal-access-token",
+			Password:    "passwordaccesstoken",
+			Description: "access token credential",
+			Type:        "accesstoken",
+			Url: map[string]string{
+				"tekton.dev/git-0": "https://github.com",
+			},
+		}
+	default:
+		t.Error("Fake template does not exist for crdType:",crdType)
+		return nil
+	}
+}

--- a/pkg/endpoints/routes_test.go
+++ b/pkg/endpoints/routes_test.go
@@ -5,12 +5,12 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"regexp"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 
 	restful "github.com/emicklei/go-restful"
+	"github.com/satori/go.uuid"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,11 +21,12 @@ var server *httptest.Server
 var methodMap = make(map[string][]string) // k, v := HTTP_METHOD, []route
 
 // Set up
+const namespace string = "fake"
+
 func TestMain(m *testing.M) {
 	wsContainer := restful.NewContainer()
 
 	resource := dummyResource()
-	namespace := "fake"
 	resource.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
 	resource.RegisterEndpoints(wsContainer)
@@ -33,131 +34,127 @@ func TestMain(m *testing.M) {
 	resource.RegisterHealthProbes(wsContainer)
 	resource.RegisterReadinessProbes(wsContainer)
 
-	regex := regexp.MustCompile("{[^}]*}")
 	for _, ws := range wsContainer.RegisteredWebServices() {
 		for _, r := range ws.Routes() {
-			// /{namespace}/pipeline/{name} -> /fake/pipeline/fake
-			// This replacement makes the following assumption:
-			// The below tests should only create one instance of particular CRDs where the identifier is also "fake"
-			fakeRoute := regex.ReplaceAllLiteralString(r.Path,"fake")
-			methodMap[r.Method] = append(methodMap[r.Method], fakeRoute)
+			route := strings.Replace(r.Path,"{namespace}","fake",1)
+			methodMap[r.Method] = append(methodMap[r.Method], route)
 		}
 	}
-
-	// Remove all Put methods that do not have a corresponding POST
-	// Cannot update what can not be created
-	checkMap := make(map[string]struct{})
-	for _, route := range methodMap[http.MethodPost] {
-		// Add identifier like PUT routes
-		checkMap[route+"/fake"] = struct{}{}
-	}
-
-	oldPutRoutes := methodMap[http.MethodPut]
-	var newPutRoutes []string
-	for _, route := range oldPutRoutes {
-		if _, ok := checkMap[route]; ok {
-			newPutRoutes = append(newPutRoutes, route)
-		}
-	}
-	methodMap[http.MethodPut] = newPutRoutes
-
 	server = httptest.NewServer(wsContainer)
 	os.Exit(m.Run())
 }
 
 
-func Test201Url(t *testing.T) {
-	// POST ROUTES:
+func TestContentLocation201(t *testing.T) {
 	t.Log("Checking POST routes for 201 StatusCode and valid Content-Location header")
-	// Make requests for all existing POST routes (POST data to get Content-Location header)
-	checkPostRoutes := sendRequests(t,methodMap[http.MethodPost],http.MethodPost)
-	// Validate Content-Location header
-	getRequests(t,checkPostRoutes)
-
-	// PUT ROUTES:
-	t.Log("Checking PUT routes for 201 StatusCode and valid Content-Location header")
-	// Make requests for all existing PUT routes (PUT "updates" data to the same values as POST to get Content-Location header)
-	checkPutRoutes := sendRequests(t,methodMap[http.MethodPut],http.MethodPut)
-	// Validate Content-Location header
-	getRequests(t,checkPutRoutes)
-}
-
-// POST/PUT CRDs according to routes
-// Return Content-Location of resources created
-func sendRequests(t *testing.T, routes []string, httpMethod string) []string {
 	var resourceLocations []string
-	for _, route := range routes {
-		t.Logf("%s method: %s",httpMethod,route)
-		resourceType := getResourceType(route,httpMethod)
-		resource := fakeCRD(t,resourceType)
-		if resource == nil {
-			continue
-		}
-		b, err := json.Marshal(&resource)
-		if err != nil {
-			t.Error("Failed to marshal resource type:",resourceType)
-			continue
-		}
-		requestBody := bytes.NewReader(b)
-		request := dummyHTTPRequest(httpMethod,server.URL+route,requestBody)
-		t.Log("Request URL:",request.URL)
-		response, err := http.DefaultClient.Do(request)
-		if err != nil {
-			t.Error("Response error from server:",err)
-			continue
-		}
-		t.Log("Response from server:",response)
+	postFunc := func(t *testing.T, request *http.Request, response *http.Response) {
 		if response.StatusCode != 201 {
 			t.Error("Status code not set to 201")
 		}
 		contentLocation, ok := response.Header["Content-Location"]
 		if !ok {
-			t.Errorf("Content-Location header not provided in %s method for resource type: %s",httpMethod,resourceType)
+			t.Errorf("Content-Location header not provided in %s method for resource type: %s",request.Method,getResourceType(request.URL.Path, request.Method))
 		} else {
 			// "Content-Location" header is only set with single value
 			resourceLocations = append(resourceLocations,contentLocation[0])
 		}
 	}
-	return resourceLocations
+	// Make requests for all existing POST routes (POST data to get Content-Location header)
+	makeRequests(t,methodMap[http.MethodPost],http.MethodPost,postFunc)
+	// Validate Content-Location header
+	makeRequests(t,resourceLocations,http.MethodGet,nil)
 }
 
-// Check that resource exists
-func getRequests(t *testing.T, routes []string) {
+func TestPut204(t *testing.T) {
+	t.Log("Checking 204 for PUT Routes")
+	// Creating resources first, then update
+	var resourceLocations []string
+	postFunc := func(t *testing.T, request *http.Request, response *http.Response) {
+		contentLocation, ok := response.Header["Content-Location"]
+		if !ok {
+			t.Errorf("Content-Location header not provided in %s method for resource type: %s",request.Method,getResourceType(request.URL.Path, request.Method))
+		} else {
+			// "Content-Location" header is only set with single value
+			resourceLocations = append(resourceLocations,contentLocation[0])
+		}
+	}
+	makeRequests(t,methodMap[http.MethodPost],http.MethodPost,postFunc)
+	// Check for 204
+	putFunc := func(t *testing.T, request *http.Request, response *http.Response) {
+		if response.StatusCode != 204 {
+			t.Error("Status code not set to 204")
+		}
+	}
+	makeRequests(t,resourceLocations,http.MethodPut,putFunc)
+
+}
+
+func makeRequests(t *testing.T, routes []string, httpMethod string, postFunc func(t *testing.T, request *http.Request, response *http.Response)) {
 	for _, route := range routes {
-		t.Log("GET method:",route)
-		request := dummyHTTPRequest(http.MethodGet,server.URL+route,bytes.NewReader([]byte{}))
-		t.Log("Request URL:",request.URL)
+		t.Logf("%s method: %s",httpMethod,route)
+		requestBody := makeRequestBody(t,route,httpMethod)
+		request := dummyHTTPRequest(httpMethod,server.URL+route,requestBody)
 		response, err := http.DefaultClient.Do(request)
 		if err != nil {
 			t.Error("Response error from server:",err)
 			continue
 		}
 		t.Log("Response from server:",response)
+		if postFunc != nil {
+			postFunc(t,request,response)
+		}
 	}
 }
 
+func makeRequestBody(t *testing.T, route string, httpMethod string) *bytes.Reader {
+	if httpMethod == http.MethodPost || httpMethod == http.MethodPut {
+		resourceType := getResourceType(route,httpMethod)
+		var resource interface{}
+		// Pass the identifier for what is being updated
+		if httpMethod != http.MethodPost {
+			identifierIndex := strings.LastIndex(route,"/")+1
+			resource = fakeCRD(t,resourceType,route[identifierIndex:])
+		} else {
+			// Get unique identifier
+			resource = fakeCRD(t,resourceType,"")
+		}
+		if resource == nil {
+			return nil
+		}
+		var requestBody *bytes.Reader
+		b, err := json.Marshal(&resource)
+		if err != nil {
+			t.Error("Failed to marshal resource type:",resourceType)
+			return nil
+		}
+		requestBody = bytes.NewReader(b)
+		return requestBody
+	}
+	return bytes.NewReader([]byte{})
+}
+
+// Extract the CRD after namespace (set as "fake")
+// .../fake/credential/{name} -> credential
 func getResourceType(route string, httpMethod string) string {
-	switch httpMethod {
-	case http.MethodPost:
-		resourceIndex := strings.LastIndex(route,"/") + 1
-		return route[resourceIndex:]
-	case http.MethodGet:
-		fallthrough
-	case http.MethodPut:
-		lastIndex := strings.LastIndex(route,"/")
-		secondLastIndex := strings.LastIndex(route[:lastIndex],"/")
-		return route[secondLastIndex+1:lastIndex]
-	default:
-		return ""
+	i := strings.Index(route,namespace)+len(namespace)+1
+	if httpMethod == http.MethodPost {
+		return route[i:]
 	}
+	i2 := strings.Index(route[i:],"/")
+	return route[i:i+i2]
 }
 
-// All identifiers/names must be set to "fake"
-func fakeCRD(t *testing.T, crdType string) interface{} {
+
+func fakeCRD(t *testing.T, crdType string, identifier string,) interface{} {
+	// Use this as the CRD identifier 
+	if identifier == "" {
+		identifier = uuid.NewV4().String()
+	}
 	switch crdType {
 	case "credential":
 		return &credential{
-			ID:          "fake",
+			Name:        identifier,
 			Username:    "personal-access-token",
 			Password:    "passwordaccesstoken",
 			Description: "access token credential",

--- a/pkg/endpoints/routes_test.go
+++ b/pkg/endpoints/routes_test.go
@@ -1,4 +1,4 @@
-package endpoints 
+package endpoints
 
 import (
 	"os"
@@ -114,7 +114,7 @@ func sendRequests(t *testing.T, routes []string, httpMethod string) []string {
 			t.Errorf("Content-Location header not provided in %s method for resource type: %s",httpMethod,resourceType)
 		} else {
 			// "Content-Location" header is only set with single value
-			resourceLocations = append(resourceLocations,contentLocation[0]) 
+			resourceLocations = append(resourceLocations,contentLocation[0])
 		}
 	}
 	return resourceLocations

--- a/pkg/endpoints/utils.go
+++ b/pkg/endpoints/utils.go
@@ -13,6 +13,9 @@ limitations under the License.
 package endpoints
 
 import (
+	"strings"
+	"net/http"
+
 	restful "github.com/emicklei/go-restful"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -101,7 +104,14 @@ func (r Resource) RegisterReadinessProbes(container *restful.Container) {
 
 // Write Content-Location header within PUT/POST methods and set StatusCode to 201
 // Headers MUST be set before writing to body (if any) to succeed
-func writeResponseLocation(request *restful.Request, response *restful.Response) {
-	response.AddHeader("Content-Location",request.SelectedRoutePath())
+func writeResponseLocation(request *restful.Request, response *restful.Response, identifier string) {
+	location := request.SelectedRoutePath()
+	for k,v := range request.PathParameters() {
+		location = strings.Replace(location,"{"+k+"}",v,-1)
+	}
+	if request.Request.Method == http.MethodPost {
+		location = location + "/" + identifier
+	}
+	response.AddHeader("Content-Location",location)
 	response.WriteHeader(201)
 }

--- a/pkg/endpoints/utils.go
+++ b/pkg/endpoints/utils.go
@@ -56,11 +56,11 @@ func (r Resource) RegisterEndpoints(container *restful.Container) {
 
 	wsv1.Route(wsv1.GET("/{namespace}/pipelinerunlog/{name}").To(r.getPipelineRunLog))
 
-	wsv1.Route(wsv1.GET("/{namespace}/credentials/").To(r.getAllCredentials))
-	wsv1.Route(wsv1.GET("/{namespace}/credentials/{id}").To(r.getCredential))
-	wsv1.Route(wsv1.POST("/{namespace}/credentials/").To(r.createCredential))
-	wsv1.Route(wsv1.PUT("/{namespace}/credentials/{id}").To(r.updateCredential))
-	wsv1.Route(wsv1.DELETE("/{namespace}/credentials/{id}").To(r.deleteCredential))
+	wsv1.Route(wsv1.GET("/{namespace}/credential").To(r.getAllCredentials))
+	wsv1.Route(wsv1.GET("/{namespace}/credential/{id}").To(r.getCredential))
+	wsv1.Route(wsv1.POST("/{namespace}/credential").To(r.createCredential))
+	wsv1.Route(wsv1.PUT("/{namespace}/credential/{id}").To(r.updateCredential))
+	wsv1.Route(wsv1.DELETE("/{namespace}/credential/{id}").To(r.deleteCredential))
 
 	container.Add(wsv1)
 }
@@ -83,7 +83,7 @@ func (r Resource) RegisterHealthProbes(container *restful.Container) {
 	wsv3.
 		Path("/health")
 
-	wsv3.Route(wsv3.GET("/").To(r.checkHealth))
+	wsv3.Route(wsv3.GET("").To(r.checkHealth))
 
 	container.Add(wsv3)
 }
@@ -94,14 +94,14 @@ func (r Resource) RegisterReadinessProbes(container *restful.Container) {
 	wsv4.
 		Path("/readiness")
 
-	wsv4.Route(wsv4.GET("/").To(r.checkHealth))
+	wsv4.Route(wsv4.GET("").To(r.checkHealth))
 
 	container.Add(wsv4)
 }
 
-// Write Content-Location header within PUT/POST methods
-// Content-Location is GET equivalent of the request route
+// Write Content-Location header within PUT/POST methods and set StatusCode to 201
 // Headers MUST be set before writing to body (if any) to succeed
-func setContentLocation(request *restful.Request, response *restful.Response) {
+func writeResponseLocation(request *restful.Request, response *restful.Response) {
 	response.AddHeader("Content-Location",request.SelectedRoutePath())
+	response.WriteHeader(201)
 }

--- a/pkg/endpoints/utils.go
+++ b/pkg/endpoints/utils.go
@@ -14,7 +14,6 @@ limitations under the License.
 package endpoints
 
 import (
-	"strings"
 	"net/http"
 
 	restful "github.com/emicklei/go-restful"
@@ -110,10 +109,7 @@ func (r Resource) RegisterReadinessProbes(container *restful.Container) {
 // Write Content-Location header within PUT/POST methods and set StatusCode to 201
 // Headers MUST be set before writing to body (if any) to succeed
 func writeResponseLocation(request *restful.Request, response *restful.Response, identifier string) {
-	location := request.SelectedRoutePath()
-	for k,v := range request.PathParameters() {
-		location = strings.Replace(location,"{"+k+"}",v,-1)
-	}
+	location := request.Request.URL.Path
 	if request.Request.Method == http.MethodPost {
 		location = location + "/" + identifier
 	}

--- a/pkg/endpoints/utils.go
+++ b/pkg/endpoints/utils.go
@@ -81,9 +81,7 @@ func (r Resource) RegisterHealthProbes(container *restful.Container) {
 	logging.Log.Info("Adding API for health")
 	wsv3 := new(restful.WebService)
 	wsv3.
-		Path("/health").
-		Consumes(restful.MIME_JSON).
-		Produces(restful.MIME_JSON)
+		Path("/health")
 
 	wsv3.Route(wsv3.GET("/").To(r.checkHealth))
 
@@ -94,11 +92,16 @@ func (r Resource) RegisterReadinessProbes(container *restful.Container) {
 	logging.Log.Info("Adding API for health")
 	wsv4 := new(restful.WebService)
 	wsv4.
-		Path("/readiness").
-		Consumes(restful.MIME_JSON).
-		Produces(restful.MIME_JSON)
+		Path("/readiness")
 
 	wsv4.Route(wsv4.GET("/").To(r.checkHealth))
 
 	container.Add(wsv4)
+}
+
+// Write Content-Location header within PUT/POST methods
+// Content-Location is GET equivalent of the request route
+// Headers MUST be set before writing to body (if any) to succeed
+func setContentLocation(request *restful.Request, response *restful.Response) {
+	response.AddHeader("Content-Location",request.SelectedRoutePath())
 }


### PR DESCRIPTION
This PR is regarding issue https://github.com/tektoncd/dashboard/issues/18:
---
Changes:
- `writeResponseLocation` function that sets the StatusCode to 201 and sets the `"Content-Location"` header appropriately (to be used within POST routes)
- New test `routes_test.go/TestContentLocation201` ensures that all POST routes MUST have a matching GET route and validates the 201 StatusCode and the resource that is identified within the `"Content-Location"` header.
- New test `routes_test.go/TestPut204` ensures PUT routes return 204
- Consolidate secretToCredential function that was implemented twice between credentials/credentials_test.go
- Modify `{id}` within route to `{name}` for credentials to align with other endpoints (and necessary credentials changes to allow for this)
- Modified routes to remove trailing slashes (new test ensures this best practice is maintained)
- Removed Consumes/Produces calls on `/health` endpoint
-  Small cleanups
- Updated DEVELOPMENT.md