### PR TITLE
Add a Stretch Docker image (Dockerfile_race_test) so we can use -race

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,7 +103,8 @@ Currently you must install the Tekton dashboard into the same namespace you wish
 While iterating on the project, you may need to:
 
 1. Run `dep ensure -v` to retrieve dependencies required to build
-1. Run the Go tests in Docker with: `docker build -f Dockerfile_test .`
+1. Run the Alpine based Go tests in Docker with: `docker build -f Dockerfile_test .`
+1. Run the Stretch based Go tests with race condition checking in Docker with: `docker build -f Dockerfile_race_test .`
 1. Install the dashboard
 1. Interact with the created Kubernetes service - we've had success using Postman on Mac and data provided must be JSON
 

--- a/Dockerfile_race_test
+++ b/Dockerfile_race_test
@@ -9,10 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12-alpine
+# Differs from alpine image used in main Dockerfile as we want to go test -race too
+FROM golang:1.12-stretch
 USER root
 
-RUN apk add curl git
+RUN apt-get install curl git
 
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x /usr/local/bin/dep
 WORKDIR /go/src/github.com/tektoncd/dashboard/
@@ -21,4 +22,5 @@ RUN dep ensure -vendor-only
 WORKDIR /go/src/github.com/tektoncd/dashboard/pkg/endpoints
 ENV WEB_RESOURCES_DIR=/go/src/github.com/tektoncd/dashboard/testdata/web/
 
-RUN CGO_ENABLED=0 NAMESPACE=default GOOS=linux go test -v
+# CGO_ENABLED=1 is needed for -race on go test
+RUN CGO_ENABLED=1 NAMESPACE=default GOOS=linux go test -race -v


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a fix for https://github.com/tektoncd/dashboard/issues/113. CGO_ENABLED is set to 1 and I've added a Stretch image for golang instead of alpine. I want to retain/add test coverage if anything and hence I've not just swapped out alpine for stretch or we'd lose our test coverage.

Necessary due to https://github.com/golang/go/issues/14481 never being resolved.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)

^^ it's a test, so kinda

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
