### PR TITLE
Fix task runs filtering for tasks without a taskRef

### DIFF
--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -409,7 +409,7 @@ func (r Resource) getAllTaskRuns(request *restful.Request, response *restful.Res
 		tmpItems := taskrunList.Items
 		taskrunList.Items = taskrunList.Items[:0]
 		for i := range tmpItems {
-			if tmpItems[i].Spec.TaskRef.Name == name {
+			if tmpItems[i].Spec.TaskRef != nil && tmpItems[i].Spec.TaskRef.Name == name {
 				taskrunList.Items = append(taskrunList.Items, tmpItems[i])
 			}
 		}

--- a/pkg/endpoints/pipeline_test.go
+++ b/pkg/endpoints/pipeline_test.go
@@ -186,11 +186,7 @@ func TestTaskRun(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "TaskRun1",
 		},
-		Spec: v1alpha1.TaskRunSpec{
-			TaskRef:        &v1alpha1.TaskRef{
-				Name: "Task1",
-			},
-		},
+		Spec: v1alpha1.TaskRunSpec{},
 
 	}
 	TaskRun2 := v1alpha1.TaskRun{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

https://github.com/tektoncd/dashboard/issues/149

Task run filtering by name would previously have failed where the were tasks in the namespace with no task ref. The test case is covered by having a combination of refless and task referenced task runs existing in the namespace being queried. It is impossible to filter an refless task run by task name.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
