### PR TITLE
Ensure consistent use of CRD names

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -19,8 +19,8 @@ import Breadcrumbs from './Breadcrumbs';
 
 storiesOf('Breadcrumbs', module)
   .addDecorator(StoryRouter())
-  .add('pipelines', () => <Breadcrumbs match={{ url: '/pipelines' }} />)
-  .add('pipeline run', () => (
+  .add('Pipelines', () => <Breadcrumbs match={{ url: '/pipelines' }} />)
+  .add('PipelineRun', () => (
     <Breadcrumbs
       match={{ url: '/pipelines/demo-pipeline/runs/demo-pipeline-run-1' }}
     />

--- a/src/components/RunHeader/RunHeader.stories.js
+++ b/src/components/RunHeader/RunHeader.stories.js
@@ -23,7 +23,7 @@ storiesOf('RunHeader', module)
   .add('default', () => (
     <RunHeader
       name={text('Pipeline Name', 'simple-pipeline')}
-      runName={text('Pipeline Run Name', 'simple-pipeline-run-1')}
+      runName={text('PipelineRun Name', 'simple-pipeline-run-1')}
       type={text('Run Type', 'pipelines')}
       typeLabel={text('Run Type Label', 'Pipelines')}
     />
@@ -31,7 +31,7 @@ storiesOf('RunHeader', module)
   .add('running', () => (
     <RunHeader
       name={text('Pipeline Name', 'simple-pipeline')}
-      runName={text('Pipeline Run Name', 'simple-pipeline-run-1')}
+      runName={text('PipelineRun Name', 'simple-pipeline-run-1')}
       reason="Running"
       status="Unknown"
       type={text('Run Type', 'pipelines')}
@@ -41,7 +41,7 @@ storiesOf('RunHeader', module)
   .add('complete', () => (
     <RunHeader
       name={text('Pipeline Name', 'simple-pipeline')}
-      runName={text('Pipeline Run Name', 'simple-pipeline-run-1')}
+      runName={text('PipelineRun Name', 'simple-pipeline-run-1')}
       status="True"
       reason="Completed"
       type={text('Run Type', 'pipelines')}
@@ -51,7 +51,7 @@ storiesOf('RunHeader', module)
   .add('failed', () => (
     <RunHeader
       name={text('Pipeline Name', 'simple-pipeline')}
-      runName={text('Pipeline Run Name', 'simple-pipeline-run-1')}
+      runName={text('PipelineRun Name', 'simple-pipeline-run-1')}
       status="False"
       reason="Failed"
       type={text('Run Type', 'pipelines')}

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -49,8 +49,9 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
     if (error) {
       return (
         <InlineNotification
+          hideCloseButton
           kind="error"
-          title="Error loading cluster tasks"
+          title="Error loading ClusterTasks"
           subtitle={error}
           lowContrast
         />
@@ -60,14 +61,14 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
       <StructuredListWrapper border selection>
         <StructuredListHead>
           <StructuredListRow head>
-            <StructuredListCell head>Cluster Task</StructuredListCell>
+            <StructuredListCell head>ClusterTask</StructuredListCell>
             <StructuredListCell head />
           </StructuredListRow>
         </StructuredListHead>
         <StructuredListBody>
           {!clusterTasks.length && (
             <StructuredListRow>
-              <StructuredListCell>No cluster tasks</StructuredListCell>
+              <StructuredListCell>No ClusterTasks</StructuredListCell>
             </StructuredListRow>
           )}
           {clusterTasks.map(task => {
@@ -79,7 +80,7 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
                 </StructuredListCell>
                 <StructuredListCell>
                   <Link
-                    title="cluster task definition"
+                    title="ClusterTask definition"
                     to={`/clustertasks/${taskName}`}
                   >
                     <Information16 className="resource-info-icon" />

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -342,7 +342,7 @@ class CreatePipelineRun extends React.Component {
             </FormGroup>
           )}
           {resourceSpecs && resourceSpecs.length !== 0 && (
-            <FormGroup legendText="Pipeline Resources">
+            <FormGroup legendText="PipelineResources">
               {resourceSpecs.map(resourceSpec => (
                 <PipelineResourcesDropdown
                   id={`create-pipelinerun--pr-dropdown-${resourceSpec.name}`}
@@ -354,7 +354,7 @@ class CreatePipelineRun extends React.Component {
                   invalid={
                     validationError && !this.state.resources[resourceSpec.name]
                   }
-                  invalidText="Pipeline Resources cannot be empty"
+                  invalidText="PipelineResources cannot be empty"
                   selectedItem={(() => {
                     const value = this.state.resources[resourceSpec.name];
                     return value ? { id: value, text: value } : '';

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -186,7 +186,7 @@ const props = {
 const validationErrorMsgRegExp = /please fix the fields with errors, then resubmit/i;
 const namespaceValidationErrorRegExp = /namespace cannot be empty/i;
 const pipelineValidationErrorRegExp = /pipeline cannot be empty/i;
-const pipelineResourceValidationErrorRegExp = /pipeline resources cannot be empty/i;
+const pipelineResourceValidationErrorRegExp = /pipelineresources cannot be empty/i;
 const paramsValidationErrorRegExp = /params cannot be empty/i;
 const apiErrorRegExp = /error creating pipelinerun/i;
 
@@ -231,9 +231,9 @@ const selectPipeline1 = getByText => {
 };
 
 const fillPipeline1Resources = getByText => {
-  fireEvent.click(getByText(/select pipeline resource/i));
+  fireEvent.click(getByText(/select pipelineresource/i));
   fireEvent.click(getByText(/pipeline-resource-1/i));
-  fireEvent.click(getByText(/select pipeline resource/i));
+  fireEvent.click(getByText(/select pipelineresource/i));
   fireEvent.click(getByText(/pipeline-resource-2/i));
 };
 

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -83,7 +83,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
       <StructuredListWrapper border selection>
         <StructuredListHead>
           <StructuredListRow head>
-            <StructuredListCell head>Pipeline Resource</StructuredListCell>
+            <StructuredListCell head>PipelineResource</StructuredListCell>
             {selectedNamespace === ALL_NAMESPACES && (
               <StructuredListCell head>Namespace</StructuredListCell>
             )}

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
@@ -38,13 +38,13 @@ class PipelineResourcesDropdown extends React.Component {
 
   render() {
     const { namespace, type, ...rest } = this.props;
-    let emptyText = `No Pipeline Resources found`;
+    let emptyText = 'No PipelineResources found';
     if (type && namespace !== ALL_NAMESPACES) {
-      emptyText = `No Pipeline Resources found of type '${type}' in the '${namespace}' namespace`;
+      emptyText = `No PipelineResources found of type '${type}' in the '${namespace}' namespace`;
     } else if (type) {
-      emptyText = `No Pipeline Resources found of type '${type}'`;
+      emptyText = `No PipelineResources found of type '${type}'`;
     } else if (namespace !== ALL_NAMESPACES) {
-      emptyText = `No Pipeline Resources found in the '${namespace}' namespace`;
+      emptyText = `No PipelineResources found in the '${namespace}' namespace`;
     }
     return <TooltipDropdown {...rest} emptyText={emptyText} />;
   }
@@ -53,8 +53,8 @@ class PipelineResourcesDropdown extends React.Component {
 PipelineResourcesDropdown.defaultProps = {
   items: [],
   loading: false,
-  label: 'Select Pipeline Resource',
-  titleText: 'Pipeline Resource'
+  label: 'Select PipelineResource',
+  titleText: 'PipelineResource'
 };
 
 function mapStateToProps(state, ownProps) {

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -102,7 +102,7 @@ const namespacesStoreAll = {
   }
 };
 
-const initialTextRegExp = new RegExp('select pipeline resource', 'i');
+const initialTextRegExp = new RegExp('select pipelineresource', 'i');
 
 const checkDropdownItems = ({
   queryByText,
@@ -282,7 +282,7 @@ it('PipelineResourcesDropdown renders empty', () => {
     </Provider>
   );
   expect(
-    queryByText(/no pipeline resources found in the 'blue' namespace/i)
+    queryByText(/no pipelineresources found in the 'blue' namespace/i)
   ).toBeTruthy();
   expect(queryByText(initialTextRegExp)).toBeFalsy();
 });
@@ -301,7 +301,7 @@ it('PipelineResourcesDropdown renders empty all namespaces', () => {
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
-  expect(queryByText(/no pipeline resources found/i)).toBeTruthy();
+  expect(queryByText(/no pipelineresources found/i)).toBeTruthy();
   expect(queryByText(initialTextRegExp)).toBeFalsy();
 });
 
@@ -321,7 +321,7 @@ it('PipelineResourcesDropdown renders empty with type', () => {
   );
   expect(
     queryByText(
-      /no pipeline resources found of type 'bogus' in the 'blue' namespace/i
+      /no pipelineresources found of type 'bogus' in the 'blue' namespace/i
     )
   ).toBeTruthy();
   expect(queryByText(initialTextRegExp)).toBeFalsy();
@@ -342,7 +342,7 @@ it('PipelineResourcesDropdown renders empty with type and all namespaces', () =>
     </Provider>
   );
   expect(
-    queryByText(/no pipeline resources found of type 'bogus'/i)
+    queryByText(/no pipelineresources found of type 'bogus'/i)
   ).toBeTruthy();
   expect(queryByText(initialTextRegExp)).toBeFalsy();
 });

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -163,7 +163,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           kind="error"
           hideCloseButton
           lowContrast
-          title="Error loading pipeline run"
+          title="Error loading PipelineRun"
           subtitle={JSON.stringify(error, Object.getOwnPropertyNames(error))}
         />
       );
@@ -175,8 +175,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           kind="info"
           hideCloseButton
           lowContrast
-          title="Cannot load pipeline run"
-          subtitle={`Pipeline Run ${pipelineRunName} not found`}
+          title="Cannot load PipelineRun"
+          subtitle={`PipelineRun ${pipelineRunName} not found`}
         />
       );
     }

--- a/src/containers/PipelineRun/PipelineRun.test.js
+++ b/src/containers/PipelineRun/PipelineRun.test.js
@@ -61,7 +61,7 @@ it('PipelineRunContainer renders', async () => {
     </Provider>
   );
   await waitForElement(() =>
-    getByText(`Pipeline Run ${pipelineRunName} not found`)
+    getByText(`PipelineRun ${pipelineRunName} not found`)
   );
 });
 
@@ -102,5 +102,5 @@ it('PipelineRunContainer handles error state', async () => {
       />
     </Provider>
   );
-  await waitForElement(() => getByText('Error loading pipeline run'));
+  await waitForElement(() => getByText('Error loading PipelineRun'));
 });

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -123,7 +123,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
           kind="error"
           hideCloseButton
           lowContrast
-          title="Error loading pipeline runs"
+          title="Error loading PipelineRuns"
           subtitle={JSON.stringify(error)}
         />
       );
@@ -161,7 +161,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
         <StructuredListWrapper border selection>
           <StructuredListHead>
             <StructuredListRow head>
-              <StructuredListCell head>Pipeline Run</StructuredListCell>
+              <StructuredListCell head>PipelineRun</StructuredListCell>
               {!pipelineName && (
                 <StructuredListCell head>Pipeline</StructuredListCell>
               )}
@@ -178,9 +178,9 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
               <StructuredListRow>
                 <StructuredListCell>
                   {pipelineName ? (
-                    <span>No pipeline runs for {pipelineName}</span>
+                    <span>No PipelineRuns for {pipelineName}</span>
                   ) : (
-                    <span>No pipeline runs</span>
+                    <span>No PipelineRuns</span>
                   )}
                 </StructuredListCell>
               </StructuredListRow>

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -67,7 +67,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
           kind="error"
           hideCloseButton
           lowContrast
-          title="Error loading pipelines"
+          title="Error loading Pipelines"
           subtitle={error}
         />
       );
@@ -87,7 +87,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
         <StructuredListBody>
           {!pipelines.length && (
             <StructuredListRow>
-              <StructuredListCell>No pipelines</StructuredListCell>
+              <StructuredListCell>No Pipelines</StructuredListCell>
             </StructuredListRow>
           )}
           {pipelines.map(pipeline => {
@@ -104,7 +104,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
                 )}
                 <StructuredListCell>
                   <Link
-                    title="pipeline definition"
+                    title="Pipeline definition"
                     to={`/namespaces/${namespace}/pipelines/${name}`}
                   >
                     <Information16 className="resource-info-icon" />

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -42,8 +42,8 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
   static notification(notification) {
     const { kind, message } = notification;
     const titles = {
-      info: 'Task run not available',
-      error: 'Error loading task run'
+      info: 'TaskRun not available',
+      error: 'Error loading TaskRun'
     };
     return (
       <InlineNotification
@@ -135,7 +135,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     if (error) {
       return TaskRunContainer.notification({
         kind: 'error',
-        message: 'Error loading task run'
+        message: 'Error loading TaskRun'
       });
     }
 
@@ -144,7 +144,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     if (!taskRun) {
       return TaskRunContainer.notification({
         kind: 'info',
-        message: 'Task run not available'
+        message: 'TaskRun not available'
       });
     }
 

--- a/src/containers/TaskRunList/TaskRunList.js
+++ b/src/containers/TaskRunList/TaskRunList.js
@@ -69,7 +69,7 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
           kind="error"
           hideCloseButton
           lowContrast
-          title="Error loading task runs"
+          title="Error loading TaskRuns"
           subtitle={JSON.stringify(error)}
         />
       );
@@ -79,7 +79,7 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
       <StructuredListWrapper border selection>
         <StructuredListHead>
           <StructuredListRow head>
-            <StructuredListCell head>Task Run</StructuredListCell>
+            <StructuredListCell head>TaskRun</StructuredListCell>
             <StructuredListCell head>Task</StructuredListCell>
             {selectedNamespace === ALL_NAMESPACES && (
               <StructuredListCell head>Namespace</StructuredListCell>
@@ -93,7 +93,7 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
           {!taskRuns.length && (
             <StructuredListRow>
               <StructuredListCell>
-                <span>No task runs</span>
+                <span>No TaskRuns</span>
               </StructuredListCell>
             </StructuredListRow>
           )}

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -45,8 +45,8 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   static notification(notification) {
     const { kind, message } = notification;
     const titles = {
-      info: 'Task runs not available',
-      error: 'Error loading task run'
+      info: 'TaskRuns not available',
+      error: 'Error loading TaskRun'
     };
     return (
       <InlineNotification
@@ -138,7 +138,7 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
     if (error) {
       return TaskRunsContainer.notification({
         kind: 'error',
-        message: 'Error loading task runs'
+        message: 'Error loading TaskRuns'
       });
     }
 

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -60,7 +60,7 @@ it('TaskRunsContainer renders', async () => {
 });
 
 it('TaskRunsContainer handles info state', async () => {
-  const notificationMessage = 'Task runs not available';
+  const notificationMessage = 'TaskRuns not available';
   const taskName = 'taskName';
   const match = {
     params: {
@@ -122,5 +122,5 @@ it('TaskRunsContainer handles error state', async () => {
       <TaskRuns match={match} />
     </Provider>
   );
-  await waitForElement(() => getByText('Error loading task run'));
+  await waitForElement(() => getByText('Error loading TaskRun'));
 });

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -61,7 +61,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
           kind="error"
           hideCloseButton
           lowContrast
-          title="Error loading tasks"
+          title="Error loading Tasks"
           subtitle={error}
         />
       );
@@ -81,7 +81,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
         <StructuredListBody>
           {!tasks.length && (
             <StructuredListRow>
-              <StructuredListCell>No tasks</StructuredListCell>
+              <StructuredListCell>No Tasks</StructuredListCell>
             </StructuredListRow>
           )}
           {tasks.map(task => {
@@ -98,7 +98,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
                 )}
                 <StructuredListCell>
                   <Link
-                    title="task definition"
+                    title="Task definition"
                     to={`/namespaces/${namespace}/tasks/${taskName}`}
                   >
                     <Information16 className="resource-info-icon" />


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/324

We surface CRD names in a number of places in the UI, e.g.:
- navigation
- error messages
- tooltips
- headings

These should all be consistent with one another, using the correct
value to reference the CRD. For example, instead of 'cluster task'
we should use 'ClusterTask'.

This PR ensure consistent use of these names across the UI.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
