### PR TITLE
Switch front-end to use kube API for Tekton resource GET requests

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -74,26 +74,26 @@ export function checkData(data) {
 }
 
 export function getPipelines({ namespace } = {}) {
-  const uri = getAPI('pipelines', { namespace });
+  const uri = getTektonAPI('pipelines', { namespace });
   return get(uri).then(checkData);
 }
 
 export function getPipeline({ name, namespace }) {
-  const uri = getAPI('pipelines', { name, namespace });
+  const uri = getTektonAPI('pipelines', { name, namespace });
   return get(uri);
 }
 
 export function getPipelineRuns({ namespace, pipelineName } = {}) {
   let queryParams;
   if (pipelineName) {
-    queryParams = { name: pipelineName };
+    queryParams = { labelSelector: `tekton.dev/pipeline=${pipelineName}` };
   }
-  const uri = getAPI('pipelineruns', { namespace }, queryParams);
+  const uri = getTektonAPI('pipelineruns', { namespace }, queryParams);
   return get(uri).then(checkData);
 }
 
 export function getPipelineRun({ name, namespace }) {
-  const uri = getAPI('pipelineruns', { name, namespace });
+  const uri = getTektonAPI('pipelineruns', { name, namespace });
   return get(uri);
 }
 
@@ -118,36 +118,36 @@ export function getClusterTask({ name }) {
 }
 
 export function getTasks({ namespace } = {}) {
-  const uri = getAPI('tasks', { namespace });
+  const uri = getTektonAPI('tasks', { namespace });
   return get(uri).then(checkData);
 }
 
 export function getTask({ name, namespace }) {
-  const uri = getAPI('tasks', { name, namespace });
+  const uri = getTektonAPI('tasks', { name, namespace });
   return get(uri);
 }
 
 export function getTaskRuns({ namespace, taskName } = {}) {
   let queryParams;
   if (taskName) {
-    queryParams = { name: taskName };
+    queryParams = { labelSelector: `tekton.dev/task=${taskName}` };
   }
-  const uri = getAPI('taskruns', { namespace }, queryParams);
+  const uri = getTektonAPI('taskruns', { namespace }, queryParams);
   return get(uri).then(checkData);
 }
 
 export function getTaskRun({ name, namespace }) {
-  const uri = getAPI('taskruns', { name, namespace });
+  const uri = getTektonAPI('taskruns', { name, namespace });
   return get(uri);
 }
 
 export function getPipelineResources({ namespace } = {}) {
-  const uri = getAPI('pipelineresources', { namespace });
+  const uri = getTektonAPI('pipelineresources', { namespace });
   return get(uri).then(checkData);
 }
 
 export function getPipelineResource({ name, namespace }) {
-  const uri = getAPI('pipelineresources', { name, namespace });
+  const uri = getTektonAPI('pipelineresources', { name, namespace });
   return get(uri);
 }
 

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -21,6 +21,8 @@ import {
   deleteCredential,
   getAPI,
   getAPIRoot,
+  getClusterTask,
+  getClusterTasks,
   getCredential,
   getCredentials,
   getExtensionBundleURL,
@@ -38,6 +40,7 @@ import {
   getTaskRun,
   getTaskRuns,
   getTasks,
+  getTektonAPI,
   updateCredential
 } from '.';
 
@@ -67,7 +70,7 @@ describe('getAPI', () => {
     expect(uri).toContain('somename');
   });
 
-  it('returns a URI containing the given, name, and namespace', () => {
+  it('returns a URI containing the given type, name, and namespace', () => {
     const uri = getAPI('pipelines', {
       name: 'somename',
       namespace: 'customnamespace'
@@ -75,6 +78,39 @@ describe('getAPI', () => {
     expect(uri).toContain('pipelines');
     expect(uri).toContain('somename');
     expect(uri).toContain('customnamespace');
+  });
+});
+
+describe('getTektonAPI', () => {
+  it('returns a URI containing the given type', () => {
+    const uri = getTektonAPI('pipelines');
+    expect(uri).toContain('pipelines');
+  });
+
+  it('returns a URI containing the given type and name', () => {
+    const uri = getTektonAPI('pipelines', { name: 'somename' });
+    expect(uri).toContain('pipelines');
+    expect(uri).toContain('somename');
+  });
+
+  it('returns a URI containing the given type, name, and namespace', () => {
+    const uri = getTektonAPI('pipelines', {
+      name: 'somename',
+      namespace: 'customnamespace'
+    });
+    expect(uri).toContain('pipelines');
+    expect(uri).toContain('somename');
+    expect(uri).toContain('namespaces');
+    expect(uri).toContain('customnamespace');
+  });
+
+  it('returns a URI without namespace when omitted', () => {
+    const uri = getTektonAPI('clustertasks', {
+      name: 'somename'
+    });
+    expect(uri).toContain('clustertasks');
+    expect(uri).toContain('somename');
+    expect(uri).not.toContain('namespaces');
   });
 });
 
@@ -156,6 +192,27 @@ it('cancelPipelineRun', () => {
     expect(fetchMock.lastOptions()).toMatchObject({
       body: JSON.stringify(payload)
     });
+    fetchMock.restore();
+  });
+});
+
+it('getClusterTasks', () => {
+  const data = {
+    items: 'clustertasks'
+  };
+  fetchMock.get(/clustertasks/, data);
+  return getClusterTasks().then(tasks => {
+    expect(tasks).toEqual(data.items);
+    fetchMock.restore();
+  });
+});
+
+it('getClusterTask', () => {
+  const name = 'foo';
+  const data = { fake: 'clustertask' };
+  fetchMock.get(`end:${name}`, data);
+  return getClusterTask({ name }).then(task => {
+    expect(task).toEqual(data);
     fetchMock.restore();
   });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/290

Requests to retrieve Tekton resources should use the kube API proxy.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
