### PR TITLE
HTTPS support - via Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ privileged         true      [*]       RunAsAny    RunAsAny           RunAsAny  
 restricted         false     []        MustRunAs   MustRunAsRange     MustRunAs   RunAsAny    <none>     false            [configMap downwardAPI emptyDir persistentVolumeClaim projected secret]
 ```
 
+### Enable TLS for dashboard access via Ingress
+**Will only work in the cluster node**
+#### Pre-requisites:
+1. Tekton pipelines & dashboard installed
+2. dashboard repo cloned
+
+#### Steps:
+1. Edit `ingress/ingress-https-setup.sh` with all the necessary info
+2. Run the script from within the dashboard repo
+3. Access dashboard via `https://tekton-dashboard.<IP_ADDRESS>.nip.io`
+
+
 ## Install on Minishift
 
 Either follow the instructions for OpenShift above or use the operator install as per the instructions below.

--- a/ingress/https-ingress.yaml
+++ b/ingress/https-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  tls:
+  - hosts:
+    - ${URL}
+    secretName: ${CERTIFICATE_SECRET_NAME}
+  rules:
+  - host: ${URL}
+    http:
+      paths:
+      - backend:
+          serviceName: tekton-dashboard
+          servicePort: 9097

--- a/ingress/ingress-https-setup.sh
+++ b/ingress/ingress-https-setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# path to dashboard repo
+export REPO_TOP_LEVEL=$(git rev-parse --show-toplevel)
+# path to cert, keys, script & yaml file
+export INGRESS_DIR=${REPO_TOP_LEVEL}"/ingress"
+
+# certificate data
+# *Make sure names contain only lowercase alphanumeric characters, . or -. Must start & end with alphanumeric characters*
+export CERTIFICATE_KEY=""
+export CERTIFICATE_KEY_PASSPHRASE=""
+export CERTIFICATE_NAME=""
+export CERTIFICATE_SECRET_NAME=""
+export IP_ADDRESS=$(ip route get 8.8.8.8 | awk '{print $NF; exit}')
+export URL="tekton-dashboard.${IP_ADDRESS}.nip.io"
+# optional certificate information
+export COUNTRY=""
+export STATE=""
+export LOCATION=""
+export ORGANIZATION=""
+export ORGANIZATIONAl_UNIT=""
+export COMMON_NAME=$URL
+
+# delete the current route if one is created otherwise comment out this line
+oc delete $(oc get route -o name -n tekton-pipelines) -n tekton-pipelines
+
+# create a private key for the CA & add passphrase
+openssl genrsa -des3 -out ${INGRESS_DIR}/$CERTIFICATE_KEY.pem -passout pass:${CERTIFICATE_KEY_PASSPHRASE} 2048
+
+# generate the root CA
+openssl req -x509 -new -nodes -key ${INGRESS_DIR}/${CERTIFICATE_KEY}.pem -sha256 -days 1825 -out ${INGRESS_DIR}/${CERTIFICATE_NAME}.pem -passin pass:${CERTIFICATE_KEY_PASSPHRASE} -subj /C=${COUNTRY}/ST=${STATE}/L=${LOCATION}/O=${ORGANIZATION}/OU=${ORGANIZATIONAl_UNIT}/CN=${COMMON_NAME}
+
+# for some reason the key wasn't being parsed when trying to create it with oc so this command fixes it
+openssl rsa -in ${INGRESS_DIR}/${CERTIFICATE_KEY}.pem -out ${INGRESS_DIR}/${CERTIFICATE_KEY}.pem -passin pass:${CERTIFICATE_KEY_PASSPHRASE}
+
+# create the secret
+oc create secret tls ${CERTIFICATE_SECRET_NAME} --cert=${INGRESS_DIR}/${CERTIFICATE_NAME}.pem --key=${INGRESS_DIR}/${CERTIFICATE_KEY}.pem -n tekton-pipelines
+
+# populate variables in https-ingress & apply yaml file:
+envsubst < ${INGRESS_DIR}/https-ingress.yaml | kubectl apply -f -
+
+echo "Done. Now access the host with https://"${URL}


### PR DESCRIPTION
issue: #370 

# Changes
Made a script that automates the creation of a TLS certificate & applies it using ingress.
The script needs to be modified by the user with the relevant information to create the certificate.
Its worth mentioning that the key & certificate created are stored under the `etc/ssl/certs` directory. 

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)