### PR TITLE
Reduce duplication in action creators for fetching single resources

### DIFF
--- a/src/actions/actionCreators.js
+++ b/src/actions/actionCreators.js
@@ -48,8 +48,28 @@ export function fetchNamespacedCollection(
     let data;
     try {
       const requestedNamespace = namespace || getSelectedNamespace(getState());
-      data = await api(requestedNamespace, ...Object.values(rest));
+      data = await api({ namespace: requestedNamespace, ...rest });
       dispatch(fetchSuccess(resourceType, data));
+    } catch (error) {
+      dispatch({ type: `${pluralType}_FETCH_FAILURE`, error });
+    }
+    return data;
+  };
+}
+
+export function fetchNamespacedResource(
+  resourceType,
+  api,
+  { namespace, ...rest }
+) {
+  const pluralType = typeToPlural(resourceType);
+  return async (dispatch, getState) => {
+    dispatch({ type: `${pluralType}_FETCH_REQUEST` });
+    let data;
+    try {
+      const requestedNamespace = namespace || getSelectedNamespace(getState());
+      data = await api({ namespace: requestedNamespace, ...rest });
+      dispatch(fetchSuccess(resourceType, [data]));
     } catch (error) {
       dispatch({ type: `${pluralType}_FETCH_FAILURE`, error });
     }

--- a/src/actions/actionCreators.test.js
+++ b/src/actions/actionCreators.test.js
@@ -14,7 +14,11 @@ limitations under the License.
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import { fetchCollection, fetchSuccess } from './actionCreators';
+import {
+  fetchCollection,
+  fetchNamespacedResource,
+  fetchSuccess
+} from './actionCreators';
 
 it('fetchSuccess', () => {
   const data = { fake: 'data' };
@@ -57,4 +61,45 @@ it('fetchCollection error', async () => {
 
   await store.dispatch(fetchCollection('Extension', fakeAPI));
   expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchNamespacedResource', async () => {
+  const data = { fake: 'data' };
+  const namespace = 'default';
+  const params = { name: 'name' };
+  const fakeAPI = jest.fn().mockImplementation(() => data);
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({ namespaces: { selected: namespace } });
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    { type: 'EXTENSIONS_FETCH_SUCCESS', data: [data] }
+  ];
+
+  await store.dispatch(fetchNamespacedResource('Extension', fakeAPI, params));
+  expect(store.getActions()).toEqual(expectedActions);
+  expect(fakeAPI).toHaveBeenCalledWith({ ...params, namespace });
+});
+
+it('fetchNamespacedResource error', async () => {
+  const namespace = 'default';
+  const params = { name: 'name' };
+  const error = new Error();
+  const fakeAPI = jest.fn().mockImplementation(() => {
+    throw error;
+  });
+
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({ namespaces: { selected: namespace } });
+
+  const expectedActions = [
+    { type: 'EXTENSIONS_FETCH_REQUEST' },
+    { type: 'EXTENSIONS_FETCH_FAILURE', error }
+  ];
+
+  await store.dispatch(fetchNamespacedResource('Extension', fakeAPI, params));
+  expect(store.getActions()).toEqual(expectedActions);
+  expect(fakeAPI).toHaveBeenCalledWith({ ...params, namespace });
 });

--- a/src/actions/pipelineResources.js
+++ b/src/actions/pipelineResources.js
@@ -12,29 +12,16 @@ limitations under the License.
 */
 
 import { getPipelineResource, getPipelineResources } from '../api';
-import { getSelectedNamespace } from '../reducers';
-import { fetchNamespacedCollection } from './actionCreators';
-
-function fetchPipelineResourcesSuccess(data) {
-  return {
-    type: 'PIPELINE_RESOURCES_FETCH_SUCCESS',
-    data
-  };
-}
+import {
+  fetchNamespacedCollection,
+  fetchNamespacedResource
+} from './actionCreators';
 
 export function fetchPipelineResource({ name, namespace }) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'PIPELINE_RESOURCES_FETCH_REQUEST' });
-    let pipelineResource;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      pipelineResource = await getPipelineResource(name, requestedNamespace);
-      dispatch(fetchPipelineResourcesSuccess([pipelineResource]));
-    } catch (error) {
-      dispatch({ type: 'PIPELINE_RESOURCES_FETCH_FAILURE', error });
-    }
-    return pipelineResource;
-  };
+  return fetchNamespacedResource('PipelineResource', getPipelineResource, {
+    name,
+    namespace
+  });
 }
 
 export function fetchPipelineResources({ namespace } = {}) {

--- a/src/actions/pipelineResources.test.js
+++ b/src/actions/pipelineResources.test.js
@@ -11,11 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
 import * as creators from './actionCreators';
 import {
   fetchPipelineResource,
@@ -23,46 +19,15 @@ import {
 } from './pipelineResources';
 
 it('fetchPipelineResource', async () => {
-  const pipelineResource = { fake: 'pipelineResource' };
-  const namespace = 'default';
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest
-    .spyOn(API, 'getPipelineResource')
-    .mockImplementation(() => pipelineResource);
-
-  const expectedActions = [
-    { type: 'PIPELINE_RESOURCES_FETCH_REQUEST' },
-    { type: 'PIPELINE_RESOURCES_FETCH_SUCCESS', data: [pipelineResource] }
-  ];
-
-  await store.dispatch(fetchPipelineResource({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchPipelineResource error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getPipelineResource').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'PIPELINE_RESOURCES_FETCH_REQUEST' },
-    { type: 'PIPELINE_RESOURCES_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchPipelineResource({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedResource');
+  const name = 'pipelineResourceName';
+  const namespace = 'namespace';
+  fetchPipelineResource({ name, namespace });
+  expect(creators.fetchNamespacedResource).toHaveBeenCalledWith(
+    'PipelineResource',
+    API.getPipelineResource,
+    { name, namespace }
+  );
 });
 
 it('fetchPipelineResources', async () => {

--- a/src/actions/pipelineRuns.js
+++ b/src/actions/pipelineRuns.js
@@ -12,29 +12,16 @@ limitations under the License.
 */
 
 import { getPipelineRun, getPipelineRuns } from '../api';
-import { getSelectedNamespace } from '../reducers';
-import { fetchNamespacedCollection } from './actionCreators';
-
-export function fetchPipelineRunsSuccess(data) {
-  return {
-    type: 'PIPELINE_RUNS_FETCH_SUCCESS',
-    data
-  };
-}
+import {
+  fetchNamespacedCollection,
+  fetchNamespacedResource
+} from './actionCreators';
 
 export function fetchPipelineRun({ name, namespace }) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'PIPELINE_RUNS_FETCH_REQUEST' });
-    let pipelineRun;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      pipelineRun = await getPipelineRun(name, requestedNamespace);
-      dispatch(fetchPipelineRunsSuccess([pipelineRun]));
-    } catch (error) {
-      dispatch({ type: 'PIPELINE_RUNS_FETCH_FAILURE', error });
-    }
-    return pipelineRun;
-  };
+  return fetchNamespacedResource('PipelineRun', getPipelineRun, {
+    name,
+    namespace
+  });
 }
 
 export function fetchPipelineRuns({ namespace, pipelineName } = {}) {

--- a/src/actions/pipelineRuns.test.js
+++ b/src/actions/pipelineRuns.test.js
@@ -11,65 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
 import * as creators from './actionCreators';
-import {
-  fetchPipelineRun,
-  fetchPipelineRuns,
-  fetchPipelineRunsSuccess
-} from './pipelineRuns';
-
-it('fetchPipelineRunsSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchPipelineRunsSuccess(data)).toEqual({
-    type: 'PIPELINE_RUNS_FETCH_SUCCESS',
-    data
-  });
-});
+import { fetchPipelineRun, fetchPipelineRuns } from './pipelineRuns';
 
 it('fetchPipelineRun', async () => {
-  const pipelineRun = { fake: 'pipelineRun' };
-  const namespace = 'default';
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest.spyOn(API, 'getPipelineRun').mockImplementation(() => pipelineRun);
-
-  const expectedActions = [
-    { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
-    fetchPipelineRunsSuccess([pipelineRun])
-  ];
-
-  await store.dispatch(fetchPipelineRun({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchPipelineRun error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getPipelineRun').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'PIPELINE_RUNS_FETCH_REQUEST' },
-    { type: 'PIPELINE_RUNS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchPipelineRun({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
+  jest.spyOn(creators, 'fetchNamespacedResource');
+  const name = 'pipelineRunName';
+  const namespace = 'namespace';
+  fetchPipelineRun({ name, namespace });
+  expect(creators.fetchNamespacedResource).toHaveBeenCalledWith(
+    'PipelineRun',
+    API.getPipelineRun,
+    { name, namespace }
+  );
 });
 
 it('fetchPipelineRuns', async () => {

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -12,29 +12,13 @@ limitations under the License.
 */
 
 import { getPipeline, getPipelines } from '../api';
-import { getSelectedNamespace } from '../reducers';
-import { fetchNamespacedCollection } from './actionCreators';
-
-export function fetchPipelinesSuccess(data) {
-  return {
-    type: 'PIPELINES_FETCH_SUCCESS',
-    data
-  };
-}
+import {
+  fetchNamespacedCollection,
+  fetchNamespacedResource
+} from './actionCreators';
 
 export function fetchPipeline({ name, namespace }) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'PIPELINES_FETCH_REQUEST' });
-    let pipeline;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      pipeline = await getPipeline(name, requestedNamespace);
-      dispatch(fetchPipelinesSuccess([pipeline]));
-    } catch (error) {
-      dispatch({ type: 'PIPELINES_FETCH_FAILURE', error });
-    }
-    return pipeline;
-  };
+  return fetchNamespacedResource('Pipeline', getPipeline, { name, namespace });
 }
 
 export function fetchPipelines({ namespace } = {}) {

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -11,65 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
 import * as creators from './actionCreators';
-import {
-  fetchPipeline,
-  fetchPipelines,
-  fetchPipelinesSuccess
-} from './pipelines';
-
-it('fetchPipelinesSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchPipelinesSuccess(data)).toEqual({
-    type: 'PIPELINES_FETCH_SUCCESS',
-    data
-  });
-});
+import { fetchPipeline, fetchPipelines } from './pipelines';
 
 it('fetchPipeline', async () => {
-  const pipeline = { fake: 'pipeline' };
+  jest.spyOn(creators, 'fetchNamespacedResource');
+  const name = 'pipelineName';
   const namespace = 'default';
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest.spyOn(API, 'getPipeline').mockImplementation(() => pipeline);
-
-  const expectedActions = [
-    { type: 'PIPELINES_FETCH_REQUEST' },
-    fetchPipelinesSuccess([pipeline])
-  ];
-
-  await store.dispatch(fetchPipeline({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchPipeline error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getPipeline').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'PIPELINES_FETCH_REQUEST' },
-    { type: 'PIPELINES_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchPipeline({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
+  fetchPipeline({ name, namespace });
+  expect(creators.fetchNamespacedResource).toHaveBeenCalledWith(
+    'Pipeline',
+    API.getPipeline,
+    { name, namespace }
+  );
 });
 
 it('fetchPipelines', async () => {

--- a/src/actions/taskRuns.js
+++ b/src/actions/taskRuns.js
@@ -12,15 +12,10 @@ limitations under the License.
 */
 
 import { getTaskRun, getTaskRuns } from '../api';
-import { getSelectedNamespace } from '../reducers';
-import { fetchNamespacedCollection } from './actionCreators';
-
-export function fetchTaskRunsSuccess(data) {
-  return {
-    type: 'TASK_RUNS_FETCH_SUCCESS',
-    data
-  };
-}
+import {
+  fetchNamespacedCollection,
+  fetchNamespacedResource
+} from './actionCreators';
 
 export function fetchTaskRuns({ namespace, taskName } = {}) {
   return fetchNamespacedCollection('TaskRun', getTaskRuns, {
@@ -29,17 +24,6 @@ export function fetchTaskRuns({ namespace, taskName } = {}) {
   });
 }
 
-export function fetchTaskRun({ taskRunName, namespace } = {}) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'TASK_RUNS_FETCH_REQUEST' });
-    let taskRun;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      taskRun = await getTaskRun(taskRunName, requestedNamespace);
-      dispatch(fetchTaskRunsSuccess([taskRun]));
-    } catch (error) {
-      dispatch({ type: 'TASK_RUNS_FETCH_FAILURE', error });
-    }
-    return taskRun;
-  };
+export function fetchTaskRun({ name, namespace }) {
+  return fetchNamespacedResource('TaskRun', getTaskRun, { name, namespace });
 }

--- a/src/actions/taskRuns.test.js
+++ b/src/actions/taskRuns.test.js
@@ -11,20 +11,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
-import { fetchTaskRun, fetchTaskRuns, fetchTaskRunsSuccess } from './taskRuns';
+import { fetchTaskRun, fetchTaskRuns } from './taskRuns';
 import * as creators from './actionCreators';
 
-it('fetchTaskRunsSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchTaskRunsSuccess(data)).toEqual({
-    type: 'TASK_RUNS_FETCH_SUCCESS',
-    data
-  });
+it('fetchTaskRun', async () => {
+  jest.spyOn(creators, 'fetchNamespacedResource');
+  const name = 'taskRunName';
+  const namespace = 'default';
+
+  fetchTaskRun({ name, namespace });
+  expect(creators.fetchNamespacedResource).toHaveBeenCalledWith(
+    'TaskRun',
+    API.getTaskRun,
+    { name, namespace }
+  );
 });
 
 it('fetchTaskRuns', async () => {
@@ -39,23 +40,12 @@ it('fetchTaskRuns', async () => {
   );
 });
 
-it('fetchTaskRun', async () => {
-  const namespace = 'default';
-  const task = { fake: 'task' };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest.spyOn(API, 'getTaskRun').mockImplementation(() => task);
-
-  const expectedActions = [
-    { type: 'TASK_RUNS_FETCH_REQUEST' },
-    fetchTaskRunsSuccess([task])
-  ];
-
-  await store.dispatch(fetchTaskRun());
-  expect(store.getActions()).toEqual(expectedActions);
+it('fetchTaskRuns no params', async () => {
+  jest.spyOn(creators, 'fetchNamespacedCollection');
+  fetchTaskRuns();
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
+    'TaskRun',
+    API.getTaskRuns,
+    { namespace: undefined, taskName: undefined }
+  );
 });

--- a/src/actions/tasks.js
+++ b/src/actions/tasks.js
@@ -12,29 +12,13 @@ limitations under the License.
 */
 
 import { getTask, getTasks } from '../api';
-import { getSelectedNamespace } from '../reducers';
-import { fetchNamespacedCollection } from './actionCreators';
-
-export function fetchTasksSuccess(data) {
-  return {
-    type: 'TASKS_FETCH_SUCCESS',
-    data
-  };
-}
+import {
+  fetchNamespacedCollection,
+  fetchNamespacedResource
+} from './actionCreators';
 
 export function fetchTask({ name, namespace }) {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'TASKS_FETCH_REQUEST' });
-    let task;
-    try {
-      const requestedNamespace = namespace || getSelectedNamespace(getState());
-      task = await getTask(name, requestedNamespace);
-      dispatch(fetchTasksSuccess([task]));
-    } catch (error) {
-      dispatch({ type: 'TASKS_FETCH_FAILURE', error });
-    }
-    return task;
-  };
+  return fetchNamespacedResource('Task', getTask, { name, namespace });
 }
 
 export function fetchTasks({ namespace } = {}) {

--- a/src/actions/tasks.test.js
+++ b/src/actions/tasks.test.js
@@ -11,61 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as API from '../api';
-import * as selectors from '../reducers';
 import * as creators from './actionCreators';
-import { fetchTask, fetchTasks, fetchTasksSuccess } from './tasks';
+import { fetchTask, fetchTasks } from './tasks';
 
 it('fetchTask', async () => {
-  const task = { fake: 'task' };
-  const namespace = 'default';
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  jest
-    .spyOn(selectors, 'getSelectedNamespace')
-    .mockImplementation(() => namespace);
-  jest.spyOn(API, 'getTask').mockImplementation(() => task);
-
-  const expectedActions = [
-    { type: 'TASKS_FETCH_REQUEST' },
-    fetchTasksSuccess([task])
-  ];
-
-  await store.dispatch(fetchTask({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchTask error', async () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore();
-
-  const error = new Error();
-
-  jest.spyOn(API, 'getTask').mockImplementation(() => {
-    throw error;
-  });
-
-  const expectedActions = [
-    { type: 'TASKS_FETCH_REQUEST' },
-    { type: 'TASKS_FETCH_FAILURE', error }
-  ];
-
-  await store.dispatch(fetchTask({ name: 'foo' }));
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('fetchTasksSuccess', () => {
-  const data = { fake: 'data' };
-  expect(fetchTasksSuccess(data)).toEqual({
-    type: 'TASKS_FETCH_SUCCESS',
-    data
-  });
+  jest.spyOn(creators, 'fetchNamespacedResource');
+  const name = 'taskName';
+  const namespace = 'namespace';
+  fetchTask({ name, namespace });
+  expect(creators.fetchNamespacedResource).toHaveBeenCalledWith(
+    'Task',
+    API.getTask,
+    { name, namespace }
+  );
 });
 
 it('fetchTasks', async () => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -59,17 +59,17 @@ export function checkData(data) {
   throw error;
 }
 
-export function getPipelines(namespace) {
+export function getPipelines({ namespace } = {}) {
   const uri = getAPI('pipelines', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getPipeline(name, namespace) {
+export function getPipeline({ name, namespace }) {
   const uri = getAPI('pipelines', { name, namespace });
   return get(uri);
 }
 
-export function getPipelineRuns(namespace, pipelineName) {
+export function getPipelineRuns({ namespace, pipelineName } = {}) {
   let queryParams;
   if (pipelineName) {
     queryParams = { name: pipelineName };
@@ -78,32 +78,32 @@ export function getPipelineRuns(namespace, pipelineName) {
   return get(uri).then(checkData);
 }
 
-export function getPipelineRun(name, namespace) {
+export function getPipelineRun({ name, namespace }) {
   const uri = getAPI('pipelineruns', { name, namespace });
   return get(uri);
 }
 
-export function cancelPipelineRun(name, namespace) {
+export function cancelPipelineRun({ name, namespace }) {
   const uri = getAPI('pipelineruns', { name, namespace });
   return put(uri, { status: 'PipelineRunCancelled' });
 }
 
-export function createPipelineRun(payload, namespace) {
+export function createPipelineRun({ namespace, payload }) {
   const uri = getAPI('pipelineruns', { namespace });
   return post(uri, payload);
 }
 
-export function getTasks(namespace) {
+export function getTasks({ namespace } = {}) {
   const uri = getAPI('tasks', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getTask(name, namespace) {
+export function getTask({ name, namespace }) {
   const uri = getAPI('tasks', { name, namespace });
   return get(uri);
 }
 
-export function getTaskRuns(namespace, taskName) {
+export function getTaskRuns({ namespace, taskName } = {}) {
   let queryParams;
   if (taskName) {
     queryParams = { name: taskName };
@@ -112,32 +112,27 @@ export function getTaskRuns(namespace, taskName) {
   return get(uri).then(checkData);
 }
 
-export function getTaskRun(name, namespace) {
+export function getTaskRun({ name, namespace }) {
   const uri = getAPI('taskruns', { name, namespace });
   return get(uri);
 }
 
-export function getPipelineResources(namespace) {
+export function getPipelineResources({ namespace } = {}) {
   const uri = getAPI('pipelineresources', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getPipelineResource(name, namespace) {
+export function getPipelineResource({ name, namespace }) {
   const uri = getAPI('pipelineresources', { name, namespace });
   return get(uri);
 }
 
-export function getPodLog(name, namespace, container) {
+export function getPodLog({ container, name, namespace }) {
   let queryParams;
   if (container) {
     queryParams = { container };
   }
   const uri = `${getAPI('logs', { name, namespace }, queryParams)}`;
-  return get(uri);
-}
-
-export function getTaskRunLog(name, namespace) {
-  const uri = getAPI('taskrunlogs', { name, namespace });
   return get(uri);
 }
 
@@ -184,7 +179,7 @@ export function getNamespaces() {
   return get(uri).then(checkData);
 }
 
-export function getServiceAccounts(namespace) {
+export function getServiceAccounts({ namespace } = {}) {
   const uri = getAPI('serviceaccounts', { namespace });
   return get(uri).then(checkData);
 }

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -33,9 +33,9 @@ import {
   getPipelineRuns,
   getPipelines,
   getPodLog,
+  getServiceAccounts,
   getTask,
   getTaskRun,
-  getTaskRunLog,
   getTaskRuns,
   getTasks,
   updateCredential
@@ -104,10 +104,10 @@ it('getPipelines', () => {
 });
 
 it('getPipeline', () => {
-  const pipelineName = 'foo';
+  const name = 'foo';
   const data = { fake: 'pipeline' };
-  fetchMock.get(`end:${pipelineName}`, data);
-  return getPipeline(pipelineName).then(pipeline => {
+  fetchMock.get(`end:${name}`, data);
+  return getPipeline({ name }).then(pipeline => {
     expect(pipeline).toEqual(data);
     fetchMock.restore();
   });
@@ -130,29 +130,29 @@ it('getPipelineRuns With Query Params', () => {
     items: 'pipelineRuns'
   };
   fetchMock.get(/pipelineruns/, data);
-  return getPipelineRuns(pipelineName).then(pipelineRuns => {
+  return getPipelineRuns({ pipelineName }).then(pipelineRuns => {
     expect(pipelineRuns).toEqual(data.items);
     fetchMock.restore();
   });
 });
 
 it('getPipelineRun', () => {
-  const pipelineRunName = 'foo';
+  const name = 'foo';
   const data = { fake: 'pipelineRun' };
-  fetchMock.get(`end:${pipelineRunName}`, data);
-  return getPipelineRun(pipelineRunName).then(pipelineRun => {
+  fetchMock.get(`end:${name}`, data);
+  return getPipelineRun({ name }).then(pipelineRun => {
     expect(pipelineRun).toEqual(data);
     fetchMock.restore();
   });
 });
 
 it('cancelPipelineRun', () => {
-  const pipelineRunName = 'foo';
+  const name = 'foo';
   const payload = {
     status: 'PipelineRunCancelled'
   };
-  fetchMock.put(`end:${pipelineRunName}`, 204);
-  return cancelPipelineRun(pipelineRunName).then(() => {
+  fetchMock.put(`end:${name}`, 204);
+  return cancelPipelineRun({ name }).then(() => {
     expect(fetchMock.lastOptions()).toMatchObject({
       body: JSON.stringify(payload)
     });
@@ -172,10 +172,10 @@ it('getTasks', () => {
 });
 
 it('getTask', () => {
-  const taskName = 'foo';
+  const name = 'foo';
   const data = { fake: 'task' };
-  fetchMock.get(`end:${taskName}`, data);
-  return getTask(taskName).then(task => {
+  fetchMock.get(`end:${name}`, data);
+  return getTask({ name }).then(task => {
     expect(task).toEqual(data);
     fetchMock.restore();
   });
@@ -198,17 +198,17 @@ it('getTaskRuns With Query Params', () => {
     items: 'taskRuns'
   };
   fetchMock.get(/taskruns/, data);
-  return getTaskRuns(taskName).then(taskRuns => {
+  return getTaskRuns({ taskName }).then(taskRuns => {
     expect(taskRuns).toEqual(data.items);
     fetchMock.restore();
   });
 });
 
 it('getTaskRun', () => {
-  const taskRunName = 'foo';
+  const name = 'foo';
   const data = { fake: 'taskRun' };
-  fetchMock.get(`end:${taskRunName}`, data);
-  return getTaskRun(taskRunName).then(taskRun => {
+  fetchMock.get(`end:${name}`, data);
+  return getTaskRun({ name }).then(taskRun => {
     expect(taskRun).toEqual(data);
     fetchMock.restore();
   });
@@ -226,10 +226,10 @@ it('getPipelineResources', () => {
 });
 
 it('getPipelineResource', () => {
-  const pipelineResourceName = 'foo';
+  const name = 'foo';
   const data = { fake: 'pipelineResource' };
-  fetchMock.get(`end:${pipelineResourceName}`, data);
-  return getPipelineResource(pipelineResourceName).then(pipelineResource => {
+  fetchMock.get(`end:${name}`, data);
+  return getPipelineResource({ name }).then(pipelineResource => {
     expect(pipelineResource).toEqual(data);
     fetchMock.restore();
   });
@@ -237,27 +237,36 @@ it('getPipelineResource', () => {
 
 it('getPodLog', () => {
   const namespace = 'default';
-  const podName = 'foo';
+  const name = 'foo';
   const data = 'logs';
   const responseConfig = {
     body: data,
     status: 200,
     headers: { 'Content-Type': 'text/plain' }
   };
-  fetchMock.get(`end:logs/${podName}`, responseConfig, {
+  fetchMock.get(`end:logs/${name}`, responseConfig, {
     sendAsJson: false
   });
-  return getPodLog(podName, namespace).then(log => {
+  return getPodLog({ name, namespace }).then(log => {
     expect(log).toEqual(data);
     fetchMock.restore();
   });
 });
 
-it('getTaskRunLog', () => {
-  const taskRunName = 'foo';
-  const data = ['logs'];
-  fetchMock.get(`end:${taskRunName}`, data);
-  return getTaskRunLog(taskRunName).then(log => {
+it('getPodLog with container name', () => {
+  const namespace = 'default';
+  const name = 'foo';
+  const container = 'containerName';
+  const data = 'logs';
+  const responseConfig = {
+    body: data,
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' }
+  };
+  fetchMock.get(`end:logs/${name}?container=${container}`, responseConfig, {
+    sendAsJson: false
+  });
+  return getPodLog({ container, name, namespace }).then(log => {
     expect(log).toEqual(data);
     fetchMock.restore();
   });
@@ -267,7 +276,7 @@ it('createPipelineRun', () => {
   const payload = { fake: 'payload' };
   const data = { fake: 'data' };
   fetchMock.post('*', data);
-  return createPipelineRun(payload).then(response => {
+  return createPipelineRun({ payload }).then(response => {
     expect(response).toEqual(data);
     expect(fetchMock.lastOptions()).toMatchObject({
       body: JSON.stringify(payload)
@@ -370,6 +379,15 @@ it('getNamespaces', () => {
   };
   fetchMock.get(/namespaces/, data);
   return getNamespaces().then(response => {
+    expect(response).toEqual(data.items);
+    fetchMock.restore();
+  });
+});
+
+it('getServiceAccounts', () => {
+  const data = { items: 'serviceaccounts' };
+  fetchMock.get(/serviceaccounts/, data);
+  return getServiceAccounts().then(response => {
     expect(response).toEqual(data.items);
     fetchMock.restore();
   });

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -215,7 +215,7 @@ class CreatePipelineRun extends React.Component {
       submitValidationError: false
     });
 
-    const namespaceValue = this.getNamespace();
+    const namespace = this.getNamespace();
     const pipelineValue = this.getPipeline();
     const payload = {
       pipelinename: pipelineValue,
@@ -229,12 +229,12 @@ class CreatePipelineRun extends React.Component {
       pipelineruntype: this.state.helmPipeline.value ? 'helm' : '',
       helmsecret: this.state.helmSecret.value
     };
-    const promise = createPipelineRun(payload, namespaceValue);
+    const promise = createPipelineRun({ namespace, payload });
     promise
       .then(headers => {
         const url = headers.get('Content-Location');
         const pipelineRunName = url.substring(url.lastIndexOf('/') + 1);
-        const finalURL = `/namespaces/${namespaceValue}/pipelines/${pipelineValue}/runs/${pipelineRunName}`;
+        const finalURL = `/namespaces/${namespace}/pipelines/${pipelineValue}/runs/${pipelineRunName}`;
         this.reset();
         this.props.onSuccess({ name: pipelineRunName, url: finalURL });
       })

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -338,7 +338,10 @@ it('CreatePipelineRun submits form', async () => {
   fireEvent.click(getByText(/submit/i));
   await wait(() => expect(createPipelineRun).toHaveBeenCalledTimes(1));
   await wait(() =>
-    expect(createPipelineRun).toHaveBeenCalledWith(formValues, 'default')
+    expect(createPipelineRun).toHaveBeenCalledWith({
+      namespace: 'default',
+      payload: formValues
+    })
   );
 });
 

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -93,7 +93,7 @@ export class ImportResources extends Component {
       return;
     }
 
-    const promise = createPipelineRun(payload, namespace);
+    const promise = createPipelineRun({ namespace, payload });
     promise
       .then(headers => {
         const logsURL = headers.get('Content-Location');

--- a/src/containers/Log/Log.js
+++ b/src/containers/Log/Log.js
@@ -64,8 +64,12 @@ export class LogContainer extends Component {
     const { namespace } = match.params;
     if (podName) {
       try {
-        const buildStepName = `build-step-${stepName}`;
-        const logs = await getPodLog(podName, namespace, buildStepName);
+        const container = `build-step-${stepName}`;
+        const logs = await getPodLog({
+          container,
+          name: podName,
+          namespace
+        });
         this.setState({ logs: logs || undefined });
       } catch {
         this.setState({ logs: 'Unable to fetch log' });

--- a/src/containers/Log/Log.test.js
+++ b/src/containers/Log/Log.test.js
@@ -36,11 +36,11 @@ it('LogContainer renders', async () => {
   await waitForElement(() => getByText(logs));
 
   expect(getPodLog).toHaveBeenCalledTimes(1);
-  expect(getPodLog).toHaveBeenCalledWith(
-    podName,
-    namespace,
-    `build-step-${stepName}`
-  );
+  expect(getPodLog).toHaveBeenCalledWith({
+    container: `build-step-${stepName}`,
+    name: podName,
+    namespace
+  });
 
   const anotherPodName = 'anotherPod';
   render(
@@ -51,11 +51,11 @@ it('LogContainer renders', async () => {
     />
   );
   expect(getPodLog).toHaveBeenCalledTimes(2);
-  expect(getPodLog).toHaveBeenCalledWith(
-    anotherPodName,
-    namespace,
-    `build-step-${stepName}`
-  );
+  expect(getPodLog).toHaveBeenCalledWith({
+    container: `build-step-${stepName}`,
+    name: anotherPodName,
+    namespace
+  });
 });
 
 it('LogContainer handles error case', async () => {
@@ -76,11 +76,11 @@ it('LogContainer handles error case', async () => {
   await waitForElement(() => getByText('Unable to fetch log'));
 
   expect(getPodLog).toHaveBeenCalledTimes(1);
-  expect(getPodLog).toHaveBeenCalledWith(
-    podName,
-    namespace,
-    `build-step-${stepName}`
-  );
+  expect(getPodLog).toHaveBeenCalledWith({
+    container: `build-step-${stepName}`,
+    name: podName,
+    namespace
+  });
 });
 
 it('LogContainer handles empty logs', async () => {
@@ -98,11 +98,11 @@ it('LogContainer handles empty logs', async () => {
   );
 
   expect(getPodLog).toHaveBeenCalledTimes(1);
-  expect(getPodLog).toHaveBeenCalledWith(
-    podName,
-    namespace,
-    `build-step-${stepName}`
-  );
+  expect(getPodLog).toHaveBeenCalledWith({
+    container: `build-step-${stepName}`,
+    name: podName,
+    namespace
+  });
 });
 
 it('LogContainer handles missing step logs', async () => {
@@ -123,9 +123,9 @@ it('LogContainer handles missing step logs', async () => {
   await waitForElement(() => getByText('No log available'));
 
   expect(getPodLog).toHaveBeenCalledTimes(1);
-  expect(getPodLog).toHaveBeenCalledWith(
-    podName,
-    namespace,
-    `build-step-${stepName}`
-  );
+  expect(getPodLog).toHaveBeenCalledWith({
+    container: `build-step-${stepName}`,
+    name: podName,
+    namespace
+  });
 });

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -103,7 +103,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
   };
 
   fetchTaskAndRuns(taskRunName, namespace) {
-    this.props.fetchTaskRun({ taskRunName, namespace }).then(taskRun => {
+    this.props.fetchTaskRun({ name: taskRunName, namespace }).then(taskRun => {
       if (taskRun && taskRun.spec.taskRef) {
         this.props
           .fetchTask({ name: taskRun.spec.taskRef.name, namespace })


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
#241 
- Provide a function to create action creators for single namespaced resources
- Update APIs to accept a single param and fix naming inconsistencies

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
