### PR TITLE
namespace field in credential struct

### DIFF
--- a/pkg/endpoints/credentials.go
+++ b/pkg/endpoints/credentials.go
@@ -36,6 +36,7 @@ type credential struct {
 	ResourceVersion string            `json:"resourceVersion,omitempty"`
 	URL             map[string]string `json:"url,omitempty"`
 	ServiceAccount  string            `json:"serviceAccount,omitempty"`
+	Namespace       string            `json:"namespace,omitempty"`
 }
 
 const (
@@ -328,6 +329,7 @@ func secretToCredential(secret *corev1.Secret, mask bool) credential {
 		URL:             secret.ObjectMeta.Annotations,
 		ResourceVersion: secret.GetResourceVersion(),
 		ServiceAccount:  saName,
+		Namespace:       secret.GetNamespace(),
 	}
 	if mask {
 		cred.Password = "********"
@@ -343,6 +345,7 @@ func credentialToSecret(cred credential, namespace string, response *restful.Res
 	secret.SetName(cred.Name)
 	secret.Data = make(map[string][]byte)
 	secret.Type = corev1.SecretTypeBasicAuth
+	secret.Data["namespace"] = []byte(namespace)
 	secret.Data["username"] = []byte(cred.Username)
 	secret.Data["password"] = []byte(cred.Password)
 	secret.Data["description"] = []byte(cred.Description)

--- a/pkg/endpoints/credentials_test.go
+++ b/pkg/endpoints/credentials_test.go
@@ -76,6 +76,7 @@ func TestCredentials(t *testing.T) {
 			"tekton.dev/docker-0": "https://gcr.io",
 		},
 		ServiceAccount: "default",
+		Namespace: "tekton-pipelines",
 	}
 	anotherBasicCred := credential{
 		Name:        "gitcreds",
@@ -86,6 +87,7 @@ func TestCredentials(t *testing.T) {
 			"tekton.dev/git-0": "https://my.git.org",
 		},
 		ServiceAccount: "default",
+		Namespace: "tekton-pipelines",
 	}
 	ns2BasicCred := credential{
 		Name:        "credentialuserpassns2",
@@ -96,6 +98,7 @@ func TestCredentials(t *testing.T) {
 			"tekton.dev/docker-0": "https://gcr.io",
 		},
 		ServiceAccount: "default",
+		Namespace: "tekton-pipelines-second-ns",
 	}
 
 	// READ ALL credentials when there are none


### PR DESCRIPTION
issue: #178 

# Changes

Added namespace field in the credentials struct so the frontend doesn't break when `All Namespaces` option is selected. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
