### PR TITLE
Reduce duplication in action creators for fetching collections

### DIFF
--- a/src/actions/actionCreators.js
+++ b/src/actions/actionCreators.js
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { getSelectedNamespace } from '../reducers';
+import { typeToPlural } from '../utils';
+
+export function fetchSuccess(resourceType, data) {
+  const pluralType = typeToPlural(resourceType);
+  return {
+    type: `${pluralType}_FETCH_SUCCESS`,
+    data
+  };
+}
+
+export function fetchCollection(resourceType, api) {
+  const pluralType = typeToPlural(resourceType);
+  return async dispatch => {
+    dispatch({ type: `${pluralType}_FETCH_REQUEST` });
+    let data;
+    try {
+      data = await api();
+      dispatch(fetchSuccess(resourceType, data));
+    } catch (error) {
+      dispatch({ type: `${pluralType}_FETCH_FAILURE`, error });
+    }
+    return data;
+  };
+}
+
+export function fetchNamespacedCollection(
+  resourceType,
+  api,
+  { namespace, ...rest }
+) {
+  const pluralType = typeToPlural(resourceType);
+  return async (dispatch, getState) => {
+    dispatch({ type: `${pluralType}_FETCH_REQUEST` });
+    let data;
+    try {
+      const requestedNamespace = namespace || getSelectedNamespace(getState());
+      data = await api(requestedNamespace, ...Object.values(rest));
+      dispatch(fetchSuccess(resourceType, data));
+    } catch (error) {
+      dispatch({ type: `${pluralType}_FETCH_FAILURE`, error });
+    }
+    return data;
+  };
+}

--- a/src/actions/actionCreators.test.js
+++ b/src/actions/actionCreators.test.js
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import { fetchCollection, fetchSuccess } from './actionCreators';
+
+it('fetchSuccess', () => {
+  const data = { fake: 'data' };
+  expect(fetchSuccess('Extension', data)).toEqual({
+    type: 'EXTENSIONS_FETCH_SUCCESS',
+    data
+  });
+});
+
+it('fetchCollection', async () => {
+  const data = { fake: 'data' };
+  const fakeAPI = jest.fn().mockImplementation(() => data);
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    { type: 'EXTENSIONS_FETCH_SUCCESS', data }
+  ];
+
+  await store.dispatch(fetchCollection('Extension', fakeAPI));
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchCollection error', async () => {
+  const error = new Error();
+  const fakeAPI = jest.fn().mockImplementation(() => {
+    throw error;
+  });
+
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore();
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    { type: 'EXTENSIONS_FETCH_FAILURE', error }
+  ];
+
+  await store.dispatch(fetchCollection('Extension', fakeAPI));
+  expect(store.getActions()).toEqual(expectedActions);
+});

--- a/src/actions/extensions.js
+++ b/src/actions/extensions.js
@@ -12,24 +12,8 @@ limitations under the License.
 */
 
 import { getExtensions } from '../api';
-
-export function fetchExtensionsSuccess(data) {
-  return {
-    type: 'EXTENSIONS_FETCH_SUCCESS',
-    data
-  };
-}
+import { fetchCollection } from './actionCreators';
 
 export function fetchExtensions() {
-  return async dispatch => {
-    dispatch({ type: 'EXTENSIONS_FETCH_REQUEST' });
-    let extensions;
-    try {
-      extensions = await getExtensions();
-      dispatch(fetchExtensionsSuccess(extensions));
-    } catch (error) {
-      dispatch({ type: 'EXTENSIONS_FETCH_FAILURE', error });
-    }
-    return extensions;
-  };
+  return fetchCollection('Extension', getExtensions);
 }

