### PR TITLE
Add panelling to Import Tekton resources from repository

### DIFF
--- a/config/pipeline0-task.yaml
+++ b/config/pipeline0-task.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: pipeline0-task
+spec:
+  inputs:
+    resources:
+    - name: git-source
+      type: git
+    params:
+    - name: pathToResourceFiles
+      description: The path to the resource files to apply
+      default: /workspace/git-source
+    - name: apply-directory
+      description: The directory from which resources are to be applied
+      default: ""
+  steps:
+  - name: kubectl-apply
+    image: lachlanevenson/k8s-kubectl
+    command:
+    - kubectl
+    args:
+    - apply
+    - -f
+    - ${inputs.params.pathToResourceFiles}/${inputs.params.apply-directory}

--- a/config/pipeline0.yaml
+++ b/config/pipeline0.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline0
+spec:
+  resources:
+  - name: git-source
+    type: git
+  params:
+  - name: pathToResourceFiles
+    description: The path to the resource files to apply
+    default: /workspace/git-source
+  - name: apply-directory
+    description: The directory from which resources are to be applied
+    default: ""
+  tasks:
+  - name: pipeline0-task
+    taskRef:
+      name: pipeline0-task
+    params:
+    - name: pathToResourceFiles
+      value: ${params.pathToResourceFiles}
+    - name: apply-directory
+      value: ${params.apply-directory}
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -85,6 +85,7 @@ type ManualPipelineRun struct {
 	REPOURL           string `json:"repourl,omitempty"`
 	HELMSECRET        string `json:"helmsecret,omitempty"`
 	REGISTRYSECRET    string `json:"registrysecret,omitempty"`
+	APPLYDIRECTORY    string `json:"applydirectory,omitempty"`
 }
 
 // PipelineRunUpdateBody - represents a request that a user may provide for updating a PipelineRun
