### PR TITLE
Add type prop to PipelineResourcesDropdown

### DIFF
--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
@@ -37,11 +37,15 @@ class PipelineResourcesDropdown extends React.Component {
   }
 
   render() {
-    const { namespace, ...rest } = this.props;
-    const emptyText =
-      namespace === ALL_NAMESPACES
-        ? `No Pipeline Resources found`
-        : `No Pipeline Resources found in the '${namespace}' namespace`;
+    const { namespace, type, ...rest } = this.props;
+    let emptyText = `No Pipeline Resources found`;
+    if (type && namespace !== ALL_NAMESPACES) {
+      emptyText = `No Pipeline Resources found of type '${type}' in the '${namespace}' namespace`;
+    } else if (type) {
+      emptyText = `No Pipeline Resources found of type '${type}'`;
+    } else if (namespace !== ALL_NAMESPACES) {
+      emptyText = `No Pipeline Resources found in the '${namespace}' namespace`;
+    }
     return <TooltipDropdown {...rest} emptyText={emptyText} />;
   }
 }
@@ -55,10 +59,11 @@ PipelineResourcesDropdown.defaultProps = {
 
 function mapStateToProps(state, ownProps) {
   const namespace = ownProps.namespace || getSelectedNamespace(state);
+  const { type } = ownProps;
   return {
-    items: getPipelineResources(state, { namespace }).map(
-      pipelineResource => pipelineResource.metadata.name
-    ),
+    items: getPipelineResources(state, { namespace })
+      .filter(pipelineResource => !type || type === pipelineResource.spec.type)
+      .map(pipelineResource => pipelineResource.metadata.name),
     loading: isFetchingPipelineResources(state),
     namespace
   };

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.stories.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.stories.js
@@ -40,28 +40,32 @@ const pipelineResourcesById = {
       name: 'default',
       namespace: 'default',
       uid: 'id-default'
-    }
+    },
+    spec: { type: 'type-1' }
   },
   'id-pipeline-resource-1': {
     metadata: {
       name: 'pipeline-resource-1',
       namespace: 'default',
       uid: 'id-pipeline-resource-1'
-    }
+    },
+    spec: { type: 'type-1' }
   },
   'id-pipeline-resource-2': {
     metadata: {
       name: 'pipeline-resource-2',
       namespace: 'default',
       uid: 'id-pipeline-resource-2'
-    }
+    },
+    spec: { type: 'type-2' }
   },
   'id-pipeline-resource-3': {
     metadata: {
       name: 'pipeline-resource-3',
       namespace: 'default',
       uid: 'id-pipeline-resource-3'
-    }
+    },
+    spec: { type: 'type-2' }
   }
 };
 
@@ -91,6 +95,24 @@ storiesOf('PipelineResourcesDropdown', module)
       </Provider>
     );
   })
+  .add('default with type', () => {
+    const store = mockStore({
+      pipelineResources: {
+        byId: pipelineResourcesById,
+        byNamespace: pipelineResourcesByNamespace,
+        isFetching: false
+      },
+      namespaces: {
+        byName: namespacesByName,
+        selected: 'default'
+      }
+    });
+    return (
+      <Provider store={store}>
+        <PipelineResourcesDropdown {...props} type="type-1" />
+      </Provider>
+    );
+  })
   .add('empty', () => {
     const store = mockStore({
       pipelineResources: {
@@ -106,6 +128,24 @@ storiesOf('PipelineResourcesDropdown', module)
     return (
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} />
+      </Provider>
+    );
+  })
+  .add('empty with type', () => {
+    const store = mockStore({
+      pipelineResources: {
+        byId: {},
+        byNamespace: {},
+        isFetching: false
+      },
+      namespaces: {
+        byName: namespacesByName,
+        selected: 'default'
+      }
+    });
+    return (
+      <Provider store={store}>
+        <PipelineResourcesDropdown {...props} type="bogus" />
       </Provider>
     );
   });

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -39,21 +39,24 @@ const pipelineResourcesById = {
       name: 'pipeline-resource-1',
       namespace: 'blue',
       uid: 'id-pipeline-resource-1'
-    }
+    },
+    spec: { type: 'type-1' }
   },
   'id-pipeline-resource-2': {
     metadata: {
       name: 'pipeline-resource-2',
       namespace: 'blue',
       uid: 'id-pipeline-resource-2'
-    }
+    },
+    spec: { type: 'type-2' }
   },
   'id-pipeline-resource-3': {
     metadata: {
       name: 'pipeline-resource-3',
       namespace: 'green',
       uid: 'id-pipeline-resource-3'
-    }
+    },
+    spec: { type: 'type-1' }
   }
 };
 
