### PR TITLE
Support web project from back and and builders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /coverage
 /dist
+/cmd/dashboard/kodata/
 /storybook-static
 /tmp
 main

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,17 +114,31 @@ Tekton Dashboard does not involve any custom resource definitions, we only inter
 You can stand up a version of the dashboard on-cluster (to your
 `kubectl config current-context`):
 
+First install and build the npm project.
+
+```shell
+npm install
+```
+
+There is a dedicated npm job for ko builds
+
+```shell
+npm run build_ko
+```
+
+This will build the static resources and add them to the `kodata` directory.
+
 ```shell
 ko apply -f config/
 ```
 
 ## Access the dashboard
 
-To access the backend API:
+To access the dashboard:
 
 `kubectl port-forward $(kubectl get pod -l app=tekton-dashboard -o name) 9097:9097`
 
-Note that we have a big TODO which is to link up the frontend to the backend and to document how to build and run the frontend for yourself.
+The web UI can be accessed at http://localhost:9097
 
 ### Redeploy dashboard
 

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -17,4 +17,5 @@ WORKDIR /go/src/github.com/tektoncd/dashboard/
 COPY . .
 RUN dep ensure -vendor-only
 WORKDIR /go/src/github.com/tektoncd/dashboard/pkg/endpoints
+ENV WEB_RESOURCES_DIR=/go/src/github.com/tektoncd/dashboard/testdata/web/
 RUN CGO_ENABLED=0 NAMESPACE=default GOOS=linux go test -v

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tekton Dashboard is a general purpose, web-based UI for Tekton Pipelines. It all
 
 ## Getting Started
 
-**Currently** to view the backend APIs, at `localhost:9097/v1/namespaces/<namespace>/<resource name>` for example:
+**Currently** to view the dashboard, at `localhost:9097/` 
  
 If you have `ko`:
 
@@ -17,6 +17,8 @@ Log in to Dockerhub and then use `ko`, for example:
 ```sh
 $ docker login
 $ export KO_DOCKER_REPO=docker.io/<mydockername>
+$ npm install
+$ npm run build_ko
 $ ko apply -f config
 ```
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -70,6 +70,7 @@ func main() {
 	}
 
 	logging.Log.Info("Registering REST endpoints")
+	resource.RegisterWeb(wsContainer)
 	resource.RegisterEndpoints(wsContainer)
 	resource.RegisterWebsocket(wsContainer)
 	resource.RegisterHealthProbes(wsContainer)

--- a/config/tekton-dashboard-deployment.yaml
+++ b/config/tekton-dashboard-deployment.yaml
@@ -32,6 +32,8 @@ spec:
         env:
         - name: PORT
           value: "9097"
+        - name: WEB_RESOURCES_DIR
+          value: /var/run/ko/web
         - name: INSTALLED_NAMESPACE
           valueFrom:
             fieldRef:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.prod.js",
+    "build_ko": "webpack --config webpack.prod.js --output-path='./cmd/dashboard/kodata/web' ",
     "eslint:check": "eslint --print-config . | eslint-config-prettier-check",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",

--- a/pkg/endpoints/router.go
+++ b/pkg/endpoints/router.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"net/http"
+	"os"
 
 	"github.com/tektoncd/dashboard/pkg/utils"
 	restful "github.com/emicklei/go-restful"
@@ -34,6 +35,14 @@ const urlKey = "tekton-dashboard-endpoints"
 const bundleLocationKey = "tekton-dashboard-bundle-location"
 // displayNameKey - extension display name annotation 
 const displayNameKey = "tekton-dashboard-display-name"
+
+var webResourcesDir = os.Getenv("WEB_RESOURCES_DIR")
+
+func (r Resource) RegisterWeb(container *restful.Container) {
+	logging.Log.Info("Adding web api")
+
+	container.Handle("/", http.FileServer(http.Dir(webResourcesDir)))
+}
 
 // Register APIs to interface with core Tekton/K8s pieces
 func (r Resource) RegisterEndpoints(container *restful.Container) {
@@ -136,7 +145,7 @@ func (r Resource) RegisterExtensions(container *restful.Container, namespace str
 	}
 	ws := new(restful.WebService)
 	ws.
-		Path("/").
+		Path("/v1").
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 

--- a/pkg/endpoints/routes_test.go
+++ b/pkg/endpoints/routes_test.go
@@ -67,6 +67,7 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Error creating the fake pipelinerun to use for tests: %s", err)
 	}
 
+	resource.RegisterWeb(wsContainer)
 	resource.RegisterEndpoints(wsContainer)
 	resource.RegisterWebsocket(wsContainer)
 	resource.RegisterHealthProbes(wsContainer)
@@ -80,6 +81,21 @@ func TestMain(m *testing.M) {
 	}
 	server = httptest.NewServer(wsContainer)
 	os.Exit(m.Run())
+}
+
+func TestGetWeb200(t *testing.T) {
+	t.Log("Checking GET route for 200 StatusCode")
+
+	getFunc := func(t *testing.T, request *http.Request, response *http.Response) {
+		t.Log("Response from server:", response)
+		if response.StatusCode != 200 {
+			t.Error("Status code not set to 200")
+		}
+	}
+
+	httpReq, _ := http.NewRequest(http.MethodGet, server.URL+"/", bytes.NewReader([]byte{}))
+	response, _ := http.DefaultClient.Do(httpReq)
+	getFunc(t, httpReq, response)
 }
 
 func TestContentLocation201(t *testing.T) {
@@ -290,7 +306,7 @@ func TestExtensionRegistration(t *testing.T) {
 		t.Errorf("Number of routes: expected: %d, returned: %d", 4, len(routes))
 		return
 	}
-	if routes[0].Path != "/path" {
+	if routes[0].Path != "/v1/path" {
 		t.Errorf("Correct path is not returned: %s", routes[0].Path)
 	}
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -14,13 +14,12 @@ limitations under the License.
 import { deleteRequest, get, post, put } from './comms';
 
 export function getAPIRoot() {
-  const apiPrefix = 'api';
   const { href, hash } = window.location;
   let baseURL = href.replace(hash, '');
   if (!baseURL.endsWith('/')) {
     baseURL += '/';
   }
-  return `${baseURL}${apiPrefix}`;
+  return baseURL;
 }
 
 const apiRoot = getAPIRoot();

--- a/testdata/web/index.html
+++ b/testdata/web/index.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        tekton dashboard
+    </body>
+</html>

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -12,9 +12,8 @@ module.exports = merge(common, {
     overlay: true,
     port: process.env.PORT || PORT,
     proxy: {
-      '/api': {
-        target: process.env.API_DOMAIN || API_DOMAIN,
-        pathRewrite: { '^/api': '' }
+      '/v1': {
+        target: process.env.API_DOMAIN || API_DOMAIN
       }
     },
     stats: 'minimal'


### PR DESCRIPTION
@AlanGreene @a-roberts Could I get a review ? Also try it out. I did have to add the tekton-pipelines service account to the deployment config to make it work but I might be missing something here. Also Ideally the same deployment wouldn't directly reference the `/var/run/ko/web` directory and instead use the variables already available [described here](https://github.com/google/ko#including-static-assets). Very open to suggestions on that one.

I've added a `npm build_ko` task which once run will combine the two in the ko builder. The regular docker build will build the two without any extra steps.

https://github.com/tektoncd/dashboard/issues/14