@@ -332,6 +333,10 @@ func (r Resource) CreatePipelineRunImpl(pipelineRunData ManualPipelineRun, names
 	if pipelineRunData.HELMSECRET != "" {
 		params = append(params, v1alpha1.Param{Name: "helm-secret", Value: pipelineRunData.HELMSECRET})
 	}
+	if pipelineRunData.APPLYDIRECTORY != "" {
+		params = append(params, v1alpha1.Param{Name: "apply-directory", Value: pipelineRunData.APPLYDIRECTORY})
+	}
+
 	// PipelineRun yaml defines references to resources
 	newPipelineRunData, err := definePipelineRun(generatedPipelineRunName, namespace, serviceAccount, pipelineRunData.REPOURL, pipeline, v1alpha1.PipelineTriggerTypeManual, resources, params)
 	if err != nil {

--- a/pkg/endpoints/router.go
+++ b/pkg/endpoints/router.go
@@ -14,11 +14,11 @@ limitations under the License.
 package endpoints
 
 import (
-	"os"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -176,7 +176,7 @@ func (r Resource) RegisterExtensions(container *restful.Container, namespace str
 			if len(url) != 0 {
 				paths = strings.Split(url, ".")
 			}
-		} 
+		}
 		for _, path := range paths {
 			// extension handler is registered at the url
 			routingPath := strings.TrimSuffix(base+"/"+path, "/")
@@ -204,7 +204,7 @@ func (ext Extension) HandleExtension(request *restful.Request, response *restful
 		return
 	}
 	logging.Log.Debugf("Path in URL: %+v", request.Request.URL.Path)
-	request.Request.URL.Path = strings.TrimPrefix(request.Request.URL.Path, fmt.Sprintf("/v1%s/%s",extensionRoot,ext.Name))
+	request.Request.URL.Path = strings.TrimPrefix(request.Request.URL.Path, fmt.Sprintf("/v1%s/%s", extensionRoot, ext.Name))
 	logging.Log.Debugf("Path in rerouting URL: %+v", request.Request.URL.Path)
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.ServeHTTP(response, request.Request)

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -128,9 +128,9 @@ export function getTaskRunLog(name, namespace) {
   return get(uri);
 }
 
-export function createPipelineRun(payload) {
-  const uri = `${apiRoot}/`;
-  return post(uri, payload);
+export function createPipelineRun(params, namespace) {
+  const uri = getAPI('pipelineruns', { namespace });
+  return post(uri, params);
 }
 
 export function getCredentials(namespace) {

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -40,7 +40,8 @@ export default function Breadcrumbs({ labels, match }) {
 const breadcrumbLabels = {
   '/pipelines': 'Pipelines',
   '/tasks': 'Tasks',
-  '/extensions': 'Extensions'
+  '/extensions': 'Extensions',
+  '/importresources': 'Import Tekton Resources'
 };
 
 Breadcrumbs.defaultProps = {

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -38,7 +38,8 @@ import {
   Tasks,
   TaskRuns,
   CustomResourceDefinition,
-  NamespacesDropdown
+  NamespacesDropdown,
+  ImportResources
 } from '..';
 
 import SideNavMenu from '../../components/SideNavMenu';
@@ -85,6 +86,13 @@ export /* istanbul ignore next */ class App extends Component {
                 <SideNavLink element={NavLink} icon={<span />} to="/tasks">
                   Tasks
                 </SideNavLink>
+                <SideNavLink
+                  element={NavLink}
+                  icon={<span />}
+                  to="/importresources"
+                >
+                  Import Tekton resources
+                </SideNavLink>
               </SideNavMenu>
               <NamespacesDropdown
                 titleText="Namespace"
@@ -126,6 +134,7 @@ export /* istanbul ignore next */ class App extends Component {
                 path="/pipelines/:pipelineName/runs/:pipelineRunName"
                 component={PipelineRun}
               />
+              <Route path="/importresources" component={ImportResources} />
               <Route path="/extensions" exact component={Extensions} />
               {extensions.map(({ displayName, name, source }) => (
                 <Route

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -1,0 +1,177 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component } from 'react';
+
+import {
+  ToastNotification,
+  TextInput,
+  Button,
+  Form
+} from 'carbon-components-react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import './ImportResources.scss';
+
+import { createPipelineRun } from '../../api';
+import ServiceAccountsDropdown from '../ServiceAccountsDropdown';
+import { getSelectedNamespace } from '../../reducers';
+
+export class ImportResources extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      repositoryURL: '',
+      serviceAccount: '',
+      submitSuccess: false,
+      invalidInput: false,
+      logsURL: '',
+      directory: ''
+    };
+  }
+
+  handleServiceAccount = data => {
+    this.setState({
+      serviceAccount: data.selectedItem.text
+    });
+  };
+
+  handleTextInput = event => {
+    const identifier = event.target.name;
+    const inputValue = event.target.value;
+    this.setState({
+      [identifier]: inputValue,
+      invalidInput: false
+    });
+  };
+
+  handleSubmit = event => {
+    const { namespace } = this.props;
+    const pipelinename = 'pipeline0';
+    const gitresourcename = 'git-source';
+    const gitcommit = 'master';
+    const applydirectory = this.state.directory;
+    const repourl = this.state.repositoryURL;
+    const serviceaccount = this.state.serviceAccount;
+    const payload = {
+      pipelinename,
+      serviceaccount,
+      gitresourcename,
+      gitcommit,
+      repourl,
+      applydirectory
+    };
+
+    if (repourl === '') {
+      this.setState({
+        invalidInput: true
+      });
+      return;
+    }
+
+    this.setState({
+      invalidInput: false
+    });
+
+    const promise = createPipelineRun(payload, namespace);
+    promise
+      .then(headers => {
+        const logsURL = headers.get('Content-Location');
+        const pipelineRunName = logsURL.substring(logsURL.lastIndexOf('/') + 1);
+        const finalURL = '/pipelines/pipeline0/runs/'.concat(pipelineRunName);
+        this.setState({
+          logsURL: finalURL,
+          submitSuccess: true,
+          invalidInput: false
+        });
+      })
+      .catch(error => {
+        const statusCode = error.response.status;
+        switch (statusCode) {
+          case 500:
+            this.setState({
+              submitSuccess: false,
+              invalidInput: true
+            });
+            break;
+          default:
+        }
+      });
+    event.preventDefault();
+  };
+
+  render() {
+    return (
+      <div className="outer">
+        <h1 className="ImportHeader">
+          Import Tekton resources from repository
+        </h1>
+        <Form>
+          <TextInput
+            required
+            type="URL"
+            invalid={this.state.invalidInput}
+            invalidText="Please submit a valid URL"
+            helperText="The location of the YAML definitions to be applied (Git URL's supported)"
+            labelText="Repository URL"
+            placeholder="Enter repository URL"
+            data-testid="repository-url-field"
+            name="repositoryURL"
+            value={this.state.repositoryURL}
+            onChange={this.handleTextInput}
+          />
+          <TextInput
+            helperText="The path from which resources will be applied at the
+          specified repository"
+            labelText="Repository directory (optional)"
+            placeholder="Enter repository directory"
+            data-testid="directory-field"
+            name="directory"
+            value={this.state.directory}
+            onChange={this.handleTextInput}
+          />
+          <ServiceAccountsDropdown
+            helperText="The SA that the PipelineRun applying resources will
+          run under"
+            titleText="Service Account (optional)"
+            className="saDropdown"
+            onChange={this.handleServiceAccount}
+          />
+          <Button kind="primary" onClick={this.handleSubmit}>
+            Import and Apply
+          </Button>
+          {this.state.submitSuccess && (
+            <ToastNotification
+              kind="success"
+              title="Triggered PipelineRun to apply Tekton resources"
+              subtitle=""
+              caption={
+                <Link to={this.state.logsURL}>View status of this run</Link>
+              }
+            />
+          )}
+        </Form>
+      </div>
+    );
+  }
+}
+
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    namespace: getSelectedNamespace(state)
+  };
+}
+
+export default connect(mapStateToProps)(ImportResources);

--- a/src/containers/ImportResources/ImportResources.scss
+++ b/src/containers/ImportResources/ImportResources.scss
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '~carbon-components/scss/globals/scss/vars';
+
+.ImportHeader {
+  margin-left: 2.5rem;
+  padding-top: 2rem;
+  font-size: 1.5rem;
+}
+
+.outer {
+  background-color: white;
+  min-height: 46rem;
+  .bx--dropdown.bx--list-box {
+    margin: 0rem;
+    margin-bottom: 2.8rem;
+    width: 30%;
+    border-bottom: 1px solid $ui-04;
+  }
+  .bx--toast-notification {
+    margin: 2.8rem;
+  }
+  .bx--dropdown__wrapper {
+    margin-left: 2.8rem;
+  }
+  .bx--btn {
+    margin-left: 2.8rem;
+  }
+  .bx--form-item {
+    margin: 2.8rem;
+  }
+  .bx--text-input__field-wrapper {
+    width: 50%;
+  }
+}

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { render, fireEvent, waitForElement } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import * as ImportResources from './ImportResources';
+import * as API from '../../api';
+import { renderWithRouter } from '../../utils/test';
+
+beforeEach(jest.resetAllMocks);
+
+describe('ImportResources component', () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    namespaces: { selected: 'default' },
+    serviceAccounts: {
+      byNamespace: ['default'],
+      errorMessage: null,
+      isFetching: false
+    }
+  });
+
+  it('Valid data submit displays success notification ', async () => {
+    const headers = {
+      get() {
+        return 'fake-tekton-pipeline-run';
+      }
+    };
+
+    jest
+      .spyOn(API, 'createPipelineRun')
+      .mockImplementation(() => Promise.resolve(headers));
+    const { getByTestId, getByText } = renderWithRouter(
+      <Provider store={store}>
+        <ImportResources.ImportResources />
+      </Provider>
+    );
+
+    const repoURLField = getByTestId('repository-url-field');
+    fireEvent.change(repoURLField, {
+      target: { value: 'https://example.com/test/testing' }
+    });
+
+    fireEvent.click(getByText('Import and Apply'));
+    await waitForElement(() =>
+      getByText(/Triggered PipelineRun to apply Tekton resources/i)
+    );
+  });
+
+  it('Invalid data submit displays invalidText', async () => {
+    const createPipelineRunResponseMock = { response: { status: 500 } };
+
+    jest
+      .spyOn(API, 'createPipelineRun')
+      .mockImplementation(() => Promise.reject(createPipelineRunResponseMock));
+    const { getByTestId, getByText } = render(
+      <Provider store={store}>
+        <ImportResources.ImportResources />
+      </Provider>
+    );
+
+    const repoURLField = getByTestId('repository-url-field');
+    fireEvent.change(repoURLField, { target: { value: 'URL' } });
+
+    fireEvent.click(getByText('Import and Apply'));
+    await waitForElement(() => getByText(/Please submit a valid URL/i));
+  });
+
+  it('Failure to populate required field displays error', async () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <ImportResources.ImportResources />
+      </Provider>
+    );
+
+    fireEvent.click(getByText('Import and Apply'));
+    await waitForElement(() => getByText(/Please submit a valid URL/i));
+  });
+
+  it('URL TextInput handles onChange event', async () => {
+    const { getByTestId, queryByDisplayValue } = render(
+      <Provider store={store}>
+        <ImportResources.ImportResources />
+      </Provider>
+    );
+    const repoURLField = getByTestId('repository-url-field');
+    fireEvent.change(repoURLField, {
+      target: { value: 'Invalid URL here' }
+    });
+
+    await waitForElement(() => queryByDisplayValue(/Invalid URL here/i));
+  });
+});

--- a/src/containers/ImportResources/index.js
+++ b/src/containers/ImportResources/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './ImportResources';

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -78,7 +78,7 @@ class ServiceAccountsDropdown extends React.Component {
 ServiceAccountsDropdown.defaultProps = {
   items: [],
   loading: true,
-  label: 'Select ServiceAccount'
+  label: 'Select Service Account'
 };
 
 function mapStateToProps(state) {

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -71,7 +71,7 @@ const namespacesByName = {
   blue: ''
 };
 
-const initialTextRegExp = new RegExp('select serviceaccount', 'i');
+const initialTextRegExp = new RegExp('select service account', 'i');
 
 const middleware = [thunk];
 const mockStore = configureStore(middleware);

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -21,5 +21,6 @@ export {
   default as CustomResourceDefinition
 } from './CustomResourceDefinition';
 export { default as TaskRuns } from './TaskRuns';
+export { default as ImportResources } from './ImportResources';
 export { default as NamespacesDropdown } from './NamespacesDropdown';
 export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add Pipeline0 and Pipeline0 task yaml definitions that are applied at install (ko apply) time, this pipeline applies all resources under the Pipeline's specified directory at the provided repository. Add the panel and associated tests to allow the user to input a repository URL and ServiceAccount and trigger a PipelineRun of Pipeline0 from this data. 

Below is a screenshot of the panel:

![Screen Shot 2019-05-24 at 15 10 49](https://user-images.githubusercontent.com/32932155/58333915-5ae80680-7e36-11e9-95c8-b7e917b55e7a.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
