### PR TITLE
issue67 - secrets management - add new secret modal - merge order: 1st

### DIFF
--- a/src/components/SecretsModal/Annotations.js
+++ b/src/components/SecretsModal/Annotations.js
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { TextInput } from 'carbon-components-react';
+import Add from '@carbon/icons-react/lib/add--alt/24';
+import Remove from '@carbon/icons-react/lib/misuse/24';
+import './SecretsModal.scss';
+
+const Annotations = props => {
+  const {
+    annotations,
+    handleChange,
+    handleAdd,
+    handleRemove,
+    invalidFields
+  } = props;
+
+  const annotationFields = annotations.map((annotation, index) => {
+    return (
+      <div className="annotationRow" key={`annotationRow${annotation.id}`}>
+        <TextInput
+          id={`annotation-label${index}`}
+          labelText=""
+          aria-label={`Annotation Label#${index}. This is the tag Tekton uses for its resources.`}
+          value={annotation.label}
+          placeholder="tekton.dev/{source}-0"
+          onChange={handleChange}
+          invalid={invalidFields.indexOf(`annotation-label${index}`) > -1}
+          autoComplete="off"
+        />
+        <div className="colon">:</div>
+        <TextInput
+          id={`annotation-value${index}`}
+          labelText=""
+          aria-label={`Annotation Value#${index}. This is the url for the given Tekton resource.`}
+          value={annotation.value}
+          placeholder="https://domain.com"
+          onChange={handleChange}
+          invalid={invalidFields.indexOf(`annotation-value${index}`) > -1}
+          autoComplete="off"
+        />
+      </div>
+    );
+  });
+
+  return (
+    <div className="annotations">
+      <div className="labelAndButtons">
+        <p className="label">Server URL:</p>
+        <Remove className="removeIcon" onClick={handleRemove} />
+        <Add className="addIcon" onClick={handleAdd} />
+      </div>
+      {annotationFields}
+    </div>
+  );
+};
+
+export default Annotations;

