### PR TITLE
Use name query parameters for pipeline and task run calls

### DIFF
--- a/src/actions/pipelineRuns.js
+++ b/src/actions/pipelineRuns.js
@@ -37,13 +37,13 @@ export function fetchPipelineRun(name) {
   };
 }
 
-export function fetchPipelineRuns() {
+export function fetchPipelineRuns(pipelineName) {
   return async (dispatch, getState) => {
     dispatch({ type: 'PIPELINE_RUNS_FETCH_REQUEST' });
     let pipelineRuns;
     try {
       const namespace = getSelectedNamespace(getState());
-      pipelineRuns = await getPipelineRuns(namespace);
+      pipelineRuns = await getPipelineRuns(namespace, pipelineName);
       dispatch(fetchPipelineRunsSuccess(pipelineRuns, namespace));
     } catch (error) {
       dispatch({ type: 'PIPELINE_RUNS_FETCH_FAILURE', error });

--- a/src/actions/taskRuns.js
+++ b/src/actions/taskRuns.js
@@ -22,13 +22,13 @@ export function fetchTaskRunsSuccess(data, namespace) {
   };
 }
 
-export function fetchTaskRuns() {
+export function fetchTaskRuns(taskName) {
   return async (dispatch, getState) => {
     dispatch({ type: 'TASK_RUNS_FETCH_REQUEST' });
     let taskRuns;
     try {
       const namespace = getSelectedNamespace(getState());
-      taskRuns = await getTaskRuns(namespace);
+      taskRuns = await getTaskRuns(namespace, taskName);
       dispatch(fetchTaskRunsSuccess(taskRuns, namespace));
     } catch (error) {
       dispatch({ type: 'TASK_RUNS_FETCH_FAILURE', error });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -24,7 +24,7 @@ export function getAPIRoot() {
 
 const apiRoot = getAPIRoot();
 
-export function getAPI(type, { name = '', namespace } = {}) {
+export function getAPI(type, { name = '', namespace } = {}, queryParams) {
   return [
     apiRoot,
     '/v1/namespaces/',
@@ -32,7 +32,8 @@ export function getAPI(type, { name = '', namespace } = {}) {
     '/',
     type,
     '/',
-    encodeURIComponent(name)
+    encodeURIComponent(name),
+    queryParams ? `?${new URLSearchParams(queryParams).toString()}` : ''
   ].join('');
 }
 
@@ -64,8 +65,12 @@ export function getPipeline(name, namespace) {
   return get(uri);
 }
 
-export function getPipelineRuns(namespace) {
-  const uri = getAPI('pipelinerun', { namespace });
+export function getPipelineRuns(namespace, pipelineName) {
+  let queryParams;
+  if (pipelineName) {
+    queryParams = { name: pipelineName };
+  }
+  const uri = getAPI('pipelinerun', { namespace }, queryParams);
   return get(uri).then(checkData);
 }
 
@@ -89,8 +94,12 @@ export function getTask(name, namespace) {
   return get(uri);
 }
 
-export function getTaskRuns(namespace) {
-  const uri = getAPI('taskrun', { namespace });
+export function getTaskRuns(namespace, taskName) {
+  let queryParams;
+  if (taskName) {
+    queryParams = { name: taskName };
+  }
+  const uri = getAPI('taskrun', { namespace }, queryParams);
   return get(uri).then(checkData);
 }
 

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -123,6 +123,18 @@ it('getPipelineRuns', () => {
   });
 });
 
+it('getPipelineRuns With Query Params', () => {
+  const pipelineName = 'pipelineName';
+  const data = {
+    items: 'pipelineRuns'
+  };
+  fetchMock.get(/pipelinerun/, data);
+  return getPipelineRuns(pipelineName).then(pipelineRuns => {
+    expect(pipelineRuns).toEqual(data.items);
+    fetchMock.restore();
+  });
+});
+
 it('getPipelineRun', () => {
   const pipelineRunName = 'foo';
   const data = { fake: 'pipelineRun' };
@@ -174,6 +186,18 @@ it('getTaskRuns', () => {
   };
   fetchMock.get(/taskrun/, data);
   return getTaskRuns().then(taskRuns => {
+    expect(taskRuns).toEqual(data.items);
+    fetchMock.restore();
+  });
+});
+
+it('getTaskRuns With Query Params', () => {
+  const taskName = 'taskName';
+  const data = {
+    items: 'taskRuns'
+  };
+  fetchMock.get(/taskrun/, data);
+  return getTaskRuns(taskName).then(taskRuns => {
     expect(taskRuns).toEqual(data.items);
     fetchMock.restore();
   });

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -35,7 +35,9 @@ import {
 
 export /* istanbul ignore next */ class PipelineRuns extends Component {
   async componentDidMount() {
-    this.props.fetchPipelineRuns();
+    const { params } = this.props.match;
+    const { pipelineName } = params;
+    this.props.fetchPipelineRuns(pipelineName);
   }
 
   render() {

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -66,13 +66,7 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   componentDidMount() {
     const { match } = this.props;
     const { taskName } = match.params;
-    Promise.all([
-      this.props.fetchTask(taskName),
-      this.props.fetchTaskRuns()
-    ]).then(() => {
-      this.setState({ loading: false });
-      this.loadTaskRuns();
-    });
+    this.fetchTaskAndRuns(taskName);
   }
 
   componentDidUpdate(prevProps) {
@@ -80,10 +74,7 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
     const { taskName } = match.params;
     if (taskName !== prevProps.match.params.taskName) {
       this.setState({ loading: true }); // eslint-disable-line
-      this.props.fetchTask(taskName).then(() => {
-        this.setState({ loading: false });
-        this.loadTaskRuns();
-      });
+      this.fetchTaskAndRuns(taskName);
     }
   }
 
@@ -122,6 +113,16 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
     }
     this.setState({ taskRuns, notification });
   };
+
+  fetchTaskAndRuns(taskName) {
+    Promise.all([
+      this.props.fetchTask(taskName),
+      this.props.fetchTaskRuns(taskName)
+    ]).then(() => {
+      this.setState({ loading: false });
+      this.loadTaskRuns();
+    });
+  }
 
   render() {
     const {


### PR DESCRIPTION
Use name query parameters to prevent components loading all task and pipeline runs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

https://github.com/tektoncd/dashboard/issues/133

# Changes

Updates the client to use query parameters fixed in https://github.com/tektoncd/dashboard/pull/122

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
