### PR TITLE
Push dashboard image based on RELEASE file to tekton-releases

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -472,3 +472,11 @@ spec:
 ```
 
 Extensions in this context are custom resources defined in the dashboard installation. The apiVersion is `dashboard.tekton.dev/v1alpha1`.
+
+## Publishing dashboard release images
+
+Commit a new version string in the RELEASE file of this repository. 
+
+Assuming all tests pass and the pull request is merged, a newly tagged image will be pushed to `gcr.io/tekton-releases/dashboard:$VERSION`, where `$VERSION` is specified in the `RELEASE` file.
+
+For example, if the RELEASE file contains `version 0.0.2`, a newly tagged `0.0.2` image will be pushed to `gcr.io/tekton-releases/dashboard:0.0.2`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -475,8 +475,4 @@ Extensions in this context are custom resources defined in the dashboard install
 
 ## Publishing dashboard release images
 
-Commit a new version string in the RELEASE file of this repository. 
-
-Assuming all tests pass and the pull request is merged, a newly tagged image will be pushed to `gcr.io/tekton-releases/dashboard:$VERSION`, where `$VERSION` is specified in the `RELEASE` file.
-
-For example, if the RELEASE file contains `version 0.0.2`, a newly tagged `0.0.2` image will be pushed to `gcr.io/tekton-releases/dashboard:0.0.2`.
+Handled by `hack/release.sh` after a manual Prow run. The version to use is extracted from the RELEASE file.

--- a/RELEASE
+++ b/RELEASE
@@ -1,0 +1,4 @@
+version 0.0.1
+# Used by test/publish-images.sh
+# If no tagged image is already found for the above version (the word after "version" is extracted and used), that image is then published
+# To do a new release, e.g. for version 0.0.2, one would edit this file and increment the number

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "Checking if RELEASE file exists and has been modified (if so we will push a newly tagged image to gcr.io-tekton-releases/dashboard"
+
+if [[ -f RELEASE ]] ; then
+  echo "Found release file containing: $(cat RELEASE)"
+  EXTRACTED_RELEASE_VERSION=$(awk -F'version ' '{print $2}' RELEASE)
+  if [[ -z "$EXTRACTED_RELEASE_VERSION" ]] ; then
+    echo "RELEASE file was found but couldn't extract the version to tag the release as"
+  else
+    echo "Found release file that specifies version ${EXTRACTED_RELEASE_VERSION}"
+    FOUND_IMAGE_TAGS=$(gcloud -q container-images list-tags)
+    if [[ $FOUND_IMAGE_TAGS == *"dashboard:${EXTRACTED_RELEASE_VERSION}"* ]]; then
+      echo "Found existing release tag on gcr.io so not republishing (manual intervention required if you really want to)"
+    else
+      dep ensure
+
+      # It's Stretch and https://github.com/tektoncd/dashboard/blob/master/package.json
+      # denotes the Node.js and npm versions
+      apt-get update
+      apt-get install -y curl
+      curl -O https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.xz
+      tar xf node-v10.15.3-linux-x64.tar.xz
+      export PATH=$PATH:$(pwd)/node-v10.15.3-linux-x64/bin
+
+      mkdir ~/.npm-global
+      npm config set prefix '~/.npm-global'
+      export PATH=$PATH:$HOME/.npm-global/bin
+      npm ci
+      npm run build_ko
+
+      # Tag it
+      gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/dashboard:latest
+
+      # Todo publish webhooks extension corresponding with this dashboard release
+      # Todo test!
+
+      export KO_DOCKER_REPO=gcr.io/tekton-releases
+      IMAGE=$(ko publish ./cmd/dashboard 2>&1 | grep "Published ${KO_DOCKER_REPO}/dashboard" | sed -n -r '/[0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+.*Published/ { s/.*Published //;p}')
+      gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/dashboard:${EXTRACTED_RELEASE_VERSION}
+    fi
+  fi
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -7617,8 +7617,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7639,14 +7638,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7661,20 +7658,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7791,8 +7785,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7804,7 +7797,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7819,7 +7811,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7827,14 +7818,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7853,7 +7842,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7934,8 +7922,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7947,7 +7934,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8033,8 +8019,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8070,7 +8055,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8090,7 +8074,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8134,14 +8117,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/test/publish-images.sh
+++ b/test/publish-images.sh
@@ -43,26 +43,3 @@ IMAGE=$(ko publish ./cmd/dashboard 2>&1 | grep "Published ${KO_DOCKER_REPO}/dash
 # Tag it
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/dashboard:latest
-
-# Todo publish webhooks extension corresponding with this dashboard release
-# Todo test!
-
-echo "Checking if RELEASE file exists and has been modified (if so we will push a newly tagged image to gcr.io-tekton-releases/dashboard"
-
-if [[ -f RELEASE ]] ; then
-  echo "Found release file containing: $(cat RELEASE)"
-  EXTRACTED_RELEASE_VERSION=$(awk -F'version ' '{print $2}' RELEASE)
-  if [[ -z "$EXTRACTED_RELEASE_VERSION" ]] ; then
-    echo "RELEASE file was found but couldn't extract the version to tag the release as"
-  else
-    echo "Found release file that specifies version ${EXTRACTED_RELEASE_VERSION}"
-    FOUND_IMAGE_TAGS=$(gcloud -q container-images list-tags)
-    if [[ $FOUND_IMAGE_TAGS == *"dashboard:${EXTRACTED_RELEASE_VERSION}"* ]]; then
-      echo "Found existing release tag on gcr.io so not republishing (manual intervention required if you really want to)"
-    else
-      export KO_DOCKER_REPO=gcr.io/tekton-releases
-      IMAGE=$(ko publish ./cmd/dashboard 2>&1 | grep "Published ${KO_DOCKER_REPO}/dashboard" | sed -n -r '/[0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+.*Published/ { s/.*Published //;p}')
-      gcloud -q container images add-tag ${IMAGE} ${KO_DOCKER_REPO}/dashboard:${EXTRACTED_RELEASE_VERSION}
-    fi
-  fi
-fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

On a merged PR, if no release images exist already for the version specified in a RELEASE file, go ahead and push/tag that image to `gcr.io/tekton-releases/dashboard:$version` as documented in DEVELOPMENT.md too.

@vdemeester please take a look 😄this is for https://github.com/tektoncd/dashboard/issues/363.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
