### PR TITLE
Fix blue displaying for secrets display table in Safari

### DIFF
--- a/src/components/SecretsTable/Secrets.scss
+++ b/src/components/SecretsTable/Secrets.scss
@@ -47,4 +47,19 @@ limitations under the License.
   .bx--table-sort {
     background-color: white;
   }
+
+  .bx--batch-actions--active {
+    justify-content: flex-end;
+    visibility: visible !important;
+  }
+
+  .bx--batch-actions {
+    visibility: hidden;
+  }
+
+  .bx--btn--primary {
+    color: #ffffff;
+    white-space: nowrap;
+    height: 3rem;
+  }
 }


### PR DESCRIPTION
This is for https://github.com/tektoncd/dashboard/issues/527

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Same as was done for https://github.com/tektoncd/dashboard/issues/527, now looks like

![image](https://user-images.githubusercontent.com/12814972/65036358-32cf6680-d943-11e9-8607-ac63dac7c70c.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
