### PR TITLE
Add a ServiceAccounts dropdown component

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,14 +19,14 @@ You must install these tools:
 1. [`dep`](https://github.com/golang/dep): For managing external Go dependencies. - Please Install dep v0.5.0 or greater.
 1. [`ko`](https://github.com/google/ko): For development. `ko` version v0.1 or higher is required for `dashboard` to work correctly.
 1. [Node.js & npm](https://nodejs.org/): For building and running the frontend locally. See `engines` in [package.json](./package.json) for versions used.
-1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For interacting with your kube cluster. 
-   
+1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For interacting with your kube cluster.
+
 Your [`$GOPATH`] setting is critical for `ko apply` to function properly: a
 successful run will typically involve building pushing images instead of only
 configuring Kubernetes resources.
 
 Note that there exists a bug in certain versions of `kubectl` whereby the `auth` field is missing from created secrets. Known good versions we've tested are __1.11.3__ and __1.13.2__.
-   
+
 ### Checkout your fork
 
 The Go tools require that you clone the repository to the
@@ -215,6 +215,14 @@ Returns HTTP code 200 and a list of namespaces in the cluster
 Returns HTTP code 404 if an error occurred getting the namespaces
 ```
 
+__Service Accounts__
+```
+GET /v1/namespaces/<namespace>/serviceaccounts
+Get all ServiceAccounts
+Returns HTTP code 200 and a list of ServiceAccounts in the cluster
+Returns HTTP code 404 if an error occurred getting the ServiceAccounts
+```
+
 __Pipelines__
 ```
 GET /v1/namespaces/<namespace>/pipelines
@@ -246,13 +254,13 @@ __Tasks__
 ```
 GET /v1/namespaces/<namespace>/tasks
 Get all Tekton tasks
-Returns HTTP code 200 and a list of Tasks in the given namespace 
+Returns HTTP code 200 and a list of Tasks in the given namespace
 Returns HTTP code 404 if an error occurred getting the Task list
 
 GET /v1/namespaces/<namespace>/tasks/<task-name>
 Get a Tekton Task by name
 Returns HTTP code 200 and the given Task in the given namespace if found
-Returns HTTP code 404 if an error occurred getting the TaskRun 
+Returns HTTP code 404 if an error occurred getting the TaskRun
 ```
 
 __TaskRuns__
@@ -260,26 +268,26 @@ __TaskRuns__
 GET /v1/namespaces/<namespace>/taskruns
 Get all Tekton TaskRuns
 Get all Tekton TaskRuns, also supports '?name=<task-name>' querying
-Returns HTTP code 200 and a list of TaskRuns in the given namespace 
+Returns HTTP code 200 and a list of TaskRuns in the given namespace
 Returns HTTP code 404 if an error occurred getting the TaskRun list
 
 GET /v1/namespaces/<namespace>/taskruns/<taskrun-name>
 Get a Tekton TaskRun by name
 Returns HTTP code 200 and the given TaskRun in the given namespace if found
-Returns HTTP code 404 if an error occurred getting the TaskRun 
+Returns HTTP code 404 if an error occurred getting the TaskRun
 ```
 
 __PipelineResources__
 ```
 GET /v1/namespaces/<namespace>/pipelineresources
 Get all Tekton PipelineResources
-Returns HTTP code 200 and a list of PipelineResources in the given namespace 
+Returns HTTP code 200 and a list of PipelineResources in the given namespace
 Returns HTTP code 404 if an error occurred getting the PipelineResource list
 
 GET /v1/namespaces/<namespace>/pipelineresources/<pipelineresource-name>
 Get a Tekton PipelineResource by name
 Returns HTTP code 200 and the given PipelineResource in the given namespace if found
-Returns HTTP code 404 if an error occurred getting the PipelineResource 
+Returns HTTP code 404 if an error occurred getting the PipelineResource
 ```
 
 __Logs__
@@ -357,7 +365,7 @@ Returns HTTP code 200 and the given credential as a Kubernetes secret in the giv
 
 __Knative__
 ```
-GET /v1/namespaces/<namespace>/knative/installstatus                     
+GET /v1/namespaces/<namespace>/knative/installstatus
 Get the install status of a Knative resource group.
 The request body should contain the resource group to check for. Shorthand values are accepted for Knative serving and eventing-sources: use ("component": "serving" or "eventing-sources"). Any Kubernetes group can be used too, for example: `extensions/v1beta1`
 
@@ -382,7 +390,7 @@ __Credentials__
 ```
 POST /v1/namespaces/<namespace>/credentials
 Create a new credential
-Request body must contain a name and type ('accesstoken' or 'userpass'). They may contain a description and the URL that the credential will be used for (e.g. the Git server). It can also include serviceAccount that gets patched with the secret. Accesstokens must contain an 'accesstoken' and type userpass must contain 'username' and 'password'. 
+Request body must contain a name and type ('accesstoken' or 'userpass'). They may contain a description and the URL that the credential will be used for (e.g. the Git server). It can also include serviceAccount that gets patched with the secret. Accesstokens must contain an 'accesstoken' and type userpass must contain 'username' and 'password'.
 
 Returns HTTP code 201 if the credential was created OK and sets the 'Content-Location' header
 Returns HTTP code 400 if a bad request was provided
@@ -398,7 +406,7 @@ Example POSTs (non-trivial as it involves the URL map):
     "type": "userpass",
     "description": "my secret for github",
     "url": {"tekton.dev/git-0": "https://github.com"}
-    "serviceAccount": "sa1"    
+    "serviceAccount": "sa1"
 }
 
 {
@@ -412,7 +420,7 @@ __PipelineRuns__
 ```
 POST /v1/namespaces/<namespace>/pipelineruns
 Creates a new manual PipelineRun based on a specified Pipeline
-Request body must contain pipelinename for the Pipeline to run 
+Request body must contain pipelinename for the Pipeline to run
 
 Optional parameters listed below may be provided in the request body depending on requirements of the Pipeline:
 
@@ -431,7 +439,7 @@ Returns HTTP code 201 if the PipelineRun was created successfully
 Returns HTTP code 400 if a bad request was provided
 Returns HTTP code 412 if the Pipeline to create the PipelineRun could not be found
 
-Example POST - for a Pipeline that clones a repository from GitHub and pushes to Dockerhub using a configured secret 
+Example POST - for a Pipeline that clones a repository from GitHub and pushes to Dockerhub using a configured secret
 {
     "pipelinename": "mypipeline",
     "serviceaccount": "tekton-pipelines",
@@ -448,7 +456,7 @@ __PUT endpoints__
 
 __Credentials__
 ```
-PUT /v1/namespaces/<namespace>/credentials/<id>                          
+PUT /v1/namespaces/<namespace>/credentials/<id>
 Update credential by ID
 Request body must contain id, username, password, type ('accesstoken' or 'userpass'), description and the URL that the credential will be used for (e.g. the Git server)
 Returns HTTP code 204 if the credential was updated OK (no contents are provided in the response)
@@ -459,11 +467,11 @@ __PipelineRuns__
 ```
 PUT /v1/namespaces/<namespace>/pipelineruns/<pipelinerun-name>
 Update pipelinerun status
-Request body must contain desired status ("status": "PipelineRunCancelled" to cancel a running one). 
+Request body must contain desired status ("status": "PipelineRunCancelled" to cancel a running one).
 
 Returns HTTP code 204 if the PipelineRun was cancelled successfully (no contents are provided in the response)
 Returns HTTP code 400 if a bad request was used
-Returns HTTP code 404 if the requested PipelineRun could not be found 
+Returns HTTP code 404 if the requested PipelineRun could not be found
 Returns HTTP code 412 if the status was already set to that
 Returns HTTP code 500 if the PipelineRun could not be stopped (an error has occurred when updating the PipelineRun)
 ```
@@ -481,7 +489,7 @@ Returns HTTP code 500 if the found credential could not be deleted
 ```
 
 
-## Extension 
+## Extension
 
 __Backend__
 

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -14,11 +14,11 @@ limitations under the License.
 package endpoints
 
 import (
+	"net/http"
+
 	"github.com/emicklei/go-restful"
 	"github.com/tektoncd/dashboard/pkg/logging"
 	"github.com/tektoncd/dashboard/pkg/utils"
-	"net/http"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,4 +32,18 @@ func (r Resource) getAllNamespaces(request *restful.Request, response *restful.R
 	}
 	logging.Log.Debugf("Found namespaces: %s", namespaces)
 	response.WriteEntity(namespaces)
+}
+
+func (r Resource) getAllServiceAccounts(request *restful.Request, response *restful.Response) {
+	requestNamespace := request.PathParameter("namespace")
+
+	serviceAccounts, err := r.K8sClient.CoreV1().ServiceAccounts(requestNamespace).List(metav1.ListOptions{})
+	logging.Log.Debugf("In getAllServiceAccounts")
+
+	if err != nil {
+		utils.RespondError(response, err, http.StatusNotFound)
+		return
+	}
+	logging.Log.Debugf("Found service accounts: %s", serviceAccounts)
+	response.WriteEntity(serviceAccounts)
 }

--- a/pkg/endpoints/cluster_test.go
+++ b/pkg/endpoints/cluster_test.go
@@ -46,3 +46,31 @@ func TestGetAllNamespaces(t *testing.T) {
 		t.Errorf("%s is not returned: %s, %s", namespace, result.Items[0].Name, result.Items[1].Name)
 	}
 }
+
+func TestGetAllServiceAccounts(t *testing.T) {
+
+	r := dummyResource()
+
+	namespace := "test-namespace"
+	r.K8sClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+
+	serviceAccount := "test-sa"
+	r.K8sClient.CoreV1().ServiceAccounts(namespace).Create(&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: serviceAccount}})
+
+	httpReq := dummyHTTPRequest("GET", "http://wwww.dummy.com:8383/v1/namespaces/test-namespace/serviceaccount", nil)
+	req := dummyRestfulRequest(httpReq, "", "")
+	httpWriter := httptest.NewRecorder()
+	resp := dummyRestfulResponse(httpWriter)
+
+	r.getAllServiceAccounts(req, resp)
+
+	result := corev1.ServiceAccountList{}
+	json.NewDecoder(httpWriter.Body).Decode(&result)
+
+	if len(result.Items) != 1 {
+		t.Errorf("Number of service accounts: expected: %d, returned: %d", 1, len(result.Items))
+	}
+	if result.Items[0].Name != serviceAccount {
+		t.Errorf("%s is not returned: %s, %s", serviceAccount, result.Items[0].Name, result.Items[1].Name)
+	}
+}

--- a/pkg/endpoints/router.go
+++ b/pkg/endpoints/router.go
@@ -79,6 +79,8 @@ func (r Resource) RegisterEndpoints(container *restful.Container) {
 	wsv1.Route(wsv1.GET("/{namespace}/taskruns").To(r.getAllTaskRuns))
 	wsv1.Route(wsv1.GET("/{namespace}/taskruns/{name}").To(r.getTaskRun))
 
+	wsv1.Route(wsv1.GET("/{namespace}/serviceaccounts").To(r.getAllServiceAccounts))
+
 	wsv1.Route(wsv1.GET("/{namespace}/logs/{name}").To(r.getPodLog))
 
 	wsv1.Route(wsv1.GET("/{namespace}/taskrunlogs/{name}").To(r.getTaskRunLog))

--- a/src/actions/serviceAccounts.js
+++ b/src/actions/serviceAccounts.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { getServiceAccounts } from '../api';
+import { getSelectedNamespace } from '../reducers';
+
+export function fetchServiceAccountsSuccess(data) {
+  return {
+    type: 'SERVICE_ACCOUNTS_FETCH_SUCCESS',
+    data
+  };
+}
+
+export function fetchServiceAccounts({ namespace } = {}) {
+  return async (dispatch, getState) => {
+    dispatch({ type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' });
+    let serviceAccounts;
+    try {
+      const requestedNamespace = namespace || getSelectedNamespace(getState());
+      serviceAccounts = await getServiceAccounts(requestedNamespace);
+      dispatch(fetchServiceAccountsSuccess(serviceAccounts));
+    } catch (error) {
+      dispatch({ type: 'SERVICE_ACCOUNTS_FETCH_FAILURE', error });
+    }
+    return serviceAccounts;
+  };
+}

--- a/src/actions/serviceAccounts.test.js
+++ b/src/actions/serviceAccounts.test.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as API from '../api';
+import * as selectors from '../reducers';
+import {
+  fetchServiceAccounts,
+  fetchServiceAccountsSuccess
+} from './serviceAccounts';
+
+it('fetchServiceAccountsSuccess', () => {
+  const data = { fake: 'data' };
+  expect(fetchServiceAccountsSuccess(data)).toEqual({
+    type: 'SERVICE_ACCOUNTS_FETCH_SUCCESS',
+    data
+  });
+});
+
+it('fetchServiceAccounts', async () => {
+  const namespace = 'default';
+  const serviceAccounts = { fake: 'serviceAccounts' };
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  jest
+    .spyOn(selectors, 'getSelectedNamespace')
+    .mockImplementation(() => namespace);
+  jest
+    .spyOn(API, 'getServiceAccounts')
+    .mockImplementation(() => serviceAccounts);
+
+  const expectedActions = [
+    { type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' },
+    fetchServiceAccountsSuccess(serviceAccounts)
+  ];
+
+  await store.dispatch(fetchServiceAccounts());
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchServiceAccounts error', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const error = new Error();
+
+  jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => {
+    throw error;
+  });
+
+  const expectedActions = [
+    { type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' },
+    { type: 'SERVICE_ACCOUNTS_FETCH_FAILURE', error }
+  ];
+
+  await store.dispatch(fetchServiceAccounts());
+  expect(store.getActions()).toEqual(expectedActions);
+});

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -167,3 +167,8 @@ export function getNamespaces() {
   const uri = `${apiRoot}/v1/namespaces`;
   return get(uri).then(checkData);
 }
+
+export function getServiceAccounts(namespace) {
+  const uri = getAPI('serviceaccounts', { namespace });
+  return get(uri).then(checkData);
+}

--- a/src/components/TooltipDropdown/TooltipDropdown.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Dropdown, DropdownSkeleton } from 'carbon-components-react';
+
+const itemToElement = ({ text }) => {
+  return (
+    <div key={text} title={text}>
+      {text}
+    </div>
+  );
+};
+
+const itemToString = ({ text }) => text;
+
+const itemStringToObject = text => ({ text });
+
+const TooltipDropdown = ({ items, loading, ...dropdownProps }) => {
+  if (loading) {
+    return <DropdownSkeleton {...dropdownProps} />;
+  }
+  const options = items.map(itemStringToObject);
+  return (
+    <Dropdown
+      {...dropdownProps}
+      itemToElement={itemToElement}
+      items={options}
+      itemToString={itemToString}
+    />
+  );
+};
+
+TooltipDropdown.defaultProps = {
+  items: [],
+  loading: true
+};
+
+export default TooltipDropdown;

--- a/src/components/TooltipDropdown/TooltipDropdown.stories.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.stories.js
@@ -12,26 +12,21 @@ limitations under the License.
 */
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { storiesOf } from '@storybook/react';
 
-import TooltipDropdown from '../../components/TooltipDropdown';
-import { getNamespaces, isFetchingNamespaces } from '../../reducers';
+import TooltipDropdown from './TooltipDropdown';
 
-const NamespacesDropdown = props => {
-  return <TooltipDropdown {...props} />;
+const props = {
+  id: 'tooltip-dropdown-id',
+  label: 'Select an item',
+  items: ['item 1', 'item 2', 'item 3'],
+  loading: false
 };
 
-NamespacesDropdown.defaultProps = {
-  items: [],
-  loading: true,
-  label: 'Select Namespace'
-};
-
-function mapStateToProps(state) {
-  return {
-    items: getNamespaces(state),
-    loading: isFetchingNamespaces(state)
-  };
-}
-
-export default connect(mapStateToProps)(NamespacesDropdown);
+storiesOf('TooltipDropdown', module)
+  .add('default', () => {
+    return <TooltipDropdown {...props} />;
+  })
+  .add('loading', () => {
+    return <TooltipDropdown {...props} loading />;
+  });

--- a/src/components/TooltipDropdown/TooltipDropdown.test.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.test.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import TooltipDropdown from './TooltipDropdown';
+
+const props = {
+  id: 'tooltip-dropdown-id',
+  label: 'select an item',
+  items: ['item 1', 'item 2', 'item 3'],
+  loading: false
+};
+
+it('TooltipDropdown renders', () => {
+  const { getByText, queryByText } = render(<TooltipDropdown {...props} />);
+  expect(queryByText(/select an item/i)).toBeTruthy();
+  fireEvent.click(getByText(/select an item/i));
+  props.items.forEach(item => {
+    const re = new RegExp(item, 'i');
+    expect(queryByText(re)).toBeTruthy();
+  });
+  fireEvent.click(getByText(/item 1/i));
+  expect(queryByText(/item 1/i)).toBeTruthy();
+  expect(queryByText(/select an item/i)).toBeFalsy();
+});
+
+it('TooltipDropdown renders loading skeleton', () => {
+  const { queryByText } = render(<TooltipDropdown {...props} loading />);
+  expect(queryByText(/select an item/i)).toBeFalsy();
+});
+
+it('TooltipDropdown handles onChange event', () => {
+  const onChange = jest.fn();
+  const { getByText } = render(
+    <TooltipDropdown {...props} onChange={onChange} />
+  );
+  fireEvent.click(getByText(/select an item/i));
+  fireEvent.click(getByText(/item 1/i));
+  expect(onChange).toHaveBeenCalledTimes(1);
+});

--- a/src/components/TooltipDropdown/index.js
+++ b/src/components/TooltipDropdown/index.js
@@ -11,12 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
-export { default as NamespacesDropdown } from './NamespacesDropdown';
-export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';
+export { default } from './TooltipDropdown';

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -36,10 +36,10 @@ import {
   PipelineRuns,
   Pipelines,
   Tasks,
-  TaskRuns
+  TaskRuns,
+  NamespacesDropdown
 } from '..';
 
-import NamespacesDropdown from '../NamespacesDropdown';
 import SideNavMenu from '../../components/SideNavMenu';
 import Header from '../../components/Header';
 import Breadcrumbs from '../../components/Breadcrumbs';

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -25,7 +25,8 @@ it('App renders successfully without extensions', () => {
   const store = mockStore({
     extensions: { byName: {} },
     namespaces: { byName: {} },
-    pipelines: { byNamespace: {} }
+    pipelines: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -47,7 +48,8 @@ it('App renders successfully with extensions', () => {
   const store = mockStore({
     extensions: { byName: {} },
     namespaces: { byName: {} },
-    pipelines: { byNamespace: {} }
+    pipelines: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
   });
   const { queryByText } = render(
     <Provider store={store}>

--- a/src/containers/Extension/actions.js
+++ b/src/containers/Extension/actions.js
@@ -1,3 +1,4 @@
 export { fetchNamespaces } from '../../actions/namespaces';
 export { fetchPipeline, fetchPipelines } from '../../actions/pipelines';
 export { fetchTask, fetchTasks } from '../../actions/tasks';
+export { fetchServiceAccounts } from '../../actions/serviceAccounts';

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.stories.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.stories.js
@@ -21,6 +21,7 @@ import thunk from 'redux-thunk';
 import NamespacesDropdown from './NamespacesDropdown';
 
 const props = {
+  id: 'namespaces dropdown',
   onChange: action('onChange')
 };
 
@@ -44,11 +45,7 @@ storiesOf('NamespacesDropdown', module)
     });
     return (
       <Provider store={store}>
-        <NamespacesDropdown
-          {...props}
-          titleText="Namespace"
-          label="Namespace"
-        />
+        <NamespacesDropdown {...props} />
       </Provider>
     );
   })

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import {
+  getServiceAccounts,
+  isFetchingServiceAccounts,
+  getSelectedNamespace
+} from '../../reducers';
+import { fetchServiceAccounts } from '../../actions/serviceAccounts';
+import TooltipDropdown from '../../components/TooltipDropdown';
+
+class ServiceAccountsDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedItem: ''
+    };
+
+    this.onChange = this.onChange.bind(this);
+    this.resetSelectedItem = this.resetSelectedItem.bind(this);
+  }
+
+  componentDidMount() {
+    this.props.fetchServiceAccounts();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { namespace } = this.props;
+    if (namespace !== prevProps.namespace) {
+      this.props.fetchServiceAccounts();
+      this.resetSelectedItem();
+    }
+  }
+
+  onChange({ selectedItem }) {
+    this.setState({
+      selectedItem
+    });
+    if (this.props.onChange) {
+      this.props.onChange({ selectedItem });
+    }
+  }
+
+  resetSelectedItem() {
+    const prevSelectedItem = this.state.selectedItem;
+    this.setState({
+      selectedItem: ''
+    });
+    if (prevSelectedItem !== '' && this.props.onChange) {
+      this.props.onChange({ selectedItem: '' });
+    }
+  }
+
+  render() {
+    return (
+      <TooltipDropdown
+        {...this.props}
+        selectedItem={this.state.selectedItem}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+ServiceAccountsDropdown.defaultProps = {
+  items: [],
+  loading: true,
+  label: 'Select ServiceAccount'
+};
+
+function mapStateToProps(state) {
+  return {
+    items: getServiceAccounts(state).map(sa => sa.metadata.name),
+    loading: isFetchingServiceAccounts(state),
+    namespace: getSelectedNamespace(state)
+  };
+}
+
+const mapDispatchToProps = {
+  fetchServiceAccounts
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ServiceAccountsDropdown);

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.stories.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.stories.js
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import ServiceAccountsDropdown from './ServiceAccountsDropdown';
+
+const props = {
+  id: 'service accounts dropdown',
+  onChange: action('onChange')
+};
+
+const serviceAccountsByNamespace = {
+  default: {
+    default: 'id-default',
+    'service-account-1': 'id-service-account-1',
+    'service-account-2': 'id-service-account-2',
+    'service-account-3': 'id-service-account-3'
+  }
+};
+
+const serviceAccountsById = {
+  'id-default': {
+    metadata: {
+      name: 'default',
+      namespace: 'default',
+      uid: 'id-default'
+    }
+  },
+  'id-service-account-1': {
+    metadata: {
+      name: 'service-account-1',
+      namespace: 'default',
+      uid: 'id-service-account-1'
+    }
+  },
+  'id-service-account-2': {
+    metadata: {
+      name: 'service-account-2',
+      namespace: 'default',
+      uid: 'id-service-account-2'
+    }
+  },
+  'id-service-account-3': {
+    metadata: {
+      name: 'service-account-3',
+      namespace: 'default',
+      uid: 'id-service-account-3'
+    }
+  }
+};
+
+const namespacesByName = {
+  default: '',
+  'kube-public': '',
+  'kube-system': '',
+  'tekton-pipelines': ''
+};
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+storiesOf('ServiceAccountsDropdown', module)
+  .add('default', () => {
+    const store = mockStore({
+      serviceAccounts: {
+        byId: serviceAccountsById,
+        byNamespace: serviceAccountsByNamespace,
+        isFetching: false
+      },
+      namespaces: {
+        byName: namespacesByName,
+        selected: 'default'
+      }
+    });
+    return (
+      <Provider store={store}>
+        <ServiceAccountsDropdown {...props} />
+      </Provider>
+    );
+  })
+  .add('loading', () => {
+    const store = mockStore({
+      serviceAccounts: {
+        byId: serviceAccountsById,
+        byNamespace: serviceAccountsByNamespace,
+        isFetching: true
+      },
+      namespaces: {
+        byName: namespacesByName,
+        selected: 'default'
+      }
+    });
+    return (
+      <Provider store={store}>
+        <ServiceAccountsDropdown {...props} />
+      </Provider>
+    );
+  });

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -1,0 +1,279 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import ServiceAccountsDropdown from './ServiceAccountsDropdown';
+import * as API from '../../api';
+
+const props = {
+  id: 'service-accounts-dropdown'
+};
+
+const serviceAccountsByNamespace = {
+  default: {
+    default: 'id-default',
+    'service-account-1': 'id-service-account-1',
+    'service-account-2': 'id-service-account-2'
+  },
+  green: {
+    'service-account-3': 'id-service-account-3'
+  }
+};
+
+const serviceAccountsById = {
+  'id-default': {
+    metadata: {
+      name: 'default',
+      namespace: 'default',
+      uid: 'id-default'
+    }
+  },
+  'id-service-account-1': {
+    metadata: {
+      name: 'service-account-1',
+      namespace: 'default',
+      uid: 'id-service-account-1'
+    }
+  },
+  'id-service-account-2': {
+    metadata: {
+      name: 'service-account-2',
+      namespace: 'default',
+      uid: 'id-service-account-2'
+    }
+  },
+  'id-service-account-3': {
+    metadata: {
+      name: 'service-account-3',
+      namespace: 'green',
+      uid: 'id-service-account-3'
+    }
+  }
+};
+
+const namespacesByName = {
+  default: '',
+  green: '',
+  blue: ''
+};
+
+const initialTextRegExp = new RegExp('select serviceaccount', 'i');
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+beforeEach(() => {
+  jest
+    .spyOn(API, 'getServiceAccounts')
+    .mockImplementation(() => serviceAccountsById);
+});
+
+it('ServiceAccountsDropdown renders items based on Redux state', () => {
+  const store = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'default'
+    }
+  });
+  const { getByText, queryByText } = render(
+    <Provider store={store}>
+      <ServiceAccountsDropdown {...props} />
+    </Provider>
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  Object.keys(serviceAccountsByNamespace.default).forEach(item => {
+    const re = new RegExp(item, 'i');
+    expect(queryByText(re)).toBeTruthy();
+  });
+  fireEvent.click(getByText(/service-account-1/i));
+  Object.keys(serviceAccountsByNamespace.default).forEach(item => {
+    if (item !== 'service-account-1') {
+      const re = new RegExp(item, 'i');
+      expect(queryByText(re)).toBeFalsy();
+    }
+  });
+  expect(queryByText(/service-account-1/i)).toBeTruthy();
+  expect(queryByText(initialTextRegExp)).toBeFalsy();
+});
+
+it('ServiceAccountsDropdown renders items based on Redux state when namespace changes', () => {
+  const store = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'default'
+    }
+  });
+  const { container, getByText, queryByText } = render(
+    <Provider store={store}>
+      <ServiceAccountsDropdown {...props} />
+    </Provider>
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  Object.keys(serviceAccountsByNamespace.default).forEach(item => {
+    const re = new RegExp(item, 'i');
+    expect(queryByText(re)).toBeTruthy();
+  });
+  fireEvent.click(getByText('service-account-1'));
+  expect(queryByText(/service-account-1/i)).toBeTruthy();
+  expect(queryByText(initialTextRegExp)).toBeFalsy();
+
+  // Change selected namespace to verify the ServiceAccounts Dropdown updates items accordingly
+  // selected item 'service-account-1' should be reset to ''
+  const newStore = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'green'
+    }
+  });
+  render(
+    <Provider store={newStore}>
+      <ServiceAccountsDropdown {...props} />
+    </Provider>,
+    { container }
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  Object.keys(serviceAccountsByNamespace.green).forEach(item => {
+    const re = new RegExp(item, 'i');
+    expect(queryByText(re)).toBeTruthy();
+  });
+  Object.keys(serviceAccountsByNamespace.default).forEach(item => {
+    const re = new RegExp(item, 'i');
+    expect(queryByText(re)).toBeFalsy();
+  });
+  fireEvent.click(getByText('service-account-3'));
+  expect(queryByText(/service-account-3/i)).toBeTruthy();
+  expect(queryByText(initialTextRegExp)).toBeFalsy();
+});
+
+it('ServiceAccountsDropdown renders loading skeleton based on Redux state', () => {
+  const store = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: true
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'default'
+    }
+  });
+  const { queryByText } = render(
+    <Provider store={store}>
+      <ServiceAccountsDropdown {...props} fetchServiceAccounts={() => {}} />
+    </Provider>
+  );
+  expect(queryByText(initialTextRegExp)).toBeFalsy();
+});
+
+it('ServiceAccountsDropdown handles onChange event', () => {
+  const store = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'default'
+    }
+  });
+  const onChange = jest.fn();
+  const { getByText } = render(
+    <Provider store={store}>
+      <ServiceAccountsDropdown {...props} onChange={onChange} />
+    </Provider>
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByText(/default/i));
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+it('ServiceAccountsDropdown handles onChange event when namespace changes', () => {
+  const storeDefaultNamespace = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'default'
+    }
+  });
+  const onChange = jest.fn();
+  const { container, getByText } = render(
+    <Provider store={storeDefaultNamespace}>
+      <ServiceAccountsDropdown {...props} onChange={onChange} />
+    </Provider>
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByText(/default/i));
+
+  // Should call onChange because selected item was 'default' and now it will be reset to ''
+  const storeGreenNamespace = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'green'
+    }
+  });
+  render(
+    <Provider store={storeGreenNamespace}>
+      <ServiceAccountsDropdown {...props} onChange={onChange} />
+    </Provider>,
+    { container }
+  );
+
+  // Should not call onChange because selected item was '' and now it will be reset to ''
+  const storeBlueNamespace = mockStore({
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    },
+    namespaces: {
+      byName: namespacesByName,
+      selected: 'blue'
+    }
+  });
+  render(
+    <Provider store={storeBlueNamespace}>
+      <ServiceAccountsDropdown {...props} onChange={onChange} />
+    </Provider>,
+    { container }
+  );
+  expect(onChange).toHaveBeenCalledTimes(2);
+});

