### PR TITLE
Fix colour issue with error message in ClusterTasks

### DIFF
--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -52,6 +52,7 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
           kind="error"
           title="Error loading tasks"
           subtitle={error}
+          lowContrast
         />
       );
     }


### PR DESCRIPTION
References task #305 

Changes the colour of the error box in ClusterTasks to be the same colour as the other tabs 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
