### PR TITLE
secrets paneling polished

### DIFF
--- a/src/actions/secrets.test.js
+++ b/src/actions/secrets.test.js
@@ -104,7 +104,7 @@ it('fetchSecrets error', async () => {
 });
 
 it('deleteSecret', async () => {
-  const name = 'secret-name';
+  const secrets = [{ name: 'secret-name', namespace: 'default' }];
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
@@ -117,31 +117,26 @@ it('deleteSecret', async () => {
 
   const expectedActions = [
     { type: 'SECRET_DELETE_REQUEST' },
-    { type: 'SECRET_DELETE_SUCCESS', name, namespace }
+    { type: 'SECRET_DELETE_SUCCESS', secrets }
   ];
 
-  await store.dispatch(deleteSecret(name, namespace));
+  await store.dispatch(deleteSecret(secrets));
   expect(store.getActions()).toEqual(expectedActions);
 });
 
 it('deleteSecret error', async () => {
-  const secret = 'secret';
+  const secrets = [{ name: 'secret-name', namespace: 'default' }];
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore();
 
-  const error = new Error('Could not delete secret "secret"');
+  jest
+    .spyOn(API, 'deleteCredential')
+    .mockImplementation(() => Promise.reject());
 
-  jest.spyOn(API, 'deleteCredential').mockImplementation(() => {
-    throw error;
-  });
+  const expectedActions = [{ type: 'SECRET_DELETE_REQUEST' }];
 
-  const expectedActions = [
-    { type: 'SECRET_DELETE_REQUEST' },
-    { type: 'SECRET_DELETE_FAILURE', error }
-  ];
-
-  await store.dispatch(deleteSecret(secret, namespace));
+  await store.dispatch(deleteSecret(secrets));
   expect(store.getActions()).toEqual(expectedActions);
 });
 

--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.js
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.js
@@ -16,7 +16,7 @@ import { Modal } from 'carbon-components-react';
 import './SecretsDeleteModal.scss';
 
 const SecretsDeleteModal = props => {
-  const { open, id, handleClick, handleDelete } = props;
+  const { open, toBeDeleted, handleClick, handleDelete } = props;
 
   return (
     <Modal
@@ -29,9 +29,13 @@ const SecretsDeleteModal = props => {
       onRequestSubmit={handleDelete}
       onRequestClose={handleClick}
     >
-      <p>
-        Are you sure you want to delete the secret <strong>{id}</strong>?
-      </p>
+      <p>Are you sure you want to delete these secrets?</p>
+      <ul>
+        {toBeDeleted.map(secret => {
+          const { name, namespace } = secret;
+          return <li key={`${name}:${namespace}`}>{name}</li>;
+        })}
+      </ul>
     </Modal>
   );
 };

--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.scss
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.scss
@@ -19,9 +19,15 @@ limitations under the License.
     line-height: 1.75rem;
   }
 
-  strong {
-    font-weight: bold;
-    color: $support-01;
+  ul {
+    list-style: disc;
+    padding: 5px 0 0 20px;
+    li {
+      font-weight: bold;
+      color: $support-01;
+      font-size: 1.25rem;
+      margin-bottom: 5px;
+    }
   }
 
   .bx--modal-footer {

--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.test.js
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.test.js
@@ -15,15 +15,35 @@ import React from 'react';
 import { fireEvent, render } from 'react-testing-library';
 import SecretsDeleteModal from './SecretsDeleteModal';
 
-it('SecretsDeleteModal renders with passed secret id', () => {
+it('SecretsDeleteModal renders with one passed secret', () => {
   const props = {
     open: true,
-    id: 'dummySecret',
+    toBeDeleted: [{ name: 'secret-name', namespace: 'default' }],
     handleClick() {},
     handleDelete() {}
   };
   const { queryByText } = render(<SecretsDeleteModal {...props} />);
-  expect(queryByText('dummySecret')).toBeTruthy();
+  expect(queryByText('secret-name')).toBeTruthy();
+  expect(queryByText('Cancel')).toBeTruthy();
+  expect(queryByText('Delete')).toBeTruthy();
+  expect(queryByText('Delete Secret')).toBeTruthy();
+});
+
+it('SecretsDeleteModal renders with multiple passed secrets', () => {
+  const props = {
+    open: true,
+    toBeDeleted: [
+      { name: 'secret-name', namespace: 'default' },
+      { name: 'other-secret', namespace: 'default' },
+      { name: 'another-one', namespace: 'default' }
+    ],
+    handleClick() {},
+    handleDelete() {}
+  };
+  const { queryByText } = render(<SecretsDeleteModal {...props} />);
+  expect(queryByText('secret-name')).toBeTruthy();
+  expect(queryByText('other-secret')).toBeTruthy();
+  expect(queryByText('another-one')).toBeTruthy();
   expect(queryByText('Cancel')).toBeTruthy();
   expect(queryByText('Delete')).toBeTruthy();
   expect(queryByText('Delete Secret')).toBeTruthy();
@@ -34,7 +54,7 @@ it('Test SecretsDeleteModal click events', () => {
   const handleDelete = jest.fn();
   const props = {
     open: true,
-    id: 'dummySecret',
+    toBeDeleted: [{ name: 'secret-name', namespace: 'default' }],
     handleClick,
     handleDelete
   };
@@ -42,7 +62,7 @@ it('Test SecretsDeleteModal click events', () => {
   const { queryByText, rerender } = render(<SecretsDeleteModal {...props} />);
   fireEvent.click(queryByText('Delete'));
   expect(handleDelete).toHaveBeenCalledTimes(1);
-  rerender(<SecretsDeleteModal open={false} />);
+  rerender(<SecretsDeleteModal {...props} open={false} />);
   fireEvent.click(queryByText('Delete'));
   expect(handleClick).toHaveBeenCalledTimes(0);
 });

--- a/src/components/SecretsModal/Annotations.js
+++ b/src/components/SecretsModal/Annotations.js
@@ -61,6 +61,8 @@ const Annotations = props => {
         <Remove className="removeIcon" onClick={handleRemove} />
         <Add className="addIcon" onClick={handleAdd} />
       </div>
+      {invalidFields.find(field => field.includes('annotation-value')) !==
+        undefined && <p className="invalidAnnotation">Required.</p>}
       {annotationFields}
     </div>
   );

--- a/src/components/SecretsModal/BasicAuthFields.js
+++ b/src/components/SecretsModal/BasicAuthFields.js
@@ -14,12 +14,15 @@ limitations under the License.
 import React from 'react';
 import { TextInput } from 'carbon-components-react';
 import './SecretsModal.scss';
+import ServiceAccountsDropdown from '../../containers/ServiceAccountsDropdown';
 
 const BasicAuthFields = props => {
   const {
     username,
     password,
-    handleChange,
+    namespace,
+    handleChangeTextInput,
+    handleChangeServiceAccount,
     invalidFields,
     serviceAccount
   } = props;
@@ -31,8 +34,9 @@ const BasicAuthFields = props => {
         placeholder="example@domain.com"
         value={username}
         labelText="Email:"
-        onChange={handleChange}
+        onChange={handleChangeTextInput}
         invalid={invalidFields.indexOf('username') > -1}
+        invalidText="Required."
       />
       <TextInput
         id="password"
@@ -41,19 +45,20 @@ const BasicAuthFields = props => {
         value={password}
         placeholder="********"
         labelText="Password/Token:"
-        onChange={handleChange}
+        onChange={handleChangeTextInput}
         invalid={invalidFields.indexOf('password') > -1}
+        invalidText="Required."
       />
-      <TextInput
+      <ServiceAccountsDropdown
         id="serviceAccount"
-        autoComplete="off"
-        type="serviceAccount"
-        value={serviceAccount}
-        placeholder="default"
-        labelText="Service Account:"
-        onChange={handleChange}
+        titleText="Service Account"
+        namespace={namespace}
+        selectedItem={
+          serviceAccount ? { id: serviceAccount, text: serviceAccount } : ''
+        }
+        onChange={handleChangeServiceAccount}
         invalid={invalidFields.indexOf('serviceAccount') > -1}
-        invalidText="Must be less than 563 characters, contain only lowercase alphanumeric characters, . or -"
+        invalidText="Required."
       />
     </>
   );

--- a/src/components/SecretsModal/SecretsModal.scss
+++ b/src/components/SecretsModal/SecretsModal.scss
@@ -18,11 +18,13 @@ limitations under the License.
     width: 30%;
   }
 
-  .bx--form-item, .bx--dropdown__wrapper{
+  .bx--form-item,
+  .bx--dropdown__wrapper {
     margin-bottom: $spacing-03;
   }
 
-  .bx--text-input__field-wrapper {
+  .bx--text-input__field-wrapper,
+  .bx--form__helper-text {
     min-width: 100%;
   }
 
@@ -43,6 +45,12 @@ limitations under the License.
 
   .annotations {
     margin-bottom: $spacing-05;
+    .invalidAnnotation {
+      color: #da1e28;
+      font-weight: 400;
+      font-size: 0.75rem;
+      letter-spacing: 0.32px;
+    }
     .labelAndButtons {
       display: flex;
       align-items: space-between;

--- a/src/components/SecretsModal/UniversalFields.js
+++ b/src/components/SecretsModal/UniversalFields.js
@@ -21,7 +21,9 @@ const itemToString = item => (item ? item.text : '');
 const UniversalFields = props => {
   const {
     name,
-    handleChange,
+    handleChangeTextInput,
+    handleChangeAccessTo,
+    handleChangeNamespace,
     accessTo,
     selectedNamespace,
     invalidFields
@@ -34,15 +36,24 @@ const UniversalFields = props => {
         placeholder="secret-name"
         value={name}
         labelText="Name:"
-        onChange={handleChange}
+        onChange={handleChangeTextInput}
         invalid={invalidFields.indexOf('name') > -1}
         invalidText="Must be less than 563 characters, contain only lowercase alphanumeric character, . or -"
         autoComplete="off"
       />
       <NamespacesDropdown
         id="namespace"
-        selectedItem={{ id: selectedNamespace, text: selectedNamespace }}
-        onChange={handleChange}
+        selectedItem={
+          selectedNamespace
+            ? {
+                id: selectedNamespace,
+                text: selectedNamespace
+              }
+            : ''
+        }
+        onChange={handleChangeNamespace}
+        invalid={invalidFields.indexOf('namespace') > -1}
+        invalidText="Required."
       />
       <Dropdown
         id="accessTo"
@@ -50,15 +61,14 @@ const UniversalFields = props => {
         label=""
         initialSelectedItem={{
           id: accessTo,
-          text: accessTo === 'git' ? 'Git Server' : 'Docker Registry',
-          component: 'accessTo'
+          text: accessTo === 'git' ? 'Git Server' : 'Docker Registry'
         }}
         items={[
-          { id: 'git', text: 'Git Server', component: 'accessTo' },
-          { id: 'docker', text: 'Docker Registry', component: 'accessTo' }
+          { id: 'git', text: 'Git Server' },
+          { id: 'docker', text: 'Docker Registry' }
         ]}
         itemToString={itemToString}
-        onChange={handleChange}
+        onChange={handleChangeAccessTo}
       />
     </>
   );

--- a/src/components/SecretsTable/Secrets.scss
+++ b/src/components/SecretsTable/Secrets.scss
@@ -13,72 +13,32 @@ limitations under the License.
 
 @import '~carbon-components/scss/globals/scss/vars';
 
-.notificationComponent {
-  position: absolute;
-  min-width: 30rem;
-  margin-bottom: $spacing-03;
-  z-index: 1000;
-  right: 0;
-  top: 7rem;
-}
-
 .secrets {
-  .header {
-    .cellText,
-    .cellIcon {
-      &:hover {
-        background: $hover-selected-ui;
-        button {
-          background: $hover-selected-ui;
-        }
-      }
-    }
-    .cellIcon {
-      fill: $support-02;
-      .bx--table-sort__icon-unsorted,
-      .bx--table-sort__icon {
-        display: none;
-      }
+  .bx--table-toolbar {
+    background: transparent;
+  }
+
+  .bx--batch-actions {
+    #delete-btn {
+      padding: 0.875rem 2.5rem 0.875rem 0.5rem;
     }
   }
 
-  .row {
-    .cellIcon {
-      fill: $support-01;
-      width: 1%;
-      white-space: nowrap;
-      text-align: center;
-      &:hover {
-        fill: $hover-danger;
-      }
-    }
-
-    .bx--inline-loading {
-      display: inline-block;
-      width: 32px;
-    }
-
-    .cellText {
-      white-space: pre;
-    }
-
-    .cellTextNone {
-      text-align: center;
-    }
-
-    .cellIconNone {
-      width: 1%;
-      white-space: nowrap;
-      text-align: center;
-    }
+  .bx--data-table thead,
+  .bx--data-table th.bx--table-column-checkbox,
+  .bx--data-table th,
+  .bx--table-sort,
+  .bx--data-table tbody,
+  .bx--data-table tbody td {
+    background-color: $ui-background;
+    background: $ui-background;
   }
 
-  .cellText:not(button),
-  .cellIcon:not(button),
-  .add,
-  .delete,
-  .cellIconNone,
-  .cellTextNone {
-    border: 3px solid white;
+  .noSecrets {
+    width: 100%;
+    text-align: center;
+    margin-top: 5px;
+    font-style: italic;
+    font-size: 1.25rem;
   }
 }

--- a/src/components/SecretsTable/SecretsTable.test.js
+++ b/src/components/SecretsTable/SecretsTable.test.js
@@ -20,12 +20,17 @@ it('SecretsTable renders with no secrets', () => {
     handleDelete() {},
     handleNew() {},
     loading: false,
-    secrets: []
+    secrets: [],
+    selectedNamespace: '*'
   };
-  const { getAllByText, queryByText } = render(<SecretsTable {...props} />);
+  const { queryByText } = render(<SecretsTable {...props} />);
   expect(queryByText(/Secret/i)).toBeTruthy();
   expect(queryByText(/Annotations/i)).toBeTruthy();
-  expect(getAllByText('-').length).toEqual(3);
+  expect(
+    queryByText(
+      "No secrets created under any namespace, click 'Add Secret' button to add a new one."
+    )
+  ).toBeTruthy();
 });
 
 it('SecretsTable renders with one secret', () => {
@@ -39,7 +44,8 @@ it('SecretsTable renders with one secret', () => {
         name: 'dummySecret',
         uid: '0'
       }
-    ]
+    ],
+    selectedNamespace: '*'
   };
   const { queryByText } = render(<SecretsTable {...props} />);
   expect(queryByText(/dummySecret/i)).toBeTruthy();
@@ -53,11 +59,13 @@ it('SecretsTable renders in loading state', () => {
     handleDelete() {},
     handleNew() {},
     loading: true,
-    secrets: []
+    secrets: [],
+    selectedNamespace: '*'
   };
-  const { queryByText } = render(<SecretsTable {...props} />);
-  expect(queryByText(/Secret/i)).toBeFalsy();
+  const { getByTestId, queryByText } = render(<SecretsTable {...props} />);
+  expect(queryByText('Secret')).toBeFalsy();
   expect(queryByText(/Annotations/i)).toBeFalsy();
+  expect(getByTestId('addButton').disabled).toBeTruthy();
 });
 
 it('SecretsTable delete click handler', () => {
@@ -72,9 +80,10 @@ it('SecretsTable delete click handler', () => {
         name: 'dummySecret',
         uid: '0'
       }
-    ]
+    ],
+    selectedNamespace: '*'
   };
   const { getByTestId } = render(<SecretsTable {...props} />);
-  fireEvent.click(getByTestId('deleteIcon'));
+  fireEvent.click(getByTestId('deleteButton'));
   expect(handleDelete).toHaveBeenCalledTimes(1);
 });

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -25,6 +25,7 @@ import {
 import {
   getSecrets,
   getSecretsErrorMessage,
+  getSelectedNamespace,
   isFetchingSecrets
 } from '../../reducers';
 
@@ -57,21 +58,20 @@ export /* istanbul ignore next */ class Secrets extends Component {
     });
   };
 
-  handleDeleteSecretClick = value => {
+  handleDeleteSecretClick = secrets => {
     this.setState({
       openDeleteSecret: true,
-      toBeDeleted: value
+      toBeDeleted: secrets
     });
   };
 
   delete = () => {
-    const { name, namespace } = this.state.toBeDeleted;
-    this.props.deleteSecret(name, namespace);
+    this.props.deleteSecret(this.state.toBeDeleted);
     this.handleDeleteSecretToggle();
   };
 
   render() {
-    const { secrets, loading, error } = this.props;
+    const { loading, error, secrets, selectedNamespace } = this.props;
     const { openNewSecret, toBeDeleted, openDeleteSecret } = this.state;
 
     return (
@@ -85,6 +85,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
             className="notificationComponent"
             data-testid="errorNotificationComponent"
             onCloseButtonClick={this.props.clearNotification}
+            lowContrast
           />
         )}
         <Table
@@ -92,6 +93,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
           handleDelete={this.handleDeleteSecretClick}
           loading={loading}
           secrets={secrets}
+          selectedNamespace={selectedNamespace}
         />
         {openNewSecret && (
           <Modal open={openNewSecret} handleNew={this.handleNewSecretClick} />
@@ -101,7 +103,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
             open={openDeleteSecret}
             handleClick={this.handleDeleteSecretToggle}
             handleDelete={this.delete}
-            id={toBeDeleted.name}
+            toBeDeleted={toBeDeleted}
           />
         )}
       </>
@@ -117,14 +119,15 @@ function mapStateToProps(state) {
   return {
     error: getSecretsErrorMessage(state),
     loading: isFetchingSecrets(state),
-    secrets: getSecrets(state)
+    secrets: getSecrets(state),
+    selectedNamespace: getSelectedNamespace(state)
   };
 }
 
 const mapDispatchToProps = {
-  fetchSecrets,
+  clearNotification,
   deleteSecret,
-  clearNotification
+  fetchSecrets
 };
 
 export default connect(

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -46,7 +46,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
     super(props);
     this.state = {
       name: '',
-      namespace: 'default',
+      namespace: '',
       accessTo: 'git',
       username: '',
       password: '',
@@ -75,6 +75,10 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       serviceAccount,
       username
     } = this.state;
+
+    if (!validateInputs(namespace, 'namespace')) {
+      invalidFields.push('namespace');
+    }
 
     if (validateInputs(name, 'name')) {
       postData.name = name;
@@ -126,21 +130,9 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
     }
   };
 
-  handleChange = e => {
-    let stateVar = '';
-    let stateValue = '';
-    if (Object.prototype.hasOwnProperty.call(e, 'target')) {
-      stateVar = e.target.id;
-      stateValue = e.target.value;
-    } else if (
-      Object.prototype.hasOwnProperty.call(e.selectedItem, 'component')
-    ) {
-      stateVar = 'accessTo';
-      stateValue = e.selectedItem.id;
-    } else {
-      stateVar = 'namespace';
-      stateValue = e.selectedItem.text;
-    }
+  handleChangeTextInput = e => {
+    const stateVar = e.target.id;
+    const stateValue = e.target.value;
     this.setState(prevState => {
       const newInvalidFields = prevState.invalidFields;
       const idIndex = newInvalidFields.indexOf(stateVar);
@@ -151,28 +143,75 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       } else if (idIndex === -1) {
         newInvalidFields.push(stateVar);
       }
+      return { [stateVar]: stateValue, invalidFields: newInvalidFields };
+    });
+  };
 
-      if (stateVar === 'accessTo') {
-        const annotations = prevState.annotations.map(annotation => {
-          let toSearch;
-          if (stateValue === 'git') {
-            toSearch = 'docker';
-          } else {
-            toSearch = 'git';
-          }
-          return {
-            label: annotation.label.split(toSearch).join(stateValue),
-            value: annotation.value,
-            id: annotation.id
-          };
-        });
-        return {
-          [stateVar]: stateValue,
-          annotations,
-          invalidFields: newInvalidFields
-        };
+  handleChangeServiceAccount = e => {
+    const stateVar = 'serviceAccount';
+    const stateValue = e.selectedItem.text;
+    this.setState(prevState => {
+      const newInvalidFields = prevState.invalidFields;
+      const idIndex = newInvalidFields.indexOf(stateVar);
+      if (validateInputs(stateValue, stateVar)) {
+        if (idIndex !== -1) {
+          newInvalidFields.splice(idIndex, 1);
+        }
+      } else if (idIndex === -1) {
+        newInvalidFields.push(stateVar);
       }
       return { [stateVar]: stateValue, invalidFields: newInvalidFields };
+    });
+  };
+
+  handleChangeNamespace = e => {
+    const stateVar = 'namespace';
+    const stateValue = e.selectedItem.text;
+    this.setState(prevState => {
+      const newInvalidFields = prevState.invalidFields;
+      const idIndex = newInvalidFields.indexOf(stateVar);
+      if (validateInputs(stateValue, stateVar)) {
+        if (idIndex !== -1) {
+          newInvalidFields.splice(idIndex, 1);
+        }
+      } else if (idIndex === -1) {
+        newInvalidFields.push(stateVar);
+      }
+      return { [stateVar]: stateValue, invalidFields: newInvalidFields };
+    });
+  };
+
+  handleChangeAccessTo = e => {
+    const stateVar = 'accessTo';
+    const stateValue = e.selectedItem.id;
+    this.setState(prevState => {
+      const newInvalidFields = prevState.invalidFields;
+      const idIndex = newInvalidFields.indexOf(stateVar);
+      if (validateInputs(stateValue, stateVar)) {
+        if (idIndex !== -1) {
+          newInvalidFields.splice(idIndex, 1);
+        }
+      } else if (idIndex === -1) {
+        newInvalidFields.push(stateVar);
+      }
+      const annotations = prevState.annotations.map(annotation => {
+        let toSearch;
+        if (stateValue === 'git') {
+          toSearch = 'docker';
+        } else {
+          toSearch = 'git';
+        }
+        return {
+          label: annotation.label.split(toSearch).join(stateValue),
+          value: annotation.value,
+          id: annotation.id
+        };
+      });
+      return {
+        [stateVar]: stateValue,
+        annotations,
+        invalidFields: newInvalidFields
+      };
     });
   };
 
@@ -261,14 +300,18 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
             name={name}
             selectedNamespace={namespace}
             accessTo={accessTo}
-            handleChange={this.handleChange}
+            handleChangeTextInput={this.handleChangeTextInput}
+            handleChangeAccessTo={this.handleChangeAccessTo}
+            handleChangeNamespace={this.handleChangeNamespace}
             invalidFields={invalidFields}
           />
           <BasicAuthFields
             username={username}
             password={password}
             serviceAccount={serviceAccount}
-            handleChange={this.handleChange}
+            namespace={namespace}
+            handleChangeTextInput={this.handleChangeTextInput}
+            handleChangeServiceAccount={this.handleChangeServiceAccount}
             invalidFields={invalidFields}
           />
           <Annotations

--- a/src/containers/SecretsModal/SecretsModal.test.js
+++ b/src/containers/SecretsModal/SecretsModal.test.js
@@ -22,80 +22,81 @@ import * as API from '../../api';
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 
+const secrets = {
+  byNamespace: {},
+  errorMessage: null,
+  isFetching: false
+};
+
+const namespaces = {
+  byName: {
+    default: {
+      metadata: {
+        name: 'default',
+        selfLink: '/api/v1/namespaces/default',
+        uid: '32b35d3b-6ce1-11e9-af21-025000000001',
+        resourceVersion: '4',
+        creationTimestamp: '2019-05-02T13:50:08Z'
+      }
+    }
+  },
+  errorMessage: null,
+  isFetching: false,
+  selected: 'default'
+};
+
+const serviceAccountsByNamespace = {
+  blue: {
+    'service-account-1': 'id-service-account-1',
+    'service-account-2': 'id-service-account-2'
+  },
+  green: {
+    'service-account-3': 'id-service-account-3'
+  }
+};
+
+const serviceAccountsById = {
+  'id-service-account-1': {
+    metadata: {
+      name: 'service-account-1',
+      namespace: 'blue',
+      uid: 'id-service-account-1'
+    }
+  },
+  'id-service-account-2': {
+    metadata: {
+      name: 'service-account-2',
+      namespace: 'blue',
+      uid: 'id-service-account-2'
+    }
+  },
+  'id-service-account-3': {
+    metadata: {
+      name: 'service-account-3',
+      namespace: 'green',
+      uid: 'id-service-account-3'
+    }
+  }
+};
+
+const store = mockStore({
+  secrets,
+  namespaces,
+  serviceAccounts: {
+    byId: serviceAccountsById,
+    byNamespace: serviceAccountsByNamespace,
+    isFetching: false
+  }
+});
+
 it('SecretsModal renders blank', () => {
   const props = {
     open: true
   };
 
-  const secrets = {
-    byNamespace: {},
-    errorMessage: null,
-    isFetching: false
-  };
-
-  const namespaces = {
-    byName: {
-      default: {
-        metadata: {
-          name: 'default',
-          selfLink: '/api/v1/namespaces/default',
-          uid: '32b35d3b-6ce1-11e9-af21-025000000001',
-          resourceVersion: '4',
-          creationTimestamp: '2019-05-02T13:50:08Z'
-        }
-      },
-      docker: {
-        metadata: {
-          name: 'docker',
-          selfLink: '/api/v1/namespaces/docker',
-          uid: '571796bd-6ce1-11e9-af21-025000000001',
-          resourceVersion: '413',
-          creationTimestamp: '2019-05-02T13:51:09Z'
-        }
-      },
-      'kube-public': {
-        metadata: {
-          name: 'kube-public',
-          selfLink: '/api/v1/namespaces/kube-public',
-          uid: '351f8763-6ce1-11e9-af21-025000000001',
-          resourceVersion: '31',
-          creationTimestamp: '2019-05-02T13:50:12Z'
-        }
-      },
-      'kube-system': {
-        metadata: {
-          name: 'kube-system',
-          selfLink: '/api/v1/namespaces/kube-system',
-          uid: '33426195-6ce1-11e9-af21-025000000001',
-          resourceVersion: '12',
-          creationTimestamp: '2019-05-02T13:50:09Z'
-        }
-      },
-      'tekton-pipelines': {
-        metadata: {
-          name: 'tekton-pipelines',
-          selfLink: '/api/v1/namespaces/tekton-pipelines',
-          uid: 'd30b0dbf-6d08-11e9-af21-025000000001',
-          resourceVersion: '12915',
-          creationTimestamp: '2019-05-02T18:33:47Z',
-          annotations: {
-            'kubectl.kubernetes.io/last-applied-configuration':
-              '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"tekton-pipelines"}}\n'
-          }
-        }
-      }
-    },
-    errorMessage: null,
-    isFetching: false,
-    selected: 'default'
-  };
-
   jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
+  jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
 
-  const store = mockStore({
-    secrets,
-    namespaces
-  });
   const { queryByText } = render(
     <Provider store={store}>
       <SecretsModal {...props} />
@@ -114,75 +115,8 @@ it('Test SecretsModal click events', () => {
     handleNew
   };
 
-  const secrets = {
-    byNamespace: {},
-    errorMessage: null,
-    isFetching: false
-  };
-
-  const namespaces = {
-    byName: {
-      default: {
-        metadata: {
-          name: 'default',
-          selfLink: '/api/v1/namespaces/default',
-          uid: '32b35d3b-6ce1-11e9-af21-025000000001',
-          resourceVersion: '4',
-          creationTimestamp: '2019-05-02T13:50:08Z'
-        }
-      },
-      docker: {
-        metadata: {
-          name: 'docker',
-          selfLink: '/api/v1/namespaces/docker',
-          uid: '571796bd-6ce1-11e9-af21-025000000001',
-          resourceVersion: '413',
-          creationTimestamp: '2019-05-02T13:51:09Z'
-        }
-      },
-      'kube-public': {
-        metadata: {
-          name: 'kube-public',
-          selfLink: '/api/v1/namespaces/kube-public',
-          uid: '351f8763-6ce1-11e9-af21-025000000001',
-          resourceVersion: '31',
-          creationTimestamp: '2019-05-02T13:50:12Z'
-        }
-      },
-      'kube-system': {
-        metadata: {
-          name: 'kube-system',
-          selfLink: '/api/v1/namespaces/kube-system',
-          uid: '33426195-6ce1-11e9-af21-025000000001',
-          resourceVersion: '12',
-          creationTimestamp: '2019-05-02T13:50:09Z'
-        }
-      },
-      'tekton-pipelines': {
-        metadata: {
-          name: 'tekton-pipelines',
-          selfLink: '/api/v1/namespaces/tekton-pipelines',
-          uid: 'd30b0dbf-6d08-11e9-af21-025000000001',
-          resourceVersion: '12915',
-          creationTimestamp: '2019-05-02T18:33:47Z',
-          annotations: {
-            'kubectl.kubernetes.io/last-applied-configuration':
-              '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"tekton-pipelines"}}\n'
-          }
-        }
-      }
-    },
-    errorMessage: null,
-    isFetching: false,
-    selected: 'default'
-  };
-
   jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
-
-  const store = mockStore({
-    secrets,
-    namespaces
-  });
+  jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
 
   const { queryByText, rerender } = render(
     <Provider store={store}>

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -151,11 +151,9 @@ export class SideNav extends Component {
           >
             Import Tekton resources
           </SideNavMenuItem>
-          {
-            // <SideNavMenuItem element={NavLink} icon={<span />} to="/secrets">
-            //   Secrets
-            // </SideNavMenuItem>
-          }
+          <SideNavMenuItem element={NavLink} icon={<span />} to="/secrets">
+            Secrets
+          </SideNavMenuItem>
           {extensions.length > 0 &&
             extensions.map(({ displayName, name }) => (
               <SideNavMenuItem

--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -30,7 +30,10 @@ function byNamespace(state = {}, action) {
       return merge({}, state, namespaces);
     case 'SECRET_DELETE_SUCCESS':
       const newState = state;
-      delete newState[action.namespace][action.name];
+      action.secrets.forEach(secret => {
+        const { name, namespace } = secret;
+        delete newState[namespace][name];
+      });
       return newState;
     default:
       return state;

--- a/src/reducers/secrets.test.js
+++ b/src/reducers/secrets.test.js
@@ -60,10 +60,9 @@ it('SECRETS_FETCH_FAILURE', () => {
   expect(selectors.getSecretsErrorMessage(state)).toEqual(message);
 });
 
-it('SECRET_DELETE_SUCCESS', () => {
-  const name = 'name';
-  const namespace = 'default';
-  const secrets = {
+it('SECRET_DELETE_SUCCESS for one secret', () => {
+  const secrets = [{ name: 'secret-name', namespace: 'default' }];
+  const secretsState = {
     byNamespace: {
       default: {
         0: {
@@ -76,8 +75,33 @@ it('SECRET_DELETE_SUCCESS', () => {
     }
   };
 
-  const action = { type: 'SECRET_DELETE_SUCCESS', name, namespace };
-  const state = secretsReducer(secrets, action);
+  const action = { type: 'SECRET_DELETE_SUCCESS', secrets };
+  const state = secretsReducer(secretsState, action);
+
+  expect(selectors.isFetchingSecrets(state)).toBe(false);
+});
+
+it('SECRET_DELETE_SUCCESS for multiple secrets', () => {
+  const secrets = [
+    { name: 'secret-name', namespace: 'default' },
+    { name: 'other-secret', namespace: 'default' },
+    { name: 'another-one', namespace: 'default' }
+  ];
+  const secretsState = {
+    byNamespace: {
+      default: {
+        0: {
+          uid: '0',
+          name: 'github-repo-access-secret',
+          namespace: 'default',
+          annotations: {}
+        }
+      }
+    }
+  };
+
+  const action = { type: 'SECRET_DELETE_SUCCESS', secrets };
+  const state = secretsReducer(secretsState, action);
 
   expect(selectors.isFetchingSecrets(state)).toBe(false);
 });


### PR DESCRIPTION
# Changes

- Update table to match the other ones in the dashboard.

- Changed service account text field for the dropdown container.

- Made error messages more specific.

- Updated actions & reducers to delete one or more secrets.

- Updated delete modal to show all secrets selected that are about to be deleted.

- Separated handle change methods to avoid clutter. 

- Updated all the necessary tests. 