### PR TITLE
Ensure error messages are displayed in a consistent manner

### DIFF
--- a/src/components/RunHeader/RunHeader.js
+++ b/src/components/RunHeader/RunHeader.js
@@ -20,7 +20,6 @@ import './RunHeader.scss';
 class RunHeader extends Component {
   render() {
     const {
-      error,
       lastTransitionTime,
       loading,
       pipelineRun,
@@ -36,9 +35,6 @@ class RunHeader extends Component {
         data-reason={reason}
       >
         {(() => {
-          if (error) {
-            return <h1>{error}</h1>;
-          }
           if (loading) {
             return <SkeletonPlaceholder className="header-skeleton" />;
           }

--- a/src/components/RunHeader/RunHeader.stories.js
+++ b/src/components/RunHeader/RunHeader.stories.js
@@ -58,7 +58,4 @@ storiesOf('RunHeader', module)
       typeLabel={text('Run Type Label', 'Pipelines')}
     />
   ))
-  .add('error', () => (
-    <RunHeader error={text('Error', 'Something went wrong')} />
-  ))
   .add('loading', () => <RunHeader loading />);

--- a/src/components/RunHeader/RunHeader.test.js
+++ b/src/components/RunHeader/RunHeader.test.js
@@ -46,10 +46,3 @@ it('RunHeader renders the failed state', () => {
   );
   expect(queryByText(/failed/i)).toBeTruthy();
 });
-
-it('RunHeader renders the pending state', () => {
-  const { queryByText } = renderWithRouter(
-    <RunHeader {...props} error="an error message" />
-  );
-  expect(queryByText(/an error message/i)).toBeTruthy();
-});

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -31,6 +31,7 @@ import {
   getClusterTasksErrorMessage,
   isFetchingClusterTasks
 } from '../../reducers';
+import { getErrorMessage } from '../../utils';
 
 import '../../components/Definitions/Definitions.scss';
 
@@ -52,7 +53,7 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
           hideCloseButton
           kind="error"
           title="Error loading ClusterTasks"
-          subtitle={error}
+          subtitle={getErrorMessage(error)}
           lowContrast
         />
       );

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -22,6 +22,7 @@ import jsYaml from 'js-yaml';
 
 import { fetchClusterTask, fetchTask } from '../../actions/tasks';
 import { fetchPipeline } from '../../actions/pipelines';
+import { getErrorMessage } from '../../utils';
 
 import {
   getClusterTask,
@@ -91,7 +92,7 @@ export /* istanbul ignore next */ class CustomResourceDefinition extends Compone
           hideCloseButton
           lowContrast
           title="Error loading resource"
-          subtitle={JSON.stringify(error)}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -29,6 +29,7 @@ import {
   getExtensionsErrorMessage,
   isFetchingExtensions
 } from '../../reducers';
+import { getErrorMessage } from '../../utils';
 
 import '../../components/Definitions/Definitions.scss';
 
@@ -48,7 +49,7 @@ export const Extensions = /* istanbul ignore next */ ({
         hideCloseButton
         lowContrast
         title="Error loading extensions"
-        subtitle={error}
+        subtitle={getErrorMessage(error)}
       />
     );
   }

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -25,6 +25,7 @@ import {
   getPipelineResourcesErrorMessage,
   isFetchingPipelineResources
 } from '../../reducers';
+import { getErrorMessage } from '../../utils';
 
 import { fetchPipelineResource } from '../../actions/pipelineResources';
 
@@ -88,7 +89,7 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
           hideCloseButton
           lowContrast
           title="Error loading PipelineResource"
-          subtitle={JSON.stringify(error, Object.getOwnPropertyNames(error))}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -25,6 +25,7 @@ import {
 } from 'carbon-components-react';
 
 import { ALL_NAMESPACES } from '../../constants';
+import { getErrorMessage } from '../../utils';
 import { fetchPipelineResources } from '../../actions/pipelineResources';
 
 import {
@@ -74,7 +75,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
           hideCloseButton
           lowContrast
           title="Error loading PipelineResources"
-          subtitle={JSON.stringify(error)}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -38,6 +38,7 @@ import RunHeader from '../../components/RunHeader';
 import StepDetails from '../../components/StepDetails';
 import TaskTree from '../../components/TaskTree';
 import {
+  getErrorMessage,
   getStatus,
   selectedTask,
   selectedTaskRun,
@@ -183,7 +184,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           hideCloseButton
           lowContrast
           title="Error loading PipelineRun"
-          subtitle={JSON.stringify(error, Object.getOwnPropertyNames(error))}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -29,7 +29,12 @@ import Add from '@carbon/icons-react/lib/add/16';
 import './PipelineRuns.scss';
 
 import { ALL_NAMESPACES } from '../../constants';
-import { getStatus, getStatusIcon, isRunning } from '../../utils';
+import {
+  getErrorMessage,
+  getStatus,
+  getStatusIcon,
+  isRunning
+} from '../../utils';
 import { fetchPipelineRuns } from '../../actions/pipelineRuns';
 
 import {
@@ -124,7 +129,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
           hideCloseButton
           lowContrast
           title="Error loading PipelineRuns"
-          subtitle={JSON.stringify(error)}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -34,6 +34,7 @@ import {
   getSelectedNamespace,
   isFetchingPipelines
 } from '../../reducers';
+import { getErrorMessage } from '../../utils';
 
 import '../../components/Definitions/Definitions.scss';
 
@@ -68,7 +69,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
           hideCloseButton
           lowContrast
           title="Error loading Pipelines"
-          subtitle={error}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -27,6 +27,7 @@ import {
   getSecretsErrorMessage,
   isFetchingSecrets
 } from '../../reducers';
+import { getErrorMessage } from '../../utils';
 
 export /* istanbul ignore next */ class Secrets extends Component {
   constructor(props) {
@@ -80,7 +81,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
           <InlineNotification
             kind="error"
             title="Error:"
-            subtitle={error}
+            subtitle={getErrorMessage(error)}
             iconDescription="Clear Notification"
             className="notificationComponent"
             data-testid="errorNotificationComponent"

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -39,8 +39,7 @@ const taskTypeKeys = { ClusterTask: 'clustertasks', Task: 'tasks' };
 
 export /* istanbul ignore next */ class TaskRunContainer extends Component {
   // once redux store is available errors will be handled properly with dedicated components
-  static notification(notification) {
-    const { kind, message } = notification;
+  static notification({ kind, message }) {
     const titles = {
       info: 'TaskRun not available',
       error: 'Error loading TaskRun'
@@ -51,7 +50,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
         hideCloseButton
         lowContrast
         title={titles[kind]}
-        subtitle={JSON.stringify(message, Object.getOwnPropertyNames(message))}
+        subtitle={message}
       />
     );
   }

--- a/src/containers/TaskRunList/TaskRunList.js
+++ b/src/containers/TaskRunList/TaskRunList.js
@@ -25,7 +25,12 @@ import {
 } from 'carbon-components-react';
 
 import { ALL_NAMESPACES } from '../../constants';
-import { getStatus, getStatusIcon, isRunning } from '../../utils';
+import {
+  getErrorMessage,
+  getStatus,
+  getStatusIcon,
+  isRunning
+} from '../../utils';
 import { fetchTaskRuns } from '../../actions/taskRuns';
 
 import {
@@ -70,7 +75,7 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
           hideCloseButton
           lowContrast
           title="Error loading TaskRuns"
-          subtitle={JSON.stringify(error)}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -42,8 +42,7 @@ import { fetchTaskRuns } from '../../actions/taskRuns';
 
 export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   // once redux store is available errors will be handled properly with dedicated components
-  static notification(notification) {
-    const { kind, message } = notification;
+  static notification({ kind, message }) {
     const titles = {
       info: 'TaskRuns not available',
       error: 'Error loading TaskRun'
@@ -54,7 +53,7 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
         hideCloseButton
         lowContrast
         title={titles[kind]}
-        subtitle={JSON.stringify(message, Object.getOwnPropertyNames(message))}
+        subtitle={message}
       />
     );
   }

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -33,6 +33,7 @@ import {
   getTasksErrorMessage,
   isFetchingTasks
 } from '../../reducers';
+import { getErrorMessage } from '../../utils';
 
 import '../../components/Definitions/Definitions.scss';
 
@@ -62,7 +63,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
           hideCloseButton
           lowContrast
           title="Error loading Tasks"
-          subtitle={error}
+          subtitle={getErrorMessage(error)}
         />
       );
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,6 +18,14 @@ import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
 
 import Spinner from '../components/Spinner';
 
+export function getErrorMessage(error) {
+  if (!error || typeof error === 'string') {
+    return error;
+  }
+
+  return JSON.stringify(error, Object.getOwnPropertyNames(error));
+}
+
 export function getStatus(resource) {
   const { conditions = [] } = resource.status || {};
   return conditions.find(condition => condition.type === 'Succeeded') || {};

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -12,12 +12,28 @@ limitations under the License.
 */
 
 import {
+  getErrorMessage,
   getStatus,
   selectedTask,
   stepsStatus,
   taskRunStep,
   typeToPlural
 } from '.';
+
+it('getErrorMessage falsy', () => {
+  expect(getErrorMessage()).toBeUndefined();
+});
+
+it('getErrorMessage string', () => {
+  const error = 'this is an error message';
+  expect(getErrorMessage(error)).toEqual(error);
+});
+
+it('getErrorMessage object', () => {
+  const message = 'this is an error message';
+  const error = new Error(message);
+  expect(getErrorMessage(error)).toContain(`"message":"${message}"`);
+});
 
 it('getStatus', () => {
   const taskRun = {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/324

Currently some InlineNotification errors are displayed wrapped
in double quotes, while others are not. This is due to unnecessary
use of `JSON.stringify` in some cases.

Add a `getErrorMessage` util that will ensure plain strings are
displayed as they are, and that we only use `JSON.stringify` when
necessary to render `Error` objects or similar for more info.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
