### PR TITLE
Fix style of running icon on TaskRuns

### DIFF
--- a/src/components/Definitions/Definitions.scss
+++ b/src/components/Definitions/Definitions.scss
@@ -42,7 +42,7 @@ main {
   .bx--data-table-header {
     background-color: transparent;
   }
-} 
+}
 
 .definition .status {
   .status-icon {
@@ -68,7 +68,7 @@ main {
     }
   }
 
-  &[data-status='Unknown'][data-reason='Running'] {
+  &[data-status='Unknown'][data-reason='Running'], &[data-status='Unknown'][data-reason='Building'] {
     .status-icon {
       fill: $running;
     }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The spinner icon on running PipelineRuns is blue, but on
TaskRuns it is black as the 'reason' fields don't match.

For PipelineRun it is 'Running', for TaskRun it is 'Building'

Update the style to support both.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
