### PR TITLE
correcting minor mistake in previous secrets table update

### DIFF
--- a/src/components/SecretsTable/SecretsTable.js
+++ b/src/components/SecretsTable/SecretsTable.js
@@ -42,7 +42,7 @@ const SecretsTable = props => {
       annotations += `${key}: ${secret.annotations[key]}\n`;
     });
     return {
-      id: secret.uid,
+      id: `${secret.namespace}:${secret.name}`,
       secret: secret.name,
       annotations,
       add: <Close />
@@ -95,7 +95,6 @@ const SecretsTable = props => {
                 {rows.map((row, index) => {
                   const lastCell =
                     rows[index].cells[rows[index].cells.length - 1];
-                  const secretName = row.cells[0].value;
                   return (
                     <TableRow key={row.id} className="row">
                       {row.cells.splice(0, row.cells.length - 1).map(cell => (
@@ -109,7 +108,7 @@ const SecretsTable = props => {
                       ))}
                       <TableCell
                         key={lastCell.id}
-                        id={secretName}
+                        id={lastCell.id}
                         className="cellIcon"
                         onClick={handleDelete}
                         data-testid="deleteIcon"

--- a/src/components/SecretsTable/SecretsTable.js
+++ b/src/components/SecretsTable/SecretsTable.js
@@ -95,6 +95,7 @@ const SecretsTable = props => {
                 {rows.map((row, index) => {
                   const lastCell =
                     rows[index].cells[rows[index].cells.length - 1];
+                  const secretName = row.cells[0].value;
                   return (
                     <TableRow key={row.id} className="row">
                       {row.cells.splice(0, row.cells.length - 1).map(cell => (
@@ -108,7 +109,7 @@ const SecretsTable = props => {
                       ))}
                       <TableCell
                         key={lastCell.id}
-                        id={lastCell.id}
+                        id={secretName}
                         className="cellIcon"
                         onClick={handleDelete}
                         data-testid="deleteIcon"


### PR DESCRIPTION
# Changes

Mistakenly switched the id of the last table cell (delete button) to use the namespace & name as value but the correct value should be just the name (like it was originally). This is because when the user clicks to delete the secret, the name of that secret is retrieved from that id & used in the process of deleting that selected secret. 