### PR TITLE
Enable linting for sort order of member imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,12 +27,16 @@ module.exports = {
   ],
   "rules": {
     "import/prefer-default-export": "off",
+    "jsx-a11y/anchor-is-valid": "off",
     "no-case-declarations": "off",
     "no-template-curly-in-string": "off",
     "react/jsx-filename-extension": "off",
     "react/destructuring-assignment": "off",
     "react/prop-types": "off",
-    "jsx-a11y/anchor-is-valid": "off"
+    "sort-imports": ["error", {
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true
+    }]
   },
   "overrides": [
     {

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -15,25 +15,25 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader/root';
 import {
-  HashRouter as Router,
   Redirect,
   Route,
+  HashRouter as Router,
   Switch
 } from 'react-router-dom';
 
 import { Content } from 'carbon-components-react/lib/components/UIShell';
 
 import {
+  CustomResourceDefinition,
   Extension,
   Extensions,
+  ImportResources,
   PipelineRun,
   PipelineRuns,
   Pipelines,
   SideNav,
-  Tasks,
   TaskRuns,
-  CustomResourceDefinition,
-  ImportResources
+  Tasks
 } from '..';
 
 import Header from '../../components/Header';

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -25,9 +25,9 @@ import { fetchPipeline } from '../../actions/pipelines';
 
 import {
   getPipeline,
+  getPipelinesErrorMessage,
   getTask,
-  getTasksErrorMessage,
-  getPipelinesErrorMessage
+  getTasksErrorMessage
 } from '../../reducers';
 
 export /* istanbul ignore next */ class CustomResourceDefinition extends Component {

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -14,10 +14,10 @@ limitations under the License.
 import React, { Component } from 'react';
 
 import {
-  ToastNotification,
-  TextInput,
   Button,
-  Form
+  Form,
+  TextInput,
+  ToastNotification
 } from 'carbon-components-react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { render, fireEvent, waitForElement } from 'react-testing-library';
+import { fireEvent, render, waitForElement } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, render, getNodeText } from 'react-testing-library';
+import { fireEvent, getNodeText, render } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -22,10 +22,10 @@ import {
 import {
   getPipelineRun,
   getPipelineRunsErrorMessage,
-  getTasks,
   getTaskRun,
-  getTasksErrorMessage,
-  getTaskRunsErrorMessage
+  getTaskRunsErrorMessage,
+  getTasks,
+  getTasksErrorMessage
 } from '../../reducers';
 
 import { fetchPipelineRun } from '../../actions/pipelineRuns';
@@ -37,10 +37,10 @@ import StepDetails from '../../components/StepDetails';
 import TaskTree from '../../components/TaskTree';
 import {
   getStatus,
-  taskRunStep,
   selectedTask,
   selectedTaskRun,
-  stepsStatus
+  stepsStatus,
+  taskRunStep
 } from '../../utils';
 
 import { getStore } from '../../store/index';

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -25,7 +25,7 @@ import {
 } from 'carbon-components-react';
 
 import { ALL_NAMESPACES } from '../../constants';
-import { getStatusIcon, getStatus } from '../../utils';
+import { getStatus, getStatusIcon } from '../../utils';
 import { fetchPipelineRuns } from '../../actions/pipelineRuns';
 
 import {

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -16,8 +16,8 @@ import { connect } from 'react-redux';
 
 import {
   getPipelines,
-  isFetchingPipelines,
-  getSelectedNamespace
+  getSelectedNamespace,
+  isFetchingPipelines
 } from '../../reducers';
 import { fetchPipelines } from '../../actions/pipelines';
 import TooltipDropdown from '../../components/TooltipDropdown';

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, render, getNodeText } from 'react-testing-library';
+import { fireEvent, getNodeText, render } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -15,9 +15,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import {
+  getSelectedNamespace,
   getServiceAccounts,
-  isFetchingServiceAccounts,
-  getSelectedNamespace
+  isFetchingServiceAccounts
 } from '../../reducers';
 import { fetchServiceAccounts } from '../../actions/serviceAccounts';
 import TooltipDropdown from '../../components/TooltipDropdown';

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, render, getNodeText } from 'react-testing-library';
+import { fireEvent, getNodeText, render } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -31,9 +31,9 @@ import StepDetails from '../../components/StepDetails';
 import TaskTree from '../../components/TaskTree';
 import {
   getStatus,
+  selectedTaskRun,
   stepsStatus,
-  taskRunStep,
-  selectedTaskRun
+  taskRunStep
 } from '../../utils';
 
 import '../../components/Run/Run.scss';

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -15,24 +15,24 @@ import {
   getExtensions,
   getExtensionsErrorMessage,
   getNamespaces,
-  getPipelines,
-  getPipelinesErrorMessage,
-  getSelectedNamespace,
   getPipelineRun,
   getPipelineRuns,
   getPipelineRunsByPipelineName,
   getPipelineRunsErrorMessage,
-  getTasks,
-  getTasksErrorMessage,
+  getPipelines,
+  getPipelinesErrorMessage,
+  getSelectedNamespace,
   getTaskRun,
   getTaskRuns,
+  getTaskRunsByTaskName,
   getTaskRunsErrorMessage,
+  getTasks,
+  getTasksErrorMessage,
   isFetchingExtensions,
-  isFetchingPipelines,
   isFetchingPipelineRuns,
-  isFetchingTasks,
+  isFetchingPipelines,
   isFetchingTaskRuns,
-  getTaskRunsByTaskName
+  isFetchingTasks
 } from '.';
 import * as extensionSelectors from './extensions';
 import * as namespaceSelectors from './namespaces';

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { getStatus, taskRunStep, selectedTask, stepsStatus } from '.';
+import { getStatus, selectedTask, stepsStatus, taskRunStep } from '.';
 
 it('getStatus', () => {
   const taskRun = {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/pull/208#discussion_r292455140

Enable linting for the sort order of member imports (`import { ... } from '...';`)
Disable declaration sorting as that might be a little more controversial / cause unexpected behaviour with some imports that don't export a binding (e.g. polyfills)
https://eslint.org/docs/rules/sort-imports

All of the code changes to `src/` in this PR are the result of `npm run lint:fix` with this rule enabled.

@ncskier @steveodonovan fyi

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
