### PR TITLE
add accept header for logs

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -181,7 +181,7 @@ export function getPodLog({ container, name, namespace }) {
     { name, namespace, subResource: 'log' },
     queryParams
   )}`;
-  return get(uri);
+  return get(uri, { Accept: 'text/plain' });
 }
 
 export function getCredentials(namespace) {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -83,7 +83,7 @@ namespaceResponse=$(curl -X GET --header Content-Type:application/json http://lo
 
 echo $namespaceResponse
 
-if [[ $namespaceResponse != *"\"name\": \"default\""* ]]; then
+if [[ $namespaceResponse != *"NamespaceList"* ]]; then
   fail_test "Could not get namespaces from dashboard proxy"
 fi
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Accept headers don always match response types. Ideally we would return the headers form the apiserver but for the logs case the request fails with 406 where the header `accept:text/plain` is passed

https://github.com/kubernetes/kubernetes/issues/61450

https://github.com/kubernetes/kubernetes/issues/61450


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
