### PR TITLE
issue67 - secrets management - actions & reducers - merge order: 1st

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { createCredential, deleteCredential, getCredentials } from '../api';
+import { getSelectedNamespace } from '../reducers';
+
+export function fetchSecretsSuccess(data) {
+  return {
+    type: 'SECRETS_FETCH_SUCCESS',
+    data
+  };
+}
+
+export function fetchSecrets({ namespace } = {}) {
+  return async (dispatch, getState) => {
+    dispatch({ type: 'SECRETS_FETCH_REQUEST' });
+    let secrets;
+    try {
+      const selectedNamespace = namespace || getSelectedNamespace(getState());
+      secrets = await getCredentials(selectedNamespace);
+      const secretsFormatted = [];
+      secrets.forEach(secret => {
+        const object = {
+          name: secret.name,
+          namespace: secret.namespace,
+          annotations: secret.url
+        };
+        secretsFormatted.push(object);
+      });
+      dispatch(fetchSecretsSuccess(secretsFormatted));
+    } catch (e) {
+      const error = new Error('Could not fetch secrets');
+      dispatch({ type: 'SECRETS_FETCH_FAILURE', error });
+    }
+    return secrets;
+  };
+}
+
+export function deleteSecret(name, namespace) {
+  return async dispatch => {
+    dispatch({ type: 'SECRET_DELETE_REQUEST' });
+    try {
+      await deleteCredential(name, namespace);
+      dispatch({ type: 'SECRET_DELETE_SUCCESS', name, namespace });
+    } catch (e) {
+      const error = new Error(`Could not delete secret ${name}`);
+      dispatch({ type: 'SECRET_DELETE_FAILURE', error });
+    }
+  };
+}
+
+/* istanbul ignore next */
+export function createSecret(postData, namespace) {
+  return async dispatch => {
+    dispatch({ type: 'SECRET_CREATE_REQUEST' });
+    try {
+      await createCredential(postData, namespace);
+      dispatch(fetchSecrets());
+    } catch (e) {
+      const error = new Error(
+        `Could not create secret ${postData.name} in namespace ${namespace}`
+      );
+      dispatch({ type: 'SECRET_CREATE_FAILURE', error });
+    }
+  };
+}
+
+export function clearNotification() {
+  return { type: 'CLEAR_SECRET_ERROR_NOTIFICATION' };
+}

