### PR TITLE
Improve resilience of UI to namespace / resource deletion

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -100,6 +100,7 @@ export class LogContainer extends Component {
         });
       } catch {
         this.setState({
+          loading: false,
           logs: [
             intl.formatMessage({
               id: 'dashboard.pipelineRun.logFailed',

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -89,6 +89,9 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
   loadTaskRun = () => {
     const { task } = this.props;
     let { taskRun } = this.props;
+    if (!taskRun) {
+      return null;
+    }
     let { steps } = taskRun.status;
     if (task) {
       steps = task.spec.steps; // eslint-disable-line

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -96,32 +96,37 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   loadTaskRuns = () => {
     const { task } = this.props;
     let { taskRuns } = this.props;
-    taskRuns = taskRuns.map(taskRun => {
-      const taskName = taskRun.spec.taskRef.name;
-      const taskRunName = taskRun.metadata.name;
-      const taskRunNamespace = taskRun.metadata.namespace;
-      const { reason, status: succeeded } = getStatus(taskRun);
-      const pipelineTaskName = taskRunName;
-      const runSteps = stepsStatus(task.spec.steps, taskRun.status.steps);
-      const { params, resources: inputResources } = taskRun.spec.inputs;
-      const { resources: outputResources } = taskRun.spec.outputs;
-      const { startTime } = taskRun.status;
-      return {
-        id: taskRun.metadata.uid,
-        pipelineTaskName,
-        pod: taskRun.status.podName,
-        reason,
-        steps: runSteps,
-        succeeded,
-        taskName,
-        taskRunName,
-        startTime,
-        namespace: taskRunNamespace,
-        params,
-        inputResources,
-        outputResources
-      };
-    });
+    taskRuns = taskRuns
+      .map(taskRun => {
+        if (!taskRun) {
+          return null;
+        }
+        const taskName = taskRun.spec.taskRef.name;
+        const taskRunName = taskRun.metadata.name;
+        const taskRunNamespace = taskRun.metadata.namespace;
+        const { reason, status: succeeded } = getStatus(taskRun);
+        const pipelineTaskName = taskRunName;
+        const runSteps = stepsStatus(task.spec.steps, taskRun.status.steps);
+        const { params, resources: inputResources } = taskRun.spec.inputs;
+        const { resources: outputResources } = taskRun.spec.outputs;
+        const { startTime } = taskRun.status;
+        return {
+          id: taskRun.metadata.uid,
+          pipelineTaskName,
+          pod: taskRun.status.podName,
+          reason,
+          steps: runSteps,
+          succeeded,
+          taskName,
+          taskRunName,
+          startTime,
+          namespace: taskRunNamespace,
+          params,
+          inputResources,
+          outputResources
+        };
+      })
+      .filter(Boolean);
     return taskRuns;
   };
 

--- a/src/reducers/reducerCreators.js
+++ b/src/reducers/reducerCreators.js
@@ -53,6 +53,9 @@ function createByNamespaceReducer({ type }) {
         return merge({}, state, resource);
       case `${type}Deleted`:
         const newState = { ...state };
+        if (!newState[action.payload.metadata.namespace]) {
+          return newState;
+        }
         delete newState[action.payload.metadata.namespace][
           action.payload.metadata.name
         ];

--- a/src/reducers/reducerCreators.test.js
+++ b/src/reducers/reducerCreators.test.js
@@ -131,6 +131,16 @@ it('PipelineResource Events', () => {
   ).toBeNull();
 });
 
+it('delete from missing namespace', () => {
+  const deleteAction = {
+    type: 'PipelineResourceDeleted',
+    payload: pipelineResource,
+    namespace
+  };
+
+  expect(() => reducer({}, deleteAction)).not.toThrow();
+});
+
 it('getPipelineResources', () => {
   const selectedNamespace = 'namespace';
   const state = { byNamespace: {} };


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/416

Depending on timing / order of events, deleting a Pipeline(Run),
Task(Run), or namespace can cause the client to render a blank page.

This change improves the resilience of the client code to these
issues ensuring that at the very least the UI shell remains, and
an error notification informing the user that the resource
cannot be loaded.

Ignore whitespace to see actual changes: https://github.com/tektoncd/dashboard/pull/463/files?w=1

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
