### PR TITLE
Issue 555: Clarify the format of the timeout duration on PipelineRun creation UI

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -148,6 +148,7 @@ class CreatePipelineRun extends React.Component {
         (acc, name) => acc && !!this.state.params[name],
         true
       );
+
     return validNamespace && validPipelineRef && validResources && validParams;
   }
 
@@ -413,7 +414,8 @@ class CreatePipelineRun extends React.Component {
             <TextInput
               id="create-pipelinerun--timeout"
               labelText="Timeout (optional)"
-              placeholder="duration"
+              helperText="See https://golang.org/pkg/time/#ParseDuration for valid duration format"
+              placeholder="60m"
               value={this.state.timeout}
               onChange={({ target: { value } }) =>
                 this.setState({ timeout: value })

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -352,7 +352,7 @@ it('CreatePipelineRun renders empty, dropdowns disabled when no namespace select
       .getElementById('create-pipelinerun--sa-dropdown')
       .className.includes('disabled')
   ).toBe(true);
-  expect(queryByPlaceholderText(/duration/i)).toBeTruthy();
+  expect(queryByPlaceholderText(/60m/i)).toBeTruthy();
   expect(queryByText(/cancel/i)).toBeTruthy();
   expect(submitButton(queryAllByText)).toBeTruthy();
 
@@ -504,8 +504,8 @@ it('CreatePipelineRun submits form', () => {
   fireEvent.click(getByText(/select service account/i));
   fireEvent.click(getByText(/service-account-1/i));
   // Fill timeout
-  fireEvent.change(getByPlaceholderText(/duration/i), {
-    target: { value: '120' }
+  fireEvent.change(getByPlaceholderText(/60m/i), {
+    target: { value: '120s' }
   });
   // Submit
   const createPipelineRun = jest
@@ -525,7 +525,7 @@ it('CreatePipelineRun submits form', () => {
       'param-2': 'value-2'
     },
     serviceAccount: 'service-account-1',
-    timeout: '120'
+    timeout: '120s'
   };
   expect(createPipelineRun).toHaveBeenCalledWith(payload);
 });


### PR DESCRIPTION
# Changes

Added helper text pointing to the parseDuration documentation - also updated the example text to state 60m (which I believe is the default).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
