### PR TITLE
Fix error with task API call from TaskRun page

### DIFF
--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -114,11 +114,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       if (taskRun && taskRun.spec.taskRef) {
         const { name, kind } = taskRun.spec.taskRef;
         this.props
-          .fetchTaskByType({
-            type: taskTypeKeys[kind],
-            name,
-            namespace
-          })
+          .fetchTaskByType(name, taskTypeKeys[kind], namespace)
           .then(() => {
             this.setState({ loading: false });
           });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
`[object Object]` was appearing in API call to retrieve a single task by name.
Fix the call to the fetchTaskByType action to pass the parameters correctly.

Only impacts functionality if loading the page directly as navigating from the TaskRuns list pre-loads the tasks anyway.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
