### PR TITLE
Expand first step of first task by default

### DIFF
--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -22,6 +22,14 @@ import './Task.scss';
 class Task extends Component {
   state = { selectedStepId: null };
 
+  componentDidMount() {
+    this.selectDefaultStep();
+  }
+
+  componentDidUpdate() {
+    this.selectDefaultStep();
+  }
+
   handleClick = event => {
     if (event) {
       event.preventDefault();
@@ -37,6 +45,15 @@ class Task extends Component {
       this.handleClick();
     });
   };
+
+  selectDefaultStep() {
+    const { expanded, steps } = this.props;
+    const { selectedStepId } = this.state;
+    if (expanded && !selectedStepId) {
+      const { id } = steps[0] || {};
+      this.handleStepSelected(id);
+    }
+  }
 
   icon() {
     const { reason, succeeded } = this.props;

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -17,6 +17,7 @@ import Task from './Task';
 import { renderWithIntl } from '../../utils/test';
 
 const props = {
+  onSelect: () => {},
   pipelineTaskName: 'A Task'
 };
 
@@ -78,6 +79,8 @@ it('Task handle click event on Step', () => {
       steps={steps}
     />
   );
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  onSelect.mockClear();
   fireEvent.click(getByText(/build/i));
   expect(onSelect).toHaveBeenCalledTimes(1);
 });

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -25,9 +25,10 @@ class TaskTree extends Component {
     const { selectedTaskId, taskRuns } = this.props;
     return (
       <ol className="task-tree">
-        {taskRuns.map(taskRun => {
+        {taskRuns.map((taskRun, index) => {
           const { id, reason, steps, succeeded, pipelineTaskName } = taskRun;
-          const expanded = selectedTaskId === id;
+          const expanded =
+            selectedTaskId === id || (!selectedTaskId && index === 0);
           return (
             <Task
               id={id}

--- a/packages/components/src/components/TaskTree/TaskTree.test.js
+++ b/packages/components/src/components/TaskTree/TaskTree.test.js
@@ -17,6 +17,7 @@ import TaskTree from './TaskTree';
 import { renderWithIntl } from '../../utils/test';
 
 const props = {
+  onSelect: () => {},
   taskRuns: [
     {
       id: 'task',
@@ -38,6 +39,8 @@ it('TaskTree handles click event on Task', () => {
   const { getByText } = renderWithIntl(
     <TaskTree {...props} onSelect={onSelect} />
   );
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  onSelect.mockClear();
   fireEvent.click(getByText(/a task/i));
   expect(onSelect).toHaveBeenCalledTimes(1);
 });
@@ -47,6 +50,7 @@ it('TaskTree handles click event on Step', () => {
   const { getByText } = renderWithIntl(
     <TaskTree {...props} selectedTaskId="task" onSelect={onSelect} />
   );
+  onSelect.mockClear();
   fireEvent.click(getByText(/build/i));
   expect(onSelect).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/488

When loading the TaskRun / PipelineRun views we should
expand the first step of the first task by default so the
user is presented with useful information without having
to take further action.

Both the TaskTree and Task components own this functionality
for their respective children.

A future change will enhance this to expand the first **failing** step (if any).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
