### PR TITLE
Fix key prop on Log component

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -228,7 +228,11 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     );
 
     const logContainer = (
-      <Log fetchLogs={fetchLogs} key={stepName} stepStatus={stepStatus} />
+      <Log
+        fetchLogs={fetchLogs}
+        key={`${selectedTaskId}:${selectedStepId}`}
+        stepStatus={stepStatus}
+      />
     );
 
     return (

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -275,7 +275,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     const logContainer = (
       <Log
         fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
-        key={stepName}
+        key={`${selectedTaskId}:${selectedStepId}`}
         stepStatus={stepStatus}
       />
     );

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -173,7 +173,7 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
     const logContainer = (
       <Log
         fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
-        key={stepName}
+        key={`${selectedTaskId}:${selectedStepId}`}
         stepStatus={stepStatus}
       />
     );


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Setting `key={stepName}` works to ensure the component is
re-mounted when the selected step changes. However, it is
possible for 2 steps in different Tasks to have the same name.

Update key to use a combination of the Task and step ids to
ensure uniqueness.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
