### PR TITLE
Display failed init steps

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -97,6 +97,26 @@ export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
       id: step.name
     };
   });
+
+  /*
+    In case of failure in an init step (git-source, init-creds, etc.),
+    include that step in the displayed list so we can surface status
+    and logs to aid the user in debugging.
+   */
+  taskRunStepsStatus.forEach(stepStatus => {
+    const { name: stepName, terminated } = stepStatus;
+    const step = taskSteps.find(taskStep => taskStep.name === stepName);
+    if (!step && terminated && terminated.exitCode !== 0) {
+      steps.push({
+        reason: terminated.reason,
+        status: 'terminated',
+        stepStatus,
+        stepName,
+        id: stepName
+      });
+    }
+  });
+
   return steps;
 }
 

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -191,6 +191,14 @@ it('stepsStatus step is waiting', () => {
   expect(returnedStep.status).toEqual('waiting');
 });
 
+it('stepsStatus init error', () => {
+  const stepName = 'git-source';
+  const taskRunStepsStatus = [{ name: stepName, terminated: { exitCode: 1 } }];
+  const steps = stepsStatus([], taskRunStepsStatus);
+  const returnedStep = steps[0];
+  expect(returnedStep.status).toEqual('terminated');
+});
+
 it('typeToPlural', () => {
   expect(typeToPlural('Extension')).toEqual('EXTENSIONS');
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/200

In case of failure with an init step (e.g. git-source, init-creds)
we should display this in the task tree on the PipelineRun and
TaskRun views to aid in debugging failures.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
