### PR TITLE
Add namespace to list views when viewing 'all namespaces'

### DIFF
--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -24,6 +24,7 @@ import {
   StructuredListWrapper
 } from 'carbon-components-react';
 
+import { ALL_NAMESPACES } from '../../constants';
 import { getStatusIcon, getStatus } from '../../utils';
 import { fetchPipelineRuns } from '../../actions/pipelineRuns';
 
@@ -61,7 +62,13 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
   }
 
   render() {
-    const { match, error, loading, pipelineRuns } = this.props;
+    const {
+      match,
+      error,
+      loading,
+      namespace: selectedNamespace,
+      pipelineRuns
+    } = this.props;
     const { pipelineName } = match.params;
 
     return (
@@ -88,6 +95,9 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
                   <StructuredListCell head>Pipeline Run</StructuredListCell>
                   {!pipelineName && (
                     <StructuredListCell head>Pipeline</StructuredListCell>
+                  )}
+                  {selectedNamespace === ALL_NAMESPACES && (
+                    <StructuredListCell head>Namespace</StructuredListCell>
                   )}
                   <StructuredListCell head>Status</StructuredListCell>
                   <StructuredListCell head>
@@ -137,6 +147,9 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
                             {pipelineRefName}
                           </Link>
                         </StructuredListCell>
+                      )}
+                      {selectedNamespace === ALL_NAMESPACES && (
+                        <StructuredListCell>{namespace}</StructuredListCell>
                       )}
                       <StructuredListCell
                         className="status"

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -26,6 +26,7 @@ import {
   StructuredListWrapper
 } from 'carbon-components-react';
 
+import { ALL_NAMESPACES } from '../../constants';
 import { fetchPipelines } from '../../actions/pipelines';
 import {
   getPipelines,
@@ -49,7 +50,12 @@ export /* istanbul ignore next */ class Pipelines extends Component {
   }
 
   render() {
-    const { error, loading, pipelines } = this.props;
+    const {
+      error,
+      loading,
+      namespace: selectedNamespace,
+      pipelines
+    } = this.props;
 
     return (
       <>
@@ -73,6 +79,9 @@ export /* istanbul ignore next */ class Pipelines extends Component {
               <StructuredListHead>
                 <StructuredListRow head>
                   <StructuredListCell head>Pipeline</StructuredListCell>
+                  {selectedNamespace === ALL_NAMESPACES && (
+                    <StructuredListCell head>Namespace</StructuredListCell>
+                  )}
                   <StructuredListCell head />
                 </StructuredListRow>
               </StructuredListHead>
@@ -93,6 +102,9 @@ export /* istanbul ignore next */ class Pipelines extends Component {
                           {name}
                         </Link>
                       </StructuredListCell>
+                      {selectedNamespace === ALL_NAMESPACES && (
+                        <StructuredListCell>{namespace}</StructuredListCell>
+                      )}
                       <StructuredListCell>
                         <Link
                           title="pipeline definition"

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -25,6 +25,7 @@ import {
 } from 'carbon-components-react';
 
 import Information16 from '@carbon/icons-react/lib/information/16';
+import { ALL_NAMESPACES } from '../../constants';
 import { fetchTasks } from '../../actions/tasks';
 import {
   getSelectedNamespace,
@@ -48,7 +49,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
   }
 
   render() {
-    const { error, loading, tasks } = this.props;
+    const { error, loading, namespace: selectedNamespace, tasks } = this.props;
 
     return (
       <>
@@ -72,6 +73,9 @@ export /* istanbul ignore next */ class Tasks extends Component {
               <StructuredListHead>
                 <StructuredListRow head>
                   <StructuredListCell head>Task</StructuredListCell>
+                  {selectedNamespace === ALL_NAMESPACES && (
+                    <StructuredListCell head>Namespace</StructuredListCell>
+                  )}
                   <StructuredListCell head />
                 </StructuredListRow>
               </StructuredListHead>
@@ -92,6 +96,9 @@ export /* istanbul ignore next */ class Tasks extends Component {
                           {taskName}
                         </Link>
                       </StructuredListCell>
+                      {selectedNamespace === ALL_NAMESPACES && (
+                        <StructuredListCell>{namespace}</StructuredListCell>
+                      )}
                       <StructuredListCell>
                         <Link
                           title="task definition"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/166

As resource names are only unique per namespace we are likely to
encounter multiple entries with the same name in the list views
when the 'All namespaces' option is chosen in the nav.

Add a namespace column to the list views that is only displayed
when 'All namespaces' is selected.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
