### PR TITLE
Skip auth (still must log in) for extension loading on Safari

### DIFF
--- a/config/openshift/openshift-tekton-dashboard.yaml
+++ b/config/openshift/openshift-tekton-dashboard.yaml
@@ -123,6 +123,7 @@ spec:
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret=SECRET
+        - --skip-auth-regex=^/v1/extensions/.*\.js
         volumeMounts:
         - mountPath: /etc/tls/private
           name: proxy-tls


### PR DESCRIPTION
# Changes
Prevents a 403, still have to log in though so I reckon this is good. Credits to @AlanGreene for finding the option, this is for https://github.com/tektoncd/experimental/issues/239

Tested on OpenShift 3.11 in Safari, the extension loads perfectly now

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
