### PR TITLE
Prevent wrapping of long run names at smaller window sizes

### DIFF
--- a/src/components/RunHeader/RunHeader.js
+++ b/src/components/RunHeader/RunHeader.js
@@ -48,7 +48,9 @@ class RunHeader extends Component {
                 <div className="block-icon">
                   {getStatusIcon({ reason, status })}
                 </div>
-                {runName}
+                <div className="run-name" title={runName}>
+                  {runName}
+                </div>
                 <span className="status-label">{reason}</span>
                 <span className="time">{lastTransitionTime}</span>
               </h1>

--- a/src/components/RunHeader/RunHeader.scss
+++ b/src/components/RunHeader/RunHeader.scss
@@ -24,12 +24,15 @@ limitations under the License.
   }
 
   h1 {
+    display: flex;
+    align-items: baseline;
     font-size: 1.6rem;
     line-height: 2rem;
     height: 2rem;
 
     .block-icon {
       display: inline-flex;
+      flex-shrink: 0;
       vertical-align: middle;
       position: relative;
       top: -0.13rem;
@@ -42,6 +45,13 @@ limitations under the License.
       }
     }
 
+    .run-name {
+      min-width: 5rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .status-label {
       margin-left: 1.15rem;
       font-size: 0.95rem;
@@ -50,9 +60,10 @@ limitations under the License.
     }
 
     .time {
-      margin-left: 1.15rem;
+      margin: 0 1.15rem;
       font-size: 0.875rem;
       font-weight: 300;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/272
Fix layout issue where long run names were wrapping and overflowing their container.
Prevent wrapping, add ellipsis on truncated text, and include full name in tooltip.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._

Before:
![image](https://user-images.githubusercontent.com/2829095/59772249-567f0400-92a3-11e9-9a7f-35055f5841e3.png)

After:
![image](https://user-images.githubusercontent.com/2829095/59772274-626ac600-92a3-11e9-8547-8e0374404604.png)
