### PR TITLE
Update redux actions and reducers to support all namespaces use case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10523,6 +10523,11 @@
       "resolved": "https://registry.npmjs.org/lodash.keyby/-/lodash.keyby-4.6.0.tgz",
       "integrity": "sha1-f2oavak/0k4icopNNh7YvLpaQ1Q="
     },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.13.0",
     "lodash.keyby": "^4.6.0",
+    "lodash.merge": "^4.6.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/src/actions/pipelineRuns.js
+++ b/src/actions/pipelineRuns.js
@@ -14,11 +14,10 @@ limitations under the License.
 import { getPipelineRun, getPipelineRuns } from '../api';
 import { getSelectedNamespace } from '../reducers';
 
-export function fetchPipelineRunsSuccess(data, namespace) {
+export function fetchPipelineRunsSuccess(data) {
   return {
     type: 'PIPELINE_RUNS_FETCH_SUCCESS',
-    data,
-    namespace
+    data
   };
 }
 
@@ -29,7 +28,7 @@ export function fetchPipelineRun({ name, namespace }) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       pipelineRun = await getPipelineRun(name, requestedNamespace);
-      dispatch(fetchPipelineRunsSuccess([pipelineRun], requestedNamespace));
+      dispatch(fetchPipelineRunsSuccess([pipelineRun]));
     } catch (error) {
       dispatch({ type: 'PIPELINE_RUNS_FETCH_FAILURE', error });
     }
@@ -44,7 +43,7 @@ export function fetchPipelineRuns({ pipelineName, namespace } = {}) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       pipelineRuns = await getPipelineRuns(requestedNamespace, pipelineName);
-      dispatch(fetchPipelineRunsSuccess(pipelineRuns, requestedNamespace));
+      dispatch(fetchPipelineRunsSuccess(pipelineRuns));
     } catch (error) {
       dispatch({ type: 'PIPELINE_RUNS_FETCH_FAILURE', error });
     }

--- a/src/actions/pipelineRuns.test.js
+++ b/src/actions/pipelineRuns.test.js
@@ -16,7 +16,11 @@ import thunk from 'redux-thunk';
 
 import * as API from '../api';
 import * as selectors from '../reducers';
-import { fetchPipelineRuns, fetchPipelineRunsSuccess } from './pipelineRuns';
+import {
+  fetchPipelineRun,
+  fetchPipelineRuns,
+  fetchPipelineRunsSuccess
+} from './pipelineRuns';
 
 it('fetchPipelineRunsSuccess', () => {
   const data = { fake: 'data' };
@@ -26,9 +30,9 @@ it('fetchPipelineRunsSuccess', () => {
   });
 });
 