--- a/src/components/SecretsModal/Annotations.test.js
+++ b/src/components/SecretsModal/Annotations.test.js
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { render } from 'react-testing-library';
+import Annotations from './Annotations';
+
+it('Annotations shows blank fields', () => {
+  const props = {
+    handleChange() {},
+    invalidFields: [],
+    annotations: [
+      { label: `tekton.dev/git-0`, value: '', id: 'aaaa' },
+      { label: `tekton.dev/git-1`, value: '', id: 'bbbb' },
+      { label: `tekton.dev/git-2`, value: '', id: 'cccc' }
+    ],
+    handleAdd() {},
+    handleRemove() {}
+  };
+  const { getAllByDisplayValue, getByText } = render(
+    <Annotations {...props} />
+  );
+
+  expect(getByText(/Server URL/i)).toBeTruthy();
+  expect(getAllByDisplayValue('').length).toEqual(3);
+  expect(getAllByDisplayValue(/tekton.dev\/git-/i).length).toEqual(3);
+});
+
+it('Annotations incorrect fields', () => {
+  const props = {
+    handleChange() {},
+    invalidFields: [
+      'annotation-label1',
+      'annotation-label2',
+      'annotation-value2'
+    ],
+    annotations: [
+      { label: `tekton.dev/git-0`, value: 'https://domain.com', id: 'aaaa' },
+      { label: `tekton.dev/git-1`, value: '', id: 'bbbb' },
+      { label: `tekton.dev/git-2`, value: 'https://domain.com', id: 'cccc' },
+      { label: `tekton.dev/git-3`, value: 'https://domain.com', id: 'dddd' }
+    ],
+    handleAdd() {},
+    handleRemove() {}
+  };
+  const { getByLabelText } = render(<Annotations {...props} />);
+
+  const annotationLabel0 = getByLabelText(/Annotation Label#0/i);
+  const annotationLabel1 = getByLabelText(/Annotation Label#1/i);
+  const annotationLabel2 = getByLabelText(/Annotation Label#2/i);
+  const annotationLabel3 = getByLabelText(/Annotation Label#3/i);
+  const annotationValue0 = getByLabelText(/Annotation Value#0/i);
+  const annotationValue1 = getByLabelText(/Annotation Value#1/i);
+  const annotationValue2 = getByLabelText(/Annotation Value#2/i);
+  const annotationValue3 = getByLabelText(/Annotation Value#3/i);
+
+  expect(annotationLabel0.getAttribute('data-invalid')).toBeFalsy();
+  expect(annotationLabel1.getAttribute('data-invalid')).toBeTruthy();
+  expect(annotationLabel2.getAttribute('data-invalid')).toBeTruthy();
+  expect(annotationLabel3.getAttribute('data-invalid')).toBeFalsy();
+  expect(annotationValue0.getAttribute('data-invalid')).toBeFalsy();
+  expect(annotationValue1.getAttribute('data-invalid')).toBeFalsy();
+  expect(annotationValue2.getAttribute('data-invalid')).toBeTruthy();
+  expect(annotationValue3.getAttribute('data-invalid')).toBeFalsy();
+});

--- a/src/components/SecretsModal/BasicAuthFields.js
+++ b/src/components/SecretsModal/BasicAuthFields.js
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { TextInput } from 'carbon-components-react';
+import './SecretsModal.scss';
+
+const BasicAuthFields = props => {
+  const {
+    username,
+    password,
+    handleChange,
+    invalidFields,
+    serviceAccount
+  } = props;
+  return (
+    <>
+      <TextInput
+        id="username"
+        autoComplete="off"
+        placeholder="example@domain.com"
+        value={username}
+        labelText="Email:"
+        onChange={handleChange}
+        invalid={invalidFields.indexOf('username') > -1}
+      />
+      <TextInput
+        id="password"
+        autoComplete="off"
+        type="password"
+        value={password}
+        placeholder="********"
+        labelText="Password/Token:"
+        onChange={handleChange}
+        invalid={invalidFields.indexOf('password') > -1}
+      />
+      <TextInput
+        id="serviceAccount"
+        autoComplete="off"
+        type="serviceAccount"
+        value={serviceAccount}
+        placeholder="default"
+        labelText="Service Account:"
+        onChange={handleChange}
+        invalid={invalidFields.indexOf('serviceAccount') > -1}
+        invalidText="Must be less than 563 characters, contain only lowercase alphanumeric characters, . or -"
+      />
+    </>
+  );
+};
+
+export default BasicAuthFields;

--- a/src/components/SecretsModal/BasicAuthFields.test.js
+++ b/src/components/SecretsModal/BasicAuthFields.test.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { render } from 'react-testing-library';
+import BasicAuthFields from './BasicAuthFields';
+
+it('BasicAuthFields renders with blank inputs', () => {
+  const props = {
+    username: '',
+    password: '',
+    serviceAccount: '',
+    handleChange() {},
+    invalidFields: []
+  };
+  const { getByLabelText, getAllByDisplayValue } = render(
+    <BasicAuthFields {...props} />
+  );
+  expect(getByLabelText(/Email/i)).toBeTruthy();
+  expect(getByLabelText(/Password\/Token/i)).toBeTruthy();
+  expect(getByLabelText(/Service Account/i)).toBeTruthy();
+  expect(getAllByDisplayValue('').length).toEqual(3);
+});
+
+it('BasicAuthFields incorrect fields', () => {
+  const props = {
+    username: 'text',
+    password: 'text',
+    serviceAccount: '',
+    handleChange() {},
+    invalidFields: ['username', 'password']
+  };
+  const { getByLabelText } = render(<BasicAuthFields {...props} />);
+
+  const usernameInput = getByLabelText(/Email/i);
+  const passwordInput = getByLabelText(/Password\/Token/i);
+  const serviceAccountInput = getByLabelText(/Service Account/i);
+
+  expect(usernameInput.getAttribute('data-invalid')).toBeTruthy();
+  expect(passwordInput.getAttribute('data-invalid')).toBeTruthy();
+  expect(serviceAccountInput.getAttribute('data-invalid')).toBeFalsy();
+});

--- a/src/components/SecretsModal/SecretsModal.scss
+++ b/src/components/SecretsModal/SecretsModal.scss
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '~carbon-components/scss/globals/scss/vars';
+
+.modal.bx--modal.is-visible {
+  .bx--modal-container {
+    width: 30%;
+  }
+
+  .bx--form-item, .bx--dropdown__wrapper{
+    margin-bottom: $spacing-03;
+  }
+
+  .bx--text-input__field-wrapper {
+    min-width: 100%;
+  }
+
+  .bx--dropdown {
+    background-color: $ui-background;
+  }
+
+  .bx--modal-content {
+    margin: 0;
+    padding: 0 $spacing-05;
+  }
+
+  .bx--modal-footer {
+    button {
+      font-size: 1.25rem;
+    }
+  }
+
+  .annotations {
+    margin-bottom: $spacing-05;
+    .labelAndButtons {
+      display: flex;
+      align-items: space-between;
+      .label {
+        color: $text-02;
+        font-size: 12px;
+        height: 29px;
+        flex: 1;
+        text-align: left;
+      }
+      .removeIcon {
+        fill: $support-01;
+        &:hover {
+          fill: $hover-danger;
+        }
+      }
+      .addIcon {
+        fill: $support-02;
+        &:hover {
+          fill: darken($support-02, 10%);
+        }
+      }
+    }
+    .annotationRow {
+      .bx--form-item.bx--text-input-wrapper {
+        width: 48%;
+        display: inline-flex;
+        vertical-align: middle;
+      }
+      .colon {
+        display: inline-block;
+        width: 4%;
+        text-align: center;
+      }
+    }
+  }
+}

--- a/src/components/SecretsModal/UniversalFields.js
+++ b/src/components/SecretsModal/UniversalFields.js
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Dropdown, TextInput } from 'carbon-components-react';
+import './SecretsModal.scss';
+import NamespacesDropdown from '../../containers/NamespacesDropdown';
+
+const itemToString = item => (item ? item.text : '');
+
+const UniversalFields = props => {
+  const {
+    name,
+    handleChange,
+    accessTo,
+    selectedNamespace,
+    invalidFields
+  } = props;
+
+  return (
+    <>
+      <TextInput
+        id="name"
+        placeholder="secret-name"
+        value={name}
+        labelText="Name:"
+        onChange={handleChange}
+        invalid={invalidFields.indexOf('name') > -1}
+        invalidText="Must be less than 563 characters, contain only lowercase alphanumeric character, . or -"
+        autoComplete="off"
+      />
+      <NamespacesDropdown
+        id="namespace"
+        selectedItem={{ id: selectedNamespace, text: selectedNamespace }}
+        onChange={handleChange}
+      />
+      <Dropdown
+        id="accessTo"
+        titleText="Access To:"
+        label=""
+        initialSelectedItem={{
+          id: accessTo,
+          text: accessTo === 'git' ? 'Git Server' : 'Docker Registry',
+          component: 'accessTo'
+        }}
+        items={[
+          { id: 'git', text: 'Git Server', component: 'accessTo' },
+          { id: 'docker', text: 'Docker Registry', component: 'accessTo' }
+        ]}
+        itemToString={itemToString}
+        onChange={handleChange}
+      />
+    </>
+  );
+};
+
+export default UniversalFields;

--- a/src/components/SecretsModal/UniversalFields.test.js
+++ b/src/components/SecretsModal/UniversalFields.test.js
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import UniversalFields from './UniversalFields';
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+const namespaces = {
+  byName: {
+    default: {
+      metadata: {
+        name: 'default',
+        selfLink: '/api/v1/namespaces/default',
+        uid: '32b35d3b-6ce1-11e9-af21-025000000001',
+        resourceVersion: '4',
+        creationTimestamp: '2019-05-02T13:50:08Z'
+      }
+    },
+    docker: {
+      metadata: {
+        name: 'docker',
+        selfLink: '/api/v1/namespaces/docker',
+        uid: '571796bd-6ce1-11e9-af21-025000000001',
+        resourceVersion: '413',
+        creationTimestamp: '2019-05-02T13:51:09Z'
+      }
+    },
+    'kube-public': {
+      metadata: {
+        name: 'kube-public',
+        selfLink: '/api/v1/namespaces/kube-public',
+        uid: '351f8763-6ce1-11e9-af21-025000000001',
+        resourceVersion: '31',
+        creationTimestamp: '2019-05-02T13:50:12Z'
+      }
+    },
+    'kube-system': {
+      metadata: {
+        name: 'kube-system',
+        selfLink: '/api/v1/namespaces/kube-system',
+        uid: '33426195-6ce1-11e9-af21-025000000001',
+        resourceVersion: '12',
+        creationTimestamp: '2019-05-02T13:50:09Z'
+      }
+    },
+    'tekton-pipelines': {
+      metadata: {
+        name: 'tekton-pipelines',
+        selfLink: '/api/v1/namespaces/tekton-pipelines',
+        uid: 'd30b0dbf-6d08-11e9-af21-025000000001',
+        resourceVersion: '12915',
+        creationTimestamp: '2019-05-02T18:33:47Z',
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration':
+            '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"tekton-pipelines"}}\n'
+        }
+      }
+    }
+  },
+  errorMessage: null,
+  isFetching: false,
+  selected: 'default'
+};
+
+const store = mockStore({
+  namespaces
+});
+
+it('UniversalFields renders with blank inputs', () => {
+  const props = {
+    name: '',
+    handleChange() {},
+    accessTo: 'git',
+    selectedNamespace: 'default',
+    invalidFields: []
+  };
+  const { getByLabelText, getAllByDisplayValue, getByText } = render(
+    <Provider store={store}>
+      <UniversalFields {...props} />
+    </Provider>
+  );
+  expect(getByLabelText(/Name/i)).toBeTruthy();
+  expect(getByLabelText(/Namespace/i)).toBeTruthy();
+  expect(getByLabelText(/Access To/i)).toBeTruthy();
+  expect(getByText(/Git Server/i)).toBeTruthy();
+  expect(getByText(/default/i)).toBeTruthy();
+  expect(getAllByDisplayValue('').length).toEqual(1);
+});
+
+it('UniversalFields incorrect fields', () => {
+  const props = {
+    name: '',
+    handleChange() {},
+    accessTo: 'git',
+    selectedNamespace: 'default',
+    invalidFields: ['name']
+  };
+  const { getByLabelText } = render(
+    <Provider store={store}>
+      <UniversalFields {...props} />
+    </Provider>
+  );
+
+  const nameInput = getByLabelText(/Name/i);
+
+  expect(nameInput.getAttribute('data-invalid')).toBeTruthy();
+});

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -1,0 +1,308 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Modal } from 'carbon-components-react';
+import UniversalFields from '../../components/SecretsModal/UniversalFields';
+import Annotations from '../../components/SecretsModal/Annotations';
+import BasicAuthFields from '../../components/SecretsModal/BasicAuthFields';
+import '../../components/SecretsModal/SecretsModal.scss';
+import { createSecret } from '../../actions/secrets';
+
+/* istanbul ignore next */
+function validateInputs(value, id) {
+  const trimmed = value.trim();
+
+  if (trimmed === '') {
+    return false;
+  }
+
+  if (id === 'name' || id === 'serviceAccount') {
+    if (trimmed.length > 253) {
+      return false;
+    }
+
+    if (/[^-.a-z1-9]/.test(trimmed)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const initialState = {
+  name: '',
+  namespace: 'default',
+  accessTo: 'git',
+  username: '',
+  password: '',
+  serviceAccount: '',
+  annotations: [
+    {
+      label: `tekton.dev/git-0`,
+      value: '',
+      id: Math.random()
+        .toString(36)
+        .substr(2, 9)
+    }
+  ],
+  invalidFields: []
+};
+
+export /* istanbul ignore next */ class SecretsModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = initialState;
+  }
+
+  componentWillUnmount() {
+    this.setState(initialState);
+  }
+
+  handleSubmit = () => {
+    const invalidFields = [];
+    const postData = { type: 'userpass' };
+    const {
+      annotations,
+      name,
+      namespace,
+      password,
+      serviceAccount,
+      username
+    } = this.state;
+
+    if (validateInputs(name, 'name')) {
+      postData.name = name;
+    } else {
+      invalidFields.push('name');
+    }
+
+    if (validateInputs(username, 'username')) {
+      postData.username = username;
+    } else {
+      invalidFields.push('username');
+    }
+
+    if (validateInputs(password, 'password')) {
+      postData.password = password;
+    } else {
+      invalidFields.push('password');
+    }
+
+    if (validateInputs(serviceAccount, 'serviceAccount')) {
+      postData.serviceAccount = serviceAccount;
+    } else {
+      invalidFields.push('serviceAccount');
+    }
+
+    const annotationsObject = {};
+    for (let i = 0; i < annotations.length; i += 1) {
+      if (
+        !validateInputs(annotations[i].label, `annotation-label${i}`) ||
+        !validateInputs(annotations[i].value, `annotation-value${i}`)
+      ) {
+        if (!validateInputs(annotations[i].label, `annotation-label${i}`)) {
+          invalidFields.push(`annotation-label${i}`);
+        }
+        if (!validateInputs(annotations[i].value, `annotation-value${i}`)) {
+          invalidFields.push(`annotation-value${i}`);
+        }
+      } else {
+        annotationsObject[annotations[i].label] = annotations[i].value;
+      }
+    }
+    postData.url = annotationsObject;
+
+    if (invalidFields.length === 0) {
+      this.props.createSecret(postData, namespace);
+      this.props.handleNew();
+    } else {
+      this.setState({ invalidFields });
+    }
+  };
+
+  handleChange = e => {
+    let stateVar = '';
+    let stateValue = '';
+    if (Object.prototype.hasOwnProperty.call(e, 'target')) {
+      stateVar = e.target.id;
+      stateValue = e.target.value;
+    } else if (
+      Object.prototype.hasOwnProperty.call(e.selectedItem, 'component')
+    ) {
+      stateVar = 'accessTo';
+      stateValue = e.selectedItem.id;
+    } else {
+      stateVar = 'namespace';
+      stateValue = e.selectedItem.text;
+    }
+    this.setState(prevState => {
+      const newInvalidFields = prevState.invalidFields;
+      const idIndex = newInvalidFields.indexOf(stateVar);
+      if (validateInputs(stateValue, stateVar)) {
+        if (idIndex !== -1) {
+          newInvalidFields.splice(idIndex, 1);
+        }
+      } else if (idIndex === -1) {
+        newInvalidFields.push(stateVar);
+      }
+
+      if (stateVar === 'accessTo') {
+        const annotations = prevState.annotations.map(annotation => {
+          let toSearch;
+          if (stateValue === 'git') {
+            toSearch = 'docker';
+          } else {
+            toSearch = 'git';
+          }
+          return {
+            label: annotation.label.split(toSearch).join(stateValue),
+            value: annotation.value,
+            id: annotation.id
+          };
+        });
+        return {
+          [stateVar]: stateValue,
+          annotations,
+          invalidFields: newInvalidFields
+        };
+      }
+      return { [stateVar]: stateValue, invalidFields: newInvalidFields };
+    });
+  };
+
+  handleAnnotationChange = e => {
+    e.persist();
+    this.setState(prevState => {
+      let { id } = e.target;
+      const { value } = e.target;
+      const newInvalidFields = prevState.invalidFields;
+      const idIndex = newInvalidFields.indexOf(id);
+      if (idIndex !== -1) {
+        newInvalidFields.splice(idIndex, 1);
+      }
+
+      if (!validateInputs(value, id)) {
+        newInvalidFields.push(id);
+      }
+
+      id = id
+        .split('-')
+        .splice(1, 2)
+        .join();
+      const index = id.substr(id.length - 1);
+      id = id.slice(0, -1);
+
+      const { annotations } = prevState;
+      annotations[index][id] = value;
+
+      return {
+        annotations,
+        invalidFields: newInvalidFields
+      };
+    });
+  };
+
+  handleAdd = () => {
+    this.setState(prevState => {
+      const { annotations, accessTo } = prevState;
+      annotations.push({
+        label: `tekton.dev/${accessTo}-${annotations.length}`,
+        value: '',
+        id: Math.random()
+          .toString(36)
+          .substr(2, 9)
+      });
+      return annotations;
+    });
+  };
+
+  handleRemove = () => {
+    this.setState(prevState => {
+      const { annotations } = prevState;
+      if (annotations.length - 1 !== 0) {
+        annotations.pop();
+      }
+      return annotations;
+    });
+  };
+
+  render() {
+    const { open, handleNew } = this.props;
+    const {
+      name,
+      namespace,
+      accessTo,
+      username,
+      password,
+      annotations,
+      invalidFields,
+      serviceAccount
+    } = this.state;
+
+    return (
+      <Modal
+        open={open}
+        className="modal"
+        primaryButtonText="Submit"
+        secondaryButtonText="Close"
+        modalHeading="Create Secret"
+        onSecondarySubmit={handleNew}
+        onRequestSubmit={this.handleSubmit}
+        onRequestClose={handleNew}
+      >
+        <form>
+          <UniversalFields
+            name={name}
+            selectedNamespace={namespace}
+            accessTo={accessTo}
+            handleChange={this.handleChange}
+            invalidFields={invalidFields}
+          />
+          <BasicAuthFields
+            username={username}
+            password={password}
+            serviceAccount={serviceAccount}
+            handleChange={this.handleChange}
+            invalidFields={invalidFields}
+          />
+          <Annotations
+            annotations={annotations}
+            handleChange={this.handleAnnotationChange}
+            handleRemove={this.handleRemove}
+            handleAdd={this.handleAdd}
+            invalidFields={invalidFields}
+          />
+        </form>
+      </Modal>
+    );
+  }
+}
+
+SecretsModal.defaultProps = {
+  open: false
+};
+
+function mapStateToProps() {
+  return {};
+}
+
+const mapDispatchToProps = {
+  createSecret
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SecretsModal);

--- a/src/containers/SecretsModal/SecretsModal.test.js
+++ b/src/containers/SecretsModal/SecretsModal.test.js
@@ -1,0 +1,201 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import SecretsModal from '.';
+import * as API from '../../api';
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+it('SecretsModal renders blank', () => {
+  const props = {
+    open: true
+  };
+
+  const secrets = {
+    byNamespace: {},
+    errorMessage: null,
+    isFetching: false
+  };
+
+  const namespaces = {
+    byName: {
+      default: {
+        metadata: {
+          name: 'default',
+          selfLink: '/api/v1/namespaces/default',
+          uid: '32b35d3b-6ce1-11e9-af21-025000000001',
+          resourceVersion: '4',
+          creationTimestamp: '2019-05-02T13:50:08Z'
+        }
+      },
+      docker: {
+        metadata: {
+          name: 'docker',
+          selfLink: '/api/v1/namespaces/docker',
+          uid: '571796bd-6ce1-11e9-af21-025000000001',
+          resourceVersion: '413',
+          creationTimestamp: '2019-05-02T13:51:09Z'
+        }
+      },
+      'kube-public': {
+        metadata: {
+          name: 'kube-public',
+          selfLink: '/api/v1/namespaces/kube-public',
+          uid: '351f8763-6ce1-11e9-af21-025000000001',
+          resourceVersion: '31',
+          creationTimestamp: '2019-05-02T13:50:12Z'
+        }
+      },
+      'kube-system': {
+        metadata: {
+          name: 'kube-system',
+          selfLink: '/api/v1/namespaces/kube-system',
+          uid: '33426195-6ce1-11e9-af21-025000000001',
+          resourceVersion: '12',
+          creationTimestamp: '2019-05-02T13:50:09Z'
+        }
+      },
+      'tekton-pipelines': {
+        metadata: {
+          name: 'tekton-pipelines',
+          selfLink: '/api/v1/namespaces/tekton-pipelines',
+          uid: 'd30b0dbf-6d08-11e9-af21-025000000001',
+          resourceVersion: '12915',
+          creationTimestamp: '2019-05-02T18:33:47Z',
+          annotations: {
+            'kubectl.kubernetes.io/last-applied-configuration':
+              '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"tekton-pipelines"}}\n'
+          }
+        }
+      }
+    },
+    errorMessage: null,
+    isFetching: false,
+    selected: 'default'
+  };
+
+  jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
+
+  const store = mockStore({
+    secrets,
+    namespaces
+  });
+  const { queryByText } = render(
+    <Provider store={store}>
+      <SecretsModal {...props} />
+    </Provider>
+  );
+  expect(queryByText('Create Secret')).toBeTruthy();
+  expect(queryByText('Close')).toBeTruthy();
+  expect(queryByText('Submit')).toBeTruthy();
+});
+
+it('Test SecretsModal click events', () => {
+  const handleNew = jest.fn();
+  const handleSubmit = jest.fn();
+  const props = {
+    open: true,
+    handleNew
+  };
+
+  const secrets = {
+    byNamespace: {},
+    errorMessage: null,
+    isFetching: false
+  };
+
+  const namespaces = {
+    byName: {
+      default: {
+        metadata: {
+          name: 'default',
+          selfLink: '/api/v1/namespaces/default',
+          uid: '32b35d3b-6ce1-11e9-af21-025000000001',
+          resourceVersion: '4',
+          creationTimestamp: '2019-05-02T13:50:08Z'
+        }
+      },
+      docker: {
+        metadata: {
+          name: 'docker',
+          selfLink: '/api/v1/namespaces/docker',
+          uid: '571796bd-6ce1-11e9-af21-025000000001',
+          resourceVersion: '413',
+          creationTimestamp: '2019-05-02T13:51:09Z'
+        }
+      },
+      'kube-public': {
+        metadata: {
+          name: 'kube-public',
+          selfLink: '/api/v1/namespaces/kube-public',
+          uid: '351f8763-6ce1-11e9-af21-025000000001',
+          resourceVersion: '31',
+          creationTimestamp: '2019-05-02T13:50:12Z'
+        }
+      },
+      'kube-system': {
+        metadata: {
+          name: 'kube-system',
+          selfLink: '/api/v1/namespaces/kube-system',
+          uid: '33426195-6ce1-11e9-af21-025000000001',
+          resourceVersion: '12',
+          creationTimestamp: '2019-05-02T13:50:09Z'
+        }
+      },
+      'tekton-pipelines': {
+        metadata: {
+          name: 'tekton-pipelines',
+          selfLink: '/api/v1/namespaces/tekton-pipelines',
+          uid: 'd30b0dbf-6d08-11e9-af21-025000000001',
+          resourceVersion: '12915',
+          creationTimestamp: '2019-05-02T18:33:47Z',
+          annotations: {
+            'kubectl.kubernetes.io/last-applied-configuration':
+              '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"tekton-pipelines"}}\n'
+          }
+        }
+      }
+    },
+    errorMessage: null,
+    isFetching: false,
+    selected: 'default'
+  };
+
+  jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
+
+  const store = mockStore({
+    secrets,
+    namespaces
+  });
+
+  const { queryByText, rerender } = render(
+    <Provider store={store}>
+      <SecretsModal {...props} />
+    </Provider>
+  );
+  fireEvent.click(queryByText('Close'));
+  expect(handleNew).toHaveBeenCalledTimes(1);
+  rerender(
+    <Provider store={store}>
+      <SecretsModal open={false} />
+    </Provider>
+  );
+  fireEvent.click(queryByText('Submit'));
+  expect(handleSubmit).toHaveBeenCalledTimes(0);
+});

--- a/src/containers/SecretsModal/index.js
+++ b/src/containers/SecretsModal/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './SecretsModal';


### PR DESCRIPTION
issue: #67

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR is focused on the add new secret modal which consists on a parent container & a couple of stateless components. Secret Modal receives as props the open variable responsible for showing or hiding the modal, namespaces array which is fetched when the container mounts & handleNew handler function that is used to close the modal when the user either clicks on the close button, X icon or outside the modal. In it state it stores all the variables used throughout the form  & an array that stores each form field that is currently invalid. The container is set to initial state when component is unmounted. It has a couple of handlers: 
1. handleSubmit is called when the user clicks the submit button in the modal & basically validates the data & if everything looks good, it fires the createSecret action with the postData & desired namespace as arguments & then closes the modal.
2. handleChange just validates the current input fields being changed (except the urls) & update its state & might even store the fields name if it was invalid. 
3. handleAnnotationChange validates the urls & maintains the correct format of the annotations state variable. 
4. handleAdd & handleRemove either add more url fields or remove them & will only work when the service account field is filled & valid. 

I decided to divide the form into three components & the reason behind this was primarily to avoid clutter, but also, if in the future some other type of secrets can be created where some other fields are required & others are not then it makes it easier to render by adding a little inline logic. Each component is passed its necessary state variables, handleChange handler & invalidFields array. Each field in the component is disabled expect the first one & will be enabled once the field before it is filled & validated. Last two components include a disabled prop which is used to know if the first field in those respective components should render disabled or not. Lastly, s worth mentioning that each field inputs, aside from some simple attributes it also has an invalid attribute that is true when that field’s name is stored in the invalidFields array)
1. UniversalFields consist of the secret name, desired namespace & accessTo which can either be docker or git. 
2. BasicAuthFields consist of username, password & service account. 
3. Annotations just consists of the urls which may be more than one.

When testing the container the only test case featured is if it renders blank & for each of the components i test to see whether it correctly renders blank, disabled & invalid fields . 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
