### PR TITLE
include namespace as prop for extension component

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -61,7 +61,7 @@ export /* istanbul ignore next */ class App extends Component {
   }
 
   render() {
-    const { extensions } = this.props;
+    const { extensions, namespace } = this.props;
 
     return (
       <Router>
@@ -149,6 +149,7 @@ export /* istanbul ignore next */ class App extends Component {
                     <Extension
                       displayName={displayName}
                       match={match}
+                      namespace={namespace}
                       source={source}
                     />
                   )}

--- a/src/containers/Extension/Extension.js
+++ b/src/containers/Extension/Extension.js
@@ -73,7 +73,11 @@ export default /* istanbul ignore next */ class Extension extends Component {
     return (
       <ErrorBoundary message="Error loading extension">
         <Suspense fallback={<div>Loading...</div>}>
-          <ExtensionComponent actions={actions} selectors={selectors} />
+          <ExtensionComponent
+            namespace={this.props.namespace}
+            actions={actions}
+            selectors={selectors}
+          />
         </Suspense>
       </ErrorBoundary>
     );


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
With this PR merged, the extension repo will be able to use the selected namespace to filter out the webhook shown in the table.

this is the PR in extension that depends on this PR: https://github.com/tektoncd/experimental/pull/148