### PR TITLE
issue67 - secret management - main container & App configuration - merge order: last

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -53,7 +53,7 @@ export function deleteSecret(name, namespace) {
       await deleteCredential(name, namespace);
       dispatch({ type: 'SECRET_DELETE_SUCCESS', name, namespace });
     } catch (e) {
-      const error = new Error(`Could not delete secret ${name}`);
+      const error = new Error(`Could not delete secret "${name}"`);
       dispatch({ type: 'SECRET_DELETE_FAILURE', error });
     }
   };
@@ -68,7 +68,7 @@ export function createSecret(postData, namespace) {
       dispatch(fetchSecrets());
     } catch (e) {
       const error = new Error(
-        `Could not create secret ${postData.name} in namespace ${namespace}`
+        `Could not create secret "${postData.name}" in namespace ${namespace}`
       );
       dispatch({ type: 'SECRET_CREATE_FAILURE', error });
     }

--- a/src/actions/secrets.test.js
+++ b/src/actions/secrets.test.js
@@ -130,7 +130,7 @@ it('deleteSecret error', async () => {
   const mockStore = configureStore(middleware);
   const store = mockStore();
 
-  const error = new Error('Could not delete secret secret');
+  const error = new Error('Could not delete secret "secret"');
 
   jest.spyOn(API, 'deleteCredential').mockImplementation(() => {
     throw error;
@@ -175,7 +175,7 @@ it('createSecret error', async () => {
   const store = mockStore();
 
   const error = new Error(
-    'Could not create secret secret-name in namespace default'
+    'Could not create secret "secret-name" in namespace default'
   );
 
   jest.spyOn(API, 'createCredential').mockImplementation(() => {

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -52,6 +52,7 @@ const breadcrumbLabels = {
   '/pipelineresources': 'PipelineResources',
   '/pipelineruns': 'PipelineRuns',
   '/pipelines': 'Pipelines',
+  '/secrets': 'Secrets',
   '/taskruns': 'TaskRuns',
   '/tasks': 'Tasks'
 };

--- a/src/components/SecretsTable/Secrets.scss
+++ b/src/components/SecretsTable/Secrets.scss
@@ -19,7 +19,7 @@ limitations under the License.
   margin-bottom: $spacing-03;
   z-index: 1000;
   right: 0;
-  top: 0;
+  top: 7rem;
 }
 
 .secrets {

--- a/src/components/SecretsTable/SecretsTable.js
+++ b/src/components/SecretsTable/SecretsTable.js
@@ -110,7 +110,12 @@ const SecretsTable = props => {
                         key={lastCell.id}
                         id={lastCell.id}
                         className="cellIcon"
-                        onClick={handleDelete}
+                        onClick={() => {
+                          handleDelete({
+                            name: secrets[index].name,
+                            namespace: secrets[index].namespace
+                          });
+                        }}
                         data-testid="deleteIcon"
                       >
                         {lastCell.value}

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -34,6 +34,7 @@ import {
   PipelineRun,
   PipelineRuns,
   Pipelines,
+  Secrets,
   SideNav,
   TaskRun,
   TaskRunList,
@@ -80,6 +81,7 @@ export /* istanbul ignore next */ class App extends Component {
                 exact
                 component={Pipelines}
               />
+              <Route path="/secrets" exact component={Secrets} />
               <Route path="/tasks" exact component={Tasks} />
               <Route
                 path="/namespaces/:namespace/tasks"

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -28,6 +28,7 @@ it('App renders successfully', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
+    secrets: { byNamespace: {} },
     extensions: { byName: {} },
     namespaces: { byName: {} },
     pipelines: { byNamespace: {} },

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { InlineNotification } from 'carbon-components-react';
+import Modal from '../SecretsModal';
+import DeleteModal from '../../components/SecretsDeleteModal';
+import Table from '../../components/SecretsTable';
+import {
+  clearNotification,
+  deleteSecret,
+  fetchSecrets
+} from '../../actions/secrets';
+import {
+  getSecrets,
+  getSecretsErrorMessage,
+  isFetchingSecrets
+} from '../../reducers';
+
+export /* istanbul ignore next */ class Secrets extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      openNewSecret: false,
+      openDeleteSecret: false,
+      toBeDeleted: null
+    };
+  }
+
+  componentDidMount() {
+    this.props.fetchSecrets();
+  }
+
+  handleNewSecretClick = () => {
+    this.setState(prevState => {
+      return {
+        openNewSecret: !prevState.openNewSecret
+      };
+    });
+  };
+
+  handleDeleteSecretToggle = () => {
+    this.setState({
+      openDeleteSecret: false,
+      toBeDeleted: null
+    });
+  };
+
+  handleDeleteSecretClick = value => {
+    this.setState({
+      openDeleteSecret: true,
+      toBeDeleted: value
+    });
+  };
+
+  delete = () => {
+    const { name, namespace } = this.state.toBeDeleted;
+    this.props.deleteSecret(name, namespace);
+    this.handleDeleteSecretToggle();
+  };
+
+  render() {
+    const { secrets, loading, error } = this.props;
+    const { openNewSecret, toBeDeleted, openDeleteSecret } = this.state;
+
+    return (
+      <>
+        {error && (
+          <InlineNotification
+            kind="error"
+            title="Error:"
+            subtitle={error}
+            iconDescription="Clear Notification"
+            className="notificationComponent"
+            data-testid="errorNotificationComponent"
+            onCloseButtonClick={this.props.clearNotification}
+          />
+        )}
+        <Table
+          handleNew={this.handleNewSecretClick}
+          handleDelete={this.handleDeleteSecretClick}
+          loading={loading}
+          secrets={secrets}
+        />
+        {openNewSecret && (
+          <Modal open={openNewSecret} handleNew={this.handleNewSecretClick} />
+        )}
+        {openDeleteSecret && (
+          <DeleteModal
+            open={openDeleteSecret}
+            handleClick={this.handleDeleteSecretToggle}
+            handleDelete={this.delete}
+            id={toBeDeleted.name}
+          />
+        )}
+      </>
+    );
+  }
+}
+
+Secrets.defaultProps = {
+  secrets: []
+};
+
+function mapStateToProps(state) {
+  return {
+    error: getSecretsErrorMessage(state),
+    loading: isFetchingSecrets(state),
+    secrets: getSecrets(state)
+  };
+}
+
+const mapDispatchToProps = {
+  fetchSecrets,
+  deleteSecret,
+  clearNotification
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Secrets);

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -1,0 +1,261 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import Secrets from '.';
+import * as API from '../../api';
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+it('click add new secret & modal appears', () => {
+  const props = {
+    secrets: [
+      {
+        name: 'github-repo-access-secret',
+        annotations: {
+          'tekton.dev/git-0': 'https://github.ibm.com'
+        }
+      }
+    ],
+    loading: false,
+    error: null
+  };
+
+  const byNamespace = {
+    default: [
+      {
+        uid: '0',
+        name: 'github-repo-access-secret',
+        type: 'userpass',
+        annotations: {
+          'tekton.dev/git-0': 'https://github.ibm.com'
+        }
+      }
+    ]
+  };
+
+  const namespaces = {
+    byName: {
+      default: {
+        metadata: {
+          name: 'default',
+          selfLink: '/api/v1/namespaces/default',
+          uid: '32b35d3b-6ce1-11e9-af21-025000000001',
+          resourceVersion: '4',
+          creationTimestamp: '2019-05-02T13:50:08Z'
+        },
+        spec: {
+          finalizers: ['kubernetes']
+        },
+        status: {
+          phase: 'Active'
+        }
+      },
+      docker: {
+        metadata: {
+          name: 'docker',
+          selfLink: '/api/v1/namespaces/docker',
+          uid: '571796bd-6ce1-11e9-af21-025000000001',
+          resourceVersion: '413',
+          creationTimestamp: '2019-05-02T13:51:09Z'
+        },
+        spec: {
+          finalizers: ['kubernetes']
+        },
+        status: {
+          phase: 'Active'
+        }
+      },
+      'kube-public': {
+        metadata: {
+          name: 'kube-public',
+          selfLink: '/api/v1/namespaces/kube-public',
+          uid: '351f8763-6ce1-11e9-af21-025000000001',
+          resourceVersion: '31',
+          creationTimestamp: '2019-05-02T13:50:12Z'
+        },
+        spec: {
+          finalizers: ['kubernetes']
+        },
+        status: {
+          phase: 'Active'
+        }
+      },
+      'kube-system': {
+        metadata: {
+          name: 'kube-system',
+          selfLink: '/api/v1/namespaces/kube-system',
+          uid: '33426195-6ce1-11e9-af21-025000000001',
+          resourceVersion: '12',
+          creationTimestamp: '2019-05-02T13:50:09Z'
+        },
+        spec: {
+          finalizers: ['kubernetes']
+        },
+        status: {
+          phase: 'Active'
+        }
+      },
+      'tekton-pipelines': {
+        metadata: {
+          name: 'tekton-pipelines',
+          selfLink: '/api/v1/namespaces/tekton-pipelines',
+          uid: 'd30b0dbf-6d08-11e9-af21-025000000001',
+          resourceVersion: '12915',
+          creationTimestamp: '2019-05-02T18:33:47Z',
+          annotations: {
+            'kubectl.kubernetes.io/last-applied-configuration':
+              '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"tekton-pipelines"}}\n'
+          }
+        },
+        spec: {
+          finalizers: ['kubernetes']
+        },
+        status: {
+          phase: 'Active'
+        }
+      }
+    },
+    errorMessage: null,
+    isFetching: false,
+    selected: 'default'
+  };
+
+  jest.spyOn(API, 'getCredentials').mockImplementation(() => []);
+
+  jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
+
+  const store = mockStore({
+    secrets: {
+      byNamespace,
+      isFetching: false,
+      errorMessage: null
+    },
+    namespaces
+  });
+  const { getByTestId, queryByText } = render(
+    <Provider store={store}>
+      <Secrets {...props} />
+    </Provider>
+  );
+
+  expect(queryByText('Create Secret')).toBeFalsy();
+  expect(queryByText('Close')).toBeFalsy();
+  expect(queryByText('Submit')).toBeFalsy();
+
+  fireEvent.click(getByTestId('addIcon'));
+
+  expect(queryByText('Create Secret')).toBeTruthy();
+  expect(queryByText('Close')).toBeTruthy();
+  expect(queryByText('Submit')).toBeTruthy();
+});
+
+it('click add delete secret & modal appears', () => {
+  const props = {
+    secrets: [
+      {
+        name: 'github-repo-access-secret',
+        annotations: {
+          'tekton.dev/git-0': 'https://github.ibm.com'
+        }
+      }
+    ],
+    loading: false,
+    error: null
+  };
+
+  const byNamespace = {
+    default: [
+      {
+        uid: '0',
+        name: 'github-repo-access-secret',
+        type: 'userpass',
+        annotations: {
+          'tekton.dev/git-0': 'https://github.ibm.com'
+        }
+      }
+    ]
+  };
+
+  const namespaces = {
+    selected: 'default'
+  };
+
+  const store = mockStore({
+    secrets: {
+      byNamespace,
+      isFetching: false,
+      errorMessage: null
+    },
+    namespaces
+  });
+  const { getByTestId, queryByText } = render(
+    <Provider store={store}>
+      <Secrets {...props} />
+    </Provider>
+  );
+
+  expect(queryByText('Delete Secret')).toBeFalsy();
+  expect(queryByText('Cancel')).toBeFalsy();
+  expect(queryByText('Delete')).toBeFalsy();
+
+  fireEvent.click(getByTestId('deleteIcon'));
+
+  expect(queryByText('Delete Secret')).toBeTruthy();
+  expect(queryByText('Cancel')).toBeTruthy();
+  expect(queryByText('Delete')).toBeTruthy();
+});
+
+it('error notification appears', () => {
+  const props = {
+    secrets: [],
+    loading: false,
+    error: 'error'
+  };
+
+  const byNamespace = {
+    default: [
+      {
+        name: 'github-repo-access-secret',
+        annotations: {
+          'tekton.dev/git-0': 'https://github.ibm.com'
+        }
+      }
+    ]
+  };
+
+  const namespaces = {
+    selected: 'default'
+  };
+
+  const store = mockStore({
+    secrets: {
+      byNamespace,
+      isFetching: false,
+      errorMessage: 'Some error message'
+    },
+    namespaces
+  });
+  const { getByTestId } = render(
+    <Provider store={store}>
+      <Secrets {...props} />
+    </Provider>
+  );
+
+  expect(getByTestId('errorNotificationComponent')).toBeTruthy();
+});

--- a/src/containers/Secrets/index.js
+++ b/src/containers/Secrets/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './Secrets';

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -41,33 +41,27 @@ function validateInputs(value, id) {
   return true;
 }
 
-const initialState = {
-  name: '',
-  namespace: 'default',
-  accessTo: 'git',
-  username: '',
-  password: '',
-  serviceAccount: '',
-  annotations: [
-    {
-      label: `tekton.dev/git-0`,
-      value: '',
-      id: Math.random()
-        .toString(36)
-        .substr(2, 9)
-    }
-  ],
-  invalidFields: []
-};
-
 export /* istanbul ignore next */ class SecretsModal extends Component {
   constructor(props) {
     super(props);
-    this.state = initialState;
-  }
-
-  componentWillUnmount() {
-    this.setState(initialState);
+    this.state = {
+      name: '',
+      namespace: 'default',
+      accessTo: 'git',
+      username: '',
+      password: '',
+      serviceAccount: '',
+      annotations: [
+        {
+          label: `tekton.dev/git-0`,
+          value: '',
+          id: Math.random()
+            .toString(36)
+            .substr(2, 9)
+        }
+      ],
+      invalidFields: []
+    };
   }
 
   handleSubmit = () => {

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -151,6 +151,11 @@ export class SideNav extends Component {
           >
             Import Tekton resources
           </SideNavMenuItem>
+          {
+            // <SideNavMenuItem element={NavLink} icon={<span />} to="/secrets">
+            //   Secrets
+            // </SideNavMenuItem>
+          }
           {extensions.length > 0 &&
             extensions.map(({ displayName, name }) => (
               <SideNavMenuItem

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -29,6 +29,7 @@ export { default as PipelineRun } from './PipelineRun';
 export { default as PipelineRuns } from './PipelineRuns';
 export { default as Pipelines } from './Pipelines';
 export { default as PipelinesDropdown } from './PipelinesDropdown';
+export { default as Secrets } from './Secrets';
 export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';
 export { default as SideNav } from './SideNav';
 export { default as Tasks } from './Tasks';


### PR DESCRIPTION
issue: #67

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR contains the main container that is linked to the App component & is rendered when “secrets” is selected from the nav bar. This container is responsible for passing the necessary props for the table to render correctly, deciding when to show the add new secret modal the modal that confirms if user really wants to delete the selected secret & a notification that appears if an error occurred.  When mounted, it calls the fetchSecrets action & from the response it decides whether the rows of the table should display blank, loading or the secrets’ information. In it state it has 3 variables, two are for keeping track of the respective modals being active & the one to know what secret is going to be deleted. It also has 4 handlers:
1. handleNewSecretClick hides or shows the modal to create a new secret.
2. handleDeleteSecretToggle just hides the confirm delete modal & wipes out the state variable containing the name of the secret to be deleted.
3. handleDeleteSecretClick grabs the name of the secret to be deleted from the element’s id that had the OnClick event (in this case the Remove Button in the table), saves it in the toBeDelete state variable & opens the deletion confirmation modal. 
4. delete executes the deleteSecret action & then calls handleDeleteSecretToggle.

Now, if giving the case that an error occurred when triggering one of the actions, a notification will appear in the right-hand corner and an if statement will be triggered which results in  a timeout function whose purpose is to call the clearNotification action after 5 seconds. Lastly, the PR includes the updated App test & the secrets test. The latter focuses on testing that each respective modal or notification appears when the respective event is fired. 

# Updates
made some minor updates from the previous PRs that are meant for the inline notification in the secrets container as well as fix a bug with the new secret modal. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