@@ -141,6 +144,33 @@ it('PipelineResourcesDropdown renders items based on Redux state', () => {
     queryByText,
     testDict: pipelineResourcesByNamespace.blue
   });
+});
+
+it('PipelineResourcesDropdown renders items based on type', () => {
+  const store = mockStore({
+    ...pipelineResourcesStoreDefault,
+    ...namespacesStoreBlue
+  });
+  const { container, getByText, queryByText } = render(
+    <Provider store={store}>
+      <PipelineResourcesDropdown {...props} type="type-1" />
+    </Provider>
+  );
+  // View items
+  fireEvent.click(getByText(initialTextRegExp));
+  expect(queryByText(/pipeline-resource-1/i)).toBeTruthy();
+  expect(queryByText(/pipeline-resource-2/i)).toBeFalsy();
+  fireEvent.click(getByText(initialTextRegExp));
+  render(
+    <Provider store={store}>
+      <PipelineResourcesDropdown {...props} type="type-2" />
+    </Provider>,
+    { container }
+  );
+  // View items
+  fireEvent.click(getByText(initialTextRegExp));
+  expect(queryByText(/pipeline-resource-1/i)).toBeFalsy();
+  expect(queryByText(/pipeline-resource-2/i)).toBeTruthy();
 });
 
 it('PipelineResourcesDropdown renders items based on Redux state when namespace changes', () => {
@@ -246,7 +276,6 @@ it('PipelineResourcesDropdown renders empty', () => {
     },
     ...namespacesStoreBlue
   });
-  // Select item 'pipeline-resource-1'
   const { queryByText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} />
@@ -267,13 +296,54 @@ it('PipelineResourcesDropdown renders empty all namespaces', () => {
     },
     ...namespacesStoreAll
   });
-  // Select item 'pipeline-resource-1'
   const { queryByText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
   expect(queryByText(/no pipeline resources found/i)).toBeTruthy();
+  expect(queryByText(initialTextRegExp)).toBeFalsy();
+});
+
+it('PipelineResourcesDropdown renders empty with type', () => {
+  const store = mockStore({
+    pipelineResources: {
+      byId: {},
+      byNamespace: {},
+      isFetching: false
+    },
+    ...namespacesStoreBlue
+  });
+  const { queryByText } = render(
+    <Provider store={store}>
+      <PipelineResourcesDropdown {...props} type="bogus" />
+    </Provider>
+  );
+  expect(
+    queryByText(
+      /no pipeline resources found of type 'bogus' in the 'blue' namespace/i
+    )
+  ).toBeTruthy();
+  expect(queryByText(initialTextRegExp)).toBeFalsy();
+});
+
+it('PipelineResourcesDropdown renders empty with type and all namespaces', () => {
+  const store = mockStore({
+    pipelineResources: {
+      byId: {},
+      byNamespace: {},
+      isFetching: false
+    },
+    ...namespacesStoreAll
+  });
+  const { queryByText } = render(
+    <Provider store={store}>
+      <PipelineResourcesDropdown {...props} type="bogus" />
+    </Provider>
+  );
+  expect(
+    queryByText(/no pipeline resources found of type 'bogus'/i)
+  ).toBeTruthy();
   expect(queryByText(initialTextRegExp)).toBeFalsy();
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This adds a `type` prop to the `PipelineResourcesDropdown` so that it will only display resources of one type; for example, `type="git"` will only display `git` resources in the dropdown.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
