### PR TITLE
Ensure node.js unit tests can fail the PR build

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -60,19 +60,19 @@ function get_node() {
 }
 
 function node_test() {
+  local failed=0
   echo "Running node tests from $(pwd)"
   mkdir ~/.npm-global
   npm config set prefix '~/.npm-global'
   export PATH=$PATH:$HOME/.npm-global/bin
-  npm ci # similar to `npm install` but ensures all versions from lock file
-  npm run test:ci
+  npm ci || failed=1 # similar to `npm install` but ensures all versions from lock file
+  npm run test:ci || failed=1
   echo ""
+  return ${failed}
 }
 
 function pre_unit_tests() {
-  local failed=0
-  node_test || failed=1
-  return ${failed}
+  node_test
 }
 
 function extra_initialization() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update presubmit-tests.sh such that a failure in either the
npm install or test scripts will cause the build to fail.

Previously the node_test function ended with an `echo ""`
meaning the exit code for that function was always 0 (success)
so any failures were ignored. This change ensures that a
failure in either step will return an error code from node_test

https://github.com/tektoncd/dashboard/issues/158

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