-it('fetchPipelineRuns', async () => {
+it('fetchPipelineRun', async () => {
+  const pipelineRun = { fake: 'pipelineRun' };
   const namespace = 'default';
-  const pipelines = { fake: 'pipelines' };
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
@@ -36,11 +40,48 @@ it('fetchPipelineRuns', async () => {
   jest
     .spyOn(selectors, 'getSelectedNamespace')
     .mockImplementation(() => namespace);
+  jest.spyOn(API, 'getPipelineRun').mockImplementation(() => pipelineRun);
+
+  const expectedActions = [
+    { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
+    fetchPipelineRunsSuccess([pipelineRun])
+  ];
+
+  await store.dispatch(fetchPipelineRun({ name: 'foo' }));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchPipelineRun error', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const error = new Error();
+
+  jest.spyOn(API, 'getPipelineRun').mockImplementation(() => {
+    throw error;
+  });
+
+  const expectedActions = [
+    { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
+    { type: 'PIPELINE_RUNS_FETCH_FAILURE', error }
+  ];
+
+  await store.dispatch(fetchPipelineRun({ name: 'foo' }));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchPipelineRuns', async () => {
+  const pipelines = { fake: 'pipelines' };
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
   jest.spyOn(API, 'getPipelineRuns').mockImplementation(() => pipelines);
 
   const expectedActions = [
     { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
-    fetchPipelineRunsSuccess(pipelines, namespace)
+    fetchPipelineRunsSuccess(pipelines)
   ];
 
   await store.dispatch(fetchPipelineRuns());

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -14,11 +14,10 @@ limitations under the License.
 import { getPipeline, getPipelines } from '../api';
 import { getSelectedNamespace } from '../reducers';
 
-export function fetchPipelinesSuccess(data, namespace) {
+export function fetchPipelinesSuccess(data) {
   return {
     type: 'PIPELINES_FETCH_SUCCESS',
-    data,
-    namespace
+    data
   };
 }
 
@@ -29,7 +28,7 @@ export function fetchPipeline({ name, namespace }) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       pipeline = await getPipeline(name, requestedNamespace);
-      dispatch(fetchPipelinesSuccess([pipeline], requestedNamespace));
+      dispatch(fetchPipelinesSuccess([pipeline]));
     } catch (error) {
       dispatch({ type: 'PIPELINES_FETCH_FAILURE', error });
     }
@@ -44,7 +43,7 @@ export function fetchPipelines({ namespace } = {}) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       pipelines = await getPipelines(requestedNamespace);
-      dispatch(fetchPipelinesSuccess(pipelines, requestedNamespace));
+      dispatch(fetchPipelinesSuccess(pipelines));
     } catch (error) {
       dispatch({ type: 'PIPELINES_FETCH_FAILURE', error });
     }

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -44,7 +44,7 @@ it('fetchPipeline', async () => {
 
   const expectedActions = [
     { type: 'PIPELINES_FETCH_REQUEST' },
-    fetchPipelinesSuccess([pipeline], namespace)
+    fetchPipelinesSuccess([pipeline])
   ];
 
   await store.dispatch(fetchPipeline({ name: 'foo' }));
@@ -72,20 +72,16 @@ it('fetchPipeline error', async () => {
 });
 
 it('fetchPipelines', async () => {
-  const namespace = 'default';
   const pipelines = { fake: 'pipelines' };
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
 
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
   jest.spyOn(API, 'getPipelines').mockImplementation(() => pipelines);
 
   const expectedActions = [
     { type: 'PIPELINES_FETCH_REQUEST' },
-    fetchPipelinesSuccess(pipelines, namespace)
+    fetchPipelinesSuccess(pipelines)
   ];
 
   await store.dispatch(fetchPipelines());

--- a/src/actions/taskRuns.js
+++ b/src/actions/taskRuns.js
@@ -14,11 +14,10 @@ limitations under the License.
 import { getTaskRuns } from '../api';
 import { getSelectedNamespace } from '../reducers';
 
-export function fetchTaskRunsSuccess(data, namespace) {
+export function fetchTaskRunsSuccess(data) {
   return {
     type: 'TASK_RUNS_FETCH_SUCCESS',
-    data,
-    namespace
+    data
   };
 }
 
@@ -29,7 +28,7 @@ export function fetchTaskRuns({ taskName, namespace } = {}) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       taskRuns = await getTaskRuns(requestedNamespace, taskName);
-      dispatch(fetchTaskRunsSuccess(taskRuns, requestedNamespace));
+      dispatch(fetchTaskRunsSuccess(taskRuns));
     } catch (error) {
       dispatch({ type: 'TASK_RUNS_FETCH_FAILURE', error });
     }

--- a/src/actions/taskRuns.test.js
+++ b/src/actions/taskRuns.test.js
@@ -40,7 +40,7 @@ it('fetchTaskRuns', async () => {
 
   const expectedActions = [
     { type: 'TASK_RUNS_FETCH_REQUEST' },
-    fetchTaskRunsSuccess(tasks, namespace)
+    fetchTaskRunsSuccess(tasks)
   ];
 
   await store.dispatch(fetchTaskRuns());

--- a/src/actions/tasks.js
+++ b/src/actions/tasks.js
@@ -14,11 +14,10 @@ limitations under the License.
 import { getTask, getTasks } from '../api';
 import { getSelectedNamespace } from '../reducers';
 
-export function fetchTasksSuccess(data, namespace) {
+export function fetchTasksSuccess(data) {
   return {
     type: 'TASKS_FETCH_SUCCESS',
-    data,
-    namespace
+    data
   };
 }
 
@@ -29,7 +28,7 @@ export function fetchTask({ name, namespace }) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       task = await getTask(name, requestedNamespace);
-      dispatch(fetchTasksSuccess([task], requestedNamespace));
+      dispatch(fetchTasksSuccess([task]));
     } catch (error) {
       dispatch({ type: 'TASKS_FETCH_FAILURE', error });
     }
@@ -44,7 +43,7 @@ export function fetchTasks({ namespace } = {}) {
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
       tasks = await getTasks(requestedNamespace);
-      dispatch(fetchTasksSuccess(tasks, requestedNamespace));
+      dispatch(fetchTasksSuccess(tasks));
     } catch (error) {
       dispatch({ type: 'TASKS_FETCH_FAILURE', error });
     }

--- a/src/actions/tasks.test.js
+++ b/src/actions/tasks.test.js
@@ -40,7 +40,7 @@ it('fetchTask', async () => {
 
   const expectedActions = [
     { type: 'TASKS_FETCH_REQUEST' },
-    fetchTasksSuccess([task], namespace)
+    fetchTasksSuccess([task])
   ];
 
   await store.dispatch(fetchTask({ name: 'foo' }));
@@ -77,19 +77,15 @@ it('fetchTasksSuccess', () => {
 
 it('fetchTasks', async () => {
   const tasks = { fake: 'tasks' };
-  const namespace = 'default';
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
 
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
   jest.spyOn(API, 'getTasks').mockImplementation(() => tasks);
 
   const expectedActions = [
     { type: 'TASKS_FETCH_REQUEST' },
-    fetchTasksSuccess(tasks, namespace)
+    fetchTasksSuccess(tasks)
   ];
 
   await store.dispatch(fetchTasks());

--- a/src/api/comms.test.js
+++ b/src/api/comms.test.js
@@ -38,7 +38,7 @@ describe('checkStatus', () => {
     const json = jest.fn(() => data);
     expect(checkStatus({ ok: true, json })).toEqual(data);
   });
-  
+
   it('returns headers on successful create', () => {
     const status = 201;
     const headers = { fake: 'headers' };

--- a/src/reducers/pipelineRuns.js
+++ b/src/reducers/pipelineRuns.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
+import merge from 'lodash.merge';
 
 function byId(state = {}, action) {
   switch (action.type) {
@@ -26,17 +27,16 @@ function byId(state = {}, action) {
 function byNamespace(state = {}, action) {
   switch (action.type) {
     case 'PIPELINE_RUNS_FETCH_SUCCESS':
-      const { namespace } = action;
-      const pipelineRuns = state[namespace] || {};
-      action.data.forEach(pipelineRun => {
-        const { name, uid } = pipelineRun.metadata;
-        pipelineRuns[name] = uid;
-      });
+      const namespaces = action.data.reduce((accumulator, pipelineRun) => {
+        const { name, namespace, uid } = pipelineRun.metadata;
+        return merge(accumulator, {
+          [namespace]: {
+            [name]: uid
+          }
+        });
+      }, {});
 
-      return {
-        ...state,
-        [namespace]: pipelineRuns
-      };
+      return merge({}, state, namespaces);
     default:
       return state;
   }

--- a/src/reducers/pipelines.js
+++ b/src/reducers/pipelines.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
+import merge from 'lodash.merge';
 
 function byId(state = {}, action) {
   switch (action.type) {
@@ -26,17 +27,16 @@ function byId(state = {}, action) {
 function byNamespace(state = {}, action) {
   switch (action.type) {
     case 'PIPELINES_FETCH_SUCCESS':
-      const { namespace } = action;
-      const pipelines = state[namespace] || {};
-      action.data.forEach(pipeline => {
-        const { name, uid } = pipeline.metadata;
-        pipelines[name] = uid;
-      });
+      const namespaces = action.data.reduce((accumulator, pipeline) => {
+        const { name, namespace, uid } = pipeline.metadata;
+        return merge(accumulator, {
+          [namespace]: {
+            [name]: uid
+          }
+        });
+      }, {});
 
-      return {
-        ...state,
-        [namespace]: pipelines
-      };
+      return merge({}, state, namespaces);
     default:
       return state;
   }

--- a/src/reducers/taskRuns.js
+++ b/src/reducers/taskRuns.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
+import merge from 'lodash.merge';
 
 function byId(state = {}, action) {
   switch (action.type) {
@@ -26,17 +27,16 @@ function byId(state = {}, action) {
 function byNamespace(state = {}, action) {
   switch (action.type) {
     case 'TASK_RUNS_FETCH_SUCCESS':
-      const { namespace } = action;
-      const taskRuns = state[namespace] || {};
-      action.data.forEach(taskRun => {
-        const { name, uid } = taskRun.metadata;
-        taskRuns[name] = uid;
-      });
+      const namespaces = action.data.reduce((accumulator, taskRun) => {
+        const { name, namespace, uid } = taskRun.metadata;
+        return merge(accumulator, {
+          [namespace]: {
+            [name]: uid
+          }
+        });
+      }, {});
 
-      return {
-        ...state,
-        [namespace]: taskRuns
-      };
+      return merge({}, state, namespaces);
     default:
       return state;
   }

--- a/src/reducers/tasks.js
+++ b/src/reducers/tasks.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
+import merge from 'lodash.merge';
 
 function byId(state = {}, action) {
   switch (action.type) {
@@ -26,17 +27,16 @@ function byId(state = {}, action) {
 function byNamespace(state = {}, action) {
   switch (action.type) {
     case 'TASKS_FETCH_SUCCESS':
-      const { namespace } = action;
-      const tasks = state[namespace] || {};
-      action.data.forEach(task => {
-        const { name, uid } = task.metadata;
-        tasks[name] = uid;
-      });
+      const namespaces = action.data.reduce((accumulator, task) => {
+        const { name, namespace, uid } = task.metadata;
+        return merge(accumulator, {
+          [namespace]: {
+            [name]: uid
+          }
+        });
+      }, {});
 
-      return {
-        ...state,
-        [namespace]: tasks
-      };
+      return merge({}, state, namespaces);
     default:
       return state;
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/166

Update to support retrieving data from 'all namespaces':
- Remove namespace from the 'success' actions as the data may come from multiple namespaces
- Update reducers to read namespace from resource metadata

We do not yet expose an 'all namespaces' option in the UI, further work at API level required before that can be implemented.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
