### PR TITLE
Additional http service for use inside the openshift cluster

### DIFF
--- a/config/openshift/openshift-tekton-dashboard.yaml
+++ b/config/openshift/openshift-tekton-dashboard.yaml
@@ -189,6 +189,23 @@ spec:
   selector:
     app: tekton-dashboard
 ---
+# ------- Insecure Dashboard Service - Do Not Expose ------ #
+kind: Service
+apiVersion: v1
+metadata:
+  name: tekton-dashboard-internal
+  namespace: tekton-pipelines
+  labels:
+    app: tekton-dashboard-internal
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9097
+      targetPort: 9097
+  selector:
+    app: tekton-dashboard
+---
 # ------------------- Pipeline0 --------------------------- #
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline


### PR DESCRIPTION
# Changes

Create additional service running on http (not https), that can be accessed inside the cluster by other pods - thus not having to use the https service.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
