### PR TITLE
Prune credentials to userpass only

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -403,17 +403,11 @@ Example POSTs (non-trivial as it involves the URL map):
     "name": "mysecretname",
     "username": "myusername",
     "password": "mypassword",
-    "type": "userpass",
     "description": "my secret for github",
     "url": {"tekton.dev/git-0": "https://github.com"}
     "serviceAccount": "sa1"
 }
 
-{
-    "name": "mytoken",
-    "type", "accesstoken",
-    "accesstoken": "34ecf56accce4"
-}
 ```
 
 __PipelineRuns__

--- a/pkg/endpoints/routes_test.go
+++ b/pkg/endpoints/routes_test.go
@@ -253,9 +253,9 @@ func fakeCRD(t *testing.T, crdType string, identifier string) interface{} {
 	case "credentials":
 		return &credential{
 			Name:        "fakeresource",
-			AccessToken: "thisismyaccesstoken",
-			Description: "access token de jour",
-			Type:        "accesstoken",
+			Username:    "thisismyusername",
+			Password:    "password",
+			Description: "cred de jour",
 			URL: map[string]string{
 				"tekton.dev/git-0": "https://github.com",
 			},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Remote accesstokens and 'dockerconfigjson' secret types, leaving credentials as user/pass only in the first instance. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
