### PR TITLE
Publish the nightly image with a stable reference

### DIFF
--- a/test/publish-images.sh
+++ b/test/publish-images.sh
@@ -36,4 +36,9 @@ npm ci
 npm run build_ko
 
 export KO_DOCKER_REPO=gcr.io/tekton-nightly
-ko publish ./cmd/dashboard
+
+# Publish the image
+IMAGE=$(ko publish ./cmd/dashboard 2>&1 | grep "Loaded ko.local/dashboard" | sed -n -r '/[0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+.*Loaded/ { s/.*Loaded //;p}')
+# Tag it
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/dashboard:latest


### PR DESCRIPTION
# Changes

This should make the nightly image being published (technically
"aliased") to gcr.io/tekton-nightly/dashboard:latest.

cc @mnuttall 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
