### PR TITLE
Sort run list views by startTime descending

### DIFF
--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -33,7 +33,8 @@ import {
   getErrorMessage,
   getStatus,
   getStatusIcon,
-  isRunning
+  isRunning,
+  sortRunsByStartTime
 } from '../../utils';
 import { fetchPipelineRuns } from '../../actions/pipelineRuns';
 
@@ -133,6 +134,8 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
         />
       );
     }
+
+    sortRunsByStartTime(pipelineRuns);
 
     return (
       <>

--- a/src/containers/TaskRunList/TaskRunList.js
+++ b/src/containers/TaskRunList/TaskRunList.js
@@ -29,7 +29,8 @@ import {
   getErrorMessage,
   getStatus,
   getStatusIcon,
-  isRunning
+  isRunning,
+  sortRunsByStartTime
 } from '../../utils';
 import { fetchTaskRuns } from '../../actions/taskRuns';
 
@@ -79,6 +80,8 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
         />
       );
     }
+
+    sortRunsByStartTime(taskRuns);
 
     return (
       <StructuredListWrapper border selection>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -80,6 +80,20 @@ export function selectedTaskRun(selectedTaskId, taskRuns = []) {
   return taskRuns.find(run => run.id === selectedTaskId);
 }
 
+export function sortRunsByStartTime(runs) {
+  runs.sort((a, b) => {
+    const aTime = a.status.startTime;
+    const bTime = b.status.startTime;
+    if (!aTime) {
+      return -1;
+    }
+    if (!bTime) {
+      return 1;
+    }
+    return -1 * aTime.localeCompare(bTime);
+  });
+}
+
 export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
   const steps = taskSteps.map(step => {
     const stepStatus =

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -15,6 +15,7 @@ import {
   getErrorMessage,
   getStatus,
   selectedTask,
+  sortRunsByStartTime,
   stepsStatus,
   taskRunStep,
   typeToPlural
@@ -121,6 +122,24 @@ it('selectedTask find exists', () => {
   const expectedTask = { metadata: { name: taskName } };
   const foundTask = selectedTask(taskName, [expectedTask]);
   expect(foundTask.metadata.name).toEqual(taskName);
+});
+
+it('sortRunsByStartTime', () => {
+  const a = { name: 'a', status: { startTime: '0' } };
+  const b = { name: 'b', status: {} };
+  const c = { name: 'c', status: { startTime: '2' } };
+  const d = { name: 'd', status: { startTime: '1' } };
+  const e = { name: 'e', status: {} };
+  const f = { name: 'f', status: { startTime: '3' } };
+
+  const runs = [a, b, c, d, e, f];
+  /*
+    sort is stable on all modern browsers so
+    input order is preserved for b and e
+   */
+  const sortedRuns = [b, e, f, c, d, a];
+  sortRunsByStartTime(runs);
+  expect(runs).toEqual(sortedRuns);
 });
 
 it('stepsStatus no steps', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/356

As a user, having the most recent runs displayed at the top of the
list is very useful. This also makes sense when manually triggering
a run from the dashboard UI as it will be displayed at the top of
the list and won't require the user to scroll to see that it was
successfully triggered.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
