### PR TITLE
issue67 - secret management - table & confirm delete modal - merge order: 1st

### DIFF
--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.js
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Modal } from 'carbon-components-react';
+import './SecretsDeleteModal.scss';
+
+const SecretsDeleteModal = props => {
+  const { open, id, handleClick, handleDelete } = props;
+
+  return (
+    <Modal
+      open={open}
+      className="deleteModal"
+      primaryButtonText="Delete"
+      secondaryButtonText="Cancel"
+      modalHeading="Delete Secret"
+      onSecondarySubmit={handleClick}
+      onRequestSubmit={handleDelete}
+      onRequestClose={handleClick}
+    >
+      <p>
+        Are you sure you want to delete the secret <strong>{id}</strong>?
+      </p>
+    </Modal>
+  );
+};
+
+export default SecretsDeleteModal;

--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.scss
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.scss
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '~carbon-components/scss/globals/scss/vars';
+
+.deleteModal {
+  p {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+
+  strong {
+    font-weight: bold;
+    color: $support-01;
+  }
+
+  .bx--modal-footer {
+    button {
+      font-size: 1.25rem;
+    }
+  }
+}

--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.test.js
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.test.js
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import SecretsDeleteModal from './SecretsDeleteModal';
+
+it('SecretsDeleteModal renders with passed secret id', () => {
+  const props = {
+    open: true,
+    id: 'dummySecret',
+    handleClick() {},
+    handleDelete() {}
+  };
+  const { queryByText } = render(<SecretsDeleteModal {...props} />);
+  expect(queryByText('dummySecret')).toBeTruthy();
+  expect(queryByText('Cancel')).toBeTruthy();
+  expect(queryByText('Delete')).toBeTruthy();
+  expect(queryByText('Delete Secret')).toBeTruthy();
+});
+
+it('Test SecretsDeleteModal click events', () => {
+  const handleClick = jest.fn();
+  const handleDelete = jest.fn();
+  const props = {
+    open: true,
+    id: 'dummySecret',
+    handleClick,
+    handleDelete
+  };
+
+  const { queryByText, rerender } = render(<SecretsDeleteModal {...props} />);
+  fireEvent.click(queryByText('Delete'));
+  expect(handleDelete).toHaveBeenCalledTimes(1);
+  rerender(<SecretsDeleteModal open={false} />);
+  fireEvent.click(queryByText('Delete'));
+  expect(handleClick).toHaveBeenCalledTimes(0);
+});

--- a/src/components/SecretsDeleteModal/index.js
+++ b/src/components/SecretsDeleteModal/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './SecretsDeleteModal';

--- a/src/components/SecretsTable/Secrets.scss
+++ b/src/components/SecretsTable/Secrets.scss
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '~carbon-components/scss/globals/scss/vars';
+
+.notificationComponent {
+  position: absolute;
+  min-width: 30rem;
+  margin-bottom: $spacing-03;
+  z-index: 1000;
+  right: 0;
+  top: 0;
+}
+
+.secrets {
+  .header {
+    .cellText,
+    .cellIcon {
+      &:hover {
+        background: $hover-selected-ui;
+        button {
+          background: $hover-selected-ui;
+        }
+      }
+    }
+    .cellIcon {
+      fill: $support-02;
+      .bx--table-sort__icon-unsorted,
+      .bx--table-sort__icon {
+        display: none;
+      }
+    }
+  }
+
+  .row {
+    .cellIcon {
+      fill: $support-01;
+      width: 1%;
+      white-space: nowrap;
+      text-align: center;
+      &:hover {
+        fill: $hover-danger;
+      }
+    }
+
+    .bx--inline-loading {
+      display: inline-block;
+      width: 32px;
+    }
+
+    .cellText {
+      white-space: pre;
+    }
+
+    .cellTextNone {
+      text-align: center;
+    }
+
+    .cellIconNone {
+      width: 1%;
+      white-space: nowrap;
+      text-align: center;
+    }
+  }
+
+  .cellText:not(button),
+  .cellIcon:not(button),
+  .add,
+  .delete,
+  .cellIconNone,
+  .cellTextNone {
+    border: 3px solid white;
+  }
+}

--- a/src/components/SecretsTable/SecretsTable.js
+++ b/src/components/SecretsTable/SecretsTable.js
@@ -1,0 +1,148 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { DataTable, DataTableSkeleton } from 'carbon-components-react';
+import Add from '@carbon/icons-react/lib/add--alt/24';
+import Close from '@carbon/icons-react/lib/misuse/24';
+import './Secrets.scss';
+
+const {
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableCell,
+  TableHeader
+} = DataTable;
+
+const SecretsTable = props => {
+  const { handleDelete, handleNew, loading, secrets } = props;
+
+  const initialHeaders = [
+    { key: 'secret', header: 'Secret' },
+    { key: 'annotations', header: 'Annotations' },
+    { key: 'add', header: <Add /> }
+  ];
+
+  const secretsFormatted = secrets.map(secret => {
+    let annotations = '';
+    Object.keys(secret.annotations).forEach(function annotationSetup(key) {
+      annotations += `${key}: ${secret.annotations[key]}\n`;
+    });
+    return {
+      id: secret.uid,
+      secret: secret.name,
+      annotations,
+      add: <Close />
+    };
+  });
+
+  return loading ? (
+    <DataTableSkeleton rowCount={1} columnCount={initialHeaders.length} />
+  ) : (
+    <DataTable
+      rows={secretsFormatted}
+      headers={initialHeaders}
+      isSortable
+      useZebraStyles
+      render={({ rows, headers, getHeaderProps }) => (
+        <TableContainer>
+          <Table className="secrets">
+            <TableHead className="header">
+              <TableRow>
+                {headers.map((header, i) => {
+                  const headerCell =
+                    headers.length !== i + 1 ? (
+                      <TableHeader
+                        {...getHeaderProps({ header })}
+                        className="cellText"
+                        key={header.key}
+                      >
+                        {header.header}
+                      </TableHeader>
+                    ) : (
+                      <TableHeader
+                        key={header.key}
+                        data-testid="addIcon"
+                        className="cellIcon"
+                        {...getHeaderProps({
+                          header,
+                          onClick: handleNew
+                        })}
+                      >
+                        {header.header}
+                      </TableHeader>
+                    );
+
+                  return headerCell;
+                })}
+              </TableRow>
+            </TableHead>
+            {secretsFormatted.length !== 0 ? (
+              <TableBody>
+                {rows.map((row, index) => {
+                  const lastCell =
+                    rows[index].cells[rows[index].cells.length - 1];
+                  const secretName = row.cells[0].value;
+                  return (
+                    <TableRow key={row.id} className="row">
+                      {row.cells.splice(0, row.cells.length - 1).map(cell => (
+                        <TableCell
+                          key={cell.id}
+                          id={cell.id}
+                          className="cellText"
+                        >
+                          {cell.value}
+                        </TableCell>
+                      ))}
+                      <TableCell
+                        key={lastCell.id}
+                        id={secretName}
+                        className="cellIcon"
+                        onClick={handleDelete}
+                        data-testid="deleteIcon"
+                      >
+                        {lastCell.value}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            ) : (
+              <TableBody>
+                <TableRow className="row">
+                  {headers.splice(0, headers.length - 1).map(header => (
+                    <TableCell
+                      key={`${header.key}-empty`}
+                      id={`${header.key}-empty`}
+                      className="cellTextNone"
+                    >
+                      -
+                    </TableCell>
+                  ))}
+                  <TableCell id="icon-empty" className="cellIconNone">
+                    -
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            )}
+          </Table>
+        </TableContainer>
+      )}
+    />
+  );
+};
+
+export default SecretsTable;

--- a/src/components/SecretsTable/SecretsTable.test.js
+++ b/src/components/SecretsTable/SecretsTable.test.js
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import SecretsTable from './SecretsTable';
+
+it('SecretsTable renders with no secrets', () => {
+  const props = {
+    handleDelete() {},
+    handleNew() {},
+    loading: false,
+    secrets: []
+  };
+  const { getAllByText, queryByText } = render(<SecretsTable {...props} />);
+  expect(queryByText(/Secret/i)).toBeTruthy();
+  expect(queryByText(/Annotations/i)).toBeTruthy();
+  expect(getAllByText('-').length).toEqual(3);
+});
+
+it('SecretsTable renders with one secret', () => {
+  const props = {
+    handleDelete() {},
+    handleNew() {},
+    loading: false,
+    secrets: [
+      {
+        annotations: { 'tekton.dev/git-0': 'https://github.ibm.com' },
+        name: 'dummySecret',
+        uid: '0'
+      }
+    ]
+  };
+  const { queryByText } = render(<SecretsTable {...props} />);
+  expect(queryByText(/dummySecret/i)).toBeTruthy();
+  expect(
+    queryByText(/tekton.dev\/git-0: https:\/\/github.ibm.com/i)
+  ).toBeTruthy();
+});
+
+it('SecretsTable renders in loading state', () => {
+  const props = {
+    handleDelete() {},
+    handleNew() {},
+    loading: true,
+    secrets: []
+  };
+  const { queryByText } = render(<SecretsTable {...props} />);
+  expect(queryByText(/Secret/i)).toBeFalsy();
+  expect(queryByText(/Annotations/i)).toBeFalsy();
+});
+
+it('SecretsTable delete click handler', () => {
+  const handleDelete = jest.fn();
+  const props = {
+    handleDelete,
+    handleNew() {},
+    loading: false,
+    secrets: [
+      {
+        annotations: { 'tekton.dev/git-0': 'https://github.ibm.com' },
+        name: 'dummySecret',
+        uid: '0'
+      }
+    ]
+  };
+  const { getByTestId } = render(<SecretsTable {...props} />);
+  fireEvent.click(getByTestId('deleteIcon'));
+  expect(handleDelete).toHaveBeenCalledTimes(1);
+});

--- a/src/components/SecretsTable/index.js
+++ b/src/components/SecretsTable/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './SecretsTable';


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Both components in this PR are stateless. The table receives as props the secrets, loading state & the event handlers that fires when the Add button is clicked (last element in header array) & the Delete button in each row. From the secrets, the rows array is created & each object element in it includes an id that distinguishes the number of rows in the table & values for each key in the header object. Now some inline logic is used when rendering this component because if the store is loading then the skeleton is rendered but if there are secrets then it basically formats them so the Data Table component can read them & output all the fields. Now the last field in the header & row array is then rendered by itself after the logic finished executing. This is because the last element has an onClick event that opens delete confirmation or new secret modal, test-id (body only) & is styled differently.  The test file is focused on testing if the table renders correctly when the store either has no secrets, is loading them or has secrets. Lastly, the .scss file of this component also has the styling for the notification banner. 

Now, the delete modal is pretty simple, as its purpose is to confirm if the user really wants to delete the selected secret. Its props are an open variable that decides whether to show or hide the modal, an id that stores the secret to be deleted & two handlers function: handleClick is fired when the user clicks on the close button, X icon or outside the modal & basically just hides the modal. handleDelete is the delete function responsible for calling the deleteSecret action. Finally, The only case in the test file is to see if the id is passed & outputted correctly. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._