### PR TITLE
Update data layer to add support for namespace selection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
       "react"
   ],
   "rules": {
+    "no-case-declarations": "off",
     "no-template-curly-in-string": "off",
     "react/jsx-filename-extension": "off",
     "react/destructuring-assignment": "off",

--- a/src/actions/pipeline.js
+++ b/src/actions/pipeline.js
@@ -12,21 +12,24 @@ limitations under the License.
 */
 
 import { getPipelines } from '../api';
+import { getSelectedNamespace } from '../reducers';
 
-export function fetchPipelinesSuccess(data) {
+export function fetchPipelinesSuccess(data, namespace) {
   return {
     type: 'PIPELINE_FETCH_SUCCESS',
-    data
+    data,
+    namespace
   };
 }
 
 export function fetchPipelines() {
-  return async dispatch => {
+  return async (dispatch, getState) => {
     dispatch({ type: 'PIPELINE_FETCH_REQUEST' });
     let pipelines;
     try {
-      pipelines = await getPipelines();
-      dispatch(fetchPipelinesSuccess(pipelines));
+      const namespace = getSelectedNamespace(getState());
+      pipelines = await getPipelines(namespace);
+      dispatch(fetchPipelinesSuccess(pipelines, namespace));
     } catch (error) {
       dispatch({ type: 'PIPELINE_FETCH_FAILURE', error });
     }

--- a/src/actions/pipeline.test.js
+++ b/src/actions/pipeline.test.js
@@ -15,6 +15,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import * as API from '../api';
+import * as selectors from '../reducers';
 import { fetchPipelines, fetchPipelinesSuccess } from './pipeline';
 
 it('fetchPipelinesSuccess', () => {
@@ -26,16 +27,20 @@ it('fetchPipelinesSuccess', () => {
 });
 
 it('fetchPipelines', async () => {
+  const namespace = 'default';
   const pipelines = { fake: 'pipelines' };
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
 
+  jest
+    .spyOn(selectors, 'getSelectedNamespace')
+    .mockImplementation(() => namespace);
   jest.spyOn(API, 'getPipelines').mockImplementation(() => pipelines);
 
   const expectedActions = [
     { type: 'PIPELINE_FETCH_REQUEST' },
-    fetchPipelinesSuccess(pipelines)
+    fetchPipelinesSuccess(pipelines, namespace)
   ];
 
   await store.dispatch(fetchPipelines());

--- a/src/actions/tasks.js
+++ b/src/actions/tasks.js
@@ -12,21 +12,24 @@ limitations under the License.
 */
 
 import { getTasks } from '../api';
+import { getSelectedNamespace } from '../reducers';
 
-export function fetchTasksSuccess(data) {
+export function fetchTasksSuccess(data, namespace) {
   return {
     type: 'TASKS_FETCH_SUCCESS',
-    data
+    data,
+    namespace
   };
 }
 
 export function fetchTasks() {
-  return async dispatch => {
+  return async (dispatch, getState) => {
     dispatch({ type: 'TASKS_FETCH_REQUEST' });
     let tasks;
     try {
-      tasks = await getTasks();
-      dispatch(fetchTasksSuccess(tasks));
+      const namespace = getSelectedNamespace(getState());
+      tasks = await getTasks(namespace);
+      dispatch(fetchTasksSuccess(tasks, namespace));
     } catch (error) {
       dispatch({ type: 'TASKS_FETCH_FAILURE', error });
     }

--- a/src/actions/tasks.test.js
+++ b/src/actions/tasks.test.js
@@ -15,6 +15,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import * as API from '../api';
+import * as selectors from '../reducers';
 import { fetchTasks, fetchTasksSuccess } from './tasks';
 
 it('fetchTasksSuccess', () => {
@@ -27,15 +28,19 @@ it('fetchTasksSuccess', () => {
 
 it('fetchTasks', async () => {
   const tasks = { fake: 'tasks' };
+  const namespace = 'default';
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
 
+  jest
+    .spyOn(selectors, 'getSelectedNamespace')
+    .mockImplementation(() => namespace);
   jest.spyOn(API, 'getTasks').mockImplementation(() => tasks);
 
   const expectedActions = [
     { type: 'TASKS_FETCH_REQUEST' },
-    fetchTasksSuccess(tasks)
+    fetchTasksSuccess(tasks, namespace)
   ];
 
   await store.dispatch(fetchTasks());

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -24,7 +24,7 @@ export function getAPIRoot() {
 
 const apiRoot = getAPIRoot();
 
-export function getAPI(type, id = '', namespace = 'default') {
+export function getAPI(type, { name = '', namespace } = {}) {
   return [
     apiRoot,
     '/v1/namespaces/',
@@ -32,7 +32,7 @@ export function getAPI(type, id = '', namespace = 'default') {
     '/',
     type,
     '/',
-    encodeURIComponent(id)
+    encodeURIComponent(name)
   ].join('');
 }
 
@@ -54,68 +54,68 @@ export function checkData(data) {
   throw error;
 }
 
-export function getPipelines() {
-  const uri = getAPI('pipeline');
+export function getPipelines(namespace) {
+  const uri = getAPI('pipeline', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getPipeline(name) {
-  const uri = getAPI('pipeline', name);
+export function getPipeline(name, namespace) {
+  const uri = getAPI('pipeline', { name, namespace });
   return get(uri);
 }
 
-export function getPipelineRuns() {
-  const uri = getAPI('pipelinerun');
+export function getPipelineRuns(namespace) {
+  const uri = getAPI('pipelinerun', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getPipelineRun(name) {
-  const uri = getAPI('pipelinerun', name);
+export function getPipelineRun(name, namespace) {
+  const uri = getAPI('pipelinerun', { name, namespace });
   return get(uri);
 }
 
-export function cancelPipelineRun(name) {
-  const uri = getAPI('pipelinerun', name);
+export function cancelPipelineRun(name, namespace) {
+  const uri = getAPI('pipelinerun', { name, namespace });
   return put(uri, { status: 'PipelineRunCancelled' });
 }
 
-export function getTasks() {
-  const uri = getAPI('task');
+export function getTasks(namespace) {
+  const uri = getAPI('task', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getTask(name) {
-  const uri = getAPI('task', name);
+export function getTask(name, namespace) {
+  const uri = getAPI('task', { name, namespace });
   return get(uri);
 }
 
-export function getTaskRuns() {
-  const uri = getAPI('taskrun');
+export function getTaskRuns(namespace) {
+  const uri = getAPI('taskrun', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getTaskRun(name) {
-  const uri = getAPI('taskrun', name);
+export function getTaskRun(name, namespace) {
+  const uri = getAPI('taskrun', { name, namespace });
   return get(uri);
 }
 
-export function getPipelineResources() {
-  const uri = getAPI('pipelineresource');
+export function getPipelineResources(namespace) {
+  const uri = getAPI('pipelineresource', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getPipelineResource(name) {
-  const uri = getAPI('pipelineresource', name);
+export function getPipelineResource(name, namespace) {
+  const uri = getAPI('pipelineresource', { name, namespace });
   return get(uri);
 }
 
-export function getPodLog(name) {
-  const uri = getAPI('log', name);
+export function getPodLog(name, namespace) {
+  const uri = getAPI('log', { name, namespace });
   return get(uri);
 }
 
-export function getTaskRunLog(name) {
-  const uri = getAPI('taskrunlog', name);
+export function getTaskRunLog(name, namespace) {
+  const uri = getAPI('taskrunlog', { name, namespace });
   return get(uri);
 }
 
@@ -124,28 +124,28 @@ export function createPipelineRun(payload) {
   return post(uri, payload);
 }
 
-export function getCredentials() {
-  const uri = getAPI('credentials');
+export function getCredentials(namespace) {
+  const uri = getAPI('credentials', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getCredential(id) {
-  const uri = getAPI('credentials', id);
+export function getCredential(id, namespace) {
+  const uri = getAPI('credentials', { name: id, namespace });
   return get(uri);
 }
 
-export function createCredential({ id, ...rest }) {
-  const uri = getAPI('credentials');
+export function createCredential({ id, ...rest }, namespace) {
+  const uri = getAPI('credentials', { namespace });
   return post(uri, { id, ...rest });
 }
 
-export function updateCredential({ id, ...rest }) {
-  const uri = getAPI('credentials', id);
+export function updateCredential({ id, ...rest }, namespace) {
+  const uri = getAPI('credentials', { name: id, namespace });
   return put(uri, { id, ...rest });
 }
 
-export function deleteCredential(id) {
-  const uri = getAPI('credentials', id);
+export function deleteCredential(id, namespace) {
+  const uri = getAPI('credentials', { name: id, namespace });
   return deleteRequest(uri);
 }
 

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -60,13 +60,16 @@ describe('getAPI', () => {
   });
 
   it('returns a URI containing the given type and name', () => {
-    const uri = getAPI('pipeline', 'somename');
+    const uri = getAPI('pipeline', { name: 'somename' });
     expect(uri).toContain('pipeline');
     expect(uri).toContain('somename');
   });
 
   it('returns a URI containing the given, name, and namespace', () => {
-    const uri = getAPI('pipeline', 'somename', 'customnamespace');
+    const uri = getAPI('pipeline', {
+      name: 'somename',
+      namespace: 'customnamespace'
+    });
     expect(uri).toContain('pipeline');
     expect(uri).toContain('somename');
     expect(uri).toContain('customnamespace');

--- a/src/components/StepDetails/StepDetails.test.js
+++ b/src/components/StepDetails/StepDetails.test.js
@@ -12,9 +12,19 @@ limitations under the License.
 */
 
 import React from 'react';
+import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
+import configureStore from 'redux-mock-store';
+
 import StepDetails from './StepDetails';
 
 it('StepDetails renders', () => {
-  render(<StepDetails />);
+  const mockStore = configureStore();
+  const store = mockStore({ namespaces: { selected: 'default' } });
+
+  render(
+    <Provider store={store}>
+      <StepDetails />
+    </Provider>
+  );
 });

--- a/src/containers/Log/Log.js
+++ b/src/containers/Log/Log.js
@@ -12,11 +12,13 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import Log from '../../components/Log';
 import { getTaskRunLog } from '../../api';
+import { getSelectedNamespace } from '../../reducers';
 
-class LogContainer extends Component {
+export class LogContainer extends Component {
   state = { logs: [] };
 
   componentDidMount() {
@@ -34,10 +36,10 @@ class LogContainer extends Component {
   }
 
   async loadLog() {
-    const { stepName, taskRunName } = this.props;
+    const { namespace, stepName, taskRunName } = this.props;
     if (taskRunName) {
       try {
-        const logs = await getTaskRunLog(taskRunName);
+        const logs = await getTaskRunLog(taskRunName, namespace);
         const buildStepName = `build-step-${stepName}`;
         const stepLog =
           (logs.StepContainers &&
@@ -57,4 +59,11 @@ class LogContainer extends Component {
   }
 }
 
-export default LogContainer;
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    namespace: getSelectedNamespace(state)
+  };
+}
+
+export default connect(mapStateToProps)(LogContainer);

--- a/src/containers/Log/Log.test.js
+++ b/src/containers/Log/Log.test.js
@@ -14,12 +14,13 @@ limitations under the License.
 import React from 'react';
 import { render, waitForElement } from 'react-testing-library';
 
-import LogContainer from './Log';
+import { LogContainer } from './Log';
 import * as API from '../../api';
 
 beforeEach(jest.resetAllMocks);
 
 it('LogContainer renders', async () => {
+  const namespace = 'namespace';
   const stepName = 'step';
   const taskRunName = 'taskRun';
   const getTaskRunLog = jest
@@ -34,23 +35,32 @@ it('LogContainer renders', async () => {
     }));
 
   const { container, getByText } = render(
-    <LogContainer stepName={stepName} taskRunName={taskRunName} />
+    <LogContainer
+      namespace={namespace}
+      stepName={stepName}
+      taskRunName={taskRunName}
+    />
   );
   await waitForElement(() => getByText('testing'));
 
   expect(getTaskRunLog).toHaveBeenCalledTimes(1);
-  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName);
+  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName, namespace);
 
   const anotherTaskRunName = 'anotherTaskRun';
   render(
-    <LogContainer stepName={stepName} taskRunName={anotherTaskRunName} />,
+    <LogContainer
+      namespace={namespace}
+      stepName={stepName}
+      taskRunName={anotherTaskRunName}
+    />,
     { container }
   );
   expect(getTaskRunLog).toHaveBeenCalledTimes(2);
-  expect(getTaskRunLog).toHaveBeenCalledWith(anotherTaskRunName);
+  expect(getTaskRunLog).toHaveBeenCalledWith(anotherTaskRunName, namespace);
 });
 
 it('LogContainer handles error case', async () => {
+  const namespace = 'namespace';
   const stepName = 'step';
   const taskRunName = 'taskRun';
   const getTaskRunLog = jest
@@ -60,15 +70,20 @@ it('LogContainer handles error case', async () => {
     });
 
   const { getByText } = render(
-    <LogContainer stepName={stepName} taskRunName={taskRunName} />
+    <LogContainer
+      namespace={namespace}
+      stepName={stepName}
+      taskRunName={taskRunName}
+    />
   );
   await waitForElement(() => getByText('Unable to fetch log'));
 
   expect(getTaskRunLog).toHaveBeenCalledTimes(1);
-  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName);
+  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName, namespace);
 });
 
 it('LogContainer handles empty logs', async () => {
+  const namespace = 'namespace';
   const stepName = 'step';
   const taskRunName = 'taskRun';
   const getTaskRunLog = jest
@@ -83,15 +98,20 @@ it('LogContainer handles empty logs', async () => {
     }));
 
   const { getByText } = render(
-    <LogContainer stepName={stepName} taskRunName={taskRunName} />
+    <LogContainer
+      namespace={namespace}
+      stepName={stepName}
+      taskRunName={taskRunName}
+    />
   );
   await waitForElement(() => getByText('No log available'));
 
   expect(getTaskRunLog).toHaveBeenCalledTimes(1);
-  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName);
+  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName, namespace);
 });
 
 it('LogContainer handles missing step logs', async () => {
+  const namespace = 'namespace';
   const stepName = 'step';
   const taskRunName = 'taskRun';
   const getTaskRunLog = jest
@@ -101,10 +121,14 @@ it('LogContainer handles missing step logs', async () => {
     }));
 
   const { getByText } = render(
-    <LogContainer stepName={stepName} taskRunName={taskRunName} />
+    <LogContainer
+      namespace={namespace}
+      stepName={stepName}
+      taskRunName={taskRunName}
+    />
   );
   await waitForElement(() => getByText('No log available'));
 
   expect(getTaskRunLog).toHaveBeenCalledTimes(1);
-  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName);
+  expect(getTaskRunLog).toHaveBeenCalledWith(taskRunName, namespace);
 });

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -13,9 +13,11 @@ limitations under the License.
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { InlineNotification } from 'carbon-components-react';
 
 import { getPipelineRun, getTaskRun, getTasks } from '../../api';
+import { getSelectedNamespace } from '../../reducers';
 
 import RunHeader from '../../components/RunHeader';
 import StepDetails from '../../components/StepDetails';
@@ -30,8 +32,7 @@ import {
 
 import '../../components/Run/Run.scss';
 
-/* istanbul ignore next */
-class PipelineRunContainer extends Component {
+export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   state = {
     error: null,
     loading: true,
@@ -59,13 +60,13 @@ class PipelineRunContainer extends Component {
   };
 
   async loadPipelineRunData() {
-    const { match } = this.props;
+    const { match, namespace } = this.props;
     const { pipelineRunName } = match.params;
 
     try {
       const [pipelineRun, tasks] = await Promise.all([
-        getPipelineRun(pipelineRunName),
-        getTasks()
+        getPipelineRun(pipelineRunName, namespace),
+        getTasks(namespace)
       ]);
       const {
         status: { taskRuns: taskRunsStatus }
@@ -92,8 +93,9 @@ class PipelineRunContainer extends Component {
   }
 
   async loadTaskRuns(taskRunNames) {
+    const { namespace } = this.props;
     let taskRuns = await Promise.all(
-      taskRunNames.map(taskRunName => getTaskRun(taskRunName))
+      taskRunNames.map(taskRunName => getTaskRun(taskRunName, namespace))
     );
 
     const {
@@ -213,4 +215,11 @@ PipelineRunContainer.propTypes = {
   }).isRequired
 };
 
-export default PipelineRunContainer;
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    namespace: getSelectedNamespace(state)
+  };
+}
+
+export default connect(mapStateToProps)(PipelineRunContainer);

--- a/src/containers/PipelineRun/PipelineRun.test.js
+++ b/src/containers/PipelineRun/PipelineRun.test.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { waitForElement } from 'react-testing-library';
 
-import PipelineRunContainer from './PipelineRun';
+import { PipelineRunContainer } from './PipelineRun';
 import * as API from '../../api';
 import { renderWithRouter } from '../../utils/test';
 

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {
   Breadcrumb,
@@ -28,10 +29,10 @@ import {
 import Header from '../../components/Header';
 
 import { getPipelineRuns } from '../../api';
+import { getSelectedNamespace } from '../../reducers';
 import { getStatusIcon, getStatus } from '../../utils';
 
-/* istanbul ignore next */
-class PipelineRuns extends Component {
+export /* istanbul ignore next */ class PipelineRuns extends Component {
   state = {
     error: null,
     loading: true,
@@ -40,10 +41,10 @@ class PipelineRuns extends Component {
 
   async componentDidMount() {
     try {
-      const { match } = this.props;
+      const { match, namespace } = this.props;
       const { pipelineName } = match.params;
 
-      let pipelineRuns = await getPipelineRuns();
+      let pipelineRuns = await getPipelineRuns(namespace);
       pipelineRuns = pipelineRuns.filter(
         pipelineRun => pipelineRun.spec.pipelineRef.name === pipelineName
       );
@@ -145,4 +146,11 @@ class PipelineRuns extends Component {
   }
 }
 
-export default PipelineRuns;
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    namespace: getSelectedNamespace(state)
+  };
+}
+
+export default connect(mapStateToProps)(PipelineRuns);

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -12,10 +12,12 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { InlineNotification } from 'carbon-components-react';
 
 import { getTasks, getTaskRuns } from '../../api';
+import { getSelectedNamespace } from '../../reducers';
 
 import RunHeader from '../../components/RunHeader';
 import StepDetails from '../../components/StepDetails';
@@ -29,8 +31,7 @@ import {
 
 import '../../components/Run/Run.scss';
 
-/* istanbul ignore next */
-class TaskRunsContainer extends Component {
+export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   // once redux store is available errors will be handled properly with dedicated components
   static notification(notification) {
     const { kind, message } = notification;
@@ -85,12 +86,13 @@ class TaskRunsContainer extends Component {
   };
 
   async loadTaskRuns(selectedTaskName) {
+    const { namespace } = this.props;
     let notification;
-    const tasks = await getTasks();
+    const tasks = await getTasks(namespace);
     const task = tasks.find(
       currentTask => currentTask.metadata.name === selectedTaskName
     );
-    let taskRuns = await getTaskRuns();
+    let taskRuns = await getTaskRuns(namespace);
     taskRuns = taskRuns
       .filter(
         taskRun =>
@@ -191,4 +193,11 @@ TaskRunsContainer.propTypes = {
   }).isRequired
 };
 
-export default TaskRunsContainer;
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    namespace: getSelectedNamespace(state)
+  };
+}
+
+export default connect(mapStateToProps)(TaskRunsContainer);

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -12,9 +12,11 @@ limitations under the License.
 */
 
 import React from 'react';
+import { Provider } from 'react-redux';
 import { waitForElement } from 'react-testing-library';
+import configureStore from 'redux-mock-store';
 
-import TaskRunsContainer from './TaskRuns';
+import { TaskRunsContainer } from './TaskRuns';
 import * as API from '../../api';
 import { renderWithRouter } from '../../utils/test';
 
@@ -27,11 +29,19 @@ it('TaskRunsContainer renders', async () => {
       taskName
     }
   };
+
+  const mockStore = configureStore();
+  const store = mockStore({});
   const tasksCall = jest.spyOn(API, 'getTasks').mockImplementation(() => '');
   const taskRunsCall = jest
     .spyOn(API, 'getTaskRuns')
     .mockImplementation(() => '');
-  const { getByText } = renderWithRouter(<TaskRunsContainer match={match} />);
+
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <TaskRunsContainer match={match} />
+    </Provider>
+  );
   await waitForElement(() => getByText(taskName));
   expect(tasksCall).toHaveBeenCalledTimes(1);
   expect(taskRunsCall).toHaveBeenCalledTimes(0);
@@ -45,13 +55,21 @@ it('TaskRunsContainer handles info state', async () => {
       taskName
     }
   };
+
+  const mockStore = configureStore();
+  const store = mockStore({});
   const tasksCall = jest
     .spyOn(API, 'getTasks')
     .mockImplementation(() => [{ metadata: { name: taskName } }]);
   const taskRunsCall = jest
     .spyOn(API, 'getTaskRuns')
     .mockImplementation(() => []);
-  const { getByText } = renderWithRouter(<TaskRunsContainer match={match} />);
+
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <TaskRunsContainer match={match} />
+    </Provider>
+  );
   await waitForElement(() => getByText(notificationMessage));
   expect(tasksCall).toHaveBeenCalledTimes(1);
   expect(taskRunsCall).toHaveBeenCalledTimes(1);
@@ -63,6 +81,10 @@ it('TaskRunsContainer handles error state', async () => {
       taskName: 'foo'
     }
   };
+
+  const mockStore = configureStore();
+  const store = mockStore({});
+
   const getTasks = jest.spyOn(API, 'getTasks').mockImplementation(() => {
     const error = new Error();
     error.response = {
@@ -70,7 +92,12 @@ it('TaskRunsContainer handles error state', async () => {
     };
     throw error;
   });
-  const { getByText } = renderWithRouter(<TaskRunsContainer match={match} />);
+
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <TaskRunsContainer match={match} />
+    </Provider>
+  );
   await waitForElement(() => getByText('Error loading task run'));
   expect(getTasks).toHaveBeenCalledTimes(1);
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -14,14 +14,20 @@ limitations under the License.
 import { combineReducers } from 'redux';
 
 import extensions, * as extensionSelectors from './extensions';
+import namespaces, * as namespaceSelectors from './namespaces';
 import pipelines, * as pipelineSelectors from './pipelines';
 import tasks, * as taskSelectors from './tasks';
 
 export default combineReducers({
   extensions,
+  namespaces,
   pipelines,
   tasks
 });
+
+export function getSelectedNamespace(state) {
+  return namespaceSelectors.getSelectedNamespace(state.namespaces);
+}
 
 export function getExtensions(state) {
   return extensionSelectors.getExtensions(state.extensions);
@@ -36,7 +42,8 @@ export function isFetchingExtensions(state) {
 }
 
 export function getPipelines(state) {
-  return pipelineSelectors.getPipelines(state.pipelines);
+  const namespace = getSelectedNamespace(state);
+  return pipelineSelectors.getPipelines(state.pipelines, namespace);
 }
 
 export function getPipelinesErrorMessage(state) {
@@ -48,7 +55,8 @@ export function isFetchingPipelines(state) {
 }
 
 export function getTasks(state) {
-  return taskSelectors.getTasks(state.tasks);
+  const namespace = getSelectedNamespace(state);
+  return taskSelectors.getTasks(state.tasks, namespace);
 }
 
 export function getTasksErrorMessage(state) {

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -29,7 +29,14 @@ import * as taskSelectors from './tasks';
 const extensions = { fake: 'extensions' };
 const pipelines = { fake: 'pipelines' };
 const tasks = { fake: 'tasks' };
-const state = { extensions, pipelines, tasks };
+const state = {
+  extensions,
+  namespaces: {
+    selected: 'default'
+  },
+  pipelines,
+  tasks
+};
 
 it('getExtensions', () => {
   jest
@@ -63,11 +70,15 @@ it('isFetchingExtensions', () => {
 });
 
 it('getPipelines', () => {
+  const namespace = 'default';
   jest
     .spyOn(pipelineSelectors, 'getPipelines')
     .mockImplementation(() => pipelines);
   expect(getPipelines(state)).toEqual(pipelines);
-  expect(pipelineSelectors.getPipelines).toHaveBeenCalledWith(state.pipelines);
+  expect(pipelineSelectors.getPipelines).toHaveBeenCalledWith(
+    state.pipelines,
+    namespace
+  );
 });
 
 it('getPipelinesErrorMessage', () => {
@@ -92,9 +103,10 @@ it('isFetchingPipelines', () => {
 });
 
 it('getTasks', () => {
+  const namespace = 'default';
   jest.spyOn(taskSelectors, 'getTasks').mockImplementation(() => tasks);
   expect(getTasks(state)).toEqual(tasks);
-  expect(taskSelectors.getTasks).toHaveBeenCalledWith(state.tasks);
+  expect(taskSelectors.getTasks).toHaveBeenCalledWith(state.tasks, namespace);
 });
 
 it('getTasksErrorMessage', () => {

--- a/src/reducers/namespaces.js
+++ b/src/reducers/namespaces.js
@@ -14,29 +14,19 @@ limitations under the License.
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 
-function byId(state = {}, action) {
+function byName(state = {}, action) {
   switch (action.type) {
-    case 'PIPELINE_FETCH_SUCCESS':
-      return keyBy(action.data, 'metadata.uid');
+    case 'NAMESPACES_FETCH_SUCCESS':
+      return keyBy(action.data, 'metadata.name');
     default:
       return state;
   }
 }
 
-function byNamespace(state = {}, action) {
+function selected(state = 'default', action) {
   switch (action.type) {
-    case 'PIPELINE_FETCH_SUCCESS':
-      const pipelines = {};
-      action.data.forEach(pipeline => {
-        const { name, uid } = pipeline.metadata;
-        pipelines[name] = uid;
-      });
-
-      const { namespace } = action;
-      return {
-        ...state,
-        [namespace]: pipelines
-      };
+    case 'NAMESPACE_SELECT':
+      return action.namespace;
     default:
       return state;
   }
@@ -44,10 +34,10 @@ function byNamespace(state = {}, action) {
 
 function isFetching(state = false, action) {
   switch (action.type) {
-    case 'PIPELINE_FETCH_REQUEST':
+    case 'NAMESPACES_FETCH_REQUEST':
       return true;
-    case 'PIPELINE_FETCH_SUCCESS':
-    case 'PIPELINE_FETCH_FAILURE':
+    case 'NAMESPACES_FETCH_SUCCESS':
+    case 'NAMESPACES_FETCH_FAILURE':
       return false;
     default:
       return state;
@@ -56,10 +46,10 @@ function isFetching(state = false, action) {
 
 function errorMessage(state = null, action) {
   switch (action.type) {
-    case 'PIPELINE_FETCH_FAILURE':
+    case 'NAMESPACES_FETCH_FAILURE':
       return action.error.message;
-    case 'PIPELINE_FETCH_REQUEST':
-    case 'PIPELINE_FETCH_SUCCESS':
+    case 'NAMESPACES_FETCH_REQUEST':
+    case 'NAMESPACES_FETCH_SUCCESS':
       return null;
     default:
       return state;
@@ -67,27 +57,24 @@ function errorMessage(state = null, action) {
 }
 
 export default combineReducers({
-  byId,
-  byNamespace,
+  byName,
   errorMessage,
-  isFetching
+  isFetching,
+  selected
 });
 
-export function getPipelines(state, namespace) {
-  const pipelines = state.byNamespace[namespace];
-  return pipelines ? Object.values(pipelines).map(id => state.byId[id]) : [];
+export function getNamespaces(state) {
+  return Object.values(state.byName);
 }
 
-export function getPipeline(state, name, namespace) {
-  const pipelines = state.byNamespace[namespace] || {};
-  const pipelineId = pipelines[name];
-  return pipelineId ? state.byId[pipelineId] : null;
+export function getSelectedNamespace(state) {
+  return state.selected;
 }
 
-export function getPipelinesErrorMessage(state) {
+export function getNamespacesErrorMessage(state) {
   return state.errorMessage;
 }
 
-export function isFetchingPipelines(state) {
+export function isFetchingNamespaces(state) {
   return state.isFetching;
 }

--- a/src/reducers/namespaces.test.js
+++ b/src/reducers/namespaces.test.js
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import namespacesReducer, * as selectors from './namespaces';
+
+it('handles init or unknown actions', () => {
+  expect(namespacesReducer(undefined, { type: 'does_not_exist' })).toEqual({
+    byName: {},
+    errorMessage: null,
+    isFetching: false,
+    selected: 'default'
+  });
+});
+
+it('NAMESPACES_FETCH_REQUEST', () => {
+  const action = { type: 'NAMESPACES_FETCH_REQUEST' };
+  const state = namespacesReducer({}, action);
+  expect(selectors.isFetchingNamespaces(state)).toBe(true);
+});
+
+it('NAMESPACES_FETCH_SUCCESS', () => {
+  const name = 'pipeline name';
+  const namespace = 'default';
+  const uid = 'some-uid';
+  const pipeline = {
+    metadata: {
+      name,
+      namespace,
+      uid
+    },
+    other: 'content'
+  };
+  const action = {
+    type: 'NAMESPACES_FETCH_SUCCESS',
+    data: [pipeline],
+    namespace
+  };
+
+  const state = namespacesReducer({}, action);
+  expect(selectors.getNamespaces(state, namespace)).toEqual([pipeline]);
+  expect(selectors.isFetchingNamespaces(state)).toBe(false);
+});
+
+it('NAMESPACES_FETCH_FAILURE', () => {
+  const message = 'fake error message';
+  const error = { message };
+  const action = {
+    type: 'NAMESPACES_FETCH_FAILURE',
+    error
+  };
+
+  const state = namespacesReducer({}, action);
+  expect(selectors.getNamespacesErrorMessage(state)).toEqual(message);
+});
+
+it('NAMESPACE_SELECT', () => {
+  const namespace = 'some-namespace';
+  const action = {
+    type: 'NAMESPACE_SELECT',
+    namespace
+  };
+
+  const state = namespacesReducer({}, action);
+  expect(selectors.getSelectedNamespace(state)).toEqual(namespace);
+});

--- a/src/reducers/pipelines.test.js
+++ b/src/reducers/pipelines.test.js
@@ -15,7 +15,8 @@ import pipelinesReducer, * as selectors from './pipelines';
 
 it('handles init or unknown actions', () => {
   expect(pipelinesReducer(undefined, { type: 'does_not_exist' })).toEqual({
-    byName: {},
+    byId: {},
+    byNamespace: {},
     errorMessage: null,
     isFetching: false
   });
@@ -29,20 +30,25 @@ it('PIPELINE_FETCH_REQUEST', () => {
 
 it('PIPELINE_FETCH_SUCCESS', () => {
   const name = 'pipeline name';
+  const namespace = 'default';
+  const uid = 'some-uid';
   const pipeline = {
     metadata: {
-      name
+      name,
+      namespace,
+      uid
     },
     other: 'content'
   };
   const action = {
     type: 'PIPELINE_FETCH_SUCCESS',
-    data: [pipeline]
+    data: [pipeline],
+    namespace
   };
 
   const state = pipelinesReducer({}, action);
-  expect(selectors.getPipelines(state)).toEqual([pipeline]);
-  expect(selectors.getPipeline(state, name)).toEqual(pipeline);
+  expect(selectors.getPipelines(state, namespace)).toEqual([pipeline]);
+  expect(selectors.getPipeline(state, name, namespace)).toEqual(pipeline);
   expect(selectors.isFetchingPipelines(state)).toBe(false);
 });
 
@@ -56,4 +62,17 @@ it('PIPELINE_FETCH_FAILURE', () => {
 
   const state = pipelinesReducer({}, action);
   expect(selectors.getPipelinesErrorMessage(state)).toEqual(message);
+});
+
+it('getPipelines', () => {
+  const namespace = 'namespace';
+  const state = { byNamespace: {} };
+  expect(selectors.getPipelines(state, namespace)).toEqual([]);
+});
+
+it('getPipeline', () => {
+  const name = 'name';
+  const namespace = 'namespace';
+  const state = { byNamespace: {} };
+  expect(selectors.getPipeline(state, name, namespace)).toBeNull();
 });


### PR DESCRIPTION
https://github.com/tektoncd/dashboard/issues/86

Move specification of namespace to the redux store instead of the API layer.
This will allow us to provide UI for the user to select the namespace to inspect.
Update existing containers and API calls to ensure the selected namespace is passed.