### PR TITLE
Remove unnecessary use of fragments in containers

### DIFF
--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -37,52 +37,46 @@ export const Extensions = /* istanbul ignore next */ ({
   loading,
   extensions
 }) => {
+  if (loading && !extensions.length) {
+    return <StructuredListSkeleton border />;
+  }
+
+  if (error) {
+    return (
+      <InlineNotification
+        kind="error"
+        hideCloseButton
+        lowContrast
+        title="Error loading extensions"
+        subtitle={error}
+      />
+    );
+  }
+
   return (
-    <>
-      {(() => {
-        if (loading && !extensions.length) {
-          return <StructuredListSkeleton border />;
-        }
-
-        if (error) {
+    <StructuredListWrapper border selection>
+      <StructuredListHead>
+        <StructuredListRow head>
+          <StructuredListCell head>Extension</StructuredListCell>
+        </StructuredListRow>
+      </StructuredListHead>
+      <StructuredListBody>
+        {!extensions.length && (
+          <StructuredListRow>
+            <StructuredListCell>No extensions</StructuredListCell>
+          </StructuredListRow>
+        )}
+        {extensions.map(({ displayName, name }) => {
           return (
-            <InlineNotification
-              kind="error"
-              hideCloseButton
-              lowContrast
-              title="Error loading extensions"
-              subtitle={error}
-            />
+            <StructuredListRow className="definition" key={name}>
+              <StructuredListCell>
+                <Link to={`/extensions/${name}`}>{displayName}</Link>
+              </StructuredListCell>
+            </StructuredListRow>
           );
-        }
-
-        return (
-          <StructuredListWrapper border selection>
-            <StructuredListHead>
-              <StructuredListRow head>
-                <StructuredListCell head>Extension</StructuredListCell>
-              </StructuredListRow>
-            </StructuredListHead>
-            <StructuredListBody>
-              {!extensions.length && (
-                <StructuredListRow>
-                  <StructuredListCell>No extensions</StructuredListCell>
-                </StructuredListRow>
-              )}
-              {extensions.map(({ displayName, name }) => {
-                return (
-                  <StructuredListRow className="definition" key={name}>
-                    <StructuredListCell>
-                      <Link to={`/extensions/${name}`}>{displayName}</Link>
-                    </StructuredListCell>
-                  </StructuredListRow>
-                );
-              })}
-            </StructuredListBody>
-          </StructuredListWrapper>
-        );
-      })()}
-    </>
+        })}
+      </StructuredListBody>
+    </StructuredListWrapper>
   );
 };
 

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -71,109 +71,96 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
     } = this.props;
     const { pipelineName } = match.params;
 
