### PR TITLE
Update dynamic import fallback to support sending credentials

### DIFF
--- a/src/containers/Extension/Extension.js
+++ b/src/containers/Extension/Extension.js
@@ -32,6 +32,7 @@ function dynamicImport(source, name) {
     };
 
     script.type = 'module';
+    script.crossorigin = 'anonymous'; // sets credentials flag to 'same-origin'
     script.onerror = () => {
       reject(new Error(`Failed to import ${source}`));
       cleanup();


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add the 'crossorigin' attribute to the script tag used in the
dynamic import ponyfill so that the browser will send cookie-
based credentials on the request. Use the value 'anonymous' so
this only happens on same-origin requests.

Found this while investigating https://github.com/tektoncd/experimental/issues/239
It does not resolve the problem in that issue, but should let us avoid a similar problem in other browsers that do not fully support dynamic import but rely on the ponyfill. See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes for details of behaviour.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
