### PR TITLE
Replace JS substr with substring

### DIFF
--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -59,7 +59,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
           placeholder: 'https://github.com',
           id: Math.random()
             .toString(36)
-            .substr(2, 9)
+            .substring(2, 11)
         }
       ],
       invalidFields: []
@@ -252,7 +252,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
         .split('-')
         .splice(1, 2)
         .join();
-      const index = id.substr(id.length - 1);
+      const index = id.substring(id.length - 1);
       id = id.slice(0, -1);
 
       const { annotations } = prevState;
@@ -280,7 +280,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
         placeholder: example,
         id: Math.random()
           .toString(36)
-          .substr(2, 9)
+          .substring(2, 11)
       });
       return annotations;
     });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
https://github.com/tektoncd/dashboard/issues/562

substr is deprecated and should not be used:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

Replace `substr` with `substring`, ensuring the parameters are
updated to reflect the subtle difference between these 2 functions,
i.e. the second param of `substr` is the number of characters
to take, whereas the second param of `substring` is the end index.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
