### PR TITLE
Handle PipelineRuns with no status in PipelineRuns table

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -16,8 +16,8 @@ import { getPodLog } from '../api';
 
 export function sortRunsByStartTime(runs) {
   runs.sort((a, b) => {
-    const aTime = a.status.startTime;
-    const bTime = b.status.startTime;
+    const aTime = (a.status || {}).startTime;
+    const bTime = (b.status || {}).startTime;
     if (!aTime) {
       return -1;
     }

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -20,13 +20,14 @@ it('sortRunsByStartTime', () => {
   const d = { name: 'd', status: { startTime: '1' } };
   const e = { name: 'e', status: {} };
   const f = { name: 'f', status: { startTime: '3' } };
+  const g = { name: 'g' };
 
-  const runs = [a, b, c, d, e, f];
+  const runs = [a, b, c, d, e, f, g];
   /*
     sort is stable on all modern browsers so
     input order is preserved for b and e
    */
-  const sortedRuns = [b, e, f, c, d, a];
+  const sortedRuns = [b, e, g, f, c, d, a];
   sortRunsByStartTime(runs);
   expect(runs).toEqual(sortedRuns);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
https://github.com/tektoncd/dashboard/issues/568

Currently get an error when attempting to sort PipelineRuns with
no status as we attempt to access the startTime.

Update the sort function to handle missing status.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
