### PR TITLE
Add support for UI extensions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,8 @@
   ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-export-default-from"
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-syntax-dynamic-import"
   ],
   "env": {
     "development": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/polyfill": "^7.4.0",
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",

--- a/src/actions/extensions.js
+++ b/src/actions/extensions.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { getExtensionBundleURL, getExtensions } from '../api';
+
+export function fetchExtensionsSuccess(data) {
+  return {
+    type: 'EXTENSIONS_FETCH_SUCCESS',
+    data
+  };
+}
+
+export function fetchExtensions() {
+  return async dispatch => {
+    dispatch({ type: 'EXTENSIONS_FETCH_REQUEST' });
+    let extensions;
+    try {
+      extensions = await getExtensions();
+      extensions = (extensions || []).map(
+        ({ bundlelocation, displayname, name, url }) => ({
+          displayName: displayname,
+          name,
+          source: getExtensionBundleURL(name, bundlelocation),
+          url
+        })
+      );
+      dispatch(fetchExtensionsSuccess(extensions));
+    } catch (error) {
+      dispatch({ type: 'EXTENSIONS_FETCH_FAILURE', error });
+    }
+    return extensions;
+  };
+}

--- a/src/actions/extensions.test.js
+++ b/src/actions/extensions.test.js
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as API from '../api';
+import { fetchExtensions, fetchExtensionsSuccess } from './extensions';
+
+it('fetchExtensionsSuccess', () => {
+  const data = { fake: 'data' };
+  expect(fetchExtensionsSuccess(data)).toEqual({
+    type: 'EXTENSIONS_FETCH_SUCCESS',
+    data
+  });
+});
+
+it('fetchExtensions', async () => {
+  const bundlelocation = 'bundlelocation';
+  const displayname = 'displayname';
+  const name = 'name';
+  const url = 'url';
+  const extensions = [{ bundlelocation, displayname, name, url }];
+  const transformedExtensions = [
+    {
+      displayName: displayname,
+      name,
+      source: API.getExtensionBundleURL(name, bundlelocation),
+      url
+    }
+  ];
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  jest.spyOn(API, 'getExtensions').mockImplementation(() => extensions);
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    fetchExtensionsSuccess(transformedExtensions)
+  ];
+
+  await store.dispatch(fetchExtensions());
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchExtensions error', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const error = new Error();
+
+  jest.spyOn(API, 'getExtensions').mockImplementation(() => {
+    throw error;
+  });
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    { type: 'EXTENSIONS_FETCH_FAILURE', error }
+  ];
+
+  await store.dispatch(fetchExtensions());
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchExtensions null', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  jest.spyOn(API, 'getExtensions').mockImplementation(() => null);
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    fetchExtensionsSuccess([])
+  ];
+
+  await store.dispatch(fetchExtensions());
+  expect(store.getActions()).toEqual(expectedActions);
+});

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -36,6 +36,14 @@ export function getAPI(type, id = '', namespace = 'default') {
   ].join('');
 }
 
