### PR TITLE
Add ponyfill for dynamic module import (used for extensions)

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -90,6 +90,7 @@ export /* istanbul ignore next */ class App extends Component {
                       <Extension
                         displayName={displayName}
                         match={match}
+                        name={name}
                         source={source}
                       />
                     )}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/7

Dynamic module import is not currently supported in Firefox or Edge.
Firefox support is due to land in FF67 and Edge support is expected
with the transition to Chromium. In the meantime we need to ensure
this functionality works as expected for users of those browsers.

Implement a ponyfill for the dynamic import functionality as it
cannot be reliably polyfilled in all browsers. The `dynamicImport`
function can be easily removed once browser support improves and
it is safe to use `import()` directly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