+    if (loading) {
+      return <StructuredListSkeleton border />;
+    }
+
+    if (error) {
+      return (
+        <InlineNotification
+          kind="error"
+          hideCloseButton
+          lowContrast
+          title="Error loading pipeline runs"
+          subtitle={JSON.stringify(error)}
+        />
+      );
+    }
+
     return (
-      <>
-        {(() => {
-          if (loading) {
-            return <StructuredListSkeleton border />;
-          }
-
-          if (error) {
-            return (
-              <InlineNotification
-                kind="error"
-                hideCloseButton
-                lowContrast
-                title="Error loading pipeline runs"
-                subtitle={JSON.stringify(error)}
-              />
-            );
-          }
-
-          return (
-            <StructuredListWrapper border selection>
-              <StructuredListHead>
-                <StructuredListRow head>
-                  <StructuredListCell head>Pipeline Run</StructuredListCell>
-                  {!pipelineName && (
-                    <StructuredListCell head>Pipeline</StructuredListCell>
-                  )}
-                  {selectedNamespace === ALL_NAMESPACES && (
-                    <StructuredListCell head>Namespace</StructuredListCell>
-                  )}
-                  <StructuredListCell head>Status</StructuredListCell>
-                  <StructuredListCell head>
-                    Last Transition Time
-                  </StructuredListCell>
-                </StructuredListRow>
-              </StructuredListHead>
-              <StructuredListBody>
-                {!pipelineRuns.length && (
-                  <StructuredListRow>
-                    <StructuredListCell>
-                      {pipelineName ? (
-                        <span>No pipeline runs for {pipelineName}</span>
-                      ) : (
-                        <span>No pipeline runs</span>
-                      )}
-                    </StructuredListCell>
-                  </StructuredListRow>
+      <StructuredListWrapper border selection>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>Pipeline Run</StructuredListCell>
+            {!pipelineName && (
+              <StructuredListCell head>Pipeline</StructuredListCell>
+            )}
+            {selectedNamespace === ALL_NAMESPACES && (
+              <StructuredListCell head>Namespace</StructuredListCell>
+            )}
+            <StructuredListCell head>Status</StructuredListCell>
+            <StructuredListCell head>Last Transition Time</StructuredListCell>
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          {!pipelineRuns.length && (
+            <StructuredListRow>
+              <StructuredListCell>
+                {pipelineName ? (
+                  <span>No pipeline runs for {pipelineName}</span>
+                ) : (
+                  <span>No pipeline runs</span>
                 )}
-                {pipelineRuns.map(pipelineRun => {
-                  const {
-                    name: pipelineRunName,
-                    namespace
-                  } = pipelineRun.metadata;
-                  const pipelineRefName = pipelineRun.spec.pipelineRef.name;
-                  const { lastTransitionTime, reason, status } = getStatus(
-                    pipelineRun
-                  );
+              </StructuredListCell>
+            </StructuredListRow>
+          )}
+          {pipelineRuns.map(pipelineRun => {
+            const { name: pipelineRunName, namespace } = pipelineRun.metadata;
+            const pipelineRefName = pipelineRun.spec.pipelineRef.name;
+            const { lastTransitionTime, reason, status } = getStatus(
+              pipelineRun
+            );
 
-                  return (
-                    <StructuredListRow
-                      className="definition"
-                      key={pipelineRun.metadata.uid}
+            return (
+              <StructuredListRow
+                className="definition"
+                key={pipelineRun.metadata.uid}
+              >
+                <StructuredListCell>
+                  <Link
+                    to={`/namespaces/${namespace}/pipelines/${pipelineRefName}/runs/${pipelineRunName}`}
+                  >
+                    {pipelineRunName}
+                  </Link>
+                </StructuredListCell>
+                {!pipelineName && (
+                  <StructuredListCell>
+                    <Link
+                      to={`/namespaces/${namespace}/pipelines/${pipelineRefName}/runs`}
                     >
-                      <StructuredListCell>
-                        <Link
-                          to={`/namespaces/${namespace}/pipelines/${pipelineRefName}/runs/${pipelineRunName}`}
-                        >
-                          {pipelineRunName}
-                        </Link>
-                      </StructuredListCell>
-                      {!pipelineName && (
-                        <StructuredListCell>
-                          <Link
-                            to={`/namespaces/${namespace}/pipelines/${pipelineRefName}/runs`}
-                          >
-                            {pipelineRefName}
-                          </Link>
-                        </StructuredListCell>
-                      )}
-                      {selectedNamespace === ALL_NAMESPACES && (
-                        <StructuredListCell>{namespace}</StructuredListCell>
-                      )}
-                      <StructuredListCell
-                        className="status"
-                        data-reason={reason}
-                        data-status={status}
-                      >
-                        {getStatusIcon({ reason, status })}
-                        {pipelineRun.status.conditions
-                          ? pipelineRun.status.conditions[0].message
-                          : ''}
-                      </StructuredListCell>
-                      <StructuredListCell>
-                        {lastTransitionTime}
-                      </StructuredListCell>
-                    </StructuredListRow>
-                  );
-                })}
-              </StructuredListBody>
-            </StructuredListWrapper>
-          );
-        })()}
-      </>
+                      {pipelineRefName}
+                    </Link>
+                  </StructuredListCell>
+                )}
+                {selectedNamespace === ALL_NAMESPACES && (
+                  <StructuredListCell>{namespace}</StructuredListCell>
+                )}
+                <StructuredListCell
+                  className="status"
+                  data-reason={reason}
+                  data-status={status}
+                >
+                  {getStatusIcon({ reason, status })}
+                  {pipelineRun.status.conditions
+                    ? pipelineRun.status.conditions[0].message
+                    : ''}
+                </StructuredListCell>
+                <StructuredListCell>{lastTransitionTime}</StructuredListCell>
+              </StructuredListRow>
+            );
+          })}
+        </StructuredListBody>
+      </StructuredListWrapper>
     );
   }
 }

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -57,72 +57,64 @@ export /* istanbul ignore next */ class Pipelines extends Component {
       pipelines
     } = this.props;
 