+export function getExtensionBaseURL(name) {
+  return `${apiRoot}/v1/extension/${name}`;
+}
+
+export function getExtensionBundleURL(name, bundlelocation) {
+  return `${getExtensionBaseURL(name)}/${bundlelocation}`;
+}
+
 export function checkData(data) {
   if (data.items) {
     return data.items;
@@ -139,4 +147,9 @@ export function updateCredential({ id, ...rest }) {
 export function deleteCredential(id) {
   const uri = getAPI('credentials', id);
   return deleteRequest(uri);
+}
+
+export function getExtensions() {
+  const uri = `${apiRoot}/v1/extensions`;
+  return get(uri);
 }

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -23,6 +23,7 @@ import {
   getAPIRoot,
   getCredential,
   getCredentials,
+  getExtensions,
   getPipeline,
   getPipelineResource,
   getPipelineResources,
@@ -299,6 +300,15 @@ it('deleteCredential', () => {
   fetchMock.delete('*', data);
   return deleteCredential(credentialId).then(response => {
     expect(response).toEqual(data);
+    fetchMock.restore();
+  });
+});
+
+it('getExtensions', () => {
+  const extensions = [{ fake: 'extension' }];
+  fetchMock.get(/extension/, extensions);
+  return getExtensions().then(response => {
+    expect(response).toEqual(extensions);
     fetchMock.restore();
   });
 });

--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -11,11 +11,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as Home } from './Home';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  state = { error: null };
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary', { error, info }); // eslint-disable-line no-console
+  }
+
+  render() {
+    const { message } = this.props;
+    if (this.state.error) {
+      return <h1>{message}</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.defaultProps = {
+  message: 'Something went wrong'
+};
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/ErrorBoundary.test.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.js
@@ -12,23 +12,29 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
-import configureStore from 'redux-mock-store';
 
-import { App } from './App';
+import ErrorBoundary from './ErrorBoundary';
 
-it('App renders successfully', () => {
-  const mockStore = configureStore();
-  const store = mockStore({
-    extensions: { byName: {} }
-  });
+it('ErrorBoundary renders children', () => {
   const { queryByText } = render(
-    <Provider store={store}>
-      <App extensions={[]} fetchExtensions={() => {}} />
-    </Provider>
+    <ErrorBoundary>
+      <span>hello</span>
+    </ErrorBoundary>
   );
-  expect(queryByText(/pipelines/i)).toBeTruthy();
-  expect(queryByText(/tasks/i)).toBeTruthy();
-  expect(queryByText(/extensions/i)).toBeFalsy();
+  expect(queryByText(/hello/i)).toBeTruthy();
+});
+
+it('ErrorBoundary renders the error message', () => {
+  function Bomb() {
+    throw new Error();
+  }
+  jest.spyOn(console, 'error').mockImplementation(() => {}); // suppress error log from test output
+  const { queryByText } = render(
+    <ErrorBoundary>
+      <Bomb />
+    </ErrorBoundary>
+  );
+  expect(queryByText(/something went wrong/i)).toBeTruthy();
+  console.error.mockRestore(); // eslint-disable-line no-console
 });

--- a/src/components/ErrorBoundary/index.js
+++ b/src/components/ErrorBoundary/index.js
@@ -11,11 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as Home } from './Home';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
+export default from './ErrorBoundary';

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -11,8 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
-import { hot } from 'react-hot-loader';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader/root';
 import {
   HashRouter as Router,
   Redirect,
@@ -21,6 +22,8 @@ import {
 } from 'react-router-dom';
 
 import {
+  Extension,
+  Extensions,
   Home,
   PipelineRun,
   PipelineRuns,
@@ -28,33 +31,78 @@ import {
   Tasks,
   TaskRuns
 } from '..';
+import { fetchExtensions } from '../../actions/extensions';
+import { getExtensions } from '../../reducers';
 
 import '../../components/App/App.scss';
 
-const App = () => (
-  <Router>
-    <Switch>
-      <Route path="/" exact component={Home} />
-      <Redirect
-        from="/pipelines/:pipelineName"
-        exact
-        to="/pipelines/:pipelineName/runs"
-      />
-      <Redirect from="/tasks/:taskName" exact to="/tasks/:taskName/runs" />
-      <Route path="/pipelines" exact component={Pipelines} />
-      <Route path="/tasks" exact component={Tasks} />
-      <Route
-        path="/pipelines/:pipelineName/runs"
-        exact
-        component={PipelineRuns}
-      />
-      <Route path="/tasks/:taskName/runs" exact component={TaskRuns} />
-      <Route
-        path="/pipelines/:pipelineName/runs/:pipelineRunName"
-        component={PipelineRun}
-      />
-    </Switch>
-  </Router>
-);
+export class App extends Component {
+  componentDidMount() {
+    this.props.fetchExtensions();
+  }
 
-export default hot(module)(App);
+  render() {
+    const { extensions } = this.props;
+
+    return (
+      <Router>
+        <Switch>
+          <Route path="/" exact component={Home} />
+          <Redirect
+            from="/pipelines/:pipelineName"
+            exact
+            to="/pipelines/:pipelineName/runs"
+          />
+          <Redirect from="/tasks/:taskName" exact to="/tasks/:taskName/runs" />
+          <Route path="/pipelines" exact component={Pipelines} />
+          <Route path="/tasks" exact component={Tasks} />
+          <Route
+            path="/pipelines/:pipelineName/runs"
+            exact
+            component={PipelineRuns}
+          />
+          <Route path="/tasks/:taskName/runs" exact component={TaskRuns} />
+          <Route
+            path="/pipelines/:pipelineName/runs/:pipelineRunName"
+            component={PipelineRun}
+          />
+          <Route path="/extensions" exact component={Extensions} />
+          {extensions
+            .filter(({ displayName }) => !!displayName)
+            .map(({ displayName, name, source }) => (
+              <Route
+                key={name}
+                path={`/extensions/${name}`}
+                render={({ match }) => (
+                  <Extension
+                    displayName={displayName}
+                    match={match}
+                    source={source}
+                  />
+                )}
+              />
+            ))}
+        </Switch>
+      </Router>
+    );
+  }
+}
+
+App.defaultProps = {
+  extensions: []
+};
+
+const mapStateToProps = state => ({
+  extensions: getExtensions(state)
+});
+
+const mapDispatchToProps = {
+  fetchExtensions
+};
+
+export default hot(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(App)
+);

--- a/src/containers/Extension/Extension.js
+++ b/src/containers/Extension/Extension.js
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component, Suspense } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Breadcrumb, BreadcrumbItem } from 'carbon-components-react';
+
+import Header from '../../components/Header';
+import ErrorBoundary from '../../components/ErrorBoundary';
+
+import './globals';
+
+export default /* istanbul ignore next */ class Extension extends Component {
+  constructor(props) {
+    super(props);
+
+    const { source } = props;
+    const ExtensionComponent = React.lazy(() =>
+      import(/* webpackIgnore: true */ source)
+    );
+
+    this.state = { ExtensionComponent };
+  }
+
+  render() {
+    const { displayName, match } = this.props;
+    const { ExtensionComponent } = this.state;
+
+    return (
+      <div className="pipelines">
+        <Header>
+          <div className="pipelines-header">
+            <Breadcrumb>
+              <BreadcrumbItem>
+                <NavLink to={match.url}>{displayName}</NavLink>
+              </BreadcrumbItem>
+            </Breadcrumb>
+          </div>
+        </Header>
+        <main>
+          <ErrorBoundary message="Error loading extension">
+            <Suspense fallback={<div>Loading...</div>}>
+              <ExtensionComponent />
+            </Suspense>
+          </ErrorBoundary>
+        </main>
+      </div>
+    );
+  }
+}

--- a/src/containers/Extension/globals.js
+++ b/src/containers/Extension/globals.js
@@ -11,11 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as Home } from './Home';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import * as ReactRouterDOM from 'react-router-dom';
+import * as CarbonComponentsReact from 'carbon-components-react';
+
+window.CarbonComponentsReact = CarbonComponentsReact;
+window.React = React;
+window.ReactDOM = ReactDOM;
+window.ReactRouterDOM = ReactRouterDOM;

--- a/src/containers/Extension/index.js
+++ b/src/containers/Extension/index.js
@@ -11,11 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as Home } from './Home';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
+export default from './Extension';

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Link, NavLink } from 'react-router-dom';
+import { connect } from 'react-redux';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  InlineNotification,
+  StructuredListBody,
+  StructuredListCell,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListSkeleton,
+  StructuredListWrapper
+} from 'carbon-components-react';
+
+import Header from '../../components/Header';
+import {
+  getExtensions,
+  getExtensionsErrorMessage,
+  isFetchingExtensions
+} from '../../reducers';
+
+import '../../components/Definitions/Definitions.scss';
+
+export const Extensions = /* istanbul ignore next */ ({
+  error,
+  loading,
+  extensions
+}) => {
+  return (
+    <div className="definitions">
+      <Header>
+        <div className="definitions-header">
+          <Breadcrumb>
+            <BreadcrumbItem>
+              <NavLink to="/extensions">Extensions</NavLink>
+            </BreadcrumbItem>
+          </Breadcrumb>
+        </div>
+      </Header>
+
+      <main>
+        {(() => {
+          if (loading && !extensions.length) {
+            return <StructuredListSkeleton border />;
+          }
+
+          if (error) {
+            return (
+              <InlineNotification
+                kind="error"
+                title="Error loading extensions"
+                subtitle={error}
+              />
+            );
+          }
+
+          return (
+            <StructuredListWrapper border selection>
+              <StructuredListHead>
+                <StructuredListRow head>
+                  <StructuredListCell head>Extension</StructuredListCell>
+                </StructuredListRow>
+              </StructuredListHead>
+              <StructuredListBody>
+                {extensions.map(({ displayName, name }) => {
+                  return (
+                    <StructuredListRow className="definition" key={name}>
+                      <StructuredListCell>
+                        <Link to={`/extensions/${name}`}>{displayName}</Link>
+                      </StructuredListCell>
+                    </StructuredListRow>
+                  );
+                })}
+              </StructuredListBody>
+            </StructuredListWrapper>
+          );
+        })()}
+      </main>
+    </div>
+  );
+};
+
+Extensions.defaultProps = {
+  extensions: []
+};
+
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    error: getExtensionsErrorMessage(state),
+    loading: isFetchingExtensions(state),
+    extensions: getExtensions(state)
+  };
+}
+
+export default connect(mapStateToProps)(Extensions);

