### PR TITLE
Issue 552: Disable dropdowns if namespace is null

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -125,6 +125,13 @@ class CreatePipelineRun extends React.Component {
     return props[PIPELINE_REF] ? props[key] : state[key];
   }
 
+  isDisabled = () => {
+    if (this.state[NAMESPACE] === '') {
+      return true;
+    }
+    return false;
+  };
+
   checkFormValidation() {
     // Namespace, PipelineRef, Resources, and Params must all have values
     const validNamespace = !!this.getPipelineInfo(NAMESPACE);
@@ -337,6 +344,7 @@ class CreatePipelineRun extends React.Component {
                 selectedItem={
                   pipelineRef ? { id: pipelineRef, text: pipelineRef } : ''
                 }
+                disabled={this.isDisabled()}
                 onChange={this.handlePipelineChange}
               />
             </FormGroup>
@@ -397,6 +405,7 @@ class CreatePipelineRun extends React.Component {
                   ? { id: serviceAccount, text: serviceAccount }
                   : ''
               }
+              disabled={this.isDisabled()}
               onChange={({ selectedItem: { text } }) =>
                 this.setState({ serviceAccount: text })
               }

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -327,19 +327,52 @@ it('CreatePipelineRun handles api error with text', async () => {
   await waitForElement(() => getByText(/example message \(error code 401\)/i));
 });
 
-it('CreatePipelineRun renders empty', () => {
-  const { queryByText, queryAllByText, queryByPlaceholderText } = render(
+it('CreatePipelineRun renders empty, dropdowns disabled when no namespace selected', async () => {
+  const {
+    queryByText,
+    queryAllByText,
+    queryByPlaceholderText,
+    getByText
+  } = render(
     <Provider store={mockStore(testStore)}>
-      <CreatePipelineRun open />
+      <CreatePipelineRun open namespace="" />
     </Provider>
   );
   expect(queryByText(/create pipelinerun/i)).toBeTruthy();
   expect(queryByText(/select namespace/i)).toBeTruthy();
   expect(queryByText(/select pipeline/i)).toBeTruthy();
+  expect(
+    document
+      .getElementById('create-pipelinerun--pipelines-dropdown')
+      .className.includes('disabled')
+  ).toBe(true);
   expect(queryByText(/select service account/i)).toBeTruthy();
+  expect(
+    document
+      .getElementById('create-pipelinerun--sa-dropdown')
+      .className.includes('disabled')
+  ).toBe(true);
   expect(queryByPlaceholderText(/duration/i)).toBeTruthy();
   expect(queryByText(/cancel/i)).toBeTruthy();
   expect(submitButton(queryAllByText)).toBeTruthy();
+
+  // Check dropdowns enabled when namespace selected
+  fireEvent.click(await waitForElement(() => getByText(/select namespace/i)));
+  fireEvent.click(await waitForElement(() => getByText(/namespace-1/i)));
+  await wait(() =>
+    expect(
+      document
+        .getElementById('create-pipelinerun--pipelines-dropdown')
+        .className.includes('disabled')
+    ).toBe(false)
+  );
+  await wait(() =>
+    expect(
+      document
+        .getElementById('create-pipelinerun--sa-dropdown')
+        .className.includes('disabled')
+    ).toBe(false)
+  );
 });
 
 it('CreatePipelineRun renders pipeline', () => {


### PR DESCRIPTION
# Changes

Introduced an isDisabled() method which returns true if the namespace is set to "".  The Pipelines and Service Accounts dropdowns then use this method to check whether or not they can be accessed.

Test updated to include checking that dropdowns are disabled and then enabled on selction of namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
