### PR TITLE
Fix ToastNotification display in Import resources view

### DIFF
--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -184,6 +184,7 @@ export class ImportResources extends Component {
                 <Link to={this.state.logsURL}>View status of this run</Link>
               }
               kind="success"
+              lowContrast
               title="Triggered PipelineRun to apply Tekton resources"
               subtitle=""
             />


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The Carbon 10.3 update changed the default styling of notifications. https://github.com/tektoncd/dashboard/pull/281 updated the InlineNotifications but missed the ToastNotification used in the import resources page.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
