### PR TITLE
Add query parameters to filter pipelineruns/taskruns by name

### DIFF
--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -126,27 +126,43 @@ func (r Resource) getPipelineImpl(name, namespace string) (v1alpha1.Pipeline, er
 	return *pipeline, nil
 }
 
-/* Get all pipeline runs in a given namespace */
+/* Get all pipeline runs in a given namespace, filters based on query parameters */
 func (r Resource) getAllPipelineRuns(request *restful.Request, response *restful.Response) {
+	// Request Params
 	namespace := request.PathParameter("namespace")
-	pipelineruns := r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace)
+	// Query Params
 	repository := request.QueryParameter("repository")
+	name := request.QueryParameter("name")
+	logging.Log.Debugf("In getAllPipelineRuns: namespace: `%s`, repository query: `%s`, repository query: `%s`", namespace, repository, name)
 
-	logging.Log.Debugf("In getAllPipelineRuns: namespace: `%s`, repository query: `%s`", namespace, repository)
-
+	pipelinerunInterface := r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace)
 	var pipelinerunList *v1alpha1.PipelineRunList
+	var labelSelector string // key1=value1,key2=value2, ...
 	var err error
+
+	// repository query filter
 	if repository != "" {
 		server, org, repo := getGitValues(repository)
-		match := gitServerLabel + "=" + server + "," + gitOrgLabel + "=" + org + "," + gitRepoLabel + "=" + repo
-		pipelinerunList, err = pipelineruns.List(metav1.ListOptions{LabelSelector: match})
-		logging.Log.Debugf("+%v", pipelinerunList.Items)
-	} else {
-		pipelinerunList, err = pipelineruns.List(metav1.ListOptions{})
-		logging.Log.Debugf("+%v", pipelinerunList.Items)
-		if err != nil {
-			utils.RespondError(response, err, http.StatusNotFound)
-			return
+		labels := []string {
+			gitServerLabel + "=" + server,
+			gitOrgLabel + "=" + org,
+			gitRepoLabel + "=" + repo,
+		}
+		labelSelector = strings.Join(labels,",")
+	}
+	pipelinerunList, err = pipelinerunInterface.List(metav1.ListOptions{LabelSelector: labelSelector})
+	logging.Log.Debugf("+%v", pipelinerunList.Items)
+	if err != nil {
+		utils.RespondError(response, err, http.StatusNotFound)
+		return
+	}
+	// name query filter
+	if name != "" {
+		for i := range pipelinerunList.Items {
+			pipelinerun := pipelinerunList.Items[i]
+			if pipelinerun.ObjectMeta.Name != name {
+				pipelinerunList.Items = append(pipelinerunList.Items[:i], pipelinerunList.Items[i+1:]...)
+			}
 		}
 	}
 	response.WriteEntity(pipelinerunList)
@@ -209,18 +225,30 @@ func (r Resource) getTask(request *restful.Request, response *restful.Response) 
 	response.WriteEntity(task)
 }
 
-/* Get all task runs in a given namespace */
+/* Get all task runs in a given namespace, filters based on query parameters */
 func (r Resource) getAllTaskRuns(request *restful.Request, response *restful.Response) {
+	// Path params
 	namespace := request.PathParameter("namespace")
-	taskruns := r.PipelineClient.TektonV1alpha1().TaskRuns(namespace)
-	logging.Log.Debugf("In getAllTaskRuns, taskruns: %s, namespace: %s", taskruns, namespace)
+	// Query params
+	name := request.QueryParameter("name")
+	logging.Log.Debugf("In getAllTaskRuns, namespace: `%s`, name query: `%s`", namespace, name)
 
-	taskrunlist, err := taskruns.List(metav1.ListOptions{})
+	taskrunInterface := r.PipelineClient.TektonV1alpha1().TaskRuns(namespace)
+	taskrunList, err := taskrunInterface.List(metav1.ListOptions{})
 	if err != nil {
 		utils.RespondError(response, err, http.StatusNotFound)
 		return
 	}
-	response.WriteEntity(taskrunlist)
+	// name query filter
+	if name != "" {
+		for i := range taskrunList.Items {
+			taskrun := taskrunList.Items[i]
+			if taskrun.ObjectMeta.Name != name {
+				taskrunList.Items = append(taskrunList.Items[:i],taskrunList.Items[i+1:]...)
+			}
+		}
+	}
+	response.WriteEntity(taskrunList)
 }
 
 /* Get a given task in a given namespace */

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -126,11 +126,9 @@ func (r Resource) getPipelineImpl(name, namespace string) (v1alpha1.Pipeline, er
 	return *pipeline, nil
 }
 
