### PR TITLE
Fix unexpected merge on websocket update events

### DIFF
--- a/src/reducers/reducerCreators.js
+++ b/src/reducers/reducerCreators.js
@@ -23,8 +23,10 @@ function createByIdReducer({ type }) {
     switch (action.type) {
       case `${type}Created`:
       case `${type}Updated`:
-        const resource = { [action.payload.metadata.uid]: action.payload };
-        return merge({}, state, resource);
+        return {
+          ...state,
+          [action.payload.metadata.uid]: action.payload
+        };
       case `${type}Deleted`:
         const newState = { ...state };
         delete newState[action.payload.metadata.uid];

--- a/src/reducers/reducerCreators.test.js
+++ b/src/reducers/reducerCreators.test.js
@@ -23,7 +23,7 @@ const createResource = (name, namespace, uid, other) => {
       namespace,
       uid
     },
-    other
+    ...other
   };
 };
 
@@ -80,24 +80,27 @@ it('PIPELINE_RESOURCES_FETCH_FAILURE', () => {
 });
 
 it('PipelineResource Events', () => {
+  const createdPipelineResource = createResource(name, namespace, uid, {
+    status: { running: true }
+  });
   const action = {
     type: 'PipelineResourceCreated',
-    payload: pipelineResource,
+    payload: createdPipelineResource,
     namespace
   };
 
   const state = reducer({}, action);
   expect(selectors.getPipelineResources(state, namespace)).toEqual([
-    pipelineResource
+    createdPipelineResource
   ]);
   expect(selectors.getPipelineResource(state, name, namespace)).toEqual(
-    pipelineResource
+    createdPipelineResource
   );
   expect(selectors.isFetchingPipelineResources(state)).toBe(false);
 
   // update pipeline resource
   const updatedPipelineResource = createResource(name, namespace, uid, {
-    fake: 'data'
+    status: { terminated: true }
   });
   const updateAction = {
     type: 'PipelineResourceUpdated',
@@ -113,7 +116,6 @@ it('PipelineResource Events', () => {
   );
 
   // delete pipeline resource
-
   const deleteAction = {
     type: 'PipelineResourceDeleted',
     payload: pipelineResource,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/91
We should replace the stored resource on a websocket update event instead of merging. This caused an issue with pipelinerun and taskrun status where it would display `waiting`, `running`, and `terminated` at the same time instead of just the expected `terminated`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
