### PR TITLE
[Do not merge] Intentional test failure to test our test reporting on Prow

### DIFF
--- a/src/api/comms.test.js
+++ b/src/api/comms.test.js
@@ -58,7 +58,7 @@ describe('checkStatus', () => {
   });
 
   it('returns headers on successful create', () => {
-    const status = 201;
+    const status = 400;
     const headers = { fake: 'headers' };
     expect(checkStatus({ ok: true, headers, status })).toEqual(headers);
   });


### PR DESCRIPTION
We've noticed for the webhooks extension, when our Node.js tests fail the unit tests still report as having passed.

I've intentionally added a test failure here to see if the same problem impacts our dashboard.