### PR TITLE
Add OpenShift install instructions using a route and scc

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,9 +5,6 @@
 Many of the instructions here replicate what's in the [tektoncd/pipeline development guide](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md), with a couple of caveats currently.
 
 - This project has not yet been tested with GKE
-- The instructions here pertain to building and deploying the backend that lets us interact with Tekton resources, as well as running the frontend locally for development.
-
-We would love to accomplish these tasks and to update this document, contributions welcome!
 
 ### Requirements
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add docs for OpenShift, tested on version 3.11 with default permissions (provisioned using IBM's Fyre service), specifically:

```
oc v3.11.0+62803d0-1
kubernetes v1.11.0+d4cacc0
features: Basic-Auth GSSAPI Kerberos SPNEGO

openshift v3.11.0+3b2d3b6-227
kubernetes v1.11.0+d4cacc0
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
