### PR TITLE
Show ServiceAccount for install namespace only when importing resources

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -349,3 +349,14 @@ export function shouldDisplayLogout() {
   });
   return get(routesUri, { Accept: 'text/plain' });
 }
+
+export async function determineInstallNamespace() {
+  const response = getInstallProperties()
+    .then(installProps => {
+      return installProps.InstallNamespace;
+    })
+    .catch(error => {
+      throw error;
+    });
+  return response;
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Only displays service accounts for the installed namespace - this is for issue https://github.com/tektoncd/dashboard/issues/493, fixing it up atm to reduce some code duplication we had

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