+    if (loading && !pipelines.length) {
+      return <StructuredListSkeleton border />;
+    }
+
+    if (error) {
+      return (
+        <InlineNotification
+          kind="error"
+          hideCloseButton
+          lowContrast
+          title="Error loading pipelines"
+          subtitle={error}
+        />
+      );
+    }
+
     return (
-      <>
-        {(() => {
-          if (loading && !pipelines.length) {
-            return <StructuredListSkeleton border />;
-          }
-
-          if (error) {
+      <StructuredListWrapper border selection>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>Pipeline</StructuredListCell>
+            {selectedNamespace === ALL_NAMESPACES && (
+              <StructuredListCell head>Namespace</StructuredListCell>
+            )}
+            <StructuredListCell head />
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          {!pipelines.length && (
+            <StructuredListRow>
+              <StructuredListCell>No pipelines</StructuredListCell>
+            </StructuredListRow>
+          )}
+          {pipelines.map(pipeline => {
+            const { name, namespace, uid } = pipeline.metadata;
             return (
-              <InlineNotification
-                kind="error"
-                hideCloseButton
-                lowContrast
-                title="Error loading pipelines"
-                subtitle={error}
-              />
-            );
-          }
-
-          return (
-            <StructuredListWrapper border selection>
-              <StructuredListHead>
-                <StructuredListRow head>
-                  <StructuredListCell head>Pipeline</StructuredListCell>
-                  {selectedNamespace === ALL_NAMESPACES && (
-                    <StructuredListCell head>Namespace</StructuredListCell>
-                  )}
-                  <StructuredListCell head />
-                </StructuredListRow>
-              </StructuredListHead>
-              <StructuredListBody>
-                {!pipelines.length && (
-                  <StructuredListRow>
-                    <StructuredListCell>No pipelines</StructuredListCell>
-                  </StructuredListRow>
+              <StructuredListRow className="definition" key={uid}>
+                <StructuredListCell>
+                  <Link to={`/namespaces/${namespace}/pipelines/${name}/runs`}>
+                    {name}
+                  </Link>
+                </StructuredListCell>
+                {selectedNamespace === ALL_NAMESPACES && (
+                  <StructuredListCell>{namespace}</StructuredListCell>
                 )}
-                {pipelines.map(pipeline => {
-                  const { name, namespace, uid } = pipeline.metadata;
-                  return (
-                    <StructuredListRow className="definition" key={uid}>
-                      <StructuredListCell>
-                        <Link
-                          to={`/namespaces/${namespace}/pipelines/${name}/runs`}
-                        >
-                          {name}
-                        </Link>
-                      </StructuredListCell>
-                      {selectedNamespace === ALL_NAMESPACES && (
-                        <StructuredListCell>{namespace}</StructuredListCell>
-                      )}
-                      <StructuredListCell>
-                        <Link
-                          title="pipeline definition"
-                          to={`/namespaces/${namespace}/pipelines/${name}`}
-                        >
-                          <Information16 className="resource-info-icon" />
-                        </Link>
-                      </StructuredListCell>
-                    </StructuredListRow>
-                  );
-                })}
-              </StructuredListBody>
-            </StructuredListWrapper>
-          );
-        })()}
-      </>
+                <StructuredListCell>
+                  <Link
+                    title="pipeline definition"
+                    to={`/namespaces/${namespace}/pipelines/${name}`}
+                  >
+                    <Information16 className="resource-info-icon" />
+                  </Link>
+                </StructuredListCell>
+              </StructuredListRow>
+            );
+          })}
+        </StructuredListBody>
+      </StructuredListWrapper>
     );
   }
 }

--- a/src/containers/TaskRunList/TaskRunList.js
+++ b/src/containers/TaskRunList/TaskRunList.js
@@ -57,107 +57,95 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
       taskRuns
     } = this.props;
 
