### PR TITLE
exporting getServiceAccountsErrorMessage fn in the reducer index

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -61,6 +61,12 @@ export function isFetchingServiceAccounts(state) {
   );
 }
 
+export function getServiceAccountsErrorMessage(state) {
+  return serviceAccountSelectors.getServiceAccountsErrorMessage(
+    state.serviceAccounts
+  );
+}
+
 export function isFetchingNamespaces(state) {
   return namespaceSelectors.isFetchingNamespaces(state.namespaces);
 }

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -30,6 +30,7 @@ import {
   getSecrets,
   getSecretsErrorMessage,
   getSelectedNamespace,
+  getServiceAccountsErrorMessage,
   getTaskByType,
   getTaskRun,
   getTaskRuns,
@@ -53,6 +54,7 @@ import * as pipelineResourcesSelectors from './pipelineResources';
 import * as pipelineSelectors from './pipelines';
 import * as pipelineRunsSelectors from './pipelineRuns';
 import * as secretSelectors from './secrets';
+import * as serviceAccountSelectors from './serviceAccounts';
 import * as taskSelectors from './tasks';
 import * as taskRunsSelectors from './taskRuns';
 
@@ -62,6 +64,7 @@ const pipelineResources = [{ fake: 'pipelineResource' }];
 const pipelines = [{ fake: 'pipeline' }];
 const pipelineRuns = [{ fake: 'pipelineRun' }];
 const secrets = [{ fake: 'secrets' }];
+const serviceAccounts = [{ fake: 'account' }];
 const task = { fake: 'task' };
 const tasks = [task];
 const clusterTask = { fake: 'clusterTask' };
@@ -82,6 +85,7 @@ const state = {
   pipelineResources,
   pipelines,
   secrets,
+  serviceAccounts,
   tasks,
   clusterTasks
 };
@@ -322,6 +326,17 @@ it('isFetchingSecrets', () => {
     .mockImplementation(() => true);
   expect(isFetchingSecrets(state)).toBe(true);
   expect(secretSelectors.isFetchingSecrets).toHaveBeenCalledWith(state.secrets);
+});
+
+it('getServiceAccountsErrorMessage', () => {
+  const errorMessage = 'fake error message';
+  jest
+    .spyOn(serviceAccountSelectors, 'getServiceAccountsErrorMessage')
+    .mockImplementation(() => errorMessage);
+  expect(getServiceAccountsErrorMessage(state)).toEqual(errorMessage);
+  expect(
+    serviceAccountSelectors.getServiceAccountsErrorMessage
+  ).toHaveBeenCalledWith(state.serviceAccounts);
 });
 
 it('getTasks', () => {


### PR DESCRIPTION
for this PR, https://github.com/tektoncd/experimental/pull/182 , in experimental repo to work the dashboard selector must provide the getServiceAccountsErrorMessage.