### PR TITLE
Update namespaces, service accounts, and logs APIs to use kube API

### DIFF
--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -301,7 +301,7 @@ it('getPodLog', () => {
     status: 200,
     headers: { 'Content-Type': 'text/plain' }
   };
-  fetchMock.get(`end:logs/${name}`, responseConfig, {
+  fetchMock.get(`end:${name}/log`, responseConfig, {
     sendAsJson: false
   });
   return getPodLog({ name, namespace }).then(log => {
@@ -320,7 +320,7 @@ it('getPodLog with container name', () => {
     status: 200,
     headers: { 'Content-Type': 'text/plain' }
   };
-  fetchMock.get(`end:logs/${name}?container=${container}`, responseConfig, {
+  fetchMock.get(`end:${name}/log?container=${container}`, responseConfig, {
     sendAsJson: false
   });
   return getPodLog({ container, name, namespace }).then(log => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/290

Update getNamespaces, getServiceAccounts, and getPodLog APIs to use
the kube API instead of the custom dashboard REST endpoints.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