--- a/src/actions/extensions.test.js
+++ b/src/actions/extensions.test.js
@@ -11,64 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import { fetchExtensions, fetchExtensionsSuccess } from './extensions';
-
-it('fetchExtensionsSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchExtensionsSuccess(data)).toEqual({
-    type: 'EXTENSIONS_FETCH_SUCCESS',
-    data
-  });
-});
+import { fetchExtensions } from './extensions';
+import * as creators from './actionCreators';
 
 it('fetchExtensions', async () => {
-  const bundlelocation = 'bundlelocation';
-  const displayName = 'displayName';
-  const name = 'name';
-  const url = 'url';
-  const extensions = [
-    {
-      displayName,
-      name,
-      source: API.getExtensionBundleURL(name, bundlelocation),
-      url
-    }
-  ];
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest.spyOn(API, 'getExtensions').mockImplementation(() => extensions);
-
-  const expectedActions = [
-    { type: 'EXTENSIONS_FETCH_REQUEST' },
-    fetchExtensionsSuccess(extensions)
-  ];
-
-  await store.dispatch(fetchExtensions());
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchExtensions error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getExtensions').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'EXTENSIONS_FETCH_REQUEST' },
-    { type: 'EXTENSIONS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchExtensions());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchCollection');
+  fetchExtensions();
+  expect(creators.fetchCollection).toHaveBeenCalledWith(
+    'Extension',
+    API.getExtensions
+  );
 });

