### PR TITLE
Trims spaces at the start and end of a secret name instead of erroring

### DIFF
--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -95,7 +95,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
     }
 
     if (validateInputs(name, 'name')) {
-      postData.name = name;
+      postData.name = name.trim();
     } else {
       invalidFields.push('name');
     }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
References: #546 
The names of secrets that contain spaces at the end or beginning will now be trimmed instead of producing a non-descriptive 400 Bad Request error.
@CarolynMabbott gets credit as well

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
