### PR TITLE
Resiliency: function even with missing status & TaskRun info for PipelineRun page

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.test.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.js
@@ -106,3 +106,54 @@ it('PipelineRunContainer handles error state', async () => {
   );
   await waitForElement(() => getByText('Error loading PipelineRun'));
 });
+
+// A scenario exists (typically with rebuild) where all PipelineRun data
+// is not yet available. Verify that the container still renders OK
+it('PipelineRunContainer handles no TaskRuns found yet', async () => {
+  const match = {
+    params: {
+      pipelineName: 'foo',
+      pipelineRunName: 'bar'
+    }
+  };
+
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+
+  const testStore = mockStore({
+    tasks: {
+      byNamespace: {}
+    },
+    taskRuns: {
+      // Nothing here
+      byId: {},
+      byNamespace: {},
+      errorMessage: null,
+      isFetching: false
+    },
+    namespaces: {
+      selected: 'default'
+    },
+    pipelineRuns: {
+      byId: {},
+      byNamespace: { default: {} },
+      errorMessage: null,
+      isFetching: false
+    }
+  });
+
+  const { getByText } = renderWithIntl(
+    <Provider store={testStore}>
+      <PipelineRun
+        match={match}
+        error={null}
+        fetchTaskRuns={() => Promise.resolve()}
+        fetchPipelineRun={() => Promise.resolve()}
+        fetchTasks={() => Promise.resolve()}
+        fetchClusterTasks={() => Promise.resolve()}
+      />
+    </Provider>
+  );
+  // But it still renders and all is well
+  await waitForElement(() => getByText('PipelineRun not found'));
+});

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -23,9 +23,17 @@ class TaskTree extends Component {
 
   render() {
     const { selectedTaskId, taskRuns } = this.props;
+
+    if (!taskRuns) {
+      return <div />;
+    }
+
     return (
       <ol className="task-tree">
         {taskRuns.map((taskRun, index) => {
+          if (!taskRun) {
+            return null;
+          }
           const { id, reason, steps, succeeded, pipelineTaskName } = taskRun;
           const expanded =
             selectedTaskId === id || (!selectedTaskId && index === 0);

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -32,7 +32,10 @@ export function getErrorMessage(error) {
 }
 
 export function selectedTask(selectedTaskName, tasks) {
-  return tasks.find(t => t.metadata.name === selectedTaskName);
+  if (tasks) {
+    return tasks.find(t => t.metadata.name === selectedTaskName);
+  }
+  return {};
 }
 
 export function selectedTaskRun(selectedTaskId, taskRuns = []) {

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -46,7 +46,6 @@ func (r Resource) ProxyRequest(request *restful.Request, response *restful.Respo
 	forwardRequest.SetHeader("Content-Type", request.HeaderParameter("Content-Type"))
 	forwardResponse := forwardRequest.Do()
 
-	logging.Log.Debugf("Forwarding to url : %s", forwardRequest.URL().String())
 	responseBody, requestError := forwardResponse.Raw()
 	if requestError != nil {
 		utils.RespondError(response, requestError, http.StatusNotFound)

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -82,6 +82,10 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
             </StructuredListRow>
           )}
           {clusterTasks.map(task => {
+            if (!task.metadata) {
+              return {};
+            }
+
             const { name: taskName, uid } = task.metadata;
             return (
               <StructuredListRow className="definition" key={uid}>

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -97,6 +97,20 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
   render() {
     const { error, intl, match, pipelineRun, tasks, taskRuns } = this.props;
+
+    if (!pipelineRun) {
+      return <PipelineRun error="PipelineRun not found" loading={false} />;
+    }
+
+    if (!pipelineRun.status) {
+      pipelineRun.status = {
+        taskRuns: []
+      };
+    }
+    if (!pipelineRun.status.taskRuns) {
+      pipelineRun.status.taskRuns = [];
+    }
+
     const { loading, showRebuildNotification } = this.state;
     const { pipelineRunName } = match.params;
 
@@ -174,6 +188,7 @@ function mapStateToProps(state, ownProps) {
       namespace
     }),
     tasks: getTasks(state, { namespace }),
+
     taskRuns: getTaskRunsByPipelineRunName(
       state,
       ownProps.match.params.pipelineRunName,

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -34,6 +34,7 @@
     "dashboard.tableHeader.value": "Value",
     "dashboard.taskRun.details": "Details",
     "dashboard.taskRun.logs": "Logs",
+    "dashboard.taskRun.noTaskRuns": "No TaskRuns found for this PipelineRun yet…",
     "dashboard.taskRun.status": "Status",
     "dashboard.taskRun.status.cancelled": "Cancelled",
     "dashboard.taskRun.status.failed": "Failed",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For https://github.com/tektoncd/dashboard/issues/567

Without this change, every fifth(ish) rebuild would fail to render due to either being unable to find .steps from something undefined, or taskruns. With this change, add hardening (returning empty in some cases, or a small amount of data so we can render the page in others), and then rely on the websocket and new data coming in to update the components accordingly.

Tested with over 20 rebuilt runs in a row and noticing the components continue to be updated with new PipelineRun information accordingly.

Also includes a backend change to generate a more unique suffix (delegating to the k8s GenerateName feature).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
Nope - sorry, desperate to get this in for 0.2.0! Thinking about adding...

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