+    if (loading) {
+      return <StructuredListSkeleton border />;
+    }
+
+    if (error) {
+      return (
+        <InlineNotification
+          kind="error"
+          hideCloseButton
+          lowContrast
+          title="Error loading task runs"
+          subtitle={JSON.stringify(error)}
+        />
+      );
+    }
+
     return (
-      <>
-        {(() => {
-          if (loading) {
-            return <StructuredListSkeleton border />;
-          }
+      <StructuredListWrapper border selection>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>Task Run</StructuredListCell>
+            <StructuredListCell head>Task</StructuredListCell>
+            {selectedNamespace === ALL_NAMESPACES && (
+              <StructuredListCell head>Namespace</StructuredListCell>
+            )}
+            <StructuredListCell head>Status</StructuredListCell>
+            <StructuredListCell head>Last Transition Time</StructuredListCell>
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          {!taskRuns.length && (
+            <StructuredListRow>
+              <StructuredListCell>
+                <span>No pipeline runs</span>
+              </StructuredListCell>
+            </StructuredListRow>
+          )}
+          {taskRuns.map(taskRun => {
+            const { name, namespace } = taskRun.metadata;
+            const taskRefName = taskRun.spec.taskRef
+              ? taskRun.spec.taskRef.name
+              : '';
+            const { lastTransitionTime, reason, status } = getStatus(taskRun);
+            let message;
+            if (!taskRun.status.conditions) {
+              message = '';
+            } else if (
+              !taskRun.status.conditions[0].message &&
+              taskRun.status.conditions[0].status
+            ) {
+              message = 'All Steps have completed executing';
+            } else {
+              message = taskRun.status.conditions[0].message; // eslint-disable-line
+            }
 
-          if (error) {
             return (
-              <InlineNotification
-                kind="error"
-                hideCloseButton
-                lowContrast
-                title="Error loading task runs"
-                subtitle={JSON.stringify(error)}
-              />
-            );
-          }
-
-          return (
-            <StructuredListWrapper border selection>
-              <StructuredListHead>
-                <StructuredListRow head>
-                  <StructuredListCell head>Task Run</StructuredListCell>
-                  <StructuredListCell head>Task</StructuredListCell>
-                  {selectedNamespace === ALL_NAMESPACES && (
-                    <StructuredListCell head>Namespace</StructuredListCell>
-                  )}
-                  <StructuredListCell head>Status</StructuredListCell>
-                  <StructuredListCell head>
-                    Last Transition Time
-                  </StructuredListCell>
-                </StructuredListRow>
-              </StructuredListHead>
-              <StructuredListBody>
-                {!taskRuns.length && (
-                  <StructuredListRow>
-                    <StructuredListCell>
-                      <span>No pipeline runs</span>
-                    </StructuredListCell>
-                  </StructuredListRow>
+              <StructuredListRow
+                className="definition"
+                key={taskRun.metadata.uid}
+              >
+                <StructuredListCell>
+                  <Link to={`/namespaces/${namespace}/taskruns/${name}`}>
+                    {name}
+                  </Link>
+                </StructuredListCell>
+                <StructuredListCell>
+                  <Link
+                    to={`/namespaces/${namespace}/tasks/${taskRefName}/runs`}
+                  >
+                    {taskRefName}
+                  </Link>
+                </StructuredListCell>
+                {selectedNamespace === ALL_NAMESPACES && (
+                  <StructuredListCell>{namespace}</StructuredListCell>
                 )}
-                {taskRuns.map(taskRun => {
-                  const { name, namespace } = taskRun.metadata;
-                  const taskRefName = taskRun.spec.taskRef
-                    ? taskRun.spec.taskRef.name
-                    : '';
-                  const { lastTransitionTime, reason, status } = getStatus(
-                    taskRun
-                  );
-                  let message;
-                  if (!taskRun.status.conditions) {
-                    message = '';
-                  } else if (
-                    !taskRun.status.conditions[0].message &&
-                    taskRun.status.conditions[0].status
-                  ) {
-                    message = 'All Steps have completed executing';
-                  } else {
-                    message = taskRun.status.conditions[0].message; // eslint-disable-line
-                  }
-
-                  return (
-                    <StructuredListRow
-                      className="definition"
-                      key={taskRun.metadata.uid}
-                    >
-                      <StructuredListCell>
-                        <Link to={`/namespaces/${namespace}/taskruns/${name}`}>
-                          {name}
-                        </Link>
-                      </StructuredListCell>
-                      <StructuredListCell>
-                        <Link
-                          to={`/namespaces/${namespace}/tasks/${taskRefName}/runs`}
-                        >
-                          {taskRefName}
-                        </Link>
-                      </StructuredListCell>
-                      {selectedNamespace === ALL_NAMESPACES && (
-                        <StructuredListCell>{namespace}</StructuredListCell>
-                      )}
-                      <StructuredListCell
-                        className="status"
-                        data-reason={reason}
-                        data-status={status}
-                      >
-                        {getStatusIcon({ reason, status })}
-                        {message}
-                      </StructuredListCell>
-                      <StructuredListCell>
-                        {lastTransitionTime}
-                      </StructuredListCell>
-                    </StructuredListRow>
-                  );
-                })}
-              </StructuredListBody>
-            </StructuredListWrapper>
-          );
-        })()}
-      </>
+                <StructuredListCell
+                  className="status"
+                  data-reason={reason}
+                  data-status={status}
+                >
+                  {getStatusIcon({ reason, status })}
+                  {message}
+                </StructuredListCell>
+                <StructuredListCell>{lastTransitionTime}</StructuredListCell>
+              </StructuredListRow>
+            );
+          })}
+        </StructuredListBody>
+      </StructuredListWrapper>
     );
   }
 }

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -51,72 +51,64 @@ export /* istanbul ignore next */ class Tasks extends Component {
   render() {
     const { error, loading, namespace: selectedNamespace, tasks } = this.props;
 
+    if (loading && !tasks.length) {
+      return <StructuredListSkeleton border />;
+    }
+
+    if (error) {
+      return (
+        <InlineNotification
+          kind="error"
+          hideCloseButton
+          lowContrast
+          title="Error loading tasks"
+          subtitle={error}
+        />
+      );
+    }
+
     return (
-      <>
-        {(() => {
-          if (loading && !tasks.length) {
-            return <StructuredListSkeleton border />;
-          }
-
-          if (error) {
+      <StructuredListWrapper border selection>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>Task</StructuredListCell>
+            {selectedNamespace === ALL_NAMESPACES && (
+              <StructuredListCell head>Namespace</StructuredListCell>
+            )}
+            <StructuredListCell head />
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          {!tasks.length && (
+            <StructuredListRow>
+              <StructuredListCell>No tasks</StructuredListCell>
+            </StructuredListRow>
+          )}
+          {tasks.map(task => {
+            const { name: taskName, namespace, uid } = task.metadata;
             return (
-              <InlineNotification
-                kind="error"
-                hideCloseButton
-                lowContrast
-                title="Error loading tasks"
-                subtitle={error}
-              />
-            );
-          }
-
-          return (
-            <StructuredListWrapper border selection>
-              <StructuredListHead>
-                <StructuredListRow head>
-                  <StructuredListCell head>Task</StructuredListCell>
-                  {selectedNamespace === ALL_NAMESPACES && (
-                    <StructuredListCell head>Namespace</StructuredListCell>
-                  )}
-                  <StructuredListCell head />
-                </StructuredListRow>
-              </StructuredListHead>
-              <StructuredListBody>
-                {!tasks.length && (
-                  <StructuredListRow>
-                    <StructuredListCell>No tasks</StructuredListCell>
-                  </StructuredListRow>
+              <StructuredListRow className="definition" key={uid}>
+                <StructuredListCell>
+                  <Link to={`/namespaces/${namespace}/tasks/${taskName}/runs`}>
+                    {taskName}
+                  </Link>
+                </StructuredListCell>
+                {selectedNamespace === ALL_NAMESPACES && (
+                  <StructuredListCell>{namespace}</StructuredListCell>
                 )}
-                {tasks.map(task => {
-                  const { name: taskName, namespace, uid } = task.metadata;
-                  return (
-                    <StructuredListRow className="definition" key={uid}>
-                      <StructuredListCell>
-                        <Link
-                          to={`/namespaces/${namespace}/tasks/${taskName}/runs`}
-                        >
-                          {taskName}
-                        </Link>
-                      </StructuredListCell>
-                      {selectedNamespace === ALL_NAMESPACES && (
-                        <StructuredListCell>{namespace}</StructuredListCell>
-                      )}
-                      <StructuredListCell>
-                        <Link
-                          title="task definition"
-                          to={`/namespaces/${namespace}/tasks/${taskName}`}
-                        >
-                          <Information16 className="resource-info-icon" />
-                        </Link>
-                      </StructuredListCell>
-                    </StructuredListRow>
-                  );
-                })}
-              </StructuredListBody>
-            </StructuredListWrapper>
-          );
-        })()}
-      </>
+                <StructuredListCell>
+                  <Link
+                    title="task definition"
+                    to={`/namespaces/${namespace}/tasks/${taskName}`}
+                  >
+                    <Information16 className="resource-info-icon" />
+                  </Link>
+                </StructuredListCell>
+              </StructuredListRow>
+            );
+          })}
+        </StructuredListBody>
+      </StructuredListWrapper>
     );
   }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Remove unnecessary use of JSX fragments in a number of the containers to improve readability of the code.
Patterns like this:

```js
return (
  <>
    {(() => {
      if (condition) {
        return <SomeJSX />;
      }

      return <OtherJSX />;
    })()}
  </>
);
```

can simply be written without the surrounding fragment and IIFE:

```js
if (condition) {
  return <SomeJSX />;
}

return <OtherJSX />;
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
