### PR TITLE
Update selectors to support retrieving resources from all namespaces

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export const ALL_NAMESPACES = '*'; // eslint-disable-line import/prefer-default-export

--- a/src/reducers/pipelineRuns.js
+++ b/src/reducers/pipelineRuns.js
@@ -15,6 +15,8 @@ import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 import merge from 'lodash.merge';
 
+import { ALL_NAMESPACES } from '../constants';
+
 function byId(state = {}, action) {
   switch (action.type) {
     case 'PIPELINE_RUNS_FETCH_SUCCESS':
@@ -74,6 +76,10 @@ export default combineReducers({
 });
 
 export function getPipelineRuns(state, namespace) {
+  if (namespace === ALL_NAMESPACES) {
+    return Object.values(state.byId);
+  }
+
   const pipelineRuns = state.byNamespace[namespace];
   return pipelineRuns
     ? Object.values(pipelineRuns).map(id => state.byId[id])

--- a/src/reducers/pipelineRuns.test.js
+++ b/src/reducers/pipelineRuns.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import pipelineRunsReducer, * as selectors from './pipelineRuns';
+import { ALL_NAMESPACES } from '../constants';
 
 it('handles init or unknown actions', () => {
   expect(pipelineRunsReducer(undefined, { type: 'does_not_exist' })).toEqual({
@@ -68,6 +69,13 @@ it('getPipelineRuns', () => {
   const namespace = 'namespace';
   const state = { byNamespace: {} };
   expect(selectors.getPipelineRuns(state, namespace)).toEqual([]);
+});
+
+it('getPipelineRuns all namespaces', () => {
+  const namespace = ALL_NAMESPACES;
+  const pipelineRun = { fake: 'pipelineRun' };
+  const state = { byId: { id: pipelineRun } };
+  expect(selectors.getPipelineRuns(state, namespace)).toEqual([pipelineRun]);
 });
 
 it('getPipelineRun', () => {

--- a/src/reducers/pipelines.js
+++ b/src/reducers/pipelines.js
@@ -15,6 +15,8 @@ import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 import merge from 'lodash.merge';
 
+import { ALL_NAMESPACES } from '../constants';
+
 function byId(state = {}, action) {
   switch (action.type) {
     case 'PIPELINES_FETCH_SUCCESS':
@@ -74,6 +76,10 @@ export default combineReducers({
 });
 
 export function getPipelines(state, namespace) {
+  if (namespace === ALL_NAMESPACES) {
+    return Object.values(state.byId);
+  }
+
   const pipelines = state.byNamespace[namespace];
   return pipelines ? Object.values(pipelines).map(id => state.byId[id]) : [];
 }

--- a/src/reducers/pipelines.test.js
+++ b/src/reducers/pipelines.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import pipelinesReducer, * as selectors from './pipelines';
+import { ALL_NAMESPACES } from '../constants';
 
 it('handles init or unknown actions', () => {
   expect(pipelinesReducer(undefined, { type: 'does_not_exist' })).toEqual({
@@ -68,6 +69,13 @@ it('getPipelines', () => {
   const namespace = 'namespace';
   const state = { byNamespace: {} };
   expect(selectors.getPipelines(state, namespace)).toEqual([]);
+});
+
+it('getPipelines all namespaces', () => {
+  const namespace = ALL_NAMESPACES;
+  const pipeline = { fake: 'pipeline' };
+  const state = { byId: { id: pipeline } };
+  expect(selectors.getPipelines(state, namespace)).toEqual([pipeline]);
 });
 
 it('getPipeline', () => {

--- a/src/reducers/serviceAccounts.js
+++ b/src/reducers/serviceAccounts.js
@@ -15,6 +15,8 @@ import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 import merge from 'lodash.merge';
 
+import { ALL_NAMESPACES } from '../constants';
+
 function byId(state = {}, action) {
   switch (action.type) {
     case 'SERVICE_ACCOUNTS_FETCH_SUCCESS':
@@ -74,6 +76,10 @@ export default combineReducers({
 });
 
 export function getServiceAccounts(state, namespace) {
+  if (namespace === ALL_NAMESPACES) {
+    return Object.values(state.byId);
+  }
+
   const serviceAccounts = state.byNamespace[namespace];
   return serviceAccounts
     ? Object.values(serviceAccounts).map(id => state.byId[id])

--- a/src/reducers/serviceAccounts.test.js
+++ b/src/reducers/serviceAccounts.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import serviceAccountsReducer, * as selectors from './serviceAccounts';
+import { ALL_NAMESPACES } from '../constants';
 
 it('handles init or unknown actions', () => {
   expect(serviceAccountsReducer(undefined, { type: 'does_not_exist' })).toEqual(
@@ -71,4 +72,13 @@ it('getServiceAccounts', () => {
   const namespace = 'default';
   const state = { byNamespace: {} };
   expect(selectors.getServiceAccounts(state, namespace)).toEqual([]);
+});
+
+it('getServiceAccounts all namespaces', () => {
+  const namespace = ALL_NAMESPACES;
+  const serviceAccount = { fake: 'serviceAccount' };
+  const state = { byId: { id: serviceAccount } };
+  expect(selectors.getServiceAccounts(state, namespace)).toEqual([
+    serviceAccount
+  ]);
 });

--- a/src/reducers/taskRuns.js
+++ b/src/reducers/taskRuns.js
@@ -15,6 +15,8 @@ import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 import merge from 'lodash.merge';
 
+import { ALL_NAMESPACES } from '../constants';
+
 function byId(state = {}, action) {
   switch (action.type) {
     case 'TASK_RUNS_FETCH_SUCCESS':
@@ -74,6 +76,10 @@ export default combineReducers({
 });
 
 export function getTaskRuns(state, namespace) {
+  if (namespace === ALL_NAMESPACES) {
+    return Object.values(state.byId);
+  }
+
   const taskRuns = state.byNamespace[namespace];
   return taskRuns ? Object.values(taskRuns).map(id => state.byId[id]) : [];
 }

--- a/src/reducers/taskRuns.test.js
+++ b/src/reducers/taskRuns.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import taskRunsReducer, * as selectors from './taskRuns';
+import { ALL_NAMESPACES } from '../constants';
 
 it('handles init or unknown actions', () => {
   expect(taskRunsReducer(undefined, { type: 'does_not_exist' })).toEqual({
@@ -64,13 +65,20 @@ it('TASK_RUNS_FETCH_FAILURE', () => {
   expect(selectors.getTaskRunsErrorMessage(state)).toEqual(message);
 });
 
-it('getPipelineRuns', () => {
+it('getTaskRuns', () => {
   const namespace = 'namespace';
   const state = { byNamespace: {} };
   expect(selectors.getTaskRuns(state, namespace)).toEqual([]);
 });
 
-it('getPipelineRun', () => {
+it('getTaskRuns all namespaces', () => {
+  const namespace = ALL_NAMESPACES;
+  const taskRun = { fake: 'taskRun' };
+  const state = { byId: { id: taskRun } };
+  expect(selectors.getTaskRuns(state, namespace)).toEqual([taskRun]);
+});
+
+it('getTaskRun', () => {
   const name = 'name';
   const namespace = 'namespace';
   const state = { byNamespace: {} };

--- a/src/reducers/tasks.js
+++ b/src/reducers/tasks.js
@@ -15,6 +15,8 @@ import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 import merge from 'lodash.merge';
 
+import { ALL_NAMESPACES } from '../constants';
+
 function byId(state = {}, action) {
   switch (action.type) {
     case 'TASKS_FETCH_SUCCESS':
@@ -74,6 +76,10 @@ export default combineReducers({
 });
 
 export function getTasks(state, namespace) {
+  if (namespace === ALL_NAMESPACES) {
+    return Object.values(state.byId);
+  }
+
   const tasks = state.byNamespace[namespace];
   return tasks ? Object.values(tasks).map(id => state.byId[id]) : [];
 }

--- a/src/reducers/tasks.test.js
+++ b/src/reducers/tasks.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import tasksReducer, * as selectors from './tasks';
+import { ALL_NAMESPACES } from '../constants';
 
 it('handles init or unknown actions', () => {
   expect(tasksReducer(undefined, { type: 'does_not_exist' })).toEqual({
@@ -68,6 +69,13 @@ it('getTasks', () => {
   const namespace = 'namespace';
   const state = { byNamespace: {} };
   expect(selectors.getTasks(state, namespace)).toEqual([]);
+});
+
+it('getTasks all namespaces', () => {
+  const namespace = ALL_NAMESPACES;
+  const task = { fake: 'task' };
+  const state = { byId: { id: task } };
+  expect(selectors.getTasks(state, namespace)).toEqual([task]);
 });
 
 it('getTask', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When the 'all namespaces' value ('*') is chosen, selectors should
recognise this and return all resources of the requested type.

The byId sub-reducer was originally introduced for this exact
purpose, and is now finally used as intended.

#166 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
