### PR TITLE
Ability to import resources into a target namespace

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -685,6 +685,7 @@
     "github.com/tektoncd/plumbing/scripts",
     "go.uber.org/zap",
     "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/informers",

--- a/config/pipeline0-task.yaml
+++ b/config/pipeline0-task.yaml
@@ -18,6 +18,9 @@ spec:
     - name: apply-directory
       description: The directory from which resources are to be applied
       default: ""
+    - name: target-namespace
+      description: The namespace in which to create the resources being imported
+      default: tekton-pipelines
   steps:
   - name: kubectl-apply
     image: lachlanevenson/k8s-kubectl
@@ -27,3 +30,5 @@ spec:
     - apply
     - -f
     - ${inputs.params.pathToResourceFiles}/${inputs.params.apply-directory}
+    - -n
+    - ${inputs.params.target-namespace}

--- a/config/pipeline0.yaml
+++ b/config/pipeline0.yaml
@@ -17,6 +17,9 @@ spec:
   - name: apply-directory
     description: The directory from which resources are to be applied
     default: ""
+  - name: target-namespace
+    description: The namespace in which to create the resources being imported
+    default: tekton-pipelines
   tasks:
   - name: pipeline0-task
     taskRef:
@@ -26,6 +29,8 @@ spec:
       value: ${params.pathToResourceFiles}
     - name: apply-directory
       value: ${params.apply-directory}
+    - name: target-namespace
+      value: ${params.target-namespace}
     resources:
       inputs:
       - name: git-source

--- a/config/release/gcr-tekton-dashboard.yaml
+++ b/config/release/gcr-tekton-dashboard.yaml
@@ -133,6 +133,9 @@ spec:
   - name: apply-directory
     description: The directory from which resources are to be applied
     default: ""
+  - name: target-namespace
+    description: The namespace in which to create the resources being imported
+    default: tekton-pipelines
   tasks:
   - name: pipeline0-task
     taskRef:
@@ -142,6 +145,8 @@ spec:
       value: ${params.pathToResourceFiles}
     - name: apply-directory
       value: ${params.apply-directory}
+    - name: target-namespace
+      value: ${params.target-namespace}
     resources:
       inputs:
       - name: git-source
@@ -165,6 +170,9 @@ spec:
     - name: apply-directory
       description: The directory from which resources are to be applied
       default: ""
+    - name: target-namespace
+      description: The namespace in which to create the resources being imported
+      default: tekton-pipelines
   steps:
   - name: kubectl-apply
     image: lachlanevenson/k8s-kubectl
@@ -174,3 +182,5 @@ spec:
     - apply
     - -f
     - ${inputs.params.pathToResourceFiles}/${inputs.params.apply-directory} 