--- a/src/actions/secrets.test.js
+++ b/src/actions/secrets.test.js
@@ -1,0 +1,203 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as API from '../api';
+import * as selectors from '../reducers';
+import {
+  clearNotification,
+  createSecret,
+  deleteSecret,
+  fetchSecrets,
+  fetchSecretsSuccess
+} from './secrets';
+
+const data = [
+  {
+    name: 'secret-name',
+    password: '********',
+    resourceVersion: '####',
+    serviceAccount: 'default',
+    type: 'userpass',
+    url: undefined,
+    username: 'someUser@email.com',
+    namespace: 'default'
+  }
+];
+const dataFormatted = [
+  {
+    name: 'secret-name',
+    annotations: undefined,
+    namespace: 'default'
+  }
+];
+const postData = {
+  name: 'secret-name',
+  namespace: 'default',
+  password: '********',
+  serviceAccount: 'default',
+  type: 'userpass',
+  url: { 'tekton.dev/git-0': 'https://github.ibm.com' },
+  username: 'someUser@email.com'
+};
+const response = { ok: true, status: 204 };
+const namespace = 'default';
+
+it('fetchSecretsSuccess', () => {
+  expect(fetchSecretsSuccess(data, namespace)).toEqual({
+    type: 'SECRETS_FETCH_SUCCESS',
+    data
+  });
+});
+
+it('fetchSecrets', async () => {
+  const secrets = data;
+  const secretsFromatted = dataFormatted;
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  jest
+    .spyOn(selectors, 'getSelectedNamespace')
+    .mockImplementation(() => namespace);
+  jest.spyOn(API, 'getCredentials').mockImplementation(() => secrets);
+
+  const expectedActions = [
+    { type: 'SECRETS_FETCH_REQUEST' },
+    fetchSecretsSuccess(secretsFromatted)
+  ];
+
+  await store.dispatch(fetchSecrets({ namespace }));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchSecrets error', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const error = new Error('Could not fetch secrets');
+
+  jest.spyOn(API, 'getCredentials').mockImplementation(() => {
+    throw error;
+  });
+
+  const expectedActions = [
+    { type: 'SECRETS_FETCH_REQUEST' },
+    { type: 'SECRETS_FETCH_FAILURE', error }
+  ];
+
+  await store.dispatch(fetchSecrets());
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('deleteSecret', async () => {
+  const name = 'secret-name';
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  jest
+    .spyOn(selectors, 'getSelectedNamespace')
+    .mockImplementation(() => namespace);
+
+  jest.spyOn(API, 'deleteCredential').mockImplementation(() => {});
+
+  const expectedActions = [
+    { type: 'SECRET_DELETE_REQUEST' },
+    { type: 'SECRET_DELETE_SUCCESS', name, namespace }
+  ];
+
+  await store.dispatch(deleteSecret(name, namespace));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('deleteSecret error', async () => {
+  const secret = 'secret';
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const error = new Error('Could not delete secret secret');
+
+  jest.spyOn(API, 'deleteCredential').mockImplementation(() => {
+    throw error;
+  });
+
+  const expectedActions = [
+    { type: 'SECRET_DELETE_REQUEST' },
+    { type: 'SECRET_DELETE_FAILURE', error }
+  ];
+
+  await store.dispatch(deleteSecret(secret, namespace));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('createSecret', async () => {
+  const secrets = data;
+  const secretsFormatted = dataFormatted;
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  jest
+    .spyOn(selectors, 'getSelectedNamespace')
+    .mockImplementation(() => namespace);
+  jest.spyOn(API, 'getCredentials').mockImplementation(() => secrets);
+
+  jest.spyOn(API, 'createCredential').mockImplementation(() => response);
+
+  const expectedActions = [
+    { type: 'SECRET_CREATE_REQUEST' },
+    { type: 'SECRETS_FETCH_REQUEST' },
+    fetchSecretsSuccess(secretsFormatted)
+  ];
+
+  await store.dispatch(createSecret(postData, namespace));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('createSecret error', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const error = new Error(
+    'Could not create secret secret-name in namespace default'
+  );
+
+  jest.spyOn(API, 'createCredential').mockImplementation(() => {
+    throw error;
+  });
+
+  const expectedActions = [
+    { type: 'SECRET_CREATE_REQUEST' },
+    { type: 'SECRET_CREATE_FAILURE', error }
+  ];
+
+  await store.dispatch(createSecret(postData, namespace));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('clearNotification', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const expectedActions = [{ type: 'CLEAR_SECRET_ERROR_NOTIFICATION' }];
+
+  await store.dispatch(clearNotification());
+  expect(store.getActions()).toEqual(expectedActions);
+});

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -143,7 +143,7 @@ export function getTaskRunLog(name, namespace) {
 
 export function getCredentials(namespace) {
   const uri = getAPI('credentials', { namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getCredential(id, namespace) {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -282,7 +282,7 @@ it('getCredentials', () => {
   };
   fetchMock.get(/credentials/, data);
   return getCredentials().then(credentials => {
-    expect(credentials).toEqual(data.items);
+    expect(credentials).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/containers/Extension/actions.js
+++ b/src/containers/Extension/actions.js
@@ -1,4 +1,5 @@
 export { fetchNamespaces } from '../../actions/namespaces';
 export { fetchPipeline, fetchPipelines } from '../../actions/pipelines';
-export { fetchTask, fetchTasks } from '../../actions/tasks';
+export { fetchSecrets } from '../../actions/secrets';
 export { fetchServiceAccounts } from '../../actions/serviceAccounts';
+export { fetchTask, fetchTasks } from '../../actions/tasks';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,10 +15,11 @@ import { combineReducers } from 'redux';
 
 import extensions, * as extensionSelectors from './extensions';
 import namespaces, * as namespaceSelectors from './namespaces';
-import serviceAccounts, * as serviceAccountSelectors from './serviceAccounts';
 import pipelines, * as pipelineSelectors from './pipelines';
 import pipelineResources, * as pipelineResourcesSelectors from './pipelineResources';
 import pipelineRuns, * as pipelineRunsSelectors from './pipelineRuns';
+import secrets, * as secretSelectors from './secrets';
+import serviceAccounts, * as serviceAccountSelectors from './serviceAccounts';
 import tasks, * as taskSelectors from './tasks';
 import taskRuns, * as taskRunsSelectors from './taskRuns';
 
@@ -28,6 +29,7 @@ export default combineReducers({
   pipelines: pipelines(),
   pipelineResources: pipelineResources(),
   pipelineRuns: pipelineRuns(),
+  secrets,
   serviceAccounts: serviceAccounts(),
   tasks: tasks(),
   taskRuns: taskRuns()
@@ -216,4 +218,19 @@ export function getTasksErrorMessage(state) {
 
 export function isFetchingTasks(state) {
   return taskSelectors.isFetchingTasks(state.tasks);
+}
+
+export function getSecrets(
+  state,
+  { namespace = getSelectedNamespace(state) } = {}
+) {
+  return secretSelectors.getSecrets(state.secrets, namespace);
+}
+
+export function getSecretsErrorMessage(state) {
+  return secretSelectors.getSecretsErrorMessage(state.secrets);
+}
+
+export function isFetchingSecrets(state) {
+  return secretSelectors.isFetchingSecrets(state.secrets);
 }

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -24,6 +24,8 @@ import {
   getPipelineRunsErrorMessage,
   getPipelines,
   getPipelinesErrorMessage,
+  getSecrets,
+  getSecretsErrorMessage,
   getSelectedNamespace,
   getTaskRun,
   getTaskRuns,
@@ -35,6 +37,7 @@ import {
   isFetchingPipelineResources,
   isFetchingPipelineRuns,
   isFetchingPipelines,
+  isFetchingSecrets,
   isFetchingTaskRuns,
   isFetchingTasks
 } from '.';
@@ -43,6 +46,7 @@ import * as namespaceSelectors from './namespaces';
 import * as pipelineResourcesSelectors from './pipelineResources';
 import * as pipelineSelectors from './pipelines';
 import * as pipelineRunsSelectors from './pipelineRuns';
+import * as secretSelectors from './secrets';
 import * as taskSelectors from './tasks';
 import * as taskRunsSelectors from './taskRuns';
 
@@ -51,6 +55,7 @@ const extension = { displayName: 'extension' };
 const pipelineResources = [{ fake: 'pipelineResource' }];
 const pipelines = [{ fake: 'pipeline' }];
 const pipelineRuns = [{ fake: 'pipelineRun' }];
+const secrets = [{ fake: 'secrets' }];
 const tasks = [{ fake: 'task' }];
 const taskName = 'myTask';
 const taskRun = { fake: 'taskRun', spec: { taskRef: { name: taskName } } };
@@ -67,6 +72,7 @@ const state = {
   },
   pipelineResources,
   pipelines,
+  secrets,
   tasks
 };
 
@@ -278,6 +284,34 @@ it('isFetchingPipelineRuns', () => {
   expect(pipelineRunsSelectors.isFetchingPipelineRuns).toHaveBeenCalledWith(
     state.pipelineRuns
   );
+});
+
+it('getSecrets', () => {
+  jest.spyOn(secretSelectors, 'getSecrets').mockImplementation(() => secrets);
+  expect(getSecrets(state)).toEqual(secrets);
+  expect(secretSelectors.getSecrets).toHaveBeenCalledWith(
+    state.secrets,
+    namespace
+  );
+});
+
+it('getSecretsErrorMessage', () => {
+  const errorMessage = 'fake error message';
+  jest
+    .spyOn(secretSelectors, 'getSecretsErrorMessage')
+    .mockImplementation(() => errorMessage);
+  expect(getSecretsErrorMessage(state)).toEqual(errorMessage);
+  expect(secretSelectors.getSecretsErrorMessage).toHaveBeenCalledWith(
+    state.secrets
+  );
+});
+
+it('isFetchingSecrets', () => {
+  jest
+    .spyOn(secretSelectors, 'isFetchingSecrets')
+    .mockImplementation(() => true);
+  expect(isFetchingSecrets(state)).toBe(true);
+  expect(secretSelectors.isFetchingSecrets).toHaveBeenCalledWith(state.secrets);
 });
 
 it('getTasks', () => {

--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { combineReducers } from 'redux';
+import merge from 'lodash.merge';
+
+import { ALL_NAMESPACES } from '../constants';
+
+function byNamespace(state = {}, action) {
+  switch (action.type) {
+    case 'SECRETS_FETCH_SUCCESS':
+      const namespaces = action.data.reduce((accumulator, secret) => {
+        const { namespace, name } = secret;
+        return merge(accumulator, {
+          [namespace]: {
+            [name]: { ...secret }
+          }
+        });
+      }, {});
+      return merge({}, state, namespaces);
+    case 'SECRET_DELETE_SUCCESS':
+      const newState = state;
+      delete newState[action.namespace][action.name];
+      return newState;
+    default:
+      return state;
+  }
+}
+
+function isFetching(state = false, action) {
+  switch (action.type) {
+    case 'SECRETS_FETCH_REQUEST':
+    case 'SECRET_DELETE_REQUEST':
+    case 'SECRET_CREATE_REQUEST':
+      return true;
+    case 'SECRETS_FETCH_SUCCESS':
+    case 'SECRET_DELETE_SUCCESS':
+    case 'SECRETS_FETCH_FAILURE':
+    case 'SECRET_DELETE_FAILURE':
+    case 'SECRET_CREATE_FAILURE':
+      return false;
+    default:
+      return state;
+  }
+}
+
+function errorMessage(state = null, action) {
+  switch (action.type) {
+    case 'SECRETS_FETCH_FAILURE':
+    case 'SECRET_DELETE_FAILURE':
+    case 'SECRET_CREATE_FAILURE':
+      return action.error.message;
+    case 'SECRETS_FETCH_REQUEST':
+    case 'SECRETS_FETCH_SUCCESS':
+    case 'CLEAR_SECRET_ERROR_NOTIFICATION':
+      return null;
+    default:
+      return state;
+  }
+}
+
+export default combineReducers({
+  byNamespace,
+  errorMessage,
+  isFetching
+});
+
+export function getSecrets(state, namespace) {
+  let secrets = [];
+  if (namespace === ALL_NAMESPACES) {
+    Object.values(state.byNamespace).forEach(secretsByNamespace => {
+      secrets = secrets.concat(Object.values(secretsByNamespace));
+    });
+    return secrets;
+  }
+
+  return Object.values(state.byNamespace[namespace] || []);
+}
+
+export function getSecretsErrorMessage(state) {
+  return state.errorMessage;
+}
+
+export function isFetchingSecrets(state) {
+  return state.isFetching;
+}

--- a/src/reducers/secrets.test.js
+++ b/src/reducers/secrets.test.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import secretsReducer, * as selectors from './secrets';
+
+it('handles init or unknown actions', () => {
+  expect(secretsReducer(undefined, { type: 'does_not_exist' })).toEqual({
+    byNamespace: {},
+    errorMessage: null,
+    isFetching: false
+  });
+});
+
+it('SECRETS_FETCH_REQUEST', () => {
+  const action = { type: 'SECRETS_FETCH_REQUEST' };
+  const state = secretsReducer({}, action);
+  expect(selectors.isFetchingSecrets(state)).toBe(true);
+});
+
+it('SECRETS_FETCH_SUCCESS', () => {
+  const name = 'secret-name';
+  const namespace = '*';
+  const uid = '0';
+  const annotations = { 'tekton.dev/git-0': 'https://github.ibm.com' };
+  const secret = {
+    name,
+    uid,
+    annotations,
+    namespace
+  };
+  const action = {
+    type: 'SECRETS_FETCH_SUCCESS',
+    data: [secret]
+  };
+
+  const state = secretsReducer({}, action);
+  expect(selectors.getSecrets(state, namespace)).toEqual([secret]);
+  expect(selectors.isFetchingSecrets(state)).toBe(false);
+});
+
+it('SECRETS_FETCH_FAILURE', () => {
+  const message = 'fake error message';
+  const error = { message };
+  const action = {
+    type: 'SECRETS_FETCH_FAILURE',
+    error
+  };
+
+  const state = secretsReducer({}, action);
+  expect(selectors.getSecretsErrorMessage(state)).toEqual(message);
+});
+
+it('SECRET_DELETE_SUCCESS', () => {
+  const name = 'name';
+  const namespace = 'default';
+  const secrets = {
+    byNamespace: {
+      default: {
+        0: {
+          uid: '0',
+          name: 'github-repo-access-secret',
+          namespace: 'default',
+          annotations: {}
+        }
+      }
+    }
+  };
+
+  const action = { type: 'SECRET_DELETE_SUCCESS', name, namespace };
+  const state = secretsReducer(secrets, action);
+
+  expect(selectors.isFetchingSecrets(state)).toBe(false);
+});
+
+it('getSecrets', () => {
+  const namespace = 'namespace';
+  const state = { byNamespace: {} };
+  expect(selectors.getSecrets(state, namespace)).toEqual([]);
+});


### PR DESCRIPTION
issue: #67 

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR includes the actions & reducers that are used throughout the whole secret management feature. Both actions & reducers mimic the format of the other resources in the dashboard. The actions consist of the typical fetch & fetchSuccess while also containing deleteSecret, createSecret & clearNotification. Only differences between deleteSecret & createSecret are the endpoints being called & that deleteSecret has an id name as parameter while createSecret has the postData & namespace. Finally, clearNotification just sends a type to the reducer. Now, the reducer really is not much different from other reducers, it just has more types to deal with. Finally, all tests file included here pass yet id like to get some confirmation on whether they were written & updated correctly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
