### PR TITLE
Update NamespacesDropdown to support 'All Namespaces' option

### DIFF
--- a/src/components/TooltipDropdown/TooltipDropdown.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.js
@@ -14,9 +14,9 @@ limitations under the License.
 import React from 'react';
 import { Dropdown, DropdownSkeleton } from 'carbon-components-react';
 
-const itemToElement = ({ text }) => {
+const itemToElement = ({ id, text }) => {
   return (
-    <div key={text} title={text}>
+    <div key={id} title={text}>
       {text}
     </div>
   );
@@ -24,13 +24,19 @@ const itemToElement = ({ text }) => {
 
 const itemToString = ({ text }) => text;
 
-const itemStringToObject = text => ({ text });
+const itemToObject = item => {
+  if (typeof item === 'string') {
+    return { id: item, text: item };
+  }
+
+  return item;
+};
 
 const TooltipDropdown = ({ items, loading, ...dropdownProps }) => {
   if (loading) {
     return <DropdownSkeleton {...dropdownProps} />;
   }
-  const options = items.map(itemStringToObject);
+  const options = items.map(itemToObject);
   return (
     <Dropdown
       {...dropdownProps}

--- a/src/components/TooltipDropdown/TooltipDropdown.test.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.test.js
@@ -18,7 +18,7 @@ import TooltipDropdown from './TooltipDropdown';
 const props = {
   id: 'tooltip-dropdown-id',
   label: 'select an item',
-  items: ['item 1', 'item 2', 'item 3'],
+  items: ['item 1', 'item 2', 'item 3', { id: '*', text: 'label' }],
   loading: false
 };
 

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -87,9 +87,9 @@ export /* istanbul ignore next */ class App extends Component {
               </SideNavMenu>
               <NamespacesDropdown
                 titleText="Namespace"
-                selectedItem={{ text: namespace }}
+                selectedItem={{ id: namespace, text: namespace }}
                 onChange={event => {
-                  this.props.selectNamespace(event.selectedItem.text);
+                  this.props.selectNamespace(event.selectedItem.id);
                 }}
               />
               {extensions.length > 0 && (

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -21,16 +21,33 @@ const NamespacesDropdown = props => {
   return <TooltipDropdown {...props} />;
 };
 
+const allNamespacesLabel = 'All Namespaces';
+
 NamespacesDropdown.defaultProps = {
+  allNamespacesLabel,
   items: [],
   loading: true,
-  label: 'Select Namespace'
+  label: 'Select Namespace',
+  showAllNamespaces: false
 };
 
-function mapStateToProps(state) {
+/* istanbul ignore next */
+function mapStateToProps(state, ownProps) {
+  const { selectedItem, showAllNamespaces } = ownProps;
+
+  if (selectedItem && selectedItem.id === '*') {
+    selectedItem.text = allNamespacesLabel;
+  }
+
+  const items = getNamespaces(state);
+  if (showAllNamespaces) {
+    items.unshift({ id: '*', text: allNamespacesLabel });
+  }
+
   return {
-    items: getNamespaces(state),
-    loading: isFetchingNamespaces(state)
+    items,
+    loading: isFetchingNamespaces(state),
+    selectedItem
   };
 }
 

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.stories.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.stories.js
@@ -14,6 +14,7 @@ limitations under the License.
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -43,9 +44,13 @@ storiesOf('NamespacesDropdown', module)
         isFetching: false
       }
     });
+
     return (
       <Provider store={store}>
-        <NamespacesDropdown {...props} />
+        <NamespacesDropdown
+          {...props}
+          showAllNamespaces={boolean('showAllNamespaces', false)}
+        />
       </Provider>
     );
   })


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/166

- Update TooltipDropdown to accept object items
- Update NamespacesDropdown to add support for an 'All Namespaces' option
- Update use of the NamespacesDropdown to use the item id for the selected item

This is not used yet but is required as part of the efforts to support displaying resources from all namespaces as well as updating the client URL to include namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
