### PR TITLE
Fix regression in PipelineRun resiliency

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -61,40 +61,50 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   };
 
   loadTaskRuns = pipelineRun => {
+    if (!pipelineRun) {
+      return [];
+    }
+
     const { tasks, taskRuns } = this.props;
     const {
       status: { taskRuns: taskRunDetails }
     } = pipelineRun;
 
-    return taskRuns.map(taskRun => {
-      const taskName = taskRun.spec.taskRef.name;
-      const task = selectedTask(taskName, tasks);
-      const {
-        name: taskRunName,
-        namespace: taskRunNamespace,
-        annotations
-      } = taskRun.metadata;
-      const { reason, status: succeeded } = getStatus(taskRun);
-      const { pipelineTaskName } = taskRunDetails[taskRunName];
-      const { params, resources: inputResources } = taskRun.spec.inputs;
-      const { resources: outputResources } = taskRun.spec.outputs;
-      const steps = stepsStatus(task.spec.steps, taskRun.status.steps);
-      return {
-        id: taskRun.metadata.uid,
-        pipelineTaskName,
-        pod: taskRun.status.podName,
-        reason,
-        steps,
-        succeeded,
-        taskName,
-        taskRunName,
-        namespace: taskRunNamespace,
-        inputResources,
-        outputResources,
-        params,
-        annotations
-      };
-    });
+    return taskRuns
+      .map(taskRun => {
+        const taskName = taskRun.spec.taskRef.name;
+        const task = selectedTask(taskName, tasks);
+        if (!task) {
+          return null;
+        }
+
+        const {
+          name: taskRunName,
+          namespace: taskRunNamespace,
+          annotations
+        } = taskRun.metadata;
+        const { reason, status: succeeded } = getStatus(taskRun);
+        const { pipelineTaskName } = taskRunDetails[taskRunName] || {};
+        const { params, resources: inputResources } = taskRun.spec.inputs;
+        const { resources: outputResources } = taskRun.spec.outputs;
+        const steps = stepsStatus(task.spec.steps, taskRun.status.steps);
+        return {
+          id: taskRun.metadata.uid,
+          pipelineTaskName,
+          pod: taskRun.status.podName,
+          reason,
+          steps,
+          succeeded,
+          taskName,
+          taskRunName,
+          namespace: taskRunNamespace,
+          inputResources,
+          outputResources,
+          params,
+          annotations
+        };
+      })
+      .filter(Boolean);
   };
 
   render() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
**NOTE**: Ignore whitespace for easier review

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/541

A previous fix in https://github.com/tektoncd/dashboard/pull/463
resolved some resiliency issues in the PipelineRun container,
particularly in relation to deleted / missing resources.

In parallel to this, we began moving some of the larger chunks
of presentational code out of the container to the components
package for re-use. As part of this move, some of the changes
from #463 were lost.

Ensure the PipelineRun component is resilient to missing
PipelineRun and Task resources during render, and that it also
handles errors gracefully during delete, displaying a notification
to the user.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
