### PR TITLE
Update client URLs to include namespace

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -17,17 +17,25 @@ import { Breadcrumb, BreadcrumbItem } from 'carbon-components-react';
 
 export default function Breadcrumbs({ labels, match }) {
   const { url } = match;
-  const pathSegments = url
-    .split('/')
-    .filter(segment => !!segment && segment !== 'runs');
+  let pathSegments = url.split('/').filter(Boolean);
+
+  let namespacePrefix = '';
+  if (pathSegments[0] === 'namespaces') {
+    namespacePrefix = `/${pathSegments.slice(0, 2).join('/')}`;
+    pathSegments = pathSegments.slice(2);
+  }
 
   return (
     <Breadcrumb>
       {pathSegments.map((segment, index) => {
+        if (segment === 'runs') {
+          return null;
+        }
         const path = `/${pathSegments.slice(0, index + 1).join('/')}`;
+        const to = labels[path] ? path : `${namespacePrefix}${path}`;
         return (
           <BreadcrumbItem key={segment}>
-            <NavLink exact to={path}>
+            <NavLink exact to={to}>
               {labels[path] || segment}
             </NavLink>
           </BreadcrumbItem>
@@ -38,10 +46,11 @@ export default function Breadcrumbs({ labels, match }) {
 }
 
 const breadcrumbLabels = {
-  '/pipelines': 'Pipelines',
-  '/tasks': 'Tasks',
   '/extensions': 'Extensions',
-  '/importresources': 'Import Tekton Resources'
+  '/importresources': 'Import Tekton Resources',
+  '/pipelineruns': 'PipelineRuns',
+  '/pipelines': 'Pipelines',
+  '/tasks': 'Tasks'
 };
 
 Breadcrumbs.defaultProps = {

--- a/src/components/Breadcrumbs/Breadcrumbs.test.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.js
@@ -26,8 +26,13 @@ it('Breadcrumbs renders with default content', () => {
 it('Breadcrumbs removes unnecessary segments', () => {
   const { queryByText } = renderWithRouter(
     <Breadcrumbs
-      match={{ url: '/pipelines/demo-pipeline/runs/demo-pipeline-run-1' }}
+      match={{
+        url:
+          '/namespaces/default/pipelines/demo-pipeline/runs/demo-pipeline-run-1'
+      }}
     />
   );
+  expect(queryByText(/namespaces/i)).toBeFalsy();
+  expect(queryByText(/default/i)).toBeFalsy();
   expect(queryByText(/runs/i)).toBeFalsy();
 });

--- a/src/components/StepDetails/StepDetails.test.js
+++ b/src/components/StepDetails/StepDetails.test.js
@@ -13,16 +13,16 @@ limitations under the License.
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render } from 'react-testing-library';
 import configureStore from 'redux-mock-store';
 
+import { renderWithRouter } from '../../utils/test';
 import StepDetails from './StepDetails';
 
 it('StepDetails renders', () => {
   const mockStore = configureStore();
   const store = mockStore({ namespaces: { selected: 'default' } });
 
-  render(
+  renderWithRouter(
     <Provider store={store}>
       <StepDetails />
     </Provider>

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -16,18 +16,12 @@ import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader/root';
 import {
   HashRouter as Router,
-  NavLink,
   Redirect,
   Route,
   Switch
 } from 'react-router-dom';
 
-import {
-  Content,
-  SideNav,
-  SideNavItems,
-  SideNavLink
-} from 'carbon-components-react/lib/components/UIShell';
+import { Content } from 'carbon-components-react/lib/components/UIShell';
 
 import {
   Extension,
@@ -35,23 +29,18 @@ import {
   PipelineRun,
   PipelineRuns,
   Pipelines,
+  SideNav,
   Tasks,
   TaskRuns,
   CustomResourceDefinition,
-  NamespacesDropdown,
   ImportResources
 } from '..';
 
-import SideNavMenu from '../../components/SideNavMenu';
 import Header from '../../components/Header';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { fetchExtensions } from '../../actions/extensions';
 import { fetchNamespaces, selectNamespace } from '../../actions/namespaces';
-import {
-  getExtensions,
-  getNamespaces,
-  getSelectedNamespace
-} from '../../reducers';
+import { getExtensions, getSelectedNamespace } from '../../reducers';
 
 import '../../components/App/App.scss';
 
@@ -62,7 +51,7 @@ export /* istanbul ignore next */ class App extends Component {
   }
 
   render() {
-    const { extensions, namespace } = this.props;
+    const { extensions } = this.props;
 
     return (
       <Router>
@@ -70,68 +59,41 @@ export /* istanbul ignore next */ class App extends Component {
           <Header>
             <Route path="*" component={Breadcrumbs} />
           </Header>
-          <SideNav defaultExpanded expanded aria-label="Side navigation">
-            <SideNavItems>
-              <SideNavMenu title="Tekton">
-                <SideNavLink element={NavLink} icon={<span />} to="/pipelines">
-                  Pipelines
-                </SideNavLink>
-                <SideNavLink
-                  element={NavLink}
-                  icon={<span />}
-                  to="/pipelineruns"
-                >
-                  PipelineRuns
-                </SideNavLink>
-                <SideNavLink element={NavLink} icon={<span />} to="/tasks">
-                  Tasks
-                </SideNavLink>
-                <SideNavLink
-                  element={NavLink}
-                  icon={<span />}
-                  to="/importresources"
-                >
-                  Import Tekton resources
-                </SideNavLink>
-              </SideNavMenu>
-              <NamespacesDropdown
-                titleText="Namespace"
-                selectedItem={{ id: namespace, text: namespace }}
-                onChange={event => {
-                  this.props.selectNamespace(event.selectedItem.id);
-                }}
-              />
-              {extensions.length > 0 && (
-                <SideNavMenu title="Extensions">
-                  {extensions.map(({ displayName, name }) => (
-                    <SideNavLink
-                      element={NavLink}
-                      icon={<span />}
-                      to={`/extensions/${name}`}
-                      key={name}
-                      title={displayName}
-                    >
-                      {displayName}
-                    </SideNavLink>
-                  ))}
-                </SideNavMenu>
-              )}
-            </SideNavItems>
-          </SideNav>
+          <Route path="/namespaces/:namespace/*">
+            {props => <SideNav {...props} />}
+          </Route>
 
           <Content>
             <Switch>
               <Route path="/pipelines" exact component={Pipelines} />
+              <Route
+                path="/namespaces/:namespace/pipelines"
+                exact
+                component={Pipelines}
+              />
               <Route path="/tasks" exact component={Tasks} />
+              <Route
+                path="/namespaces/:namespace/tasks"
+                exact
+                component={Tasks}
+              />
               <Route path="/pipelineruns" component={PipelineRuns} />
               <Route
-                path="/pipelines/:pipelineName/runs"
+                path="/namespaces/:namespace/pipelineruns"
+                component={PipelineRuns}
+              />
+              <Route
+                path="/namespaces/:namespace/pipelines/:pipelineName/runs"
                 exact
                 component={PipelineRuns}
               />
-              <Route path="/tasks/:taskName/runs" exact component={TaskRuns} />
               <Route
-                path="/pipelines/:pipelineName/runs/:pipelineRunName"
+                path="/namespaces/:namespace/tasks/:taskName/runs"
+                exact
+                component={TaskRuns}
+              />
+              <Route
+                path="/namespaces/:namespace/pipelines/:pipelineName/runs/:pipelineRunName"
                 component={PipelineRun}
               />
               <Route path="/importresources" component={ImportResources} />
@@ -150,7 +112,7 @@ export /* istanbul ignore next */ class App extends Component {
                 />
               ))}
               <Route
-                path="/:type/:name"
+                path="/namespaces/:namespace/:type/:name"
                 exact
                 component={CustomResourceDefinition}
               />
@@ -164,15 +126,13 @@ export /* istanbul ignore next */ class App extends Component {
 }
 
 App.defaultProps = {
-  extensions: [],
-  namespaces: ['default']
+  extensions: []
 };
 
 /* istanbul ignore next */
 const mapStateToProps = state => ({
   extensions: getExtensions(state),
-  namespace: getSelectedNamespace(state),
-  namespaces: getNamespaces(state)
+  namespace: getSelectedNamespace(state)
 });
 
 const mapDispatchToProps = {

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -19,7 +19,7 @@ import thunk from 'redux-thunk';
 
 import { App } from './App';
 
-it('App renders successfully without extensions', () => {
+it('App renders successfully', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
@@ -39,36 +39,4 @@ it('App renders successfully without extensions', () => {
   );
   expect(queryByText(/pipelines/i)).toBeTruthy();
   expect(queryByText(/tasks/i)).toBeTruthy();
-  expect(queryByText(/extensions/i)).toBe(null);
-});
-
-it('App renders successfully with extensions', () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore({
-    extensions: { byName: {} },
-    namespaces: { byName: {} },
-    pipelines: { byNamespace: {} },
-    serviceAccounts: { byNamespace: {} }
-  });
-  const { queryByText } = render(
-    <Provider store={store}>
-      <App
-        extensions={[
-          {
-            name: 'dashboard-esaxtension',
-            url: 'sample',
-            port: '3000',
-            displayname: 'tekton_dashboard_extension',
-            bundlelocation: '/bundle'
-          }
-        ]}
-        fetchExtensions={() => {}}
-        fetchNamespaces={() => {}}
-      />
-    </Provider>
-  );
-  expect(queryByText(/pipelines/i)).toBeTruthy();
-  expect(queryByText(/tasks/i)).toBeTruthy();
-  expect(queryByText(/extensions/i)).toBeTruthy();
 });

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -25,7 +25,6 @@ import { fetchPipeline } from '../../actions/pipelines';
 
 import {
   getPipeline,
-  getSelectedNamespace,
   getTask,
   getTasksErrorMessage,
   getPipelinesErrorMessage
@@ -38,27 +37,35 @@ export /* istanbul ignore next */ class CustomResourceDefinition extends Compone
 
   componentDidMount() {
     const { match } = this.props;
-    const { name, type } = match.params;
-    this.fetch(type, name).then(() => this.setState({ loading: false }));
+    const { name, namespace, type } = match.params;
+    this.fetch({ name, namespace, type }).then(() =>
+      this.setState({ loading: false })
+    );
   }
 
   componentDidUpdate(prevProps) {
-    const { match, namespace } = this.props;
-    const { name, type } = match.params;
-    const { match: prevMatch, namespace: prevNamespace } = prevProps;
-    const { name: prevName, type: prevType } = prevMatch.params;
+    const { match } = this.props;
+    const { name, namespace, type } = match.params;
+    const { match: prevMatch } = prevProps;
+    const {
+      name: prevName,
+      namespace: prevNamespace,
+      type: prevType
+    } = prevMatch.params;
     if (namespace !== prevNamespace || name !== prevName || type !== prevType) {
       this.setState({ loading: true }); // eslint-disable-line
-      this.fetch(type, name).then(() => this.setState({ loading: false }));
+      this.fetch({ name, namespace, type }).then(() =>
+        this.setState({ loading: false })
+      );
     }
   }
 
-  fetch = (type, name) => {
+  fetch = ({ name, namespace, type }) => {
     switch (type) {
       case 'tasks':
-        return this.props.fetchTask({ name });
+        return this.props.fetchTask({ name, namespace });
       case 'pipelines':
-        return this.props.fetchPipeline({ name });
+        return this.props.fetchPipeline({ name, namespace });
       default:
         return Promise.resolve();
     }
@@ -93,14 +100,16 @@ export /* istanbul ignore next */ class CustomResourceDefinition extends Compone
 }
 
 /* istanbul ignore next */
-function mapStateToProps(state, props) {
+function mapStateToProps(state, ownProps) {
+  const { match } = ownProps;
+  const { namespace } = match.params;
   return {
-    namespace: getSelectedNamespace(state),
     error: getTasksErrorMessage(state) || getPipelinesErrorMessage(state),
+    namespace,
     resource:
-      props.match.params.type === 'tasks'
-        ? getTask(state, { name: props.match.params.name })
-        : getPipeline(state, { name: props.match.params.name })
+      ownProps.match.params.type === 'tasks'
+        ? getTask(state, { name: ownProps.match.params.name, namespace })
+        : getPipeline(state, { name: ownProps.match.params.name, namespace })
   };
 }
 

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -89,7 +89,7 @@ export class ImportResources extends Component {
       .then(headers => {
         const logsURL = headers.get('Content-Location');
         const pipelineRunName = logsURL.substring(logsURL.lastIndexOf('/') + 1);
-        const finalURL = '/pipelines/pipeline0/runs/'.concat(pipelineRunName);
+        const finalURL = `/namespaces/${namespace}/pipelines/pipeline0/runs/${pipelineRunName}`;
         this.setState({
           logsURL: finalURL,
           submitSuccess: true,

--- a/src/containers/Log/Log.js
+++ b/src/containers/Log/Log.js
@@ -12,11 +12,10 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import Log from '../../components/Log';
 import { getTaskRunLog } from '../../api';
-import { getSelectedNamespace } from '../../reducers';
 
 export class LogContainer extends Component {
   state = { logs: [] };
@@ -26,17 +25,27 @@ export class LogContainer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { stepName, taskRunName } = this.props;
+    const { match, stepName, taskRunName } = this.props;
+    const { namespace } = match.params;
+    const {
+      match: prevMatch,
+      stepName: prevStepName,
+      taskRunName: prevTaskRunName
+    } = prevProps;
+    const { namespace: prevNamespace } = prevMatch.params;
+
     if (
-      taskRunName !== prevProps.taskRunName ||
-      stepName !== prevProps.stepName
+      taskRunName !== prevTaskRunName ||
+      stepName !== prevStepName ||
+      namespace !== prevNamespace
     ) {
       this.loadLog();
     }
   }
 
   async loadLog() {
-    const { namespace, stepName, taskRunName } = this.props;
+    const { match, stepName, taskRunName } = this.props;
+    const { namespace } = match.params;
     if (taskRunName) {
       try {
         const logs = await getTaskRunLog(taskRunName, namespace);
@@ -59,11 +68,4 @@ export class LogContainer extends Component {
   }
 }
 
-/* istanbul ignore next */
-function mapStateToProps(state) {
-  return {
-    namespace: getSelectedNamespace(state)
-  };
-}
-
-export default connect(mapStateToProps)(LogContainer);
+export default withRouter(LogContainer);

--- a/src/containers/Log/Log.test.js
+++ b/src/containers/Log/Log.test.js
@@ -36,7 +36,7 @@ it('LogContainer renders', async () => {
 
   const { container, getByText } = render(
     <LogContainer
-      namespace={namespace}
+      match={{ params: { namespace } }}
       stepName={stepName}
       taskRunName={taskRunName}
     />
@@ -49,7 +49,7 @@ it('LogContainer renders', async () => {
   const anotherTaskRunName = 'anotherTaskRun';
   render(
     <LogContainer
-      namespace={namespace}
+      match={{ params: { namespace } }}
       stepName={stepName}
       taskRunName={anotherTaskRunName}
     />,
@@ -71,7 +71,7 @@ it('LogContainer handles error case', async () => {
 
   const { getByText } = render(
     <LogContainer
-      namespace={namespace}
+      match={{ params: { namespace } }}
       stepName={stepName}
       taskRunName={taskRunName}
     />
@@ -99,7 +99,7 @@ it('LogContainer handles empty logs', async () => {
 
   const { getByText } = render(
     <LogContainer
-      namespace={namespace}
+      match={{ params: { namespace } }}
       stepName={stepName}
       taskRunName={taskRunName}
     />
@@ -122,7 +122,7 @@ it('LogContainer handles missing step logs', async () => {
 
   const { getByText } = render(
     <LogContainer
-      namespace={namespace}
+      match={{ params: { namespace } }}
       stepName={stepName}
       taskRunName={taskRunName}
     />

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 
 import TooltipDropdown from '../../components/TooltipDropdown';
 import { getNamespaces, isFetchingNamespaces } from '../../reducers';
+import { ALL_NAMESPACES } from '../../constants';
 
 const NamespacesDropdown = props => {
   return <TooltipDropdown {...props} />;
@@ -35,13 +36,13 @@ NamespacesDropdown.defaultProps = {
 function mapStateToProps(state, ownProps) {
   const { selectedItem, showAllNamespaces } = ownProps;
 
-  if (selectedItem && selectedItem.id === '*') {
+  if (selectedItem && selectedItem.id === ALL_NAMESPACES) {
     selectedItem.text = allNamespacesLabel;
   }
 
   const items = getNamespaces(state);
   if (showAllNamespaces) {
-    items.unshift({ id: '*', text: allNamespacesLabel });
+    items.unshift({ id: ALL_NAMESPACES, text: allNamespacesLabel });
   }
 
   return {

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -52,9 +52,12 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
   }
 
   fetchPipelineRuns() {
-    const { params } = this.props.match;
-    const { pipelineName } = params;
-    this.props.fetchPipelineRuns({ pipelineName });
+    const { match, namespace } = this.props;
+    const { pipelineName } = match.params;
+    this.props.fetchPipelineRuns({
+      pipelineName,
+      namespace
+    });
   }
 
   render() {
@@ -105,7 +108,10 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
                   </StructuredListRow>
                 )}
                 {pipelineRuns.map(pipelineRun => {
-                  const pipelineRunName = pipelineRun.metadata.name;
+                  const {
+                    name: pipelineRunName,
+                    namespace
+                  } = pipelineRun.metadata;
                   const pipelineRefName = pipelineRun.spec.pipelineRef.name;
                   const { lastTransitionTime, reason, status } = getStatus(
                     pipelineRun
@@ -118,14 +124,16 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
                     >
                       <StructuredListCell>
                         <Link
-                          to={`/pipelines/${pipelineRefName}/runs/${pipelineRunName}`}
+                          to={`/namespaces/${namespace}/pipelines/${pipelineRefName}/runs/${pipelineRunName}`}
                         >
                           {pipelineRunName}
                         </Link>
                       </StructuredListCell>
                       {!pipelineName && (
                         <StructuredListCell>
-                          <Link to={`/pipelines/${pipelineRefName}/runs`}>
+                          <Link
+                            to={`/namespaces/${namespace}/pipelines/${pipelineRefName}/runs`}
+                          >
                             {pipelineRefName}
                           </Link>
                         </StructuredListCell>
@@ -155,16 +163,19 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
 
 /* istanbul ignore next */
 function mapStateToProps(state, props) {
-  const { pipelineName } = props.match.params;
+  const { namespace: namespaceParam, pipelineName } = props.match.params;
+  const namespace = namespaceParam || getSelectedNamespace(state);
+
   return {
     error: getPipelineRunsErrorMessage(state),
     loading: isFetchingPipelineRuns(state),
-    namespace: getSelectedNamespace(state),
+    namespace,
     pipelineRuns: pipelineName
       ? getPipelineRunsByPipelineName(state, {
-          name: props.match.params.pipelineName
+          name: props.match.params.pipelineName,
+          namespace
         })
-      : getPipelineRuns(state)
+      : getPipelineRuns(state, { namespace })
   };
 }
 

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -83,21 +83,20 @@ export /* istanbul ignore next */ class Pipelines extends Component {
                   </StructuredListRow>
                 )}
                 {pipelines.map(pipeline => {
-                  const pipelineName = pipeline.metadata.name;
+                  const { name, namespace, uid } = pipeline.metadata;
                   return (
-                    <StructuredListRow
-                      className="definition"
-                      key={pipeline.metadata.uid}
-                    >
+                    <StructuredListRow className="definition" key={uid}>
                       <StructuredListCell>
-                        <Link to={`/pipelines/${pipelineName}/runs`}>
-                          {pipelineName}
+                        <Link
+                          to={`/namespaces/${namespace}/pipelines/${name}/runs`}
+                        >
+                          {name}
                         </Link>
                       </StructuredListCell>
                       <StructuredListCell>
                         <Link
                           title="pipeline definition"
-                          to={`/pipelines/${pipelineName}`}
+                          to={`/namespaces/${namespace}/pipelines/${name}`}
                         >
                           <Information16 className="resource-info-icon" />
                         </Link>
@@ -119,12 +118,15 @@ Pipelines.defaultProps = {
 };
 
 /* istanbul ignore next */
-function mapStateToProps(state) {
+function mapStateToProps(state, props) {
+  const { namespace: namespaceParam } = props.match.params;
+  const namespace = namespaceParam || getSelectedNamespace(state);
+
   return {
     error: getPipelinesErrorMessage(state),
     loading: isFetchingPipelines(state),
-    namespace: getSelectedNamespace(state),
-    pipelines: getPipelines(state)
+    namespace,
+    pipelines: getPipelines(state, { namespace })
   };
 }
 

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { generatePath, NavLink } from 'react-router-dom';
+import {
+  SideNav as CarbonSideNav,
+  SideNavItems,
+  SideNavLink
+} from 'carbon-components-react/lib/components/UIShell';
+
+import { NamespacesDropdown } from '..';
+import SideNavMenu from '../../components/SideNavMenu';
+
+import { selectNamespace } from '../../actions/namespaces';
+import { getExtensions, getSelectedNamespace } from '../../reducers';
+import { ALL_NAMESPACES } from '../../constants';
+
+export class SideNav extends Component {
+  componentDidMount() {
+    const { match } = this.props;
+
+    if (match && match.params.namespace) {
+      this.props.selectNamespace(match.params.namespace);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { match } = this.props;
+    if (!match) {
+      return;
+    }
+
+    const { namespace } = match.params;
+    const { match: prevMatch } = prevProps;
+    const prevNamespace = prevMatch && prevMatch.params.namespace;
+
+    if (namespace !== prevNamespace) {
+      this.props.selectNamespace(namespace);
+    }
+  }
+
+  getPath(path) {
+    const { match } = this.props;
+    let namespacePrefix = '';
+    if (match && match.params.namespace) {
+      namespacePrefix = `/namespaces/${match.params.namespace}`;
+    }
+
+    return `${namespacePrefix}${path}`;
+  }
+
+  selectNamespace = event => {
+    const namespace = event.selectedItem.id;
+    const { history, match } = this.props;
+
+    if (!match) {
+      this.props.selectNamespace(namespace);
+      return;
+    }
+
+    if (namespace === ALL_NAMESPACES) {
+      this.props.selectNamespace(namespace);
+      history.push('/');
+      return;
+    }
+
+    const newURL = generatePath(match.path, { namespace, 0: match.params[0] });
+    history.push(newURL);
+  };
+
+  render() {
+    const { extensions, namespace } = this.props;
+
+    return (
+      <CarbonSideNav defaultExpanded expanded aria-label="Side navigation">
+        <SideNavItems>
+          <SideNavMenu title="Tekton">
+            <SideNavLink
+              element={NavLink}
+              icon={<span />}
+              to={this.getPath('/pipelines')}
+            >
+              Pipelines
+            </SideNavLink>
+            <SideNavLink
+              element={NavLink}
+              icon={<span />}
+              to={this.getPath('/pipelineruns')}
+            >
+              PipelineRuns
+            </SideNavLink>
+            <SideNavLink
+              element={NavLink}
+              icon={<span />}
+              to={this.getPath('/tasks')}
+            >
+              Tasks
+            </SideNavLink>
+            <SideNavLink
+              element={NavLink}
+              icon={<span />}
+              to="/importresources"
+            >
+              Import Tekton resources
+            </SideNavLink>
+          </SideNavMenu>
+          <NamespacesDropdown
+            id="sidenav-namespace-dropdown"
+            titleText="Namespace"
+            selectedItem={{ id: namespace, text: namespace }}
+            showAllNamespaces
+            onChange={this.selectNamespace}
+          />
+          {extensions.length > 0 && (
+            <SideNavMenu title="Extensions">
+              {extensions.map(({ displayName, name }) => (
+                <SideNavLink
+                  element={NavLink}
+                  icon={<span />}
+                  to={`/extensions/${name}`}
+                  key={name}
+                  title={displayName}
+                >
+                  {displayName}
+                </SideNavLink>
+              ))}
+            </SideNavMenu>
+          )}
+        </SideNavItems>
+      </CarbonSideNav>
+    );
+  }
+}
+
+/* istanbul ignore next */
+const mapStateToProps = state => ({
+  extensions: getExtensions(state),
+  namespace: getSelectedNamespace(state)
+});
+
+const mapDispatchToProps = {
+  selectNamespace
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SideNav);

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -1,0 +1,193 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { fireEvent } from 'react-testing-library';
+
+import { renderWithRouter } from '../../utils/test';
+import { ALL_NAMESPACES } from '../../constants';
+import SideNavContainer, { SideNav } from './SideNav';
+
+it('SideNav renders with extensions', () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    extensions: {
+      byName: {
+        'dashboard-extension': {
+          displayName: 'tekton_dashboard_extension',
+          name: 'dashboard-extension',
+          url: 'sample'
+        }
+      }
+    },
+    namespaces: { byName: {} }
+  });
+  const { queryByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNavContainer />
+    </Provider>
+  );
+  expect(queryByText(/pipelines/i)).toBeTruthy();
+  expect(queryByText(/tasks/i)).toBeTruthy();
+  expect(queryByText(/extensions/i)).toBeTruthy();
+});
+
+it('SideNav selects namespace based on URL', () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    namespaces: { byName: {} }
+  });
+  const namespace = 'default';
+  const selectNamespace = jest.fn();
+  const { container } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        match={{ params: { namespace } }}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  expect(selectNamespace).toHaveBeenCalledWith(namespace);
+
+  const updatedNamespace = 'another';
+  renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        match={{ params: { namespace: updatedNamespace } }}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>,
+    { container }
+  );
+
+  expect(selectNamespace).toHaveBeenCalledWith(updatedNamespace);
+
+  renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        match={{ params: { namespace: updatedNamespace } }}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>,
+    { container }
+  );
+  expect(selectNamespace).toHaveBeenCalledTimes(2);
+});
+
+it('SideNav selects namespace when no namespace in URL', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const otherNamespace = 'foo';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true,
+        [otherNamespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByText(otherNamespace));
+  expect(selectNamespace).toHaveBeenCalledWith(otherNamespace);
+});
+
+it('SideNav redirects to root when all namespaces selected on namespaced URL', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const push = jest.fn();
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        history={{ push }}
+        match={{ params: { namespace } }}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByText(/all namespaces/i));
+  expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
+  expect(push).toHaveBeenCalledWith('/');
+});
+
+it('SideNav updates namespace in URL', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const otherNamespace = 'foo';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true,
+        [otherNamespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const push = jest.fn();
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        history={{ push }}
+        match={{
+          params: { namespace },
+          path: '/namespaces/:namespace/pipelines'
+        }}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  selectNamespace.mockClear();
+  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByText(otherNamespace));
+  expect(selectNamespace).not.toHaveBeenCalled();
+  expect(push).toHaveBeenCalledWith(expect.stringContaining(otherNamespace));
+});

--- a/src/containers/SideNav/index.js
+++ b/src/containers/SideNav/index.js
@@ -1,0 +1,1 @@
+export { default } from './SideNav';

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -65,20 +65,20 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   };
 
   componentDidMount() {
-    const { match } = this.props;
+    const { match, namespace } = this.props;
     const { taskName } = match.params;
-    this.fetchTaskAndRuns(taskName);
+    this.fetchTaskAndRuns(taskName, namespace);
   }
 
   componentDidUpdate(prevProps) {
     const { match, namespace } = this.props;
     const { taskName } = match.params;
-    if (
-      taskName !== prevProps.match.params.taskName ||
-      namespace !== prevProps.namespace
-    ) {
+    const { match: prevMatch, namespace: prevNamespace } = prevProps;
+    const { taskName: prevTaskName } = prevMatch.params;
+
+    if (taskName !== prevTaskName || namespace !== prevNamespace) {
       this.setState({ loading: true }); // eslint-disable-line
-      this.fetchTaskAndRuns(taskName);
+      this.fetchTaskAndRuns(taskName, namespace);
     }
   }
 
@@ -118,9 +118,9 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
     this.setState({ taskRuns, notification });
   };
 
-  fetchTaskAndRuns(taskName) {
+  fetchTaskAndRuns(taskName, namespace) {
     Promise.all([
-      this.props.fetchTask({ name: taskName }),
+      this.props.fetchTask({ name: taskName, namespace }),
       this.props.fetchTaskRuns({ taskName })
     ]).then(() => {
       this.setState({ loading: false });
@@ -199,14 +199,20 @@ TaskRunsContainer.propTypes = {
 };
 
 /* istanbul ignore next */
-function mapStateToProps(state, props) {
+function mapStateToProps(state, ownProps) {
+  const { match } = ownProps;
+  const { namespace: namespaceParam, taskName } = match.params;
+
+  const namespace = namespaceParam || getSelectedNamespace(state);
+
   return {
     error: getTaskRunsErrorMessage(state),
-    namespace: getSelectedNamespace(state),
+    namespace,
     taskRuns: getTaskRunsByTaskName(state, {
-      name: props.match.params.taskName
+      name: taskName,
+      namespace
     }),
-    task: getTask(state, { name: props.match.params.taskName })
+    task: getTask(state, { name: taskName, namespace })
   };
 }
 

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -82,17 +82,21 @@ export /* istanbul ignore next */ class Tasks extends Component {
                   </StructuredListRow>
                 )}
                 {tasks.map(task => {
-                  const taskName = task.metadata.name;
+                  const { name: taskName, namespace, uid } = task.metadata;
                   return (
-                    <StructuredListRow
-                      className="definition"
-                      key={task.metadata.uid}
-                    >
+                    <StructuredListRow className="definition" key={uid}>
                       <StructuredListCell>
-                        <Link to={`/tasks/${taskName}/runs`}>{taskName}</Link>
+                        <Link
+                          to={`/namespaces/${namespace}/tasks/${taskName}/runs`}
+                        >
+                          {taskName}
+                        </Link>
                       </StructuredListCell>
                       <StructuredListCell>
-                        <Link title="task definition" to={`/tasks/${taskName}`}>
+                        <Link
+                          title="task definition"
+                          to={`/namespaces/${namespace}/tasks/${taskName}`}
+                        >
                           <Information16 className="resource-info-icon" />
                         </Link>
                       </StructuredListCell>
@@ -113,12 +117,15 @@ Tasks.defaultProps = {
 };
 
 /* istanbul ignore next */
-function mapStateToProps(state) {
+function mapStateToProps(state, props) {
+  const { namespace: namespaceParam } = props.match.params;
+  const namespace = namespaceParam || getSelectedNamespace(state);
+
   return {
     error: getTasksErrorMessage(state),
     loading: isFetchingTasks(state),
-    namespace: getSelectedNamespace(state),
-    tasks: getTasks(state)
+    namespace,
+    tasks: getTasks(state, { namespace })
   };
 }
 

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -11,16 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { default as Extension } from './Extension';
-export { default as Extensions } from './Extensions';
-export { default as PipelineRun } from './PipelineRun';
-export { default as PipelineRuns } from './PipelineRuns';
-export { default as Pipelines } from './Pipelines';
-export { default as Tasks } from './Tasks';
 export {
   default as CustomResourceDefinition
 } from './CustomResourceDefinition';
-export { default as TaskRuns } from './TaskRuns';
+export { default as Extension } from './Extension';
+export { default as Extensions } from './Extensions';
 export { default as ImportResources } from './ImportResources';
 export { default as NamespacesDropdown } from './NamespacesDropdown';
+export { default as PipelineRun } from './PipelineRun';
+export { default as PipelineRuns } from './PipelineRuns';
+export { default as Pipelines } from './Pipelines';
 export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';
+export { default as SideNav } from './SideNav';
+export { default as Tasks } from './Tasks';
+export { default as TaskRuns } from './TaskRuns';

--- a/src/reducers/namespaces.js
+++ b/src/reducers/namespaces.js
@@ -14,6 +14,8 @@ limitations under the License.
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 
+import { ALL_NAMESPACES } from '../constants';
+
 function byName(state = { default: {} }, action) {
   switch (action.type) {
     case 'NAMESPACES_FETCH_SUCCESS':
@@ -23,7 +25,7 @@ function byName(state = { default: {} }, action) {
   }
 }
 
-function selected(state = 'default', action) {
+function selected(state = ALL_NAMESPACES, action) {
   switch (action.type) {
     case 'NAMESPACE_SELECT':
       return action.namespace;

--- a/src/reducers/namespaces.test.js
+++ b/src/reducers/namespaces.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import namespacesReducer, * as selectors from './namespaces';
+import { ALL_NAMESPACES } from '../constants';
 
 it('handles init or unknown actions', () => {
   expect(namespacesReducer(undefined, { type: 'does_not_exist' })).toEqual({
@@ -20,7 +21,7 @@ it('handles init or unknown actions', () => {
     },
     errorMessage: null,
     isFetching: false,
-    selected: 'default'
+    selected: ALL_NAMESPACES
   });
 });
 

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -20,11 +20,12 @@ export function renderWithRouter( // eslint-disable-line import/prefer-default-e
   ui,
   {
     route = '/',
-    history = createMemoryHistory({ initialEntries: [route] })
+    history = createMemoryHistory({ initialEntries: [route] }),
+    container
   } = {}
 ) {
   return {
-    ...render(<Router history={history}>{ui}</Router>),
+    ...render(<Router history={history}>{ui}</Router>, { container }),
     // adding `history` to the returned utilities to allow us
     // to reference it in our tests (just try to avoid using
     // this to test implementation details).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/166

A user should be able to bookmark / share links to individual resources
displayed in the dashboard. Before this change that was not always possible
as the URL did not include the selected namespace. If a namespace other
than 'default' was selected, the user would need to manually select the
correct namespace from the dropdown in the side navigation to view the
resource referenced by the URL.

Update the URL for single Tekton resources to include the namespace so
that a URL will point to the correct view regardless of which namespace
was selected at the time the URL was copied.

Also provide namespace scoped URLs for the list views.
Link URL and namespace dropdown so they're kept in sync.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
