### PR TITLE
Issue #537: Make pipeline0 pass correct parameters to API call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6868,6 +6868,26 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-loader": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
@@ -6927,6 +6947,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {
@@ -11984,6 +12010,22 @@
       "dev": true,
       "requires": {
         "detect-newline": "^2.1.0"
+      }
+    },
+    "jest-dom": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jest-dom/-/jest-dom-3.5.0.tgz",
+      "integrity": "sha512-xHnP3Qo/29oLAo2iixaZsoDrm3XKSVrMH5Wf2ZEiLychJQBTNzOeVMPxrCygCgJiyQMbnymXltme8bPzuiGOIA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "css": "^2.2.3",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "lodash": "^4.17.11",
+        "pretty-format": "^24.0.0",
+        "redent": "^2.0.0"
       }
     },
     "jest-each": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.3.1",
     "jest": "^24.5.0",
+    "jest-dom": "^3.4.0",
     "lerna": "^3.16.4",
     "lint-staged": "^8.1.5",
     "lodash.difference": "^4.5.0",

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -93,7 +93,8 @@ export class ImportResources extends Component {
       directory: applydirectory,
       namespace,
       repositoryURL: repourl,
-      serviceAccount
+      serviceAccount,
+      installNamespace
     } = this.state;
     const pipelineName = 'pipeline0';
     const gitresourcename = 'git-source';
@@ -112,7 +113,7 @@ export class ImportResources extends Component {
       kind: 'PipelineResource',
       metadata: {
         generateName: gitresourcename,
-        namespace
+        namespace: installNamespace
       },
       spec: {
         type: 'git',
@@ -129,7 +130,7 @@ export class ImportResources extends Component {
       }
     };
 
-    createPipelineResource({ namespace, resource })
+    createPipelineResource({ namespace: installNamespace, resource })
       .then(data => {
         const labels = getGitValues(repourl);
         const pipelineRun = {
@@ -140,16 +141,17 @@ export class ImportResources extends Component {
             'apply-directory': applydirectory,
             'target-namespace': namespace
           },
-          namespace,
+          namespace: installNamespace,
           labels
         };
+
         const promise = createPipelineRun(pipelineRun);
         promise
           .then(headers => {
             const pipelineRunName = headers.metadata.name;
 
             const finalURL = urls.pipelineRuns.byName({
-              namespace,
+              namespace: installNamespace,
               pipelineName: 'pipeline0',
               pipelineRunName
             });


### PR DESCRIPTION
# Changes
For https://github.com/tektoncd/dashboard/issues/537

Changes on the ImportResource.js file made incorrect calls to the
api, passing the target namespace as the namespace in which to
create the pipelinerun and resources required by pipeline0.  

This has been changed such that the installNamespace is used as
the namespace resources/pipelineruns for pipeline0 are created in.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