--- a/src/actions/namespaces.js
+++ b/src/actions/namespaces.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import { getNamespaces } from '../api';
+import { fetchCollection } from './actionCreators';
 
 export function selectNamespace(namespace) {
   return {
@@ -20,23 +21,6 @@ export function selectNamespace(namespace) {
   };
 }
 
-export function fetchNamespacesSuccess(data) {
-  return {
-    type: 'NAMESPACES_FETCH_SUCCESS',
-    data
-  };
-}
-
 export function fetchNamespaces() {
-  return async dispatch => {
-    dispatch({ type: 'NAMESPACES_FETCH_REQUEST' });
-    let namespaces;
-    try {
-      namespaces = await getNamespaces();
-      dispatch(fetchNamespacesSuccess(namespaces));
-    } catch (error) {
-      dispatch({ type: 'NAMESPACES_FETCH_FAILURE', error });
-    }
-    return namespaces;
-  };
+  return fetchCollection('Namespace', getNamespaces);
 }

--- a/src/actions/namespaces.test.js
+++ b/src/actions/namespaces.test.js
@@ -11,16 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
-import {
-  fetchNamespaces,
-  fetchNamespacesSuccess,
-  selectNamespace
-} from './namespaces';
+import * as creators from './actionCreators';
+import { fetchNamespaces, selectNamespace } from './namespaces';
 
 it('selectNamespace', () => {
   const namespace = 'namespace';
@@ -29,51 +22,11 @@ it('selectNamespace', () => {
   });
 });
 
-it('fetchNamespacesSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchNamespacesSuccess(data)).toEqual({
-    type: 'NAMESPACES_FETCH_SUCCESS',
-    data
-  });
-});
-
 it('fetchNamespaces', async () => {
-  const namespace = 'default';
-  const namespaces = { fake: 'namespaces' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest.spyOn(API, 'getNamespaces').mockImplementation(() => namespaces);
-
-  const expectedActions = [
-    { type: 'NAMESPACES_FETCH_REQUEST' },
-    fetchNamespacesSuccess(namespaces, namespace)
-  ];
-
-  await store.dispatch(fetchNamespaces());
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchNamespaces error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getNamespaces').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'NAMESPACES_FETCH_REQUEST' },
-    { type: 'NAMESPACES_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchNamespaces());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchCollection');
+  fetchNamespaces();
+  expect(creators.fetchCollection).toHaveBeenCalledWith(
+    'Namespace',
+    API.getNamespaces
+  );
 });

--- a/src/actions/pipelineResources.js
+++ b/src/actions/pipelineResources.js
@@ -13,8 +13,9 @@ limitations under the License.
 
 import { getPipelineResource, getPipelineResources } from '../api';
 import { getSelectedNamespace } from '../reducers';
+import { fetchNamespacedCollection } from './actionCreators';
 
-export function fetchPipelineResourcesSuccess(data) {
+function fetchPipelineResourcesSuccess(data) {
   return {
     type: 'PIPELINE_RESOURCES_FETCH_SUCCESS',
     data
@@ -37,16 +38,7 @@ export function fetchPipelineResource({ name, namespace }) {
 }
 
 export function fetchPipelineResources({ namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'PIPELINE_RESOURCES_FETCH_REQUEST' });
-    let pipelineResources;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      pipelineResources = await getPipelineResources(requestedNamespace);
-      dispatch(fetchPipelineResourcesSuccess(pipelineResources));
-    } catch (error) {
-      dispatch({ type: 'PIPELINE_RESOURCES_FETCH_FAILURE', error });
-    }
-    return pipelineResources;
-  };
+  return fetchNamespacedCollection('PipelineResource', getPipelineResources, {
+    namespace
+  });
 }

--- a/src/actions/pipelineResources.test.js
+++ b/src/actions/pipelineResources.test.js
@@ -16,19 +16,11 @@ import thunk from 'redux-thunk';
 
 import * as API from '../api';
 import * as selectors from '../reducers';
+import * as creators from './actionCreators';
 import {
   fetchPipelineResource,
-  fetchPipelineResources,
-  fetchPipelineResourcesSuccess
+  fetchPipelineResources
 } from './pipelineResources';
-
-it('fetchPipelineResourcesSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchPipelineResourcesSuccess(data)).toEqual({
-    type: 'PIPELINE_RESOURCES_FETCH_SUCCESS',
-    data
-  });
-});
 
 it('fetchPipelineResource', async () => {
   const pipelineResource = { fake: 'pipelineResource' };
@@ -46,7 +38,7 @@ it('fetchPipelineResource', async () => {
 
   const expectedActions = [
     { type: 'PIPELINE_RESOURCES_FETCH_REQUEST' },
-    fetchPipelineResourcesSuccess([pipelineResource])
+    { type: 'PIPELINE_RESOURCES_FETCH_SUCCESS', data: [pipelineResource] }
   ];
 
   await store.dispatch(fetchPipelineResource({ name: 'foo' }));
@@ -74,38 +66,22 @@ it('fetchPipelineResource error', async () => {
 });
 
 it('fetchPipelineResources', async () => {
-  const pipelines = { fake: 'pipelines' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest.spyOn(API, 'getPipelineResources').mockImplementation(() => pipelines);
-
-  const expectedActions = [
-    { type: 'PIPELINE_RESOURCES_FETCH_REQUEST' },
-    fetchPipelineResourcesSuccess(pipelines)
-  ];
-
-  await store.dispatch(fetchPipelineResources());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  const namespace = 'namespace';
+  fetchPipelineResources({ namespace });
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'PipelineResource',
+    API.getPipelineResources,
+    { namespace }
+  );
 });
 
-it('fetchPipelineResources error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getPipelineResources').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'PIPELINE_RESOURCES_FETCH_REQUEST' },
-    { type: 'PIPELINE_RESOURCES_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchPipelineResources());
-  expect(store.getActions()).toEqual(expectedActions);
+it('fetchPipelineResources no namespace', async () => {
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  fetchPipelineResources();
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'PipelineResource',
+    API.getPipelineResources,
+    { namespace: undefined }
+  );
 });

--- a/src/actions/pipelineRuns.js
+++ b/src/actions/pipelineRuns.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { getPipelineRun, getPipelineRuns } from '../api';
 import { getSelectedNamespace } from '../reducers';
+import { fetchNamespacedCollection } from './actionCreators';
 
 export function fetchPipelineRunsSuccess(data) {
   return {
@@ -36,17 +37,9 @@ export function fetchPipelineRun({ name, namespace }) {
   };
 }
 
-export function fetchPipelineRuns({ pipelineName, namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'PIPELINE_RUNS_FETCH_REQUEST' });
-    let pipelineRuns;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      pipelineRuns = await getPipelineRuns(requestedNamespace, pipelineName);
-      dispatch(fetchPipelineRunsSuccess(pipelineRuns));
-    } catch (error) {
-      dispatch({ type: 'PIPELINE_RUNS_FETCH_FAILURE', error });
-    }
-    return pipelineRuns;
-  };
+export function fetchPipelineRuns({ namespace, pipelineName } = {}) {
+  return fetchNamespacedCollection('PipelineRun', getPipelineRuns, {
+    namespace,
+    pipelineName
+  });
 }

--- a/src/actions/pipelineRuns.test.js
+++ b/src/actions/pipelineRuns.test.js
@@ -16,6 +16,7 @@ import thunk from 'redux-thunk';
 
 import * as API from '../api';
 import * as selectors from '../reducers';
+import * as creators from './actionCreators';
 import {
   fetchPipelineRun,
   fetchPipelineRuns,
@@ -72,38 +73,23 @@ it('fetchPipelineRun error', async () => {
 });
 
 it('fetchPipelineRuns', async () => {
-  const pipelines = { fake: 'pipelines' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest.spyOn(API, 'getPipelineRuns').mockImplementation(() => pipelines);
-
-  const expectedActions = [
-    { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
-    fetchPipelineRunsSuccess(pipelines)
-  ];
-
-  await store.dispatch(fetchPipelineRuns());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  const namespace = 'namespace';
+  const pipelineName = 'pipelineName';
+  fetchPipelineRuns({ namespace, pipelineName });
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'PipelineRun',
+    API.getPipelineRuns,
+    { namespace, pipelineName }
+  );
 });
 
-it('fetchPipelineRuns error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getPipelineRuns').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
-    { type: 'PIPELINE_RUNS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchPipelineRuns());
-  expect(store.getActions()).toEqual(expectedActions);
+it('fetchPipelineRuns no params', async () => {
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  fetchPipelineRuns();
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'PipelineRun',
+    API.getPipelineRuns,
+    { namespace: undefined, pipelineName: undefined }
+  );
 });

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { getPipeline, getPipelines } from '../api';
 import { getSelectedNamespace } from '../reducers';
+import { fetchNamespacedCollection } from './actionCreators';
 
 export function fetchPipelinesSuccess(data) {
   return {
@@ -37,16 +38,5 @@ export function fetchPipeline({ name, namespace }) {
 }
 
 export function fetchPipelines({ namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'PIPELINES_FETCH_REQUEST' });
-    let pipelines;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      pipelines = await getPipelines(requestedNamespace);
-      dispatch(fetchPipelinesSuccess(pipelines));
-    } catch (error) {
-      dispatch({ type: 'PIPELINES_FETCH_FAILURE', error });
-    }
-    return pipelines;
-  };
+  return fetchNamespacedCollection('Pipeline', getPipelines, { namespace });
 }

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -16,6 +16,7 @@ import thunk from 'redux-thunk';
 
 import * as API from '../api';
 import * as selectors from '../reducers';
+import * as creators from './actionCreators';
 import {
   fetchPipeline,
   fetchPipelines,
@@ -72,38 +73,22 @@ it('fetchPipeline error', async () => {
 });
 
 it('fetchPipelines', async () => {
-  const pipelines = { fake: 'pipelines' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest.spyOn(API, 'getPipelines').mockImplementation(() => pipelines);
-
-  const expectedActions = [
-    { type: 'PIPELINES_FETCH_REQUEST' },
-    fetchPipelinesSuccess(pipelines)
-  ];
-
-  await store.dispatch(fetchPipelines());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  const namespace = 'namespace';
+  fetchPipelines({ namespace });
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'Pipeline',
+    API.getPipelines,
+    { namespace }
+  );
 });
 
-it('fetchPipelines error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getPipelines').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'PIPELINES_FETCH_REQUEST' },
-    { type: 'PIPELINES_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchPipelines());
-  expect(store.getActions()).toEqual(expectedActions);
+it('fetchPipelines no namespace', async () => {
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  fetchPipelines();
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'Pipeline',
+    API.getPipelines,
+    { namespace: undefined }
+  );
 });

--- a/src/actions/serviceAccounts.js
+++ b/src/actions/serviceAccounts.js
@@ -12,26 +12,10 @@ limitations under the License.
 */
 
 import { getServiceAccounts } from '../api';
-import { getSelectedNamespace } from '../reducers';
-
-export function fetchServiceAccountsSuccess(data) {
-  return {
-    type: 'SERVICE_ACCOUNTS_FETCH_SUCCESS',
-    data
-  };
-}
+import { fetchNamespacedCollection } from './actionCreators';
 
 export function fetchServiceAccounts({ namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' });
-    let serviceAccounts;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      serviceAccounts = await getServiceAccounts(requestedNamespace);
-      dispatch(fetchServiceAccountsSuccess(serviceAccounts));
-    } catch (error) {
-      dispatch({ type: 'SERVICE_ACCOUNTS_FETCH_FAILURE', error });
-    }
-    return serviceAccounts;
-  };
+  return fetchNamespacedCollection('ServiceAccount', getServiceAccounts, {
+    namespace
+  });
 }

--- a/src/actions/serviceAccounts.test.js
+++ b/src/actions/serviceAccounts.test.js
@@ -11,63 +11,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
-import {
-  fetchServiceAccounts,
-  fetchServiceAccountsSuccess
-} from './serviceAccounts';
-
-it('fetchServiceAccountsSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchServiceAccountsSuccess(data)).toEqual({
-    type: 'SERVICE_ACCOUNTS_FETCH_SUCCESS',
-    data
-  });
-});
+import * as creators from './actionCreators';
+import { fetchServiceAccounts } from './serviceAccounts';
 
 it('fetchServiceAccounts', async () => {
-  const namespace = 'default';
-  const serviceAccounts = { fake: 'serviceAccounts' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest
-    .spyOn(API, 'getServiceAccounts')
-    .mockImplementation(() => serviceAccounts);
-
-  const expectedActions = [
-    { type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' },
-    fetchServiceAccountsSuccess(serviceAccounts)
-  ];
-
-  await store.dispatch(fetchServiceAccounts());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  const namespace = 'namespace';
+  fetchServiceAccounts({ namespace });
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'ServiceAccount',
+    API.getServiceAccounts,
+    { namespace }
+  );
 });
 
-it('fetchServiceAccounts error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'SERVICE_ACCOUNTS_FETCH_REQUEST' },
-    { type: 'SERVICE_ACCOUNTS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchServiceAccounts());
-  expect(store.getActions()).toEqual(expectedActions);
+it('fetchServiceAccounts no namespace', async () => {
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  fetchServiceAccounts();
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'ServiceAccount',
+    API.getServiceAccounts,
+    { namespace: undefined }
+  );
 });

--- a/src/actions/taskRuns.js
+++ b/src/actions/taskRuns.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { getTaskRun, getTaskRuns } from '../api';
 import { getSelectedNamespace } from '../reducers';
+import { fetchNamespacedCollection } from './actionCreators';
 
 export function fetchTaskRunsSuccess(data) {
   return {
@@ -21,19 +22,11 @@ export function fetchTaskRunsSuccess(data) {
   };
 }
 
-export function fetchTaskRuns({ taskName, namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'TASK_RUNS_FETCH_REQUEST' });
-    let taskRuns;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      taskRuns = await getTaskRuns(requestedNamespace, taskName);
-      dispatch(fetchTaskRunsSuccess(taskRuns));
-    } catch (error) {
-      dispatch({ type: 'TASK_RUNS_FETCH_FAILURE', error });
-    }
-    return taskRuns;
-  };
+export function fetchTaskRuns({ namespace, taskName } = {}) {
+  return fetchNamespacedCollection('TaskRun', getTaskRuns, {
+    namespace,
+    taskName
+  });
 }
 
 export function fetchTaskRun({ taskRunName, namespace } = {}) {

--- a/src/actions/taskRuns.test.js
+++ b/src/actions/taskRuns.test.js
@@ -17,6 +17,7 @@ import thunk from 'redux-thunk';
 import * as API from '../api';
 import * as selectors from '../reducers';
 import { fetchTaskRun, fetchTaskRuns, fetchTaskRunsSuccess } from './taskRuns';
+import * as creators from './actionCreators';
 
 it('fetchTaskRunsSuccess', () => {
   const data = { fake: 'data' };
@@ -27,24 +28,15 @@ it('fetchTaskRunsSuccess', () => {
 });
 
 it('fetchTaskRuns', async () => {
-  const namespace = 'default';
-  const tasks = { fake: 'tasks' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest.spyOn(API, 'getTaskRuns').mockImplementation(() => tasks);
-
-  const expectedActions = [
-    { type: 'TASK_RUNS_FETCH_REQUEST' },
-    fetchTaskRunsSuccess(tasks)
-  ];
-
-  await store.dispatch(fetchTaskRuns());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  const namespace = 'namespace';
+  const taskName = 'taskName';
+  fetchTaskRuns({ namespace, taskName });
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'TaskRun',
+    API.getTaskRuns,
+    { namespace, taskName }
+  );
 });
 
 it('fetchTaskRun', async () => {
@@ -65,25 +57,5 @@ it('fetchTaskRun', async () => {
   ];
 
   await store.dispatch(fetchTaskRun());
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchTaskRuns error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getTaskRuns').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'TASK_RUNS_FETCH_REQUEST' },
-    { type: 'TASK_RUNS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchTaskRuns());
   expect(store.getActions()).toEqual(expectedActions);
 });

--- a/src/actions/tasks.js
+++ b/src/actions/tasks.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { getTask, getTasks } from '../api';
 import { getSelectedNamespace } from '../reducers';
+import { fetchNamespacedCollection } from './actionCreators';
 
 export function fetchTasksSuccess(data) {
   return {
@@ -37,16 +38,5 @@ export function fetchTask({ name, namespace }) {
 }
 
 export function fetchTasks({ namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'TASKS_FETCH_REQUEST' });
-    let tasks;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      tasks = await getTasks(requestedNamespace);
-      dispatch(fetchTasksSuccess(tasks));
-    } catch (error) {
-      dispatch({ type: 'TASKS_FETCH_FAILURE', error });
-    }
-    return tasks;
-  };
+  return fetchNamespacedCollection('Task', getTasks, { namespace });
 }

--- a/src/actions/tasks.test.js
+++ b/src/actions/tasks.test.js
@@ -16,15 +16,8 @@ import thunk from 'redux-thunk';
 
 import * as API from '../api';
 import * as selectors from '../reducers';
+import * as creators from './actionCreators';
 import { fetchTask, fetchTasks, fetchTasksSuccess } from './tasks';
-
-it('fetchTaskSuccess', () => {
-  const data = [{ fake: 'data' }];
-  expect(fetchTasksSuccess(data)).toEqual({
-    type: 'TASKS_FETCH_SUCCESS',
-    data
-  });
-});
 
 it('fetchTask', async () => {
   const task = { fake: 'task' };
@@ -76,38 +69,22 @@ it('fetchTasksSuccess', () => {
 });
 
 it('fetchTasks', async () => {
-  const tasks = { fake: 'tasks' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest.spyOn(API, 'getTasks').mockImplementation(() => tasks);
-
-  const expectedActions = [
-    { type: 'TASKS_FETCH_REQUEST' },
-    fetchTasksSuccess(tasks)
-  ];
-
-  await store.dispatch(fetchTasks());
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  const namespace = 'namespace';
+  fetchTasks({ namespace });
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'Task',
+    API.getTasks,
+    { namespace }
+  );
 });
 
-it('fetchTasks error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getTasks').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'TASKS_FETCH_REQUEST' },
-    { type: 'TASKS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchTasks());
-  expect(store.getActions()).toEqual(expectedActions);
+it('fetchTasks no params', async () => {
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  fetchTasks();
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'Task',
+    API.getTasks,
+    { namespace: undefined }
+  );
 });

--- a/src/reducers/reducerCreators.js
+++ b/src/reducers/reducerCreators.js
@@ -14,11 +14,8 @@ limitations under the License.
 import { combineReducers } from 'redux';
 import keyBy from 'lodash.keyby';
 import merge from 'lodash.merge';
-import snakeCase from 'lodash.snakecase';
 
-function typeToPlural(type) {
-  return `${snakeCase(type).toUpperCase()}S`;
-}
+import { typeToPlural } from '../utils';
 
 function createByIdReducer({ type }) {
   const typePlural = typeToPlural(type);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import snakeCase from 'lodash.snakecase';
 import CheckmarkFilled from '@carbon/icons-react/lib/checkmark--filled/16';
 import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
 
@@ -91,4 +92,8 @@ export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
     };
   });
   return steps;
+}
+
+export function typeToPlural(type) {
+  return `${snakeCase(type).toUpperCase()}S`;
 }

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -11,7 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { getStatus, selectedTask, stepsStatus, taskRunStep } from '.';
+import {
+  getStatus,
+  selectedTask,
+  stepsStatus,
+  taskRunStep,
+  typeToPlural
+} from '.';
 
 it('getStatus', () => {
   const taskRun = {
@@ -183,4 +189,8 @@ it('stepsStatus step is waiting', () => {
   const steps = stepsStatus(taskSteps, taskRunStepsStatus);
   const returnedStep = steps[0];
   expect(returnedStep.status).toEqual('waiting');
+});
+
+it('typeToPlural', () => {
+  expect(typeToPlural('Extension')).toEqual('EXTENSIONS');
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/241
Provide a set of functions to create action creators
- fetch success (for handling API response)
- fetch collection
- fetch collection with namespace and other optional params

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
