### PR TITLE
Containers should re-fetch their data on a websocket reconnect

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -53,19 +53,36 @@ import {
 import { shouldDisplayLogout } from '../../api';
 import { fetchExtensions } from '../../actions/extensions';
 import { fetchNamespaces, selectNamespace } from '../../actions/namespaces';
-import { getExtensions, getLocale, getSelectedNamespace } from '../../reducers';
+import {
+  getExtensions,
+  getLocale,
+  getSelectedNamespace,
+  isWebSocketConnected
+} from '../../reducers';
 import messages from '../../nls/messages_en.json';
 
 import '../../components/App/App.scss';
 
 export /* istanbul ignore next */ class App extends Component {
   componentDidMount() {
-    this.props.fetchExtensions();
-    this.props.fetchNamespaces();
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (webSocketConnected && prevWebSocketConnected === false) {
+      this.fetchData();
+    }
   }
 
   componentWillUnmount() {
     this.props.onUnload();
+  }
+
+  fetchData() {
+    this.props.fetchExtensions();
+    this.props.fetchNamespaces();
   }
 
   render() {
@@ -237,7 +254,8 @@ App.defaultProps = {
 const mapStateToProps = state => ({
   extensions: getExtensions(state),
   namespace: getSelectedNamespace(state),
-  lang: getLocale(state)
+  lang: getLocale(state),
+  webSocketConnected: isWebSocketConnected(state)
 });
 
 const mapDispatchToProps = {

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -31,6 +31,7 @@ it('App renders successfully', () => {
     secrets: { byNamespace: {} },
     extensions: { byName: {} },
     namespaces: { byName: {} },
+    notifications: {},
     pipelines: { byNamespace: {} },
     pipelineRuns: { byNamespace: {} },
     serviceAccounts: { byNamespace: {} }

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -30,7 +30,8 @@ import { fetchClusterTasks } from '../../actions/tasks';
 import {
   getClusterTasks,
   getClusterTasksErrorMessage,
-  isFetchingClusterTasks
+  isFetchingClusterTasks,
+  isWebSocketConnected
 } from '../../reducers';
 
 import '../../components/Definitions/Definitions.scss';
@@ -38,6 +39,14 @@ import '../../components/Definitions/Definitions.scss';
 export /* istanbul ignore next */ class ClusterTasksContainer extends Component {
   componentDidMount() {
     this.props.fetchClusterTasks();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (webSocketConnected && prevWebSocketConnected === false) {
+      this.props.fetchClusterTasks();
+    }
   }
 
   render() {
@@ -113,9 +122,10 @@ ClusterTasksContainer.defaultProps = {
 /* istanbul ignore next */
 function mapStateToProps(state) {
   return {
+    clusterTasks: getClusterTasks(state),
     error: getClusterTasksErrorMessage(state),
     loading: isFetchingClusterTasks(state),
-    clusterTasks: getClusterTasks(state)
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -153,10 +153,11 @@ const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
   ...namespacesTestStore,
-  ...pipelinesTestStore,
-  ...serviceAccountsTestStore,
+  notifications: {},
   ...pipelineResourcesTestStore,
-  ...pipelineRunsTestStore
+  ...pipelineRunsTestStore,
+  ...pipelinesTestStore,
+  ...serviceAccountsTestStore
 };
 
 afterEach(cleanup);

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -33,6 +33,7 @@ describe('ImportResources component', () => {
       isFetching: false,
       selected: ALL_NAMESPACES
     },
+    notifications: {},
     serviceAccounts: {
       byId: {},
       byNamespace: {},

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -24,7 +24,8 @@ import { getErrorMessage } from '@tektoncd/dashboard-utils';
 import {
   getPipelineResource,
   getPipelineResourcesErrorMessage,
-  isFetchingPipelineResources
+  isFetchingPipelineResources,
+  isWebSocketConnected
 } from '../../reducers';
 
 import { fetchPipelineResource } from '../../actions/pipelineResources';
@@ -45,9 +46,12 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
   }
 
   componentDidUpdate(prevProps) {
-    const { match } = this.props;
+    const { match, webSocketConnected } = this.props;
     const { namespace, pipelineResourceName } = match.params;
-    const { match: prevMatch } = prevProps;
+    const {
+      match: prevMatch,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
     const {
       namespace: prevNamespace,
       pipelineResourceName: prevPipelineResourceName
@@ -55,7 +59,8 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
 
     if (
       namespace !== prevNamespace ||
-      pipelineResourceName !== prevPipelineResourceName
+      pipelineResourceName !== prevPipelineResourceName ||
+      (webSocketConnected && prevWebSocketConnected === false)
     ) {
       this.fetchData();
     }
@@ -226,7 +231,8 @@ function mapStateToProps(state, ownProps) {
     pipelineResource: getPipelineResource(state, {
       name,
       namespace
-    })
+    }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -35,7 +35,8 @@ import {
   getPipelineResources,
   getPipelineResourcesErrorMessage,
   getSelectedNamespace,
-  isFetchingPipelineResources
+  isFetchingPipelineResources,
+  isWebSocketConnected
 } from '../../reducers';
 
 export /* istanbul ignore next */ class PipelineResources extends Component {
@@ -44,10 +45,16 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    const { namespace: prevNamespace } = prevProps;
+    const { namespace, webSocketConnected } = this.props;
+    const {
+      namespace: prevNamespace,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
 
-    if (namespace !== prevNamespace) {
+    if (
+      namespace !== prevNamespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.fetchPipelineResources();
     }
   }
@@ -147,7 +154,8 @@ function mapStateToProps(state, props) {
     error: getPipelineResourcesErrorMessage(state),
     loading: isFetchingPipelineResources(state),
     namespace,
-    pipelineResources: getPipelineResources(state, { namespace })
+    pipelineResources: getPipelineResources(state, { namespace }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
@@ -18,7 +18,8 @@ import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import {
   getPipelineResources,
   getSelectedNamespace,
-  isFetchingPipelineResources
+  isFetchingPipelineResources,
+  isWebSocketConnected
 } from '../../reducers';
 import { fetchPipelineResources } from '../../actions/pipelineResources';
 import TooltipDropdown from '../../components/TooltipDropdown';
@@ -30,8 +31,12 @@ class PipelineResourcesDropdown extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    if (namespace !== prevProps.namespace) {
+    const { namespace, webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (
+      namespace !== prevProps.namespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.props.fetchPipelineResources({ namespace });
     }
   }
@@ -65,7 +70,8 @@ function mapStateToProps(state, ownProps) {
       .filter(pipelineResource => !type || type === pipelineResource.spec.type)
       .map(pipelineResource => pipelineResource.metadata.name),
     loading: isFetchingPipelineResources(state),
-    namespace
+    namespace,
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -130,7 +130,8 @@ beforeEach(() => {
 it('PipelineResourcesDropdown renders items based on Redux state', () => {
   const store = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { getByText, getAllByText, queryByText } = render(
     <Provider store={store}>
@@ -149,7 +150,8 @@ it('PipelineResourcesDropdown renders items based on Redux state', () => {
 it('PipelineResourcesDropdown renders items based on type', () => {
   const store = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { container, getByText, queryByText } = render(
     <Provider store={store}>
@@ -176,7 +178,8 @@ it('PipelineResourcesDropdown renders items based on type', () => {
 it('PipelineResourcesDropdown renders items based on Redux state when namespace changes', () => {
   const blueStore = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { container, getByText, getAllByText, queryByText } = render(
     <Provider store={blueStore}>
@@ -195,7 +198,8 @@ it('PipelineResourcesDropdown renders items based on Redux state when namespace 
   // Change selected namespace from 'blue' to 'green'
   const greenStore = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreGreen
+    ...namespacesStoreGreen,
+    notifications: {}
   });
   render(
     <Provider store={greenStore}>
@@ -215,7 +219,8 @@ it('PipelineResourcesDropdown renders items based on Redux state when namespace 
 it('PipelineResourcesDropdown renders controlled selection', () => {
   const store = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select item 'pipeline-resource-1'
   const { container, queryByText } = render(
@@ -251,7 +256,8 @@ it('PipelineResourcesDropdown renders controlled selection', () => {
 it('PipelineResourcesDropdown renders controlled namespace', () => {
   const store = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select namespace 'green'
   const { queryByText, getByText, getAllByText } = render(
@@ -274,7 +280,8 @@ it('PipelineResourcesDropdown renders empty', () => {
       byNamespace: {},
       isFetching: false
     },
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -294,7 +301,8 @@ it('PipelineResourcesDropdown renders empty all namespaces', () => {
       byNamespace: {},
       isFetching: false
     },
-    ...namespacesStoreAll
+    ...namespacesStoreAll,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -312,7 +320,8 @@ it('PipelineResourcesDropdown renders empty with type', () => {
       byNamespace: {},
       isFetching: false
     },
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -334,7 +343,8 @@ it('PipelineResourcesDropdown renders empty with type and all namespaces', () =>
       byNamespace: {},
       isFetching: false
     },
-    ...namespacesStoreAll
+    ...namespacesStoreAll,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -350,7 +360,8 @@ it('PipelineResourcesDropdown renders empty with type and all namespaces', () =>
 it('PipelineResourcesDropdown renders loading skeleton based on Redux state', () => {
   const store = mockStore({
     ...pipelineResourcesStoreFetching,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -363,7 +374,8 @@ it('PipelineResourcesDropdown renders loading skeleton based on Redux state', ()
 it('PipelineResourcesDropdown handles onChange event', () => {
   const store = mockStore({
     ...pipelineResourcesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const onChange = jest.fn();
   const { getByText } = render(

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -26,7 +26,8 @@ import {
   getTaskRunsByPipelineRunName,
   getTaskRunsErrorMessage,
   getTasks,
-  getTasksErrorMessage
+  getTasksErrorMessage,
+  isWebSocketConnected
 } from '../../reducers';
 
 import { fetchPipelineRun } from '../../actions/pipelineRuns';
@@ -56,9 +57,12 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { match } = this.props;
+    const { match, webSocketConnected } = this.props;
     const { namespace, pipelineRunName } = match.params;
-    const { match: prevMatch } = prevProps;
+    const {
+      match: prevMatch,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
     const {
       namespace: prevNamespace,
       pipelineRunName: prevPipelineRunName
@@ -66,7 +70,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
     if (
       namespace !== prevNamespace ||
-      pipelineRunName !== prevPipelineRunName
+      pipelineRunName !== prevPipelineRunName ||
+      (webSocketConnected && prevWebSocketConnected === false)
     ) {
       this.fetchData();
     }
@@ -176,7 +181,8 @@ function mapStateToProps(state, ownProps) {
         namespace
       }
     ),
-    clusterTasks: getClusterTasks(state)
+    clusterTasks: getClusterTasks(state),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -39,7 +39,8 @@ import {
   getPipelineRunsByPipelineName,
   getPipelineRunsErrorMessage,
   getSelectedNamespace,
-  isFetchingPipelineRuns
+  isFetchingPipelineRuns,
+  isWebSocketConnected
 } from '../../reducers';
 import { cancelPipelineRun } from '../../api';
 
@@ -76,17 +77,22 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { match, namespace } = this.props;
+    const { match, namespace, webSocketConnected } = this.props;
     const { filters } = this.state;
     const { filters: prevFilters } = prevState;
     const { pipelineName } = match.params;
-    const { match: prevMatch, namespace: prevNamespace } = prevProps;
+    const {
+      match: prevMatch,
+      namespace: prevNamespace,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
     const { pipelineName: prevPipelineName } = prevMatch.params;
 
     if (
       namespace !== prevNamespace ||
       pipelineName !== prevPipelineName ||
-      filters !== prevFilters
+      filters !== prevFilters ||
+      (webSocketConnected && prevWebSocketConnected === false)
     ) {
       this.reset();
       this.fetchPipelineRuns();
@@ -394,7 +400,8 @@ function mapStateToProps(state, props) {
       : getPipelineRuns(state, {
           filters,
           namespace
-        })
+        }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -149,10 +149,11 @@ const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
   ...namespacesTestStore,
-  ...pipelinesTestStore,
-  ...serviceAccountsTestStore,
+  notifications: {},
   ...pipelineResourcesTestStore,
-  ...pipelineRunsTestStore
+  ...pipelineRunsTestStore,
+  ...pipelinesTestStore,
+  ...serviceAccountsTestStore
 };
 
 beforeEach(() => {

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -36,7 +36,8 @@ import {
   getPipelines,
   getPipelinesErrorMessage,
   getSelectedNamespace,
-  isFetchingPipelines
+  isFetchingPipelines,
+  isWebSocketConnected
 } from '../../reducers';
 
 import '../../components/Definitions/Definitions.scss';
@@ -47,8 +48,12 @@ export /* istanbul ignore next */ class Pipelines extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    if (namespace !== prevProps.namespace) {
+    const { namespace, webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (
+      namespace !== prevProps.namespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.props.fetchPipelines();
     }
   }
@@ -145,7 +150,8 @@ function mapStateToProps(state, props) {
     error: getPipelinesErrorMessage(state),
     loading: isFetchingPipelines(state),
     namespace,
-    pipelines: getPipelines(state, { namespace })
+    pipelines: getPipelines(state, { namespace }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -18,7 +18,8 @@ import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import {
   getPipelines,
   getSelectedNamespace,
-  isFetchingPipelines
+  isFetchingPipelines,
+  isWebSocketConnected
 } from '../../reducers';
 import { fetchPipelines } from '../../actions/pipelines';
 import TooltipDropdown from '../../components/TooltipDropdown';
@@ -30,8 +31,12 @@ class PipelinesDropdown extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    if (namespace !== prevProps.namespace) {
+    const { namespace, webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (
+      namespace !== prevProps.namespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.props.fetchPipelines({ namespace });
     }
   }
@@ -60,7 +65,8 @@ function mapStateToProps(state, ownProps) {
       pipeline => pipeline.metadata.name
     ),
     loading: isFetchingPipelines(state),
-    namespace
+    namespace,
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
@@ -119,7 +119,8 @@ beforeEach(() => {
 it('PipelinesDropdown renders items based on Redux state', () => {
   const store = mockStore({
     ...pipelinesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { getByText, getAllByText, queryByText } = render(
     <Provider store={store}>
@@ -138,7 +139,8 @@ it('PipelinesDropdown renders items based on Redux state', () => {
 it('PipelinesDropdown renders items based on Redux state when namespace changes', () => {
   const blueStore = mockStore({
     ...pipelinesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { container, getByText, getAllByText, queryByText } = render(
     <Provider store={blueStore}>
@@ -157,7 +159,8 @@ it('PipelinesDropdown renders items based on Redux state when namespace changes'
   // Change selected namespace from 'blue' to 'green'
   const greenStore = mockStore({
     ...pipelinesStoreDefault,
-    ...namespacesStoreGreen
+    ...namespacesStoreGreen,
+    notifications: {}
   });
   render(
     <Provider store={greenStore}>
@@ -177,7 +180,8 @@ it('PipelinesDropdown renders items based on Redux state when namespace changes'
 it('PipelinesDropdown renders controlled selection', () => {
   const store = mockStore({
     ...pipelinesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select item 'pipeline-1'
   const { container, queryByText } = render(
@@ -207,7 +211,8 @@ it('PipelinesDropdown renders controlled selection', () => {
 it('PipelinesDropdown renders controlled namespace', () => {
   const store = mockStore({
     ...pipelinesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select namespace 'green'
   const { queryByText, getByText, getAllByText } = render(
@@ -230,7 +235,8 @@ it('PipelinesDropdown renders empty', () => {
       byNamespace: {},
       isFetching: false
     },
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -246,7 +252,8 @@ it('PipelinesDropdown renders empty', () => {
 it('PipelinesDropdown renders loading skeleton based on Redux state', () => {
   const store = mockStore({
     ...pipelinesStoreFetching,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -259,7 +266,8 @@ it('PipelinesDropdown renders loading skeleton based on Redux state', () => {
 it('PipelinesDropdown handles onChange event', () => {
   const store = mockStore({
     ...pipelinesStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const onChange = jest.fn();
   const { getByText } = render(

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -31,7 +31,7 @@ import {
 } from '@tektoncd/dashboard-utils';
 
 import { getCustomResources } from '../../api';
-import { getSelectedNamespace } from '../../reducers';
+import { getSelectedNamespace, isWebSocketConnected } from '../../reducers';
 
 export /* istanbul ignore next */ class ResourceListContainer extends Component {
   state = {
@@ -46,9 +46,13 @@ export /* istanbul ignore next */ class ResourceListContainer extends Component 
   }
 
   componentDidUpdate(prevProps) {
-    const { match, namespace } = this.props;
+    const { match, namespace, webSocketConnected } = this.props;
     const { group, version, type } = match.params;
-    const { match: prevMatch, namespace: prevNamespace } = prevProps;
+    const {
+      match: prevMatch,
+      namespace: prevNamespace,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
     const {
       type: prevType,
       group: prevGroup,
@@ -59,7 +63,8 @@ export /* istanbul ignore next */ class ResourceListContainer extends Component 
       namespace !== prevNamespace ||
       type !== prevType ||
       group !== prevGroup ||
-      version !== prevVersion
+      version !== prevVersion ||
+      (webSocketConnected && prevWebSocketConnected === false)
     ) {
       this.fetchResources(group, version, type, namespace);
     }
@@ -166,7 +171,8 @@ function mapStateToProps(state, props) {
   const namespace = namespaceParam || getSelectedNamespace(state);
 
   return {
-    namespace
+    namespace,
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -28,7 +28,8 @@ import {
   getSecrets,
   getSecretsErrorMessage,
   getSelectedNamespace,
-  isFetchingSecrets
+  isFetchingSecrets,
+  isWebSocketConnected
 } from '../../reducers';
 
 export /* istanbul ignore next */ class Secrets extends Component {
@@ -43,6 +44,14 @@ export /* istanbul ignore next */ class Secrets extends Component {
 
   componentDidMount() {
     this.props.fetchSecrets();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (webSocketConnected && prevWebSocketConnected === false) {
+      this.props.fetchSecrets();
+    }
   }
 
   handleNewSecretClick = () => {
@@ -122,7 +131,8 @@ function mapStateToProps(state) {
     error: getSecretsErrorMessage(state),
     loading: isFetchingSecrets(state),
     secrets: getSecrets(state),
-    selectedNamespace: getSelectedNamespace(state)
+    selectedNamespace: getSelectedNamespace(state),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -99,6 +99,7 @@ let store = mockStore({
     errorMessage: null
   },
   namespaces,
+  notifications: {},
   serviceAccounts: {
     byId: serviceAccountsById,
     byNamespace: serviceAccountsByNamespace,
@@ -185,7 +186,8 @@ it('error notification appears', () => {
       isFetching: false,
       errorMessage: 'Some error message'
     },
-    namespaces
+    namespaces,
+    notifications: {}
   });
   const { getByTestId } = render(
     <Provider store={store}>

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -19,7 +19,7 @@ import Annotations from '../../components/SecretsModal/Annotations';
 import BasicAuthFields from '../../components/SecretsModal/BasicAuthFields';
 import '../../components/SecretsModal/SecretsModal.scss';
 import { createSecret } from '../../actions/secrets';
-import { getServiceAccounts } from '../../reducers';
+import { getServiceAccounts, isWebSocketConnected } from '../../reducers';
 import { fetchServiceAccounts } from '../../actions/serviceAccounts';
 
 /* istanbul ignore next */
@@ -68,6 +68,14 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
 
   componentDidMount() {
     this.props.fetchServiceAccounts();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (webSocketConnected && prevWebSocketConnected === false) {
+      this.props.fetchServiceAccounts();
+    }
   }
 
   handleSubmit = () => {
@@ -351,7 +359,8 @@ SecretsModal.defaultProps = {
 
 function mapStateToProps(state) {
   return {
-    serviceAccounts: getServiceAccounts(state)
+    serviceAccounts: getServiceAccounts(state),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/SecretsModal/SecretsModal.test.js
+++ b/src/containers/SecretsModal/SecretsModal.test.js
@@ -82,6 +82,7 @@ const serviceAccountsById = {
 const store = mockStore({
   secrets,
   namespaces,
+  notifications: {},
   serviceAccounts: {
     byId: serviceAccountsById,
     byNamespace: serviceAccountsByNamespace,

--- a/src/containers/SecretsModal/SecretsModalAnnotationText.test.js
+++ b/src/containers/SecretsModal/SecretsModalAnnotationText.test.js
@@ -81,6 +81,7 @@ const serviceAccountsById = {
 const store = mockStore({
   secrets,
   namespaces,
+  notifications: {},
   serviceAccounts: {
     byId: serviceAccountsById,
     byNamespace: serviceAccountsByNamespace,

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -18,7 +18,8 @@ import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import {
   getSelectedNamespace,
   getServiceAccounts,
-  isFetchingServiceAccounts
+  isFetchingServiceAccounts,
+  isWebSocketConnected
 } from '../../reducers';
 import { fetchServiceAccounts } from '../../actions/serviceAccounts';
 import TooltipDropdown from '../../components/TooltipDropdown';
@@ -30,8 +31,12 @@ class ServiceAccountsDropdown extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    if (namespace !== prevProps.namespace) {
+    const { namespace, webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (
+      namespace !== prevProps.namespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.props.fetchServiceAccounts({ namespace });
     }
   }
@@ -58,7 +63,8 @@ function mapStateToProps(state, ownProps) {
   return {
     items: getServiceAccounts(state, { namespace }).map(sa => sa.metadata.name),
     loading: isFetchingServiceAccounts(state),
-    namespace
+    namespace,
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -120,7 +120,8 @@ beforeEach(() => {
 it('ServiceAccountsDropdown renders items based on Redux state', () => {
   const store = mockStore({
     ...serviceAccountsStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { getByText, getAllByText, queryByText } = render(
     <Provider store={store}>
@@ -139,7 +140,8 @@ it('ServiceAccountsDropdown renders items based on Redux state', () => {
 it('ServiceAccountsDropdown renders items based on Redux state when namespace changes', () => {
   const blueStore = mockStore({
     ...serviceAccountsStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { container, getByText, getAllByText, queryByText } = render(
     <Provider store={blueStore}>
@@ -158,7 +160,8 @@ it('ServiceAccountsDropdown renders items based on Redux state when namespace ch
   // Change selected namespace from 'blue' to 'green'
   const greenStore = mockStore({
     ...serviceAccountsStoreDefault,
-    ...namespacesStoreGreen
+    ...namespacesStoreGreen,
+    notifications: {}
   });
   render(
     <Provider store={greenStore}>
@@ -178,7 +181,8 @@ it('ServiceAccountsDropdown renders items based on Redux state when namespace ch
 it('ServiceAccountsDropdown renders controlled selection', () => {
   const store = mockStore({
     ...serviceAccountsStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select item 'service-account-1'
   const { container, queryByText } = render(
@@ -214,7 +218,8 @@ it('ServiceAccountsDropdown renders controlled selection', () => {
 it('ServiceAccountsDropdown renders controlled namespace', () => {
   const store = mockStore({
     ...serviceAccountsStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select namespace 'green'
   const { queryByText, getByText, getAllByText } = render(
@@ -237,7 +242,8 @@ it('ServiceAccountsDropdown renders empty', () => {
       byNamespace: {},
       isFetching: false
     },
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   // Select item 'service-account-1'
   const { queryByText } = render(
@@ -254,7 +260,8 @@ it('ServiceAccountsDropdown renders empty', () => {
 it('ServiceAccountsDropdown renders loading skeleton based on Redux state', () => {
   const store = mockStore({
     ...serviceAccountsStoreFetching,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const { queryByText } = render(
     <Provider store={store}>
@@ -267,7 +274,8 @@ it('ServiceAccountsDropdown renders loading skeleton based on Redux state', () =
 it('ServiceAccountsDropdown handles onChange event', () => {
   const store = mockStore({
     ...serviceAccountsStoreDefault,
-    ...namespacesStoreBlue
+    ...namespacesStoreBlue,
+    notifications: {}
   });
   const onChange = jest.fn();
   const { getByText } = render(

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -32,7 +32,8 @@ import {
   getSelectedNamespace,
   getTaskByType,
   getTaskRun,
-  getTaskRunsErrorMessage
+  getTaskRunsErrorMessage,
+  isWebSocketConnected
 } from '../../reducers';
 
 import '../../components/Run/Run.scss';
@@ -71,12 +72,20 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { match, namespace } = this.props;
+    const { match, namespace, webSocketConnected } = this.props;
     const { taskRunName } = match.params;
-    const { match: prevMatch, namespace: prevNamespace } = prevProps;
+    const {
+      match: prevMatch,
+      namespace: prevNamespace,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
     const { taskRunName: prevTaskRunName } = prevMatch.params;
 
-    if (taskRunName !== prevTaskRunName || namespace !== prevNamespace) {
+    if (
+      taskRunName !== prevTaskRunName ||
+      namespace !== prevNamespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.setState({ loading: true }); // eslint-disable-line
       this.fetchTaskAndRuns(taskRunName, namespace);
     }
@@ -233,7 +242,8 @@ function mapStateToProps(state, ownProps) {
     error: getTaskRunsErrorMessage(state),
     namespace,
     taskRun,
-    task
+    task,
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/TaskRunList/TaskRunList.js
+++ b/src/containers/TaskRunList/TaskRunList.js
@@ -40,7 +40,8 @@ import {
   getSelectedNamespace,
   getTaskRuns,
   getTaskRunsErrorMessage,
-  isFetchingTaskRuns
+  isFetchingTaskRuns,
+  isWebSocketConnected
 } from '../../reducers';
 import { cancelTaskRun } from '../../api';
 
@@ -50,10 +51,16 @@ export /* istanbul ignore next */ class TaskRunList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    const { namespace: prevNamespace } = prevProps;
+    const { namespace, webSocketConnected } = this.props;
+    const {
+      namespace: prevNamespace,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
 
-    if (namespace !== prevNamespace) {
+    if (
+      namespace !== prevNamespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.props.fetchTaskRuns();
     }
   }
@@ -203,7 +210,8 @@ function mapStateToProps(state, props) {
     error: getTaskRunsErrorMessage(state),
     loading: isFetchingTaskRuns(state),
     namespace,
-    taskRuns: getTaskRuns(state, { namespace })
+    taskRuns: getTaskRuns(state, { namespace }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -35,7 +35,8 @@ import {
   getSelectedNamespace,
   getTaskByType,
   getTaskRunsByTaskName,
-  getTaskRunsErrorMessage
+  getTaskRunsErrorMessage,
+  isWebSocketConnected
 } from '../../reducers';
 
 import '../../components/Run/Run.scss';
@@ -74,15 +75,20 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { match, namespace } = this.props;
+    const { match, namespace, webSocketConnected } = this.props;
     const { taskName, taskType } = match.params;
-    const { match: prevMatch, namespace: prevNamespace } = prevProps;
+    const {
+      match: prevMatch,
+      namespace: prevNamespace,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
     const { taskName: prevTaskName, taskType: prevTaskType } = prevMatch.params;
 
     if (
       taskName !== prevTaskName ||
       namespace !== prevNamespace ||
-      taskType !== prevTaskType
+      taskType !== prevTaskType ||
+      (webSocketConnected && prevWebSocketConnected === false)
     ) {
       this.setState({ loading: true }); // eslint-disable-line
       this.fetchTaskAndRuns(taskName, taskType, namespace);
@@ -231,7 +237,8 @@ function mapStateToProps(state, ownProps) {
       name: taskName,
       namespace
     }),
-    task: getTaskByType(state, { type: taskType, name: taskName, namespace })
+    task: getTaskByType(state, { type: taskType, name: taskName, namespace }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -39,6 +39,7 @@ it('TaskRunsContainer renders', async () => {
     namespaces: {
       selected: 'default'
     },
+    notifications: {},
     taskRuns: {
       byId: {},
       byNamespace: { default: {} },
@@ -77,6 +78,7 @@ it('TaskRunsContainer handles info state', async () => {
     namespaces: {
       selected: 'default'
     },
+    notifications: {},
     taskRuns: {
       byId: {},
       byNamespace: { default: {} },
@@ -109,6 +111,7 @@ it('TaskRunsContainer handles error state', async () => {
     namespaces: {
       selected: 'default'
     },
+    notifications: {},
     taskRuns: {
       byId: {},
       byNamespace: { default: {} },

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -35,7 +35,8 @@ import {
   getSelectedNamespace,
   getTasks,
   getTasksErrorMessage,
-  isFetchingTasks
+  isFetchingTasks,
+  isWebSocketConnected
 } from '../../reducers';
 
 import '../../components/Definitions/Definitions.scss';
@@ -46,8 +47,12 @@ export /* istanbul ignore next */ class Tasks extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace } = this.props;
-    if (namespace !== prevProps.namespace) {
+    const { namespace, webSocketConnected } = this.props;
+    const { webSocketConnected: prevWebSocketConnected } = prevProps;
+    if (
+      namespace !== prevProps.namespace ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
       this.props.fetchTasks();
     }
   }
@@ -140,7 +145,8 @@ function mapStateToProps(state, props) {
     error: getTasksErrorMessage(state),
     loading: isFetchingTasks(state),
     namespace,
-    tasks: getTasks(state, { namespace })
+    tasks: getTasks(state, { namespace }),
+    webSocketConnected: isWebSocketConnected(state)
   };
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -17,6 +17,7 @@ import clusterTasks, * as clusterTaskSelectors from './clusterTasks';
 import extensions, * as extensionSelectors from './extensions';
 import locale, * as localeSelectors from './locale';
 import namespaces, * as namespaceSelectors from './namespaces';
+import notifications, * as notificationSelectors from './notifications';
 import pipelines, * as pipelineSelectors from './pipelines';
 import pipelineResources, * as pipelineResourcesSelectors from './pipelineResources';
 import pipelineRuns, * as pipelineRunsSelectors from './pipelineRuns';
@@ -30,6 +31,7 @@ export default combineReducers({
   extensions,
   locale,
   namespaces,
+  notifications,
   pipelines: pipelines(),
   pipelineResources: pipelineResources(),
   pipelineRuns: pipelineRuns(),
@@ -300,4 +302,8 @@ export function isFetchingSecrets(state) {
 
 export function getLocale(state) {
   return localeSelectors.getLocale(state.locale);
+}
+
+export function isWebSocketConnected(state) {
+  return notificationSelectors.isWebSocketConnected(state.notifications);
 }

--- a/src/reducers/notifications.js
+++ b/src/reducers/notifications.js
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const initialState = {
+  webSocketConnected: null
+};
+
+export default function notification(state = initialState, action) {
+  switch (action.type) {
+    case 'WEBSOCKET_CONNECTED':
+      return { ...state, webSocketConnected: true };
+    case 'WEBSOCKET_DISCONNECTED':
+      return { ...state, webSocketConnected: false };
+    default:
+      return state;
+  }
+}
+
+export function isWebSocketConnected(state) {
+  return state.webSocketConnected;
+}

--- a/src/reducers/notifications.test.js
+++ b/src/reducers/notifications.test.js
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import notificationsReducer, * as selectors from './notifications';
+
+it('handles init or unknown actions', () => {
+  expect(notificationsReducer(undefined, { type: 'does_not_exist' })).toEqual({
+    webSocketConnected: null
+  });
+});
+
+it('WEBSOCKET_CONNECTED', () => {
+  const action = { type: 'WEBSOCKET_CONNECTED' };
+  const state = notificationsReducer({}, action);
+  expect(selectors.isWebSocketConnected(state)).toBe(true);
+});
+
+it('WEBSOCKET_DISCONNECTED', () => {
+  const action = { type: 'WEBSOCKET_DISCONNECTED' };
+  const state = notificationsReducer({}, action);
+  expect(selectors.isWebSocketConnected(state)).toBe(false);
+});

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -13,6 +13,14 @@ limitations under the License.
 
 export function createWebSocketMiddleware(socket) {
   return ({ dispatch }) => {
+    socket.addEventListener('close', () => {
+      dispatch({ type: 'WEBSOCKET_DISCONNECTED' });
+    });
+
+    socket.addEventListener('open', () => {
+      dispatch({ type: 'WEBSOCKET_CONNECTED' });
+    });
+
     socket.addEventListener('message', event => {
       if (event.type !== 'message') {
         return;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/501

If the websocket connection drops we automatically attempt to
reconnect. However, once we do reconnect we do not receive any
potentially missed messages.

To avoid the risk of continuing to show stale data, and without
making significant changes to the current websocket implementation,
containers are responsible for re-fetching relevant data on
reconnect. This was not done centrally as not all containers
will need to re-fetch data, and not all data is required for
any given view. We already fetch required data on page
navigation so this is only to address potential staleness of
currently displayed data.

The websocket middleware dispatches actions on both connect and
disconnect so any container can respond to these events as they
see fit.

~~**NOTE:** https://github.com/tektoncd/dashboard/pull/500 should be merged first~~ (merged)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
