### PR TITLE
Hide params and resource on step details tab for 3rd parties

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -108,7 +108,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   };
 
   render() {
-    const { error, loading, fetchLogs, intl, rebuild } = this.props;
+    const { error, loading, fetchLogs, intl, rebuild, showIO } = this.props;
 
     const { selectedStepId, selectedTaskId } = this.state;
 
@@ -226,6 +226,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
               definition={definition}
               logContainer={logContainer}
               reason={reason}
+              showIO={showIO}
               status={status}
               stepName={stepName}
               stepStatus={stepStatus}

--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 // TODO: rename. Details section of a step
 
-import React from 'react';
+import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import jsYaml from 'js-yaml';
 import { FormattedMessage, injectIntl } from 'react-intl';
@@ -63,57 +63,77 @@ const resourceTable = (title, namespace, resources, intl) => {
   );
 };
 
-const StepDefinition = ({ definition, intl, taskRun }) => {
-  const yaml = jsYaml.dump(
-    definition ||
-      intl.formatMessage({
-        id: 'dashboard.step.definitionNotAvailable',
-        defaultMessage: 'description: step definition not available'
-      })
-  );
-  return (
-    <div className="step-definition">
-      <div className="title">
-        <FormattedMessage
-          id="dashboard.step.stepDefinition"
-          defaultMessage="Step definition"
-        />
-        :
+class StepDefinition extends Component {
+  getIOTables() {
+    const { intl, showIO, taskRun } = this.props;
+
+    if (!showIO) {
+      return null;
+    }
+
+    return (
+      <>
+        {taskRun.params && (
+          <ResourceTable
+            title="Parameters"
+            rows={taskRun.params.map(({ name, value }) => ({
+              id: name,
+              name,
+              value
+            }))}
+            headers={[
+              { key: 'name', header: 'Name' },
+              { key: 'value', header: 'Value' }
+            ]}
+          />
+        )}
+        {taskRun.inputResources &&
+          resourceTable(
+            'Input Resources',
+            taskRun.namespace,
+            taskRun.inputResources,
+            intl
+          )}
+        {taskRun.outputResources &&
+          resourceTable(
+            'Output Resources',
+            taskRun.namespace,
+            taskRun.outputResources,
+            intl
+          )}
+      </>
+    );
+  }
+
+  render() {
+    const { definition, intl } = this.props;
+    const yaml = jsYaml.dump(
+      definition ||
+        intl.formatMessage({
+          id: 'dashboard.step.definitionNotAvailable',
+          defaultMessage: 'description: step definition not available'
+        })
+    );
+
+    const paramsResources = this.getIOTables();
+    return (
+      <div className="step-definition">
+        <div className="title">
+          <FormattedMessage
+            id="dashboard.step.stepDefinition"
+            defaultMessage="Step definition"
+          />
+          :
+        </div>
+        <pre>{yaml}</pre>
+        {paramsResources}
       </div>
-      <pre>{yaml}</pre>
-      {taskRun.params && (
-        <ResourceTable
-          title="Parameters"
-          rows={taskRun.params.map(({ name, value }) => ({
-            id: name,
-            name,
-            value
-          }))}
-          headers={[
-            { key: 'name', header: 'Name' },
-            { key: 'value', header: 'Value' }
-          ]}
-        />
-      )}
-      {taskRun.inputResources &&
-        resourceTable(
-          'Input Resources',
-          taskRun.namespace,
-          taskRun.inputResources,
-          intl
-        )}
-      {taskRun.outputResources &&
-        resourceTable(
-          'Output Resources',
-          taskRun.namespace,
-          taskRun.outputResources,
-          intl
-        )}
-    </div>
-  );
-};
+    );
+  }
+}
 
 StepDefinition.defaultProps = {
+  showIO: false,
   taskRun: {}
 };
 

--- a/packages/components/src/components/StepDefinition/StepDefinition.test.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.test.js
@@ -71,7 +71,7 @@ it('StepDefinition renders the provided content with resources and params', () =
     name: 'test name'
   };
   const { queryByText } = renderWithRouter(
-    <StepDefinition definition={definition} taskRun={taskRun} />
+    <StepDefinition definition={definition} showIO taskRun={taskRun} />
   );
 
   expect(queryByText(/--someArg/)).toBeTruthy();

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -24,6 +24,7 @@ const StepDetails = props => {
     intl,
     logContainer,
     reason,
+    showIO,
     status,
     stepName,
     stepStatus,
@@ -63,7 +64,11 @@ const StepDetails = props => {
             defaultMessage: 'Details'
           })}
         >
-          <StepDefinition definition={definition} taskRun={taskRun} />
+          <StepDefinition
+            definition={definition}
+            showIO={showIO}
+            taskRun={taskRun}
+          />
         </Tab>
       </Tabs>
     </div>
@@ -71,6 +76,7 @@ const StepDetails = props => {
 };
 
 StepDetails.defaultProps = {
+  showIO: false,
   taskRun: {}
 };
 

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -140,6 +140,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           loading={loading}
           fetchLogs={fetchLogs}
           pipelineRun={pipelineRun}
+          showIO
           tasks={tasks}
           taskRuns={taskRuns}
           rebuild={rebuild}

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -200,6 +200,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
               definition={definition}
               logContainer={logContainer}
               reason={reason}
+              showIO
               status={status}
               stepName={stepName}
               stepStatus={stepStatus}

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -203,6 +203,7 @@ export /* istanbul ignore next */ class TaskRunsContainer extends Component {
               definition={definition}
               logContainer={logContainer}
               reason={reason}
+              showIO
               status={status}
               stepName={stepName}
               stepStatus={stepStatus}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/585

- Add new prop to StepDefinition to hide IO tables by default
- StepDetails for each of the dashboard 'run' views overrides this

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