-/* Get all pipeline runs in a given namespace, filters based on query parameters */
+/* Get all pipeline runs in a given namespace, filters based on parameters */
 func (r Resource) getAllPipelineRuns(request *restful.Request, response *restful.Response) {
-	// Request Params
 	namespace := request.PathParameter("namespace")
-	// Query Params
 	repository := request.QueryParameter("repository")
 	name := request.QueryParameter("name")
 	logging.Log.Debugf("In getAllPipelineRuns: namespace: `%s`, repository query: `%s`, repository query: `%s`", namespace, repository, name)
@@ -221,11 +219,9 @@ func (r Resource) getTask(request *restful.Request, response *restful.Response) 
 	response.WriteEntity(task)
 }
 
-/* Get all task runs in a given namespace, filters based on query parameters */
+/* Get all task runs in a given namespace, filters based on parameters */
 func (r Resource) getAllTaskRuns(request *restful.Request, response *restful.Response) {
-	// Path params
 	namespace := request.PathParameter("namespace")
-	// Query params
 	name := request.QueryParameter("name")
 	logging.Log.Debugf("In getAllTaskRuns, namespace: `%s`, name query: `%s`", namespace, name)
 

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -133,10 +133,10 @@ func (r Resource) getAllPipelineRuns(request *restful.Request, response *restful
 	name := request.QueryParameter("name")
 
 	var queryParams []string
-	if repository != "" { 
+	if repository != "" {
 		queryParams = append(queryParams,"repository: "+repository)
 	}
-	if name != "" { 
+	if name != "" {
 		queryParams = append(queryParams,"name: "+name)
 	}
 	logging.Log.Debugf("In getAllPipelineRuns, namespace: %s, parameters: %s", namespace, strings.Join(queryParams,","))
@@ -232,7 +232,7 @@ func (r Resource) getAllTaskRuns(request *restful.Request, response *restful.Res
 	namespace := request.PathParameter("namespace")
 	name := request.QueryParameter("name")
 	var queryParams []string
-	if name != "" { 
+	if name != "" {
 		queryParams = append(queryParams,"name: "+name)
 	}
 	logging.Log.Debugf("In getAllTaskRuns, namespace: %s, parameters: %s", namespace, strings.Join(queryParams,","))

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -131,7 +131,15 @@ func (r Resource) getAllPipelineRuns(request *restful.Request, response *restful
 	namespace := request.PathParameter("namespace")
 	repository := request.QueryParameter("repository")
 	name := request.QueryParameter("name")
-	logging.Log.Debugf("In getAllPipelineRuns: namespace: `%s`, repository query: `%s`, repository query: `%s`", namespace, repository, name)
+
+	var queryParams []string
+	if repository != "" { 
+		queryParams = append(queryParams,"repository: "+repository)
+	}
+	if name != "" { 
+		queryParams = append(queryParams,"name: "+name)
+	}
+	logging.Log.Debugf("In getAllPipelineRuns, namespace: %s, parameters: %s", namespace, strings.Join(queryParams,","))
 
 	pipelinerunInterface := r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace)
 	var pipelinerunList *v1alpha1.PipelineRunList
@@ -223,7 +231,11 @@ func (r Resource) getTask(request *restful.Request, response *restful.Response) 
 func (r Resource) getAllTaskRuns(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	name := request.QueryParameter("name")
-	logging.Log.Debugf("In getAllTaskRuns, namespace: `%s`, name query: `%s`", namespace, name)
+	var queryParams []string
+	if name != "" { 
+		queryParams = append(queryParams,"name: "+name)
+	}
+	logging.Log.Debugf("In getAllTaskRuns, namespace: %s, parameters: %s", namespace, strings.Join(queryParams,","))
 
 	taskrunInterface := r.PipelineClient.TektonV1alpha1().TaskRuns(namespace)
 

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -158,7 +158,6 @@ func (r Resource) getAllPipelineRuns(request *restful.Request, response *restful
 		labelSelector = strings.Join(labels,",")
 	}
 	pipelinerunList, err = pipelinerunInterface.List(metav1.ListOptions{LabelSelector: labelSelector})
-	logging.Log.Debugf("+%v", pipelinerunList.Items)
 	if err != nil {
 		utils.RespondError(response, err, http.StatusNotFound)
 		return

--- a/pkg/endpoints/pipeline_test.go
+++ b/pkg/endpoints/pipeline_test.go
@@ -232,7 +232,7 @@ func TestTaskRun(t *testing.T) {
 
 	// Test getAllTaskRuns function
 	// Sample request and response
-	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun/", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -253,6 +253,27 @@ func TestTaskRun(t *testing.T) {
 	}
 	if result.Items[0].Name != "TaskRun2" && result.Items[1].Name != "TaskRun2" {
 		t.Errorf("Task2 is not returned: %s, %s", result.Items[0].Name, result.Items[1].Name)
+	}
+
+	// Test getAllTaskRuns function with name query
+	// Sample request and response
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=TaskRun1", nil)
+	req = dummyRestfulRequest(httpReq, "ns1", "")
+	httpWriter = httptest.NewRecorder()
+	resp = dummyRestfulResponse(httpWriter)
+
+	//  Test the function
+	r.getAllTaskRuns(req, resp)
+
+	// Decode the response
+	result = v1alpha1.TaskRunList{}
+	json.NewDecoder(httpWriter.Body).Decode(&result)
+	// Verify the response
+	if len(result.Items) != 1 {
+		t.Errorf("Number of tasks: expected: %d, returned: %d", 1, len(result.Items))
+	}
+	if result.Items[0].Name != "TaskRun1" {
+		t.Errorf("Task1 is not returned: %s", result.Items[0].Name)
 	}
 
 	// Test getTaskRun function
@@ -329,7 +350,7 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getAllPipelineRuns function
 	// Sample request and response
-	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun/", nil)
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun", nil)
 	req := dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter := httptest.NewRecorder()
 	resp := dummyRestfulResponse(httpWriter)
@@ -352,9 +373,31 @@ func TestPipelineRun(t *testing.T) {
 		t.Errorf("Task2 is not returned: %s, %s", result.Items[0].Name, result.Items[1].Name)
 	}
 
-	// Test getAllPipelineRuns function with query
+	// Test getAllPipelineRuns function with repository query
 	// Sample request and response
 	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?repository=http://github.com/foo/bar", nil)
+	req = dummyRestfulRequest(httpReq, "ns1", "")
+	httpWriter = httptest.NewRecorder()
+	resp = dummyRestfulResponse(httpWriter)
+
+	//  Test the function
+	r.getAllPipelineRuns(req, resp)
+
+	// Decode the response
+	result = v1alpha1.PipelineRunList{}
+	json.NewDecoder(httpWriter.Body).Decode(&result)
+
+	// Verify the response
+	if len(result.Items) != 1 {
+		t.Errorf("Number of PipelineRuns: expected: %d, returned: %d", 1, len(result.Items))
+	}
+	if result.Items[0].Name != "PipelineRun1" {
+		t.Errorf("PipelineRun1 is not returned: %s", result.Items[0].Name)
+	}
+
+	// Test getAllPipelineRuns function with name query
+	// Sample request and response
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=PipelineRun1", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)

--- a/pkg/endpoints/pipeline_test.go
+++ b/pkg/endpoints/pipeline_test.go
@@ -257,24 +257,25 @@ func TestTaskRun(t *testing.T) {
 
 	// Test getAllTaskRuns function with name query
 	// Sample request and response
-	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=TaskRun1", nil)
-	req = dummyRestfulRequest(httpReq, "ns1", "")
-	httpWriter = httptest.NewRecorder()
-	resp = dummyRestfulResponse(httpWriter)
+	// FakeClient does not support filtering by fields(metadata.name/namespace)/labels at the moment, block test
+	// httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=TaskRun1", nil)
+	// req = dummyRestfulRequest(httpReq, "ns1", "")
+	// httpWriter = httptest.NewRecorder()
+	// resp = dummyRestfulResponse(httpWriter)
 
-	//  Test the function
-	r.getAllTaskRuns(req, resp)
+	// //  Test the function
+	// r.getAllTaskRuns(req, resp)
 
-	// Decode the response
-	result = v1alpha1.TaskRunList{}
-	json.NewDecoder(httpWriter.Body).Decode(&result)
-	// Verify the response
-	if len(result.Items) != 1 {
-		t.Errorf("Number of tasks: expected: %d, returned: %d", 1, len(result.Items))
-	}
-	if result.Items[0].Name != "TaskRun1" {
-		t.Errorf("Task1 is not returned: %s", result.Items[0].Name)
-	}
+	// // Decode the response
+	// result = v1alpha1.TaskRunList{}
+	// json.NewDecoder(httpWriter.Body).Decode(&result)
+	// // Verify the response
+	// if len(result.Items) != 1 {
+	// 	t.Errorf("Number of tasks: expected: %d, returned: %d", 1, len(result.Items))
+	// }
+	// if result.Items[0].Name != "TaskRun1" {
+	// 	t.Errorf("Task1 is not returned: %s", result.Items[0].Name)
+	// }
 
 	// Test getTaskRun function
 	// Sample request and response
@@ -397,25 +398,26 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getAllPipelineRuns function with name query
 	// Sample request and response
-	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=PipelineRun1", nil)
-	req = dummyRestfulRequest(httpReq, "ns1", "")
-	httpWriter = httptest.NewRecorder()
-	resp = dummyRestfulResponse(httpWriter)
+	// FakeClient does not support filtering by fields(metadata.name/namespace)/labels at the moment, block test
+	// httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=PipelineRun1", nil)
+	// req = dummyRestfulRequest(httpReq, "ns1", "")
+	// httpWriter = httptest.NewRecorder()
+	// resp = dummyRestfulResponse(httpWriter)
 
-	//  Test the function
-	r.getAllPipelineRuns(req, resp)
+	// //  Test the function
+	// r.getAllPipelineRuns(req, resp)
 
-	// Decode the response
-	result = v1alpha1.PipelineRunList{}
-	json.NewDecoder(httpWriter.Body).Decode(&result)
+	// // Decode the response
+	// result = v1alpha1.PipelineRunList{}
+	// json.NewDecoder(httpWriter.Body).Decode(&result)
 
-	// Verify the response
-	if len(result.Items) != 1 {
-		t.Errorf("Number of PipelineRuns: expected: %d, returned: %d", 1, len(result.Items))
-	}
-	if result.Items[0].Name != "PipelineRun1" {
-		t.Errorf("PipelineRun1 is not returned: %s", result.Items[0].Name)
-	}
+	// // Verify the response
+	// if len(result.Items) != 1 {
+	// 	t.Errorf("Number of PipelineRuns: expected: %d, returned: %d", 1, len(result.Items))
+	// }
+	// if result.Items[0].Name != "PipelineRun1" {
+	// 	t.Errorf("PipelineRun1 is not returned: %s", result.Items[0].Name)
+	// }
 
 	// Test getPipelineRun function
 	// Sample request and response

--- a/pkg/endpoints/pipeline_test.go
+++ b/pkg/endpoints/pipeline_test.go
@@ -257,25 +257,24 @@ func TestTaskRun(t *testing.T) {
 
 	// Test getAllTaskRuns function with name query
 	// Sample request and response
-	// FakeClient does not support filtering by fields(metadata.name/namespace)/labels at the moment, block test
-	// httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=TaskRun1", nil)
-	// req = dummyRestfulRequest(httpReq, "ns1", "")
-	// httpWriter = httptest.NewRecorder()
-	// resp = dummyRestfulResponse(httpWriter)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=TaskRun1", nil)
+	req = dummyRestfulRequest(httpReq, "ns1", "")
+	httpWriter = httptest.NewRecorder()
+	resp = dummyRestfulResponse(httpWriter)
 
 	// //  Test the function
-	// r.getAllTaskRuns(req, resp)
+	r.getAllTaskRuns(req, resp)
 
 	// // Decode the response
-	// result = v1alpha1.TaskRunList{}
-	// json.NewDecoder(httpWriter.Body).Decode(&result)
-	// // Verify the response
-	// if len(result.Items) != 1 {
-	// 	t.Errorf("Number of tasks: expected: %d, returned: %d", 1, len(result.Items))
-	// }
-	// if result.Items[0].Name != "TaskRun1" {
-	// 	t.Errorf("Task1 is not returned: %s", result.Items[0].Name)
-	// }
+	result = v1alpha1.TaskRunList{}
+	json.NewDecoder(httpWriter.Body).Decode(&result)
+	// Verify the response
+	if len(result.Items) != 1 {
+		t.Errorf("Number of tasks: expected: %d, returned: %d", 1, len(result.Items))
+	}
+	if result.Items[0].Name != "TaskRun1" {
+		t.Errorf("Task1 is not returned: %s", result.Items[0].Name)
+	}
 
 	// Test getTaskRun function
 	// Sample request and response
@@ -398,26 +397,25 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getAllPipelineRuns function with name query
 	// Sample request and response
-	// FakeClient does not support filtering by fields(metadata.name/namespace)/labels at the moment, block test
-	// httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=PipelineRun1", nil)
-	// req = dummyRestfulRequest(httpReq, "ns1", "")
-	// httpWriter = httptest.NewRecorder()
-	// resp = dummyRestfulResponse(httpWriter)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=PipelineRun1", nil)
+	req = dummyRestfulRequest(httpReq, "ns1", "")
+	httpWriter = httptest.NewRecorder()
+	resp = dummyRestfulResponse(httpWriter)
 
 	// //  Test the function
-	// r.getAllPipelineRuns(req, resp)
+	r.getAllPipelineRuns(req, resp)
 
-	// // Decode the response
-	// result = v1alpha1.PipelineRunList{}
-	// json.NewDecoder(httpWriter.Body).Decode(&result)
+	// Decode the response
+	result = v1alpha1.PipelineRunList{}
+	json.NewDecoder(httpWriter.Body).Decode(&result)
 
-	// // Verify the response
-	// if len(result.Items) != 1 {
-	// 	t.Errorf("Number of PipelineRuns: expected: %d, returned: %d", 1, len(result.Items))
-	// }
-	// if result.Items[0].Name != "PipelineRun1" {
-	// 	t.Errorf("PipelineRun1 is not returned: %s", result.Items[0].Name)
-	// }
+	// Verify the response
+	if len(result.Items) != 1 {
+		t.Errorf("Number of PipelineRuns: expected: %d, returned: %d", 1, len(result.Items))
+	}
+	if result.Items[0].Name != "PipelineRun1" {
+		t.Errorf("PipelineRun1 is not returned: %s", result.Items[0].Name)
+	}
 
 	// Test getPipelineRun function
 	// Sample request and response

--- a/pkg/endpoints/test-utils.go
+++ b/pkg/endpoints/test-utils.go
@@ -21,23 +21,15 @@ import (
 
 	fakeclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	fakek8sclientset "k8s.io/client-go/kubernetes/fake"
-	//"k8s.io/client-go/testing"
-	//"k8s.io/apimachinery/pkg/runtime"
 )
 
 func dummyK8sClientset() *fakek8sclientset.Clientset {
 	result := fakek8sclientset.NewSimpleClientset()
-	// result.PrependReactor("*","*",func(action testing.Action) (handled bool, ret runtime.Object, err error) {
-	// 	return false, nil, nil
-	// })
 	return result
 }
 
 func dummyClientset() *fakeclientset.Clientset {
 	result := fakeclientset.NewSimpleClientset()
-	// result.PrependReactor("*","*",func(action testing.Action) (handled bool, ret runtime.Object, err error) {
-	// 	return false, nil, nil
-	// })
 	return result
 }
 

--- a/pkg/endpoints/test-utils.go
+++ b/pkg/endpoints/test-utils.go
@@ -18,17 +18,26 @@ import (
 	"net/http"
 
 	restful "github.com/emicklei/go-restful"
+
 	fakeclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	fakek8sclientset "k8s.io/client-go/kubernetes/fake"
+	//"k8s.io/client-go/testing"
+	//"k8s.io/apimachinery/pkg/runtime"
 )
 
 func dummyK8sClientset() *fakek8sclientset.Clientset {
 	result := fakek8sclientset.NewSimpleClientset()
+	// result.PrependReactor("*","*",func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+	// 	return false, nil, nil
+	// })
 	return result
 }
 
 func dummyClientset() *fakeclientset.Clientset {
 	result := fakeclientset.NewSimpleClientset()
+	// result.PrependReactor("*","*",func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+	// 	return false, nil, nil
+	// })
 	return result
 }
 


### PR DESCRIPTION
From the below snippet of code, being able to grab all such Run objects based on their reference is likely a desirable filter. This PR adds query filtering to both pipelineruns and taskruns and adds the corresponding tests .
```
type PipelineRun struct {
	metav1.TypeMeta `json:",inline"`
	// +optional
	metav1.ObjectMeta `json:"metadata,omitempty"`

	// +optional
	Spec PipelineRunSpec `json:"spec,omitempty"`
	// +optional
	Status PipelineRunStatus `json:"status,omitempty"`
}
type PipelineRunSpec struct {
	PipelineRef PipelineRef     `json:"pipelineRef"`
...
}
type PipelineResourceRef struct {
	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
	Name string `json:"name"`
	// API version of the referent
	// +optional
	APIVersion string `json:"apiVersion,omitempty"`
}
```