### PR TITLE
Handle inline task runs in the client

### DIFF
--- a/src/api/comms.test.js
+++ b/src/api/comms.test.js
@@ -38,7 +38,7 @@ describe('checkStatus', () => {
     const json = jest.fn(() => data);
     expect(checkStatus({ ok: true, json })).toEqual(data);
   });
-  
+
   it('returns headers on successful create', () => {
     const status = 201;
     const headers = { fake: 'headers' };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -131,7 +131,9 @@ export function getTaskRunsByTaskName(
   { name, namespace = getSelectedNamespace(state) }
 ) {
   const runs = getTaskRuns(state, { namespace });
-  return runs.filter(taskRun => taskRun.spec.taskRef.name === name);
+  return runs.filter(
+    taskRun => taskRun.spec.taskRef && taskRun.spec.taskRef.name === name
+  );
 }
 
 export function getTasks(

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -31,7 +31,8 @@ import {
   isFetchingPipelines,
   isFetchingPipelineRuns,
   isFetchingTasks,
-  isFetchingTaskRuns
+  isFetchingTaskRuns,
+  getTaskRunsByTaskName
 } from '.';
 import * as extensionSelectors from './extensions';
 import * as namespaceSelectors from './namespaces';
@@ -45,8 +46,10 @@ const extension = { displayName: 'extension' };
 const pipelines = [{ fake: 'pipeline' }];
 const pipelineRuns = [{ fake: 'pipelineRun' }];
 const tasks = [{ fake: 'task' }];
-const taskRun = { fake: 'taskRun' };
-const taskRuns = [taskRun];
+const taskName = 'myTask';
+const taskRun = { fake: 'taskRun', spec: { taskRef: { name: taskName } } };
+const inlineTaskRun = { fake: 'taskRun', spec: {} };
+const taskRuns = [taskRun, inlineTaskRun];
 const state = {
   extensions: {
     byName: {
@@ -265,6 +268,13 @@ it('getTaskRuns', () => {
     state.taskRuns,
     namespace
   );
+});
+
+it('getTaskRunsByTaskName', () => {
+  jest
+    .spyOn(taskRunsSelectors, 'getTaskRuns')
+    .mockImplementation(() => taskRuns);
+  expect(getTaskRunsByTaskName(state, { name: taskName })).toEqual([taskRun]);
 });
 
 it('getTaskRunsErrorMessage', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

https://github.com/tektoncd/dashboard/issues/172

Update client to handle inline task runs. This was not expected to be possible given the client cannot navigate to any task runs. That assumption failed to consider the fetchAllTaskRuns calls use in pipeline rendering (for now)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
