### PR TITLE
Task runs and pipeline runs by name not working as expected

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -231,6 +231,7 @@ Returns HTTP code 404 if an error occurred getting the Pipeline
 __PipelineRuns__
 ```
 GET /v1/namespaces/<namespace>/pipelinerun
+Get all Tekton PipelineRuns, also supports '?name=<pipeline-name>' querying
 Get all Tekton PipelineRuns, also supports '?repository=https://gitserver/foo/bar' querying
 Returns HTTP code 200 and a list of PipelineRuns, optionally matching the above query, in the given namespace
 Returns HTTP code 404 if an error occurred getting the PipelineRun list
@@ -258,6 +259,7 @@ __TaskRuns__
 ```
 GET /v1/namespaces/<namespace>/taskrun
 Get all Tekton TaskRuns
+Get all Tekton TaskRuns, also supports '?name=<task-name>' querying
 Returns HTTP code 200 and a list of TaskRuns in the given namespace 
 Returns HTTP code 404 if an error occurred getting the TaskRun list
 

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -209,9 +209,11 @@ func (r Resource) GetAllPipelineRunsImpl(namespace, repository, name string) (v1
 		return v1alpha1.PipelineRunList{}, AppResponse{err, "", http.StatusNotFound}
 	}
 	if name != "" {
-		for i := range pipelinerunList.Items {
-			if pipelinerunList.Items[i].Name != name {
-				pipelinerunList.Items = append(pipelinerunList.Items[:i], pipelinerunList.Items[i+1:]...)
+		tmpItems := pipelinerunList.Items
+		pipelinerunList.Items = pipelinerunList.Items[:0]
+		for i := range tmpItems {
+			if tmpItems[i].Spec.PipelineRef.Name == name {
+				pipelinerunList.Items = append(pipelinerunList.Items, tmpItems[i])
 			}
 		}
 	}
@@ -404,9 +406,11 @@ func (r Resource) getAllTaskRuns(request *restful.Request, response *restful.Res
 		return
 	}
 	if name != "" {
-		for i := range taskrunList.Items {
-			if taskrunList.Items[i].Name != name {
-				taskrunList.Items = append(taskrunList.Items[:i], taskrunList.Items[i+1:]...)
+		tmpItems := taskrunList.Items
+		taskrunList.Items = taskrunList.Items[:0]
+		for i := range tmpItems {
+			if tmpItems[i].Spec.TaskRef.Name == name {
+				taskrunList.Items = append(taskrunList.Items, tmpItems[i])
 			}
 		}
 	}

--- a/pkg/endpoints/pipeline_test.go
+++ b/pkg/endpoints/pipeline_test.go
@@ -186,19 +186,32 @@ func TestTaskRun(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "TaskRun1",
 		},
-		Spec: v1alpha1.TaskRunSpec{},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef:        &v1alpha1.TaskRef{
+				Name: "Task1",
+			},
+		},
+
 	}
 	TaskRun2 := v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "TaskRun2",
 		},
-		Spec: v1alpha1.TaskRunSpec{},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef:        &v1alpha1.TaskRef{
+				Name: "Task2",
+			},
+		},
 	}
 	TaskRun3 := v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "TaskRun3",
 		},
-		Spec: v1alpha1.TaskRunSpec{},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef:        &v1alpha1.TaskRef{
+				Name: "Task3",
+			},
+		},
 	}
 
 	// Add sample TaskRuns
@@ -238,7 +251,7 @@ func TestTaskRun(t *testing.T) {
 
 	// Test getAllTaskRuns function with name query
 	// Sample request and response
-	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=TaskRun1", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/taskrun?name=Task2", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -253,8 +266,8 @@ func TestTaskRun(t *testing.T) {
 	if len(result.Items) != 1 {
 		t.Errorf("Number of tasks: expected: %d, returned: %d", 1, len(result.Items))
 	}
-	if result.Items[0].Name != "TaskRun1" {
-		t.Errorf("Task1 is not returned: %s", result.Items[0].Name)
+	if result.Items[0].Name != "TaskRun2" {
+		t.Errorf("TaskRun2 is not returned: %s", result.Items[0].Name)
 	}
 
 	// Test getTaskRun function
@@ -293,21 +306,33 @@ func TestPipelineRun(t *testing.T) {
 			Name:   "PipelineRun1",
 			Labels: labels1,
 		},
-		Spec: v1alpha1.PipelineRunSpec{},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "Pipeline1",
+			},
+		},
 	}
 	PipelineRun2 := v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "PipelineRun2",
 			Labels: labels2,
 		},
-		Spec: v1alpha1.PipelineRunSpec{},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "Pipeline2",
+			},
+		},
 	}
 	PipelineRun3 := v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "PipelineRun3",
 			Labels: labels1,
 		},
-		Spec: v1alpha1.PipelineRunSpec{},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "Pipeline3",
+			},
+		},
 	}
 
 	// Add sample PipelineRuns
@@ -365,7 +390,7 @@ func TestPipelineRun(t *testing.T) {
 
 	// Test getAllPipelineRuns function with name query
 	// Sample request and response
-	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=PipelineRun1", nil)
+	httpReq = dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/ns1/pipelinerun?name=Pipeline2", nil)
 	req = dummyRestfulRequest(httpReq, "ns1", "")
 	httpWriter = httptest.NewRecorder()
 	resp = dummyRestfulResponse(httpWriter)
@@ -380,8 +405,8 @@ func TestPipelineRun(t *testing.T) {
 	if len(result.Items) != 1 {
 		t.Errorf("Number of PipelineRuns: expected: %d, returned: %d", 1, len(result.Items))
 	}
-	if result.Items[0].Name != "PipelineRun1" {
-		t.Errorf("PipelineRun1 is not returned: %s", result.Items[0].Name)
+	if result.Items[0].Name != "PipelineRun2" {
+		t.Errorf("PipelineRun2 is not returned: %s", result.Items[0].Name)
 	}
 
 	// Test getPipelineRun function


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

https://github.com/tektoncd/dashboard/issues/121

# Changes

Fix name filtering on task runs. The api at the moment cant handle the empty response and is filtering by the wrong field.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._]


@a-roberts Could I get a review please ? Thanks