### PR TITLE
Modify the readme for dockerbuild installation method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Alternatively you can do the following:
 
 ```sh
 $ docker build -t <mydockername>/dashboard:<mytag> .
+$ docker push <mydockername>/dashboard:<mytag>
 - Replace the image path at `config/tekton-dashboard-deployment.yaml` with the value for <mydockername>/dashboard:<mytag>
+- Replace the WEB_RESOURCES_DIR value in the same file with the value __./web__
 $ kubectl apply -f tekton-dashboard-deployment.yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Alternatively you can do the following:
 ```sh
 $ docker build -t <mydockername>/dashboard:<mytag> .
 $ docker push <mydockername>/dashboard:<mytag>
+```
 - Replace the image path at `config/tekton-dashboard-deployment.yaml` with the value for <mydockername>/dashboard:<mytag>
 - Replace the WEB_RESOURCES_DIR value in the same file with the value __./web__
+```
 $ kubectl apply -f tekton-dashboard-deployment.yaml
 ```
 


### PR DESCRIPTION
The docker build version of the install instruction do not mention docker pushing the image or more importantly the need to modify the location of the web resource bundle, this PR corrects that.