### PR TITLE
Add paneling for manually creating a PipelineRun

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -418,7 +418,7 @@ Optional parameters listed below may be provided in the request body depending o
   - gitresourcename, gitcommit, and repourl can be provided in the request body if your Pipeline requires a PipelineResource of type `git`
   - imageresourcename, gitcommit and reponame can be provided in the request body if your Pipeline requires a PipelineResource of type `image`
 
-  - helmsecret and registrysecret are optional depending on whether the Pipeline requires secrets for accessing an insecure registry or using Helm
+  - helmsecret is optional depending on whether the Pipeline requires a secret for using Helm
 
   - serviceaccount can be provided to specify the serviceaccount to use for the PipelineRun
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add curl git
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x /usr/local/bin/dep
 WORKDIR /go/src/github.com/tektoncd/dashboard
 COPY . .
-RUN dep ensure -vendor-only 
+RUN dep ensure -vendor-only
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tekton_dashboard_backend ./cmd/dashboard
 
 FROM alpine@sha256:7df6db5aa61ae9480f52f0b3a06a140ab98d427f86d8d5de0bedab9b8df6b1c0

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -22,12 +22,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
-	"github.com/tektoncd/dashboard/pkg/utils"
-
 	restful "github.com/emicklei/go-restful"
 	uuid "github.com/satori/go.uuid"
+	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
+	"github.com/tektoncd/dashboard/pkg/utils"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions"
 	v1 "k8s.io/api/core/v1"
@@ -84,7 +83,6 @@ type ManualPipelineRun struct {
 	REPONAME          string `json:"reponame,omitempty"`
 	REPOURL           string `json:"repourl,omitempty"`
 	HELMSECRET        string `json:"helmsecret,omitempty"`
-	REGISTRYSECRET    string `json:"registrysecret,omitempty"`
 	APPLYDIRECTORY    string `json:"applydirectory,omitempty"`
 }
 
@@ -327,9 +325,6 @@ func (r Resource) CreatePipelineRunImpl(pipelineRunData ManualPipelineRun, names
 		params = []v1alpha1.Param{{Name: "target-namespace", Value: namespace}}
 	}
 
-	if pipelineRunData.REGISTRYSECRET != "" {
-		params = append(params, v1alpha1.Param{Name: "registry-secret", Value: pipelineRunData.REGISTRYSECRET})
-	}
 	if pipelineRunData.HELMSECRET != "" {
 		params = append(params, v1alpha1.Param{Name: "helm-secret", Value: pipelineRunData.HELMSECRET})
 	}
@@ -804,7 +799,6 @@ func (r Resource) StartResourcesController(stopCh <-chan struct{}) {
 	logging.Log.Info("Resource Events Controller Started")
 }
 
