### PR TITLE
Remove extra forward slash in API URLs

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -16,8 +16,8 @@ import { deleteRequest, get, post, put } from './comms';
 export function getAPIRoot() {
   const { href, hash } = window.location;
   let baseURL = href.replace(hash, '');
-  if (!baseURL.endsWith('/')) {
-    baseURL += '/';
+  if (baseURL.endsWith('/')) {
+    baseURL = baseURL.slice(0, -1);
   }
   return baseURL;
 }

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -44,12 +44,12 @@ beforeEach(jest.resetAllMocks);
 describe('getAPIRoot', () => {
   it('handles base URL with trailing slash', () => {
     window.history.pushState({}, 'Title', '/path/#hash');
-    expect(getAPIRoot()).toContain('/path/api');
+    expect(getAPIRoot()).toContain('/path');
   });
 
   it('handles base URL without trailing slash', () => {
     window.history.pushState({}, 'Title', '/path#hash');
-    expect(getAPIRoot()).toContain('/path/api');
+    expect(getAPIRoot()).toContain('/path');
   });
 });
 


### PR DESCRIPTION
https://github.com/tektoncd/dashboard/issues/14

Follow up to https://github.com/tektoncd/dashboard/pull/78, remove additional forward slash in the API URLs that can cause problems in dev environment.