--- a/src/containers/ServiceAccountsDropdown/index.js
+++ b/src/containers/ServiceAccountsDropdown/index.js
@@ -11,12 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
-export { default as TaskRuns } from './TaskRuns';
-export { default as NamespacesDropdown } from './NamespacesDropdown';
-export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';
+export { default } from './ServiceAccountsDropdown';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,6 +15,7 @@ import { combineReducers } from 'redux';
 
 import extensions, * as extensionSelectors from './extensions';
 import namespaces, * as namespaceSelectors from './namespaces';
+import serviceAccounts, * as serviceAccountSelectors from './serviceAccounts';
 import pipelines, * as pipelineSelectors from './pipelines';
 import pipelineRuns, * as pipelineRunsSelectors from './pipelineRuns';
 import tasks, * as taskSelectors from './tasks';
@@ -26,7 +27,8 @@ export default combineReducers({
   pipelines,
   pipelineRuns,
   tasks,
-  taskRuns
+  taskRuns,
+  serviceAccounts
 });
 
 export function getSelectedNamespace(state) {
@@ -35,6 +37,22 @@ export function getSelectedNamespace(state) {
 
 export function getNamespaces(state) {
   return namespaceSelectors.getNamespaces(state.namespaces);
+}
+
+export function getServiceAccounts(
+  state,
+  { namespace = getSelectedNamespace(state) } = {}
+) {
+  return serviceAccountSelectors.getServiceAccounts(
+    state.serviceAccounts,
+    namespace
+  );
+}
+
+export function isFetchingServiceAccounts(state) {
+  return serviceAccountSelectors.isFetchingServiceAccounts(
+    state.serviceAccounts
+  );
 }
 
 export function isFetchingNamespaces(state) {

--- a/src/reducers/serviceAccounts.js
+++ b/src/reducers/serviceAccounts.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { combineReducers } from 'redux';
+import keyBy from 'lodash.keyby';
+import merge from 'lodash.merge';
+
+function byId(state = {}, action) {
+  switch (action.type) {
+    case 'SERVICE_ACCOUNTS_FETCH_SUCCESS':
+      return { ...state, ...keyBy(action.data, 'metadata.uid') };
+    default:
+      return state;
+  }
+}
+
+function byNamespace(state = {}, action) {
+  switch (action.type) {
+    case 'SERVICE_ACCOUNTS_FETCH_SUCCESS':
+      const namespaces = action.data.reduce((accumulator, serviceAccount) => {
+        const { name, namespace, uid } = serviceAccount.metadata;
+        return merge(accumulator, {
+          [namespace]: {
+            [name]: uid
+          }
+        });
+      }, {});
+
+      return merge({}, state, namespaces);
+    default:
+      return state;
+  }
+}
+
+function isFetching(state = false, action) {
+  switch (action.type) {
+    case 'SERVICE_ACCOUNTS_FETCH_REQUEST':
+      return true;
+    case 'SERVICE_ACCOUNTS_FETCH_SUCCESS':
+    case 'SERVICE_ACCOUNTS_FETCH_FAILURE':
+      return false;
+    default:
+      return state;
+  }
+}
+
+function errorMessage(state = null, action) {
+  switch (action.type) {
+    case 'SERVICE_ACCOUNTS_FETCH_FAILURE':
+      return action.error.message;
+    case 'SERVICE_ACCOUNTS_FETCH_REQUEST':
+    case 'SERVICE_ACCOUNTS_FETCH_SUCCESS':
+      return null;
+    default:
+      return state;
+  }
+}
+
+export default combineReducers({
+  byId,
+  byNamespace,
+  errorMessage,
+  isFetching
+});
+
+export function getServiceAccounts(state, namespace) {
+  const serviceAccounts = state.byNamespace[namespace];
+  return serviceAccounts
+    ? Object.values(serviceAccounts).map(id => state.byId[id])
+    : [];
+}
+
+export function getServiceAccountsErrorMessage(state) {
+  return state.errorMessage;
+}
+
+export function isFetchingServiceAccounts(state) {
+  return state.isFetching;
+}

--- a/src/reducers/serviceAccounts.test.js
+++ b/src/reducers/serviceAccounts.test.js
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import serviceAccountsReducer, * as selectors from './serviceAccounts';
+
+it('handles init or unknown actions', () => {
+  expect(serviceAccountsReducer(undefined, { type: 'does_not_exist' })).toEqual(
+    {
+      byId: {},
+      byNamespace: {},
+      errorMessage: null,
+      isFetching: false
+    }
+  );
+});
+
+it('SERVICE_ACCOUNTS_FETCH_REQUEST', () => {
+  const action = { type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' };
+  const state = serviceAccountsReducer({}, action);
+  expect(selectors.isFetchingServiceAccounts(state)).toBe(true);
+});
+
+it('SERVICE_ACCOUNTS_FETCH_SUCCESS', () => {
+  const name = 'service-account-name';
+  const namespace = 'default';
+  const uid = 'some-uid';
+  const serviceAccount = {
+    metadata: {
+      name,
+      namespace,
+      uid
+    },
+    other: 'content'
+  };
+  const action = {
+    type: 'SERVICE_ACCOUNTS_FETCH_SUCCESS',
+    data: [serviceAccount],
+    namespace
+  };
+
+  const state = serviceAccountsReducer({}, action);
+  expect(selectors.getServiceAccounts(state, namespace)).toEqual([
+    serviceAccount
+  ]);
+  expect(selectors.isFetchingServiceAccounts(state)).toBe(false);
+});
+
+it('SERVICE_ACCOUNTS_FETCH_FAILURE', () => {
+  const message = 'fake error message';
+  const error = { message };
+  const action = {
+    type: 'SERVICE_ACCOUNTS_FETCH_FAILURE',
+    error
+  };
+
+  const state = serviceAccountsReducer({}, action);
+  expect(selectors.getServiceAccountsErrorMessage(state)).toEqual(message);
+});
+
+it('getServiceAccounts', () => {
+  const namespace = 'default';
+  const state = { byNamespace: {} };
+  expect(selectors.getServiceAccounts(state, namespace)).toEqual([]);
+});


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adding a ServiceAccounts dropdown component that can be reused many places in our future UI.
This PR adds a new `serviceaccounts` endpoint to the dashboard with accompanying documentation in `DEVELOPMENT.md`. Backend and frontend test files are included as well as a storybook file.

I also updated the namespaces dropdown to have a default label "Select Namespace" to match the service accounts dropdown default label "Select ServiceAccount". The label will appear when nothing is selected, and as a prop it can be overwritten.

Thanks @jessm12 for the initial work on this component.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
