### PR TITLE
Ignore stale resources from REST response and websocket payloads

### DIFF
--- a/packages/components/src/components/LogoutButton/LogoutButton.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.js
@@ -17,6 +17,7 @@ import { injectIntl } from 'react-intl';
 import React, { Component } from 'react';
 import './LogoutButton.scss';
 
+/* istanbul ignore next */
 function handleLogout() {
   window.location.href = '/oauth/sign_out';
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -89,6 +89,7 @@ export function getExtensionBundleURL(name, bundlelocation) {
   return `${getExtensionBaseURL(name)}/${bundlelocation}`;
 }
 
+/* istanbul ignore next */
 export function getWebSocketURL() {
   return `${apiRoot.replace(/^http/, 'ws')}/v1/websockets/resources`;
 }

--- a/src/reducers/reducerCreators.test.js
+++ b/src/reducers/reducerCreators.test.js
@@ -16,11 +16,13 @@ import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { createNamespacedReducer } from './reducerCreators';
 import * as selectors from './pipelineResources';
 
-const createResource = (name, namespace, uid, other) => {
+const existingResourceVersion = 123;
+const createResource = (name, namespace, resourceVersion, uid, other) => {
   return {
     metadata: {
       name,
       namespace,
+      resourceVersion,
       uid
     },
     ...other
@@ -33,7 +35,12 @@ const reducer = createNamespacedReducer({ type: resourceType });
 const name = 'pipeline name';
 const namespace = 'default';
 const uid = 'some-uid';
-const pipelineResource = createResource(name, namespace, uid);
+const pipelineResource = createResource(
+  name,
+  namespace,
+  existingResourceVersion,
+  uid
+);
 
 it('handles init or unknown actions', () => {
   expect(reducer(undefined, { type: 'does_not_exist' })).toEqual({
@@ -67,6 +74,29 @@ it('PIPELINE_RESOURCES_FETCH_SUCCESS', () => {
   expect(selectors.isFetchingPipelineResources(state)).toBe(false);
 });
 
+it('PIPELINE_RESOURCES_FETCH_SUCCESS with stale content', () => {
+  const action = {
+    type: 'PIPELINE_RESOURCES_FETCH_SUCCESS',
+    data: [pipelineResource],
+    namespace
+  };
+  let state = reducer({}, action);
+
+  const staleResourceVersion = existingResourceVersion - 1;
+  const actionWithStaleResource = {
+    type: 'PIPELINE_RESOURCES_FETCH_SUCCESS',
+    data: [createResource(name, namespace, staleResourceVersion, uid)]
+  };
+  state = reducer(state, actionWithStaleResource);
+
+  expect(selectors.getPipelineResources(state, namespace)).toEqual([
+    pipelineResource
+  ]);
+  expect(selectors.getPipelineResource(state, name, namespace)).toEqual(
+    pipelineResource
+  );
+});
+
 it('PIPELINE_RESOURCES_FETCH_FAILURE', () => {
   const message = 'fake error message';
   const error = { message };
@@ -80,9 +110,15 @@ it('PIPELINE_RESOURCES_FETCH_FAILURE', () => {
 });
 
 it('PipelineResource Events', () => {
-  const createdPipelineResource = createResource(name, namespace, uid, {
-    status: { running: true }
-  });
+  const createdPipelineResource = createResource(
+    name,
+    namespace,
+    existingResourceVersion,
+    uid,
+    {
+      status: { running: true }
+    }
+  );
   const action = {
     type: 'PipelineResourceCreated',
     payload: createdPipelineResource,
@@ -99,9 +135,15 @@ it('PipelineResource Events', () => {
   expect(selectors.isFetchingPipelineResources(state)).toBe(false);
 
   // update pipeline resource
-  const updatedPipelineResource = createResource(name, namespace, uid, {
-    status: { terminated: true }
-  });
+  const updatedPipelineResource = createResource(
+    name,
+    namespace,
+    existingResourceVersion,
+    uid,
+    {
+      status: { terminated: true }
+    }
+  );
   const updateAction = {
     type: 'PipelineResourceUpdated',
     payload: updatedPipelineResource,
@@ -114,6 +156,32 @@ it('PipelineResource Events', () => {
   expect(selectors.getPipelineResource(updatedState, name, namespace)).toEqual(
     updatedPipelineResource
   );
+
+  // attempt update with stale resource, should be ignored
+  const stalePipelineResource = createResource(
+    name,
+    namespace,
+    existingResourceVersion - 1,
+    uid,
+    {
+      status: { terminated: true }
+    }
+  );
+  const updateActionWithStaleResource = {
+    type: 'PipelineResourceUpdated',
+    payload: stalePipelineResource,
+    namespace
+  };
+  const updatedStateAfterStale = reducer(
+    updatedState,
+    updateActionWithStaleResource
+  );
+  expect(
+    selectors.getPipelineResources(updatedStateAfterStale, namespace)
+  ).toEqual([updatedPipelineResource]);
+  expect(
+    selectors.getPipelineResource(updatedStateAfterStale, name, namespace)
+  ).toEqual(updatedPipelineResource);
 
   // delete pipeline resource
   const deleteAction = {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -45,3 +45,16 @@ export async function fetchLogs(stepName, stepStatus, taskRun) {
   }
   return logs;
 }
+
+export function isStale(resource, state, resourceIdField = 'uid') {
+  const { [resourceIdField]: identifier } = resource.metadata;
+  if (!state[identifier]) {
+    return false;
+  }
+  const existingVersion = parseInt(
+    state[identifier].metadata.resourceVersion,
+    10
+  );
+  const incomingVersion = parseInt(resource.metadata.resourceVersion, 10);
+  return existingVersion > incomingVersion;
+}

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { sortRunsByStartTime, typeToPlural } from '.';
+import { isStale, sortRunsByStartTime, typeToPlural } from '.';
 
 it('sortRunsByStartTime', () => {
   const a = { name: 'a', status: { startTime: '0' } };
@@ -33,4 +33,26 @@ it('sortRunsByStartTime', () => {
 
 it('typeToPlural', () => {
   expect(typeToPlural('Extension')).toEqual('EXTENSIONS');
+});
+
+it('isStale', () => {
+  const uid = 'fake_uid';
+  const existingResource = {
+    metadata: {
+      uid,
+      resourceVersion: '123'
+    }
+  };
+  const incomingResource = {
+    metadata: {
+      uid,
+      resourceVersion: '45'
+    }
+  };
+  const state = {
+    [uid]: existingResource
+  };
+  expect(isStale(incomingResource, {})).toBe(false);
+  expect(isStale(incomingResource, state)).toBe(true);
+  expect(isStale(existingResource, state)).toBe(false);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/499

Before merging resources into the store, ensure any stale
resources are ignored. Most reducers use the reducerCreators
so this serves as a logical location for the filtering.

Some reducers either don't support updates or do a full replace
on receiving a list response so they have been skipped.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
