### PR TITLE
issue195 - removed transform value so modals display properly

### DIFF
--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -68,5 +68,6 @@ main {
 
   .bx--content {
     margin-top: 7rem;
+    transform: none;
   }
 }


### PR DESCRIPTION
issue: #195 

# Changes

Before this change we had to hardcode styles so modals fit properly when displayed but a weird bug was happening that it was not fixed in the dashboard & disappeared when one was scrolling through the page. This was easily fixed by removing the transform value. 