--- a/src/containers/Extensions/index.js
+++ b/src/containers/Extensions/index.js
@@ -11,11 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as Home } from './Home';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
+export { default } from './Extensions';

--- a/src/containers/Home/Home.js
+++ b/src/containers/Home/Home.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {
   Breadcrumb,
@@ -24,11 +25,11 @@ import {
 } from 'carbon-components-react';
 
 import Header from '../../components/Header';
+import { getExtensions } from '../../reducers';
 
 import '../../components/Definitions/Definitions.scss';
 
-/* istanbul ignore next */
-const Home = () => {
+export const Home = /* istanbul ignore next */ ({ extensions }) => {
   return (
     <div className="definitions">
       <Header>
@@ -57,6 +58,13 @@ const Home = () => {
                 <Link to="/tasks">Tasks</Link>
               </StructuredListCell>
             </StructuredListRow>
+            {!!extensions.length && (
+              <StructuredListRow className="pipeline">
+                <StructuredListCell>
+                  <Link to="/extensions">Extensions</Link>
+                </StructuredListCell>
+              </StructuredListRow>
+            )}
           </StructuredListBody>
         </StructuredListWrapper>
       </main>
@@ -64,4 +72,8 @@ const Home = () => {
   );
 };
 
-export default Home;
+const mapStateToProps = state => ({
+  extensions: getExtensions(state)
+});
+
+export default connect(mapStateToProps)(Home);

--- a/src/reducers/extensions.js
+++ b/src/reducers/extensions.js
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { combineReducers } from 'redux';
+import keyBy from 'lodash.keyby';
+
+function byName(state = {}, action) {
+  switch (action.type) {
+    case 'EXTENSIONS_FETCH_SUCCESS':
+      return keyBy(action.data, 'name');
+    default:
+      return state;
+  }
+}
+
+function isFetching(state = false, action) {
+  switch (action.type) {
+    case 'EXTENSIONS_FETCH_REQUEST':
+      return true;
+    case 'EXTENSIONS_FETCH_SUCCESS':
+    case 'EXTENSIONS_FETCH_FAILURE':
+      return false;
+    default:
+      return state;
+  }
+}
+
+function errorMessage(state = null, action) {
+  switch (action.type) {
+    case 'EXTENSIONS_FETCH_FAILURE':
+      return action.error.message;
+    case 'EXTENSIONS_FETCH_REQUEST':
+    case 'EXTENSIONS_FETCH_SUCCESS':
+      return null;
+    default:
+      return state;
+  }
+}
+
+export default combineReducers({
+  byName,
+  errorMessage,
+  isFetching
+});
+
+export function getExtensions(state) {
+  return Object.values(state.byName);
+}
+
+export function getExtension(state, name) {
+  return state.byName[name];
+}
+
+export function getExtensionsErrorMessage(state) {
+  return state.errorMessage;
+}
+
+export function isFetchingExtensions(state) {
+  return state.isFetching;
+}

--- a/src/reducers/extensions.test.js
+++ b/src/reducers/extensions.test.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import extensionsReducer, * as selectors from './extensions';
+
+it('handles init or unknown actions', () => {
+  expect(extensionsReducer(undefined, { type: 'does_not_exist' })).toEqual({
+    byName: {},
+    errorMessage: null,
+    isFetching: false
+  });
+});
+
+it('EXTENSIONS_FETCH_REQUEST', () => {
+  const action = { type: 'EXTENSIONS_FETCH_REQUEST' };
+  const state = extensionsReducer({}, action);
+  expect(selectors.isFetchingExtensions(state)).toBe(true);
+});
+
+it('EXTENSIONS_FETCH_SUCCESS', () => {
+  const name = 'extension name';
+  const extension = {
+    name,
+    other: 'content'
+  };
+  const action = {
+    type: 'EXTENSIONS_FETCH_SUCCESS',
+    data: [extension]
+  };
+
+  const state = extensionsReducer({}, action);
+  expect(selectors.getExtensions(state)).toEqual([extension]);
+  expect(selectors.getExtension(state, name)).toEqual(extension);
+  expect(selectors.isFetchingExtensions(state)).toBe(false);
+});
+
+it('EXTENSIONS_FETCH_FAILURE', () => {
+  const message = 'fake error message';
+  const error = { message };
+  const action = {
+    type: 'EXTENSIONS_FETCH_FAILURE',
+    error
+  };
+
+  const state = extensionsReducer({}, action);
+  expect(selectors.getExtensionsErrorMessage(state)).toEqual(message);
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,13 +13,27 @@ limitations under the License.
 
 import { combineReducers } from 'redux';
 
+import extensions, * as extensionSelectors from './extensions';
 import pipelines, * as pipelineSelectors from './pipelines';
 import tasks, * as taskSelectors from './tasks';
 
 export default combineReducers({
+  extensions,
   pipelines,
   tasks
 });
+
+export function getExtensions(state) {
+  return extensionSelectors.getExtensions(state.extensions);
+}
+
+export function getExtensionsErrorMessage(state) {
+  return extensionSelectors.getExtensionsErrorMessage(state.extensions);
+}
+
+export function isFetchingExtensions(state) {
+  return extensionSelectors.isFetchingExtensions(state.extensions);
+}
 
 export function getPipelines(state) {
   return pipelineSelectors.getPipelines(state.pipelines);

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -12,19 +12,55 @@ limitations under the License.
 */
 
 import {
+  getExtensions,
+  getExtensionsErrorMessage,
   getPipelines,
   getPipelinesErrorMessage,
   getTasks,
   getTasksErrorMessage,
+  isFetchingExtensions,
   isFetchingPipelines,
   isFetchingTasks
 } from '.';
+import * as extensionSelectors from './extensions';
 import * as pipelineSelectors from './pipelines';
 import * as taskSelectors from './tasks';
 
+const extensions = { fake: 'extensions' };
 const pipelines = { fake: 'pipelines' };
 const tasks = { fake: 'tasks' };
-const state = { pipelines, tasks };
+const state = { extensions, pipelines, tasks };
+
+it('getExtensions', () => {
+  jest
+    .spyOn(extensionSelectors, 'getExtensions')
+    .mockImplementation(() => extensions);
+  expect(getExtensions(state)).toEqual(extensions);
+  expect(extensionSelectors.getExtensions).toHaveBeenCalledWith(
+    state.extensions
+  );
+});
+
+it('getExtensionsErrorMessage', () => {
+  const errorMessage = 'fake error message';
+  jest
+    .spyOn(extensionSelectors, 'getExtensionsErrorMessage')
+    .mockImplementation(() => errorMessage);
+  expect(getExtensionsErrorMessage(state)).toEqual(errorMessage);
+  expect(extensionSelectors.getExtensionsErrorMessage).toHaveBeenCalledWith(
+    state.extensions
+  );
+});
+
+it('isFetchingExtensions', () => {
+  jest
+    .spyOn(extensionSelectors, 'isFetchingExtensions')
+    .mockImplementation(() => true);
+  expect(isFetchingExtensions(state)).toBe(true);
+  expect(extensionSelectors.isFetchingExtensions).toHaveBeenCalledWith(
+    state.extensions
+  );
+});
 
 it('getPipelines', () => {
   jest

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,6 +3,17 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 const { API_DOMAIN, PORT } = require('./config_frontend/config.json');
 
+const extensionConfig = {
+  '/api/v1/extensions': {
+    target: 'http://localhost:9999',
+    pathRewrite: { '^/api/v1/extensions': '' }
+  },
+  '/api/v1/extension/dev-extension': {
+    target: 'http://localhost:9999',
+    pathRewrite: { '^/api/v1/extension/dev-extension': '' }
+  }
+};
+
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'eval-source-map',
@@ -12,6 +23,7 @@ module.exports = merge(common, {
     overlay: true,
     port: process.env.PORT || PORT,
     proxy: {
+      ...(process.env.EXTENSIONS_LOCAL_DEV ? extensionConfig : {}),
       '/v1': {
         target: process.env.API_DOMAIN || API_DOMAIN
       }


### PR DESCRIPTION
https://github.com/tektoncd/dashboard/issues/7

~~Still need to verify against final back end code, likely needs some minor tweaks to API calls before it's ready to merge.~~ Updated to reflect latest discussions on https://github.com/tektoncd/dashboard/issues/80

A future PR will extend this to provide access to a set of front-end APIs that can be consumed by extensions, e.g. accessing redux store.