+    - -n
+    - ${inputs.params.target-namespace}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7617,7 +7617,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7638,12 +7639,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7658,17 +7661,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7785,7 +7791,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7797,6 +7804,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7811,6 +7819,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7818,12 +7827,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7842,6 +7853,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7922,7 +7934,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7934,6 +7947,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8019,7 +8033,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8055,6 +8070,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8074,6 +8090,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8117,12 +8134,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -14,15 +14,20 @@ limitations under the License.
 package endpoints
 
 import (
-	"net/http"
-	"net/url"
-
 	restful "github.com/emicklei/go-restful"
 	"github.com/tektoncd/dashboard/pkg/logging"
+	"net/http"
+	"net/url"
+	"os"
 
 	"github.com/tektoncd/dashboard/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Properties : properties we want to be able to retrieve via REST
+type Properties struct {
+	InstallNamespace string
+}
 
 /* Get all tasks in a given namespace */
 func (r Resource) ProxyRequest(request *restful.Request, response *restful.Response) {
@@ -59,4 +64,10 @@ func (r Resource) GetIngress(request *restful.Request, response *restful.Respons
 		return
 	}
 	response.WriteEntity(ingressHost)
+}
+
+func (r Resource) GetProperties(request *restful.Request, response *restful.Response) {
+
+	properties := Properties{InstallNamespace: os.Getenv("INSTALLED_NAMESPACE")}
+	response.WriteEntity(properties)
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -63,6 +63,7 @@ func Register(resource endpoints.Resource) *restful.Container {
 	logging.Log.Info("Registering all endpoints")
 	registerWeb(wsContainer)
 	registerEndpoints(resource, wsContainer)
+	registerPropertiesEndpoint(resource, wsContainer)
 	registerWebsocket(resource, wsContainer)
 	registerHealthProbe(resource, wsContainer)
 	registerReadinessProbe(resource, wsContainer)
@@ -119,6 +120,7 @@ func registerEndpoints(r endpoints.Resource, container *restful.Container) {
 	wsv1.Route(wsv1.DELETE("/{namespace}/credentials/{name}").To(r.DeleteCredential))
 
 	container.Add(wsv1)
+
 }
 
 // RegisterWebsocket - this registers a websocket with which we can send log information to
@@ -155,6 +157,19 @@ func registerReadinessProbe(r endpoints.Resource, container *restful.Container) 
 	wsv4.Route(wsv4.GET("").To(r.CheckHealth))
 
 	container.Add(wsv4)
+}
+
+// Add endpoint for obtaining any properties we want to serve, such as install namespace
+func registerPropertiesEndpoint(r endpoints.Resource, container *restful.Container) {
+	logging.Log.Info("Adding API for properties")
+	wsDefaults := new(restful.WebService)
+	wsDefaults.
+		Path("/v1/properties").
+		Consumes(restful.MIME_JSON, "text/plain").
+		Produces(restful.MIME_JSON, "text/plain")
+
+	wsDefaults.Route(wsDefaults.GET("/").To(r.GetProperties))
+	container.Add(wsDefaults)
 }
 
 // Back-end extension: Requests to the URL are passed through to the Port of the Name service (extension)

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -287,3 +287,8 @@ export function getServiceAccounts({ namespace } = {}) {
   const uri = getKubeAPI('serviceaccounts', { namespace });
   return get(uri).then(checkData);
 }
+
+export function getInstallProperties() {
+  const uri = `${apiRoot}/v1/properties`;
+  return get(uri);
+}

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -23,7 +23,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { ALL_NAMESPACES } from '../../constants';
-import { createPipelineRun } from '../../api';
+import { createPipelineRun, getInstallProperties } from '../../api';
 import { getSelectedNamespace } from '../../reducers';
 import { NamespacesDropdown, ServiceAccountsDropdown } from '..';
 
@@ -96,14 +96,30 @@ export class ImportResources extends Component {
     const promise = createPipelineRun({ namespace, payload });
     promise
       .then(headers => {
-        const logsURL = headers.get('Content-Location');
-        const pipelineRunName = logsURL.substring(logsURL.lastIndexOf('/') + 1);
-        const finalURL = `/namespaces/${namespace}/pipelines/pipeline0/runs/${pipelineRunName}`;
-        this.setState({
-          logsURL: finalURL,
-          submitSuccess: true,
-          invalidInput: false
-        });
+        const props = getInstallProperties();
+        props
+          .then(properties => {
+            const logsURL = headers.get('Content-Location');
+            const pipelineRunName = logsURL.substring(
+              logsURL.lastIndexOf('/') + 1
+            );
+
+            const finalURL = `/namespaces/${
+              properties.InstallNamespace
+            }/pipelines/pipeline0/runs/${pipelineRunName}`;
+            this.setState({
+              logsURL: finalURL,
+              submitSuccess: true,
+              invalidInput: false
+            });
+          })
+          .catch(() => {
+            this.setState({
+              logsURL: `/pipelineruns`,
+              submitSuccess: true,
+              invalidInput: false
+            });
+          });
       })
       .catch(error => {
         const statusCode = error.response.status;


### PR DESCRIPTION
This code modifies pipeline0 and the import resource code, such that
the pipeline takes a target namespace as one of its inputs - essentially
making the resultant code run kubectl apply -f foo -n bar.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