-
 //pipeline events
 func (r Resource) pipelineCreated(obj interface{}) {
 	logging.Log.Debug("In pipelineCreated")
@@ -838,7 +832,6 @@ func (r Resource) pipelineDeleted(obj interface{}) {
 
 	resourcesChannel <- data
 }
-
 
 // task events
 func (r Resource) taskCreated(obj interface{}) {
@@ -907,7 +900,6 @@ func (r Resource) pipelineRunDeleted(obj interface{}) {
 
 	resourcesChannel <- data
 }
-
 
 // task run events
 func (r Resource) taskRunCreated(obj interface{}) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -88,6 +88,11 @@ export function cancelPipelineRun(name, namespace) {
   return put(uri, { status: 'PipelineRunCancelled' });
 }
 
+export function createPipelineRun(payload, namespace) {
+  const uri = getAPI('pipelineruns', { namespace });
+  return post(uri, payload);
+}
+
 export function getTasks(namespace) {
   const uri = getAPI('tasks', { namespace });
   return get(uri).then(checkData);
@@ -134,11 +139,6 @@ export function getPodLog(name, namespace, container) {
 export function getTaskRunLog(name, namespace) {
   const uri = getAPI('taskrunlogs', { name, namespace });
   return get(uri);
-}
-
-export function createPipelineRun(params, namespace) {
-  const uri = getAPI('pipelineruns', { namespace });
-  return post(uri, params);
 }
 
 export function getCredentials(namespace) {

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -25,13 +25,6 @@ main {
   padding: 2em 5%;
 }
 
-.bx--dropdown.bx--list-box {
-  margin: 0 1em 1.5em 1.5em;
-  border: none;
-  margin-bottom: 1.5em;
-  width: auto;
-}
-
 .bx--header ~ {
   nav.bx--side-nav {
     padding-top: 1em;
@@ -64,10 +57,31 @@ main {
     .bx--side-nav__link-text {
       color: $text-01;
     }
+
+    .bx--dropdown.bx--list-box {
+      margin: 0 1em 1.5em 1.5em;
+      border: none;
+      margin-bottom: 1.5em;
+      width: auto;
+    }
   }
 
   .bx--content {
     margin-top: 7rem;
     transform: none;
   }
+}
+
+.bx--modal-header,
+.bx--modal-content {
+  width: 100%;
+}
+
+.bx--modal-content,
+.bx--modal-header {
+  padding-right: 1rem;
+}
+
+.bx--modal-content {
+  margin-bottom: $carbon--spacing-07
 }

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -18,6 +18,11 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { App } from './App';
+import * as API from '../../api';
+
+beforeEach(() => {
+  jest.spyOn(API, 'getPipelines').mockImplementation(() => {});
+});
 
 it('App renders successfully', () => {
   const middleware = [thunk];

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -1,0 +1,521 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { connect } from 'react-redux';
+import {
+  Button,
+  ComposedModal,
+  Form,
+  FormGroup,
+  InlineNotification,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+  Toggle
+} from 'carbon-components-react';
+import {
+  NamespacesDropdown,
+  PipelinesDropdown,
+  ServiceAccountsDropdown
+} from '..';
+import { getSelectedNamespace } from '../../reducers';
+import { createPipelineRun } from '../../api';
+
+import './CreatePipelineRun.scss';
+import { ALL_NAMESPACES } from '../../constants';
+
+const resourceNameRegExp = /^[-.a-z0-9]{1,253}$/;
+const resourceNameInvalidText =
+  'Must consist of only lower case alphanumeric characters, -, and . with at most 253 characters';
+const noSpacesRegExp = /^\S*$/;
+const noSpacesInvalidText = 'Must contain no spaces';
+const urlRegExp = /^https?:\/\/.+/;
+const urlInvalidText = 'Must be a valid URL';
+
+const formValidation = {
+  namespace: {
+    required: true
+  },
+  pipeline: {
+    required: true
+  },
+  serviceAccount: {
+    required: true
+  },
+  gitName: {
+    required: false,
+    regexp: resourceNameRegExp
+  },
+  gitRepoURL: {
+    required: false,
+    regexp: urlRegExp
+  },
+  gitRevision: {
+    required: false,
+    regexp: noSpacesRegExp
+  },
+  imageName: {
+    required: false,
+    regexp: resourceNameRegExp
+  },
+  imageRegistryName: {
+    required: false,
+    regexp: noSpacesRegExp
+  },
+  imageRepoName: {
+    required: false,
+    regexp: noSpacesRegExp
+  },
+  helmPipeline: {
+    required: false
+  },
+  helmSecret: {
+    required: false,
+    regexp: resourceNameRegExp
+  }
+};
+
+const initialState = {
+  namespace: {
+    value: '',
+    invalid: false
+  },
+  pipeline: {
+    value: '',
+    invalid: false
+  },
+  serviceAccount: {
+    value: '',
+    invalid: false
+  },
+  gitName: {
+    value: '',
+    invalid: false
+  },
+  gitRevision: {
+    value: '',
+    invalid: false
+  },
+  gitRepoURL: {
+    value: '',
+    invalid: false
+  },
+  imageName: {
+    value: '',
+    invalid: false
+  },
+  imageRegistryName: {
+    value: '',
+    invalid: false
+  },
+  imageRepoName: {
+    value: '',
+    invalid: false
+  },
+  helmPipeline: {
+    value: false,
+    invalid: false
+  },
+  helmSecret: {
+    value: '',
+    invalid: false
+  },
+  errorMessage: '',
+  submitValidationError: false
+};
+
+class CreatePipelineRun extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = initialState;
+
+    this.onChange = this.onChange.bind(this);
+    this.onNamespaceChange = this.onNamespaceChange.bind(this);
+    this.onInputChange = this.onInputChange.bind(this);
+    this.onHelmToggleChange = this.onHelmToggleChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onClose = this.onClose.bind(this);
+    this.reset = this.reset.bind(this);
+    this.getPipeline = this.getPipeline.bind(this);
+    this.checkFormValidation = this.checkFormValidation.bind(this);
+    this.checkValidation = this.checkValidation.bind(this);
+  }
+
+  onChange({ name, value }) {
+    this.checkValidation(name, value);
+    this.setState(state => {
+      return {
+        [name]: {
+          ...state[name],
+          value
+        }
+      };
+    });
+  }
+
+  onNamespaceChange({ name, value }) {
+    if (this.getNamespace() !== value) {
+      this.setState(state => {
+        return {
+          pipeline: {
+            ...state.pipeline,
+            value: ''
+          },
+          serviceAccount: {
+            ...state.serviceAccount,
+            value: ''
+          }
+        };
+      });
+    }
+    this.onChange({ name, value });
+  }
+
+  onInputChange(event) {
+    const { name, value } = event.target;
+    this.onChange({ name, value });
+  }
+
+  onHelmToggleChange(value) {
+    this.checkValidation('helmPipeline', value);
+    this.setState(state => {
+      return {
+        helmPipeline: {
+          ...state.helmPipeline,
+          value
+        }
+      };
+    });
+  }
+
+  onSubmit(event) {
+    event.preventDefault();
+
+    if (!this.checkFormValidation()) {
+      this.setState({
+        submitValidationError: true
+      });
+      return;
+    }
+    this.setState({
+      errorMessage: '',
+      submitValidationError: false
+    });
+
+    const namespaceValue = this.getNamespace();
+    const pipelineValue = this.getPipeline();
+    const payload = {
+      pipelinename: pipelineValue,
+      serviceaccount: this.state.serviceAccount.value,
+      repourl: this.state.gitRepoURL.value,
+      gitresourcename: this.state.gitName.value,
+      gitcommit: this.state.gitRevision.value,
+      registrylocation: this.state.imageRegistryName.value,
+      reponame: this.state.imageRepoName.value,
+      imageresourcename: this.state.imageName.value,
+      pipelineruntype: this.state.helmPipeline.value ? 'helm' : '',
+      helmsecret: this.state.helmSecret.value
+    };
+    const promise = createPipelineRun(payload, namespaceValue);
+    promise
+      .then(headers => {
+        const url = headers.get('Content-Location');
+        const pipelineRunName = url.substring(url.lastIndexOf('/') + 1);
+        const finalURL = `/namespaces/${namespaceValue}/pipelines/${pipelineValue}/runs/${pipelineRunName}`;
+        this.reset();
+        this.props.onSuccess({ name: pipelineRunName, url: finalURL });
+      })
+      .catch(error => {
+        error.response.text().then(text => {
+          let errorMessage = text;
+          if (text === '') {
+            const statusCode = error.response.status;
+            switch (statusCode) {
+              case 400:
+                errorMessage = 'bad request';
+                break;
+              case 412:
+                errorMessage = 'pipeline not found';
+                break;
+              default:
+                errorMessage = `error code ${statusCode}`;
+            }
+          }
+          this.setState({ errorMessage });
+        });
+      });
+  }
+
+  onClose() {
+    this.reset();
+    this.props.onClose();
+  }
+
+  getPipeline() {
+    return this.props.pipelineName || this.state.pipeline.value;
+  }
+
+  getNamespace() {
+    if (this.props.namespace) {
+      return this.props.namespace;
+    }
+    if (this.state.namespace.value !== '') {
+      return this.state.namespace.value;
+    }
+    if (this.props.selectedNamespace !== ALL_NAMESPACES) {
+      return this.props.selectedNamespace;
+    }
+    return '';
+  }
+
+  checkValidation(key, value) {
+    const { required, regexp } = formValidation[key];
+    const invalid =
+      (required && value === '') ||
+      (regexp && !regexp.test(value) && (required || value !== ''));
+    this.setState(state => {
+      return {
+        [key]: {
+          ...state[key],
+          invalid
+        }
+      };
+    });
+    return !invalid;
+  }
+
+  checkFormValidation() {
+    const reducer = (acc, key) => {
+      if (key === 'namespace') {
+        return this.checkValidation(key, this.getNamespace()) && acc;
+      }
+      if (key === 'pipeline') {
+        return this.checkValidation(key, this.getPipeline()) && acc;
+      }
+      return this.checkValidation(key, this.state[key].value) && acc;
+    };
+    return Object.keys(formValidation).reduce(reducer, true);
+  }
+
+  reset() {
+    this.setState(initialState);
+  }
+
+  render() {
+    const { pipelineName, open, namespace } = this.props;
+    const { errorMessage } = this.state;
+    const namespaceValue = this.getNamespace();
+    const pipelineValue = this.getPipeline();
+
+    return (
+      <Form onSubmit={this.onSubmit}>
+        <ComposedModal
+          className="create-pipelinerun"
+          onClose={this.onClose}
+          open={open}
+        >
+          <ModalHeader
+            id="create-pipelinerun--header"
+            title="Create PipelineRun"
+            label={pipelineName}
+            closeModal={this.onClose}
+          />
+          <ModalBody>
+            {errorMessage !== '' && (
+              <InlineNotification
+                kind="error"
+                title="Error creating PipelineRun"
+                subtitle={errorMessage}
+              />
+            )}
+            {this.state.submitValidationError && (
+              <InlineNotification
+                kind="error"
+                title="Unable to submit"
+                subtitle="Please fix the fields with errors"
+              />
+            )}
+            <NamespacesDropdown
+              id="namespaces-dropdown"
+              selectedItem={
+                namespaceValue !== ''
+                  ? { id: namespaceValue, text: namespaceValue }
+                  : ''
+              }
+              onChange={({ selectedItem }) =>
+                this.onNamespaceChange({
+                  name: 'namespace',
+                  value: selectedItem.text
+                })
+              }
+              disabled={!!namespace}
+              invalid={this.state.namespace.invalid}
+              invalidText="Namespace cannot be empty"
+            />
+            <PipelinesDropdown
+              id="dropdown-pipeline"
+              namespace={namespaceValue}
+              selectedItem={
+                pipelineValue !== ''
+                  ? { id: pipelineValue, text: pipelineValue }
+                  : ''
+              }
+              onChange={({ selectedItem }) =>
+                this.onChange({
+                  name: 'pipeline',
+                  value: selectedItem.text
+                })
+              }
+              disabled={!!pipelineName}
+              invalid={this.state.pipeline.invalid}
+              invalidText="Pipeline cannot be empty"
+            />
+            <ServiceAccountsDropdown
+              id="dropdown-service-account"
+              namespace={namespaceValue}
+              selectedItem={
+                this.state.serviceAccount.value !== ''
+                  ? {
+                      id: this.state.serviceAccount.value,
+                      text: this.state.serviceAccount.value
+                    }
+                  : ''
+              }
+              onChange={({ selectedItem }) =>
+                this.onChange({
+                  name: 'serviceAccount',
+                  value: selectedItem.text
+                })
+              }
+              invalid={this.state.serviceAccount.invalid}
+              invalidText="Service Account cannot be empty"
+            />
+
+            <FormGroup legendText="Git Resource (optional)">
+              <TextInput
+                id="git-resource-name-text-input"
+                labelText="Name"
+                placeholder="git-source"
+                name="gitName"
+                invalidText={resourceNameInvalidText}
+                invalid={this.state.gitName.invalid}
+                value={this.state.gitName.value}
+                onChange={this.onInputChange}
+              />
+              <TextInput
+                id="git-repo-url-text-input"
+                labelText="Repository URL"
+                placeholder="https://github.com/user/project"
+                name="gitRepoURL"
+                invalidText={urlInvalidText}
+                invalid={this.state.gitRepoURL.invalid}
+                value={this.state.gitRepoURL.value}
+                onChange={this.onInputChange}
+              />
+              <TextInput
+                id="git-revision-text-input"
+                labelText="Revision"
+                helperText="Branch name or commit ID"
+                placeholder="master"
+                name="gitRevision"
+                invalidText={noSpacesInvalidText}
+                invalid={this.state.gitRevision.invalid}
+                value={this.state.gitRevision.value}
+                onChange={this.onInputChange}
+              />
+            </FormGroup>
+
+            <FormGroup legendText="Image Resource (optional)">
+              <TextInput
+                id="image-name-text-input"
+                labelText="Name"
+                placeholder="docker-image"
+                name="imageName"
+                invalidText={resourceNameInvalidText}
+                invalid={this.state.imageName.invalid}
+                value={this.state.imageName.value}
+                onChange={this.onInputChange}
+              />
+              <TextInput
+                id="image-registry-text-input"
+                labelText="Registry"
+                placeholder="registryname"
+                name="imageRegistryName"
+                invalidText={noSpacesInvalidText}
+                invalid={this.state.imageRegistryName.invalid}
+                value={this.state.imageRegistryName.value}
+                onChange={this.onInputChange}
+              />
+              <TextInput
+                id="image-repo-text-input"
+                labelText="Repository"
+                placeholder="reponame"
+                name="imageRepoName"
+                invalidText={noSpacesInvalidText}
+                invalid={this.state.imageRepoName.invalid}
+                value={this.state.imageRepoName.value}
+                onChange={this.onInputChange}
+              />
+            </FormGroup>
+
+            <FormGroup legendText="Helm (optional)">
+              <Toggle
+                id="helm-pipeline-toggle"
+                data-testid="helm-pipeline-toggle"
+                labelText="Toggle On when using a Helm pipeline"
+                name="helmPipeline"
+                toggled={this.state.helmPipeline.value}
+                onToggle={this.onHelmToggleChange}
+              />
+              <TextInput
+                id="helm-secret-text-input"
+                labelText="Secret"
+                placeholder="helm-secret"
+                name="helmSecret"
+                invalidText={resourceNameInvalidText}
+                invalid={this.state.helmSecret.invalid}
+                value={this.state.helmSecret.value}
+                onChange={this.onInputChange}
+              />
+            </FormGroup>
+          </ModalBody>
+          <ModalFooter>
+            <Button kind="secondary" onClick={this.onClose}>
+              Cancel
+            </Button>
+            <Button kind="primary" type="submit">
+              Submit
+            </Button>
+          </ModalFooter>
+        </ComposedModal>
+      </Form>
+    );
+  }
+}
+
+CreatePipelineRun.defaultProps = {
+  open: false,
+  onClose: () => {},
+  onSuccess: () => {}
+};
+
+const mapStateToProps = state => {
+  return {
+    selectedNamespace: getSelectedNamespace(state)
+  };
+};
+
+export default connect(mapStateToProps)(CreatePipelineRun);

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.scss
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.scss
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '~carbon-components/scss/globals/scss/vars';
+
+.create-pipelinerun {
+  .bx--text-input__field-wrapper {
+    width: 100%;
+  }
+
+  .bx--dropdown__wrapper,
+  .bx--form-item {
+    margin-bottom: $carbon--spacing-06;
+  }
+
+  .bx--list-box__menu,
+  .bx--list-box {
+    background-color: $ui-background;
+  }
+}

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -1,0 +1,456 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { fireEvent, render, wait, waitForElement } from 'react-testing-library';
+
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import CreatePipelineRun from './CreatePipelineRun';
+import * as API from '../../api';
+import { ALL_NAMESPACES } from '../../constants';
+
+const invalidK8sName = 'invalidName';
+const invalidK8sNameRegExp = /must consist of only lower case alphanumeric characters, -, and . with at most 253 characters/i;
+const invalidNoSpacesName = 'invalid name';
+const invalidNoSpacesNameRegExp = /must contain no spaces/i;
+
+const allNamespacesTestStore = {
+  namespaces: {
+    selected: ALL_NAMESPACES,
+    byName: {
+      default: ''
+    },
+    isFetching: false
+  }
+};
+const defaultNamespacesTestStore = {
+  namespaces: {
+    selected: 'default',
+    byName: {
+      default: ''
+    },
+    isFetching: false
+  }
+};
+const pipelinesTestStore = {
+  pipelines: {
+    byNamespace: {
+      default: {
+        'pipeline-1': 'id-pipeline-1'
+      }
+    },
+    byId: {
+      'id-pipeline-1': {
+        metadata: {
+          name: 'pipeline-1',
+          namespace: 'default',
+          uid: 'id-pipeline-1'
+        }
+      }
+    },
+    isFetching: false
+  }
+};
+const serviceAccountsTestStore = {
+  serviceAccounts: {
+    byNamespace: {
+      default: {
+        'service-account-1': 'id-service-account-1'
+      }
+    },
+    byId: {
+      'id-service-account-1': {
+        metadata: {
+          name: 'service-account-1',
+          namespace: 'default',
+          uid: 'id-service-account-1'
+        }
+      }
+    },
+    isFetching: false
+  }
+};
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+const testStoreAllNamespaces = mockStore({
+  ...allNamespacesTestStore,
+  ...pipelinesTestStore,
+  ...serviceAccountsTestStore,
+  pipelineRuns: {
+    errorMessage: '',
+    isFetching: false,
+    byId: {},
+    byNamespace: {}
+  }
+});
+const testStoreDefaultNamespace = mockStore({
+  ...defaultNamespacesTestStore,
+  ...pipelinesTestStore,
+  ...serviceAccountsTestStore,
+  pipelineRuns: {
+    errorMessage: '',
+    isFetching: false,
+    byId: {},
+    byNamespace: {}
+  }
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest
+    .spyOn(API, 'getServiceAccounts')
+    .mockImplementation(() => serviceAccountsTestStore.serviceAccounts.byId);
+  jest
+    .spyOn(API, 'getPipelines')
+    .mockImplementation(() => pipelinesTestStore.pipelines.byId);
+  jest.spyOn(API, 'getPipelineRuns').mockImplementation(() => {});
+});
+
+const fillNamespace = getByText => {
+  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByText(/default/i));
+};
+
+const fillPipeline = getByText => {
+  fireEvent.click(getByText(/select pipeline/i));
+  fireEvent.click(getByText(/pipeline-1/i));
+};
+
+const fillServiceAccount = getByText => {
+  fireEvent.click(getByText(/select service account/i));
+  fireEvent.click(getByText(/service-account-1/i));
+};
+
+const fillRequiredFields = getByText => {
+  fillNamespace(getByText);
+  fillPipeline(getByText);
+  fillServiceAccount(getByText);
+};
+
+const testValidateTextInputField = (
+  placeholderTextRegExp,
+  textValue,
+  invalidTextRegExp
+) => {
+  const { getByText, getByPlaceholderText, queryByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  fillRequiredFields(getByText);
+  // Set invalid text input
+  fireEvent.change(getByPlaceholderText(placeholderTextRegExp), {
+    target: { value: textValue }
+  });
+  expect(queryByText(invalidTextRegExp)).toBeTruthy();
+  fireEvent.click(getByText(/submit/i));
+  expect(queryByText(/unable to submit/i)).toBeTruthy();
+  // Set back to valid
+  fireEvent.change(getByPlaceholderText(placeholderTextRegExp), {
+    target: { value: '' }
+  });
+  expect(queryByText(invalidTextRegExp)).toBeFalsy();
+};
+
+it('CreatePipelineRun renders', () => {
+  const { queryByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  expect(queryByText(/create pipelinerun/i)).toBeTruthy();
+});
+
+it('CreatePipelineRun renders controlled pipeline selection', () => {
+  const { queryByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open pipelineName="pipeline-1" namespace="default" />
+    </Provider>
+  );
+  expect(queryByText(/create pipelinerun/i)).toBeTruthy();
+  expect(queryByText(/pipeline-1/i)).toBeTruthy();
+  expect(queryByText(/default/i)).toBeTruthy();
+});
+
+it('CreatePipelineRun renders namespace dropdown for selected namespace', () => {
+  const { queryByText } = render(
+    <Provider store={testStoreDefaultNamespace}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  expect(queryByText(/default/i)).toBeTruthy();
+});
+
+it('CreatePipelineRun resets pipeline and service account when namespace changes', () => {
+  const { getByText, getAllByText } = render(
+    <Provider store={testStoreDefaultNamespace}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  fillPipeline(getByText);
+  fillServiceAccount(getByText);
+  expect(getByText(/pipeline-1/i));
+  expect(getByText(/service-account-1/i));
+  fireEvent.click(getByText(/default/i));
+  fireEvent.click(getAllByText(/default/i)[1]);
+  expect(getByText(/pipeline-1/i));
+  expect(getByText(/service-account-1/i));
+});
+
+it('CreatePipelineRun validates form namespace', () => {
+  const { getByText, queryByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  fillServiceAccount(getByText);
+  fillPipeline(getByText);
+  fireEvent.click(getByText(/submit/i));
+  expect(queryByText(/unable to submit/i)).toBeTruthy();
+  expect(queryByText(/namespace cannot be empty/i)).toBeTruthy();
+});
+
+it('CreatePipelineRun validates form pipeline', () => {
+  const { getByText, queryByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  fillNamespace(getByText);
+  fillServiceAccount(getByText);
+  fireEvent.click(getByText(/submit/i));
+  expect(queryByText(/unable to submit/i)).toBeTruthy();
+  expect(queryByText(/pipeline cannot be empty/i)).toBeTruthy();
+});
+
+it('CreatePipelineRun validates form service account', () => {
+  const { getByText, queryByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  fillNamespace(getByText);
+  fillPipeline(getByText);
+  fireEvent.click(getByText(/submit/i));
+  expect(queryByText(/unable to submit/i)).toBeTruthy();
+  expect(queryByText(/service account cannot be empty/i)).toBeTruthy();
+});
+
+it('CreatePipelineRun validates form git resource name', () => {
+  testValidateTextInputField(
+    /git-source/i,
+    invalidK8sName,
+    invalidK8sNameRegExp
+  );
+});
+
+it('CreatePipelineRun validates form git repo url', () => {
+  testValidateTextInputField(
+    /https:\/\/github.com\/user\/project/i,
+    'I am not a URL',
+    /must be a valid url/i
+  );
+});
+
+it('CreatePipelineRun validates form git revision', () => {
+  testValidateTextInputField(
+    /master/i,
+    invalidNoSpacesName,
+    invalidNoSpacesNameRegExp
+  );
+});
+
+it('CreatePipelineRun validates form image name', () => {
+  testValidateTextInputField(
+    /docker-image/i,
+    invalidK8sName,
+    invalidK8sNameRegExp
+  );
+});
+
+it('CreatePipelineRun validates form image registry', () => {
+  testValidateTextInputField(
+    /registryname/i,
+    invalidNoSpacesName,
+    invalidNoSpacesNameRegExp
+  );
+});
+
+it('CreatePipelineRun validates form image repo', () => {
+  testValidateTextInputField(
+    /reponame/i,
+    invalidNoSpacesName,
+    invalidNoSpacesNameRegExp
+  );
+});
+
+it('CreatePipelineRun validates form helm secret', () => {
+  testValidateTextInputField(
+    /helm-secret/i,
+    invalidK8sName,
+    invalidK8sNameRegExp
+  );
+});
+
+it('CreatePipelineRun submits form', async () => {
+  const formValues = {
+    gitcommit: '',
+    gitresourcename: '',
+    helmsecret: '',
+    imageresourcename: '',
+    pipelinename: 'pipeline-1',
+    pipelineruntype: 'helm',
+    registrylocation: '',
+    reponame: '',
+    repourl: '',
+    serviceaccount: 'service-account-1'
+  };
+  const { getByText, getByTestId } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  fillRequiredFields(getByText);
+  // Set Helm Pipeline
+  fireEvent.click(getByTestId('helm-pipeline-toggle'));
+  // Submit
+  const createPipelineRun = jest
+    .spyOn(API, 'createPipelineRun')
+    .mockImplementation(() =>
+      Promise.resolve({
+        get: () => {
+          return '/v1/namespaces/default/pipelineruns//tekton-pipeline-run';
+        }
+      })
+    );
+  fireEvent.click(getByText(/submit/i));
+  await wait(() => expect(createPipelineRun).toHaveBeenCalledTimes(1));
+  await wait(() =>
+    expect(createPipelineRun).toHaveBeenCalledWith(formValues, 'default')
+  );
+});
+
+it('CreatePipelineRun handles error state', async () => {
+  const { getByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  // Fill required fields
+  fillRequiredFields(getByText);
+  // Submit create request
+  const createPipelineRunResponseMock = {
+    response: { status: 400, text: () => Promise.resolve('test error message') }
+  };
+  jest
+    .spyOn(API, 'createPipelineRun')
+    .mockImplementation(() => Promise.reject(createPipelineRunResponseMock));
+  fireEvent.click(getByText(/submit/i));
+  await waitForElement(() => getByText(/error creating pipelinerun/i));
+  await waitForElement(() => getByText(/test error message/i));
+});
+
+it('CreatePipelineRun handles error state 400', async () => {
+  const { getByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  // Fill required fields
+  fillRequiredFields(getByText);
+  // Submit create request
+  const createPipelineRunResponseMock = {
+    response: { status: 400, text: () => Promise.resolve('') }
+  };
+  jest
+    .spyOn(API, 'createPipelineRun')
+    .mockImplementation(() => Promise.reject(createPipelineRunResponseMock));
+  fireEvent.click(getByText(/submit/i));
+  await waitForElement(() => getByText(/error creating pipelinerun/i));
+  await waitForElement(() => getByText(/bad request/i));
+});
+
+it('CreatePipelineRun handles error state 412', async () => {
+  const { getByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  // Fill required fields
+  fillRequiredFields(getByText);
+  // Submit create request
+  const createPipelineRunResponseMock = {
+    response: { status: 412, text: () => Promise.resolve('') }
+  };
+  jest
+    .spyOn(API, 'createPipelineRun')
+    .mockImplementation(() => Promise.reject(createPipelineRunResponseMock));
+  fireEvent.click(getByText(/submit/i));
+  await waitForElement(() => getByText(/error creating pipelinerun/i));
+  await waitForElement(() => getByText(/pipeline not found/i));
+});
+
+it('CreatePipelineRun handles error state abnormal code', async () => {
+  const { getByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open />
+    </Provider>
+  );
+  // Fill required fields
+  fillRequiredFields(getByText);
+  // Submit create request
+  const createPipelineRunResponseMock = {
+    response: { status: 0, text: () => Promise.resolve('') }
+  };
+  jest
+    .spyOn(API, 'createPipelineRun')
+    .mockImplementation(() => Promise.reject(createPipelineRunResponseMock));
+  fireEvent.click(getByText(/submit/i));
+  await waitForElement(() => getByText(/error creating pipelinerun/i));
+  await waitForElement(() => getByText(/error code 0/i));
+});
+
+it('CreatePipelineRun handles onSuccess event', async () => {
+  const onSuccess = jest.fn();
+  const { getByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open onSuccess={onSuccess} />
+    </Provider>
+  );
+  // Fill required fields
+  fillRequiredFields(getByText);
+
+  // Submit create request
+  jest.spyOn(API, 'createPipelineRun').mockImplementation(() =>
+    Promise.resolve({
+      get: () => {
+        return '/v1/namespaces/default/pipelineruns//tekton-pipeline-run';
+      }
+    })
+  );
+  fireEvent.click(getByText(/submit/i));
+  await wait(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+});
+
+it('CreatePipelineRun handles onClose event', () => {
+  const onClose = jest.fn();
+  const { getByText } = render(
+    <Provider store={testStoreAllNamespaces}>
+      <CreatePipelineRun open onClose={onClose} />
+    </Provider>
+  );
+  fireEvent.click(getByText(/cancel/i));
+  expect(onClose).toHaveBeenCalledTimes(1);
+});

--- a/src/containers/CreatePipelineRun/index.js
+++ b/src/containers/CreatePipelineRun/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './CreatePipelineRun';

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -156,7 +156,6 @@ export class ImportResources extends Component {
             onChange={this.handleNamespace}
             required
             selectedItem={selectedNamespace}
-            titleText="Namespace"
           />
           <TextInput
             data-testid="directory-field"

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -29,6 +29,7 @@ NamespacesDropdown.defaultProps = {
   items: [],
   loading: false,
   label: 'Select Namespace',
+  titleText: 'Namespace',
   emptyText: 'No Namespaces found',
   showAllNamespaces: false
 };

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -21,28 +21,28 @@ import {
 } from '../../reducers';
 import { fetchPipelines } from '../../actions/pipelines';
 import TooltipDropdown from '../../components/TooltipDropdown';
+import { ALL_NAMESPACES } from '../../constants';
 
 class PipelinesDropdown extends React.Component {
   componentDidMount() {
-    this.props.fetchPipelines();
+    const { namespace } = this.props;
+    this.props.fetchPipelines({ namespace });
   }
 
   componentDidUpdate(prevProps) {
     const { namespace } = this.props;
     if (namespace !== prevProps.namespace) {
-      this.props.fetchPipelines();
+      this.props.fetchPipelines({ namespace });
     }
   }
 
   render() {
-    return (
-      <TooltipDropdown
-        {...this.props}
-        emptyText={`No Pipelines found in the '${
-          this.props.namespace
-        }' namespace`}
-      />
-    );
+    const { namespace, ...rest } = this.props;
+    const emptyText =
+      namespace === ALL_NAMESPACES
+        ? `No Pipelines found`
+        : `No Pipelines found in the '${namespace}' namespace`;
+    return <TooltipDropdown {...rest} emptyText={emptyText} />;
   }
 }
 
@@ -53,11 +53,14 @@ PipelinesDropdown.defaultProps = {
   titleText: 'Pipeline'
 };
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
+  const namespace = ownProps.namespace || getSelectedNamespace(state);
   return {
-    items: getPipelines(state).map(pipeline => pipeline.metadata.name),
+    items: getPipelines(state, { namespace }).map(
+      pipeline => pipeline.metadata.name
+    ),
     loading: isFetchingPipelines(state),
-    namespace: getSelectedNamespace(state)
+    namespace
   };
 }
 

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
@@ -204,6 +204,25 @@ it('PipelinesDropdown renders controlled selection', () => {
   expect(queryByText(initialTextRegExp)).toBeTruthy();
 });
 
+it('PipelinesDropdown renders controlled namespace', () => {
+  const store = mockStore({
+    ...pipelinesStoreDefault,
+    ...namespacesStoreBlue
+  });
+  // Select namespace 'green'
+  const { queryByText, getByText, getAllByText } = render(
+    <Provider store={store}>
+      <PipelinesDropdown {...props} namespace="green" />
+    </Provider>
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  checkDropdownItems({
+    getAllByText,
+    queryByText,
+    testDict: pipelinesByNamespace.green
+  });
+});
+
 it('PipelinesDropdown renders empty', () => {
   const store = mockStore({
     pipelines: {

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -211,6 +211,25 @@ it('ServiceAccountsDropdown renders controlled selection', () => {
   expect(queryByText(initialTextRegExp)).toBeTruthy();
 });
 
+it('ServiceAccountsDropdown renders controlled namespace', () => {
+  const store = mockStore({
+    ...serviceAccountsStoreDefault,
+    ...namespacesStoreBlue
+  });
+  // Select namespace 'green'
+  const { queryByText, getByText, getAllByText } = render(
+    <Provider store={store}>
+      <ServiceAccountsDropdown {...props} namespace="green" />
+    </Provider>
+  );
+  fireEvent.click(getByText(initialTextRegExp));
+  checkDropdownItems({
+    getAllByText,
+    queryByText,
+    testDict: serviceAccountsByNamespace.green
+  });
+});
+
 it('ServiceAccountsDropdown renders empty', () => {
   const store = mockStore({
     serviceAccounts: {
@@ -220,6 +239,7 @@ it('ServiceAccountsDropdown renders empty', () => {
     },
     ...namespacesStoreBlue
   });
+  // Select item 'service-account-1'
   const { queryByText } = render(
     <Provider store={store}>
       <ServiceAccountsDropdown {...props} />

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -125,7 +125,6 @@ export class SideNav extends Component {
           </SideNavMenu>
           <NamespacesDropdown
             id="sidenav-namespace-dropdown"
-            titleText="Namespace"
             selectedItem={{ id: namespace, text: namespace }}
             showAllNamespaces
             onChange={this.selectNamespace}

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -14,6 +14,7 @@ limitations under the License.
 export {
   default as CustomResourceDefinition
 } from './CustomResourceDefinition';
+export { default as CreatePipelineRun } from './CreatePipelineRun';
 export { default as Extension } from './Extension';
 export { default as Extensions } from './Extensions';
 export { default as ImportResources } from './ImportResources';
@@ -23,6 +24,7 @@ export { default as PipelineResources } from './PipelineResources';
 export { default as PipelineRun } from './PipelineRun';
 export { default as PipelineRuns } from './PipelineRuns';
 export { default as Pipelines } from './Pipelines';
+export { default as PipelinesDropdown } from './PipelinesDropdown';
 export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';
 export { default as SideNav } from './SideNav';
 export { default as Tasks } from './Tasks';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This PR addresses issue https://github.com/tektoncd/dashboard/issues/108 to add the web paneling for manually creating a PipelineRun. There is a new "Create PipelineRun" button at the top of the PipelineRuns page, and each Pipeline's individual page. This button presents a modal form with validation from which the user can create their PipelineRun.

This PR depends on my previous PR https://github.com/tektoncd/dashboard/pull/201 with the PipelinesDropdown container, so please DO NOT MERGE it until that first PR goes in.

Also, @AlanGreene I'm sorry for the large PR, but I wasn't sure how to break down my code further. Please let me know if this PR is too large and if so, how I could go about breaking it down.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
