### PR TITLE
Fix to PR 155 - HandleExtension was missing slash in proxy reroute

### DIFF
--- a/pkg/endpoints/router.go
+++ b/pkg/endpoints/router.go
@@ -14,10 +14,11 @@ limitations under the License.
 package endpoints
 
 import (
+	"os"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
@@ -167,19 +168,17 @@ func (r Resource) RegisterExtensions(container *restful.Container, namespace str
 		ext := Extension{Name: svc.ObjectMeta.Name, URL: url, Port: getPort(svc),
 			DisplayName:    svc.ObjectMeta.Annotations[displayNameKey],
 			BundleLocation: svc.ObjectMeta.Annotations[bundleLocationKey]}
-		paths := []string{}
+		// Base extension path
+		paths := []string{""}
 		if ok {
-			paths = strings.Split(url, ".")
-			if len(paths) == 0 {
-				paths = []string{""}
+			if len(url) != 0 {
+				paths = strings.Split(url, ".")
 			}
-		} else {
-			paths = []string{""}
-		}
+		} 
 		for _, path := range paths {
 			// extension handler is registered at the url
 			routingPath := strings.TrimSuffix(base+"/"+path, "/")
-			logging.Log.Debugf("Registering path: %s", base+"/"+path)
+			logging.Log.Debugf("Registering path: %s", routingPath)
 			ws.Route(ws.GET(routingPath).To(ext.HandleExtension))
 			ws.Route(ws.POST(routingPath).To(ext.HandleExtension))
 			ws.Route(ws.PUT(routingPath).To(ext.HandleExtension))
@@ -203,7 +202,7 @@ func (ext Extension) HandleExtension(request *restful.Request, response *restful
 		return
 	}
 	logging.Log.Debugf("Path in URL: %+v", request.Request.URL.Path)
-	request.Request.URL.Path = strings.TrimPrefix(request.Request.URL.Path, "/v1"+extensionRoot+ext.Name)
+	request.Request.URL.Path = strings.TrimPrefix(request.Request.URL.Path, fmt.Sprintf("/v1%s/%s",extensionRoot,ext.Name))
 	logging.Log.Debugf("Path in rerouting URL: %+v", request.Request.URL.Path)
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.ServeHTTP(response, request.Request)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This PR addresses PR 155 that omitted a slash within HandleExtension and some small related cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
