### PR TITLE
Use newly added name field in step status to find correct results

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -158,12 +158,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:58dc2abfa0d3901dde142cd636abf13d495f37c125564390c7a5791d1fa29e80"
+  digest = "1:b6fca2d4933db5050e8729d0931acc650c2492daa13decc64ad62d48145f7d20"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
     "apis/duck",
-    "apis/duck/v1alpha1",
+    "apis/duck/v1beta1",
     "kmp",
   ]
   pruneopts = "UT"
@@ -227,7 +227,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:aff35c0379f09633e57e10fcd3a00e7563a2669c668e184fe3e2f94a5915f028"
+  digest = "1:07ae092e1affb61ecc09de330fbedd53b77e68fdda590a3879db7fe8e57e709c"
   name = "github.com/tektoncd/pipeline"
   packages = [
     "pkg/apis/pipeline",
@@ -247,7 +247,7 @@
     "pkg/templating",
   ]
   pruneopts = "UT"
-  revision = "c463f1230adc340ee96c02c60f074fff83240210"
+  revision = "3415c18f7728476c132f692d9a55a70b7b194c5d"
 
 [[projects]]
   digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -64,9 +64,11 @@ export function selectedTaskRun(selectedTaskId, taskRuns) {
   return taskRuns.find(run => run.id === selectedTaskId);
 }
 
-export function stepsStatus(taskSteps, taskRunStepsStatus) {
-  const steps = taskSteps.map((step, index) => {
-    const stepStatus = taskRunStepsStatus ? taskRunStepsStatus[index] : {};
+export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
+  const steps = taskSteps.map(step => {
+    const stepStatus =
+      taskRunStepsStatus.find(status => status.name === step.name) || {};
+
     let status;
     let reason;
     if (stepStatus.terminated) {

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -118,7 +118,12 @@ it('stepsStatus no status', () => {
 it('stepsStatus step is running', () => {
   const stepName = 'testStep';
   const taskSteps = [{ name: stepName, image: 'test' }];
-  const taskRunStepsStatus = [{ running: { startedAt: '2019' } }];
+  const taskRunStepsStatus = [
+    {
+      name: stepName,
+      running: { startedAt: '2019' }
+    }
+  ];
   const steps = stepsStatus(taskSteps, taskRunStepsStatus);
   const returnedStep = steps[0];
   expect(returnedStep.status).toEqual('running');
@@ -131,6 +136,7 @@ it('stepsStatus step is completed', () => {
   const taskSteps = [{ name: stepName, image: 'test' }];
   const taskRunStepsStatus = [
     {
+      name: stepName,
       terminated: {
         exitCode: 0,
         reason,
@@ -153,6 +159,7 @@ it('stepsStatus step is terminated with error', () => {
   const taskSteps = [{ name: stepName, image: 'test' }];
   const taskRunStepsStatus = [
     {
+      name: stepName,
       terminated: {
         exitCode: 1,
         reason,
@@ -172,7 +179,7 @@ it('stepsStatus step is terminated with error', () => {
 it('stepsStatus step is waiting', () => {
   const stepName = 'testStep';
   const taskSteps = [{ name: stepName, image: 'test' }];
-  const taskRunStepsStatus = [{ waiting: {} }];
+  const taskRunStepsStatus = [{ name: stepName, waiting: {} }];
   const steps = stepsStatus(taskSteps, taskRunStepsStatus);
   const returnedStep = steps[0];
   expect(returnedStep.status).toEqual('waiting');


### PR DESCRIPTION
https://github.com/tektoncd/dashboard/issues/56

Instead of attempting to match step status in task runs by index,
accounting for presence / order of init containers, use the
newly added name field in the step status so we can reliably
link steps to their status and logs regardless of order.

This involves updating Gopkg.lock to use github.com/tektoncd/pipeline
revision 3415c18f7728476c132f692d9a55a70b7b194c5d which introduced
the new field.