### PR TITLE
Use INSTALLED_NAMESPACE var to match Go code expectations

### DIFF
--- a/config/tekton-dashboard-deployment.yaml
+++ b/config/tekton-dashboard-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         env:
         - name: PORT
           value: "9097"
-        - name: INSTALL_NAMESPACE
+        - name: INSTALLED_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace


### PR DESCRIPTION
See https://github.com/tektoncd/dashboard/pull/34#pullrequestreview-229667903

@akihikokuroda mentioned `This value is set automatically so it doesn’t need to be set manually.` but I don't think it is: we don't get INSTALL_NAMESPACE for free in our pod unless it's defined as an env var. The Go code looks for INSTALLED_NAMESPACE and so we should use INSTALLED_NAMESPACE.