### PR TITLE
Update URL for PipelineRun page and ensure PipelineRuns active in left nav

### DIFF
--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -26,7 +26,6 @@ storiesOf('Breadcrumbs', module)
       match={{
         url: urls.pipelineRuns.byName({
           namespace: 'default',
-          pipelineName: 'demo-pipeline',
           pipelineRunName: 'demo-pipeline-run-1'
         })
       }}

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -103,7 +103,6 @@ const PipelineRuns = ({
         const { lastTransitionTime, reason, status } = getStatus(pipelineRun);
         const url = createPipelineRunURL({
           namespace,
-          pipelineName: pipelineRefName,
           pipelineRunName,
           annotations
         });

--- a/packages/components/src/components/Rebuild/Rebuild.js
+++ b/packages/components/src/components/Rebuild/Rebuild.js
@@ -23,7 +23,6 @@ export class Rebuild extends Component {
       event.preventDefault();
     }
 
-    const pipelineName = this.props.pipelineRun.spec.pipelineRef.name;
     const { namespace } = this.props.pipelineRun.metadata;
     const payload = {
       pipelinerunname: this.props.runName
@@ -38,7 +37,6 @@ export class Rebuild extends Component {
         );
         const finalURL = urls.pipelineRuns.byName({
           namespace,
-          pipelineName,
           pipelineRunName: newPipelineRunName
         });
         this.props.setShowRebuildNotification({

--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -53,11 +53,14 @@ export const paths = {
       return byNamespace({ path: '/pipelineruns' });
     },
     byPipeline() {
-      return byNamespace({ path: '/pipelines/:pipelineName/runs' });
+      return byNamespace({
+        path:
+          '/pipelineruns?labelSelector=tekton.dev%2Fpipeline%3D:pipelineName'
+      });
     },
     byName() {
       return byNamespace({
-        path: '/pipelines/:pipelineName/runs/:pipelineRunName'
+        path: '/pipelineruns/:pipelineRunName'
       });
     }
   },

--- a/packages/utils/src/utils/router.test.js
+++ b/packages/utils/src/utils/router.test.js
@@ -105,12 +105,9 @@ describe('pipelineRuns', () => {
   });
 
   it('byName', () => {
-    expect(
-      urls.pipelineRuns.byName({ namespace, pipelineName, pipelineRunName })
-    ).toEqual(
+    expect(urls.pipelineRuns.byName({ namespace, pipelineRunName })).toEqual(
       generatePath(paths.pipelineRuns.byName(), {
         namespace,
-        pipelineName,
         pipelineRunName
       })
     );

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -116,51 +116,19 @@ export /* istanbul ignore next */ class App extends Component {
                   exact
                   component={Pipelines}
                 />
-                <Route path={paths.secrets.all()} exact component={Secrets} />
-                <Route path={paths.tasks.all()} exact component={Tasks} />
-                <Route
-                  path={paths.tasks.byNamespace()}
-                  exact
-                  component={Tasks}
-                />
-                <Route
-                  path={paths.clusterTasks.all()}
-                  exact
-                  component={ClusterTasks}
-                />
                 <Route
                   path={paths.pipelineRuns.all()}
                   component={PipelineRuns}
                 />
                 <Route
                   path={paths.pipelineRuns.byNamespace()}
+                  exact
                   component={PipelineRuns}
-                />
-                <Route
-                  path={paths.taskRuns.byNamespace()}
-                  exact
-                  component={TaskRunList}
-                />
-                <Route
-                  path={paths.taskRuns.byName()}
-                  exact
-                  component={TaskRun}
                 />
                 <Route
                   path={paths.pipelineRuns.byPipeline()}
                   exact
                   component={PipelineRuns}
-                />
-                <Route path={paths.taskRuns.all()} component={TaskRunList} />
-                <Route
-                  path={paths.taskRuns.byTask()}
-                  exact
-                  component={TaskRuns}
-                />
-                <Route
-                  path={paths.taskRuns.byClusterTask()}
-                  exact
-                  component={TaskRuns}
                 />
                 <Route
                   path={paths.pipelineRuns.byName()}
@@ -181,10 +149,45 @@ export /* istanbul ignore next */ class App extends Component {
                   exact
                   component={PipelineResource}
                 />
+                <Route path={paths.tasks.all()} exact component={Tasks} />
+                <Route
+                  path={paths.tasks.byNamespace()}
+                  exact
+                  component={Tasks}
+                />
+                <Route path={paths.taskRuns.all()} component={TaskRunList} />
+                <Route
+                  path={paths.taskRuns.byNamespace()}
+                  exact
+                  component={TaskRunList}
+                />
+                <Route
+                  path={paths.taskRuns.byTask()}
+                  exact
+                  component={TaskRuns}
+                />
+                <Route
+                  path={paths.taskRuns.byName()}
+                  exact
+                  component={TaskRun}
+                />
+                <Route
+                  path={paths.clusterTasks.all()}
+                  exact
+                  component={ClusterTasks}
+                />
+                <Route
+                  path={paths.taskRuns.byClusterTask()}
+                  exact
+                  component={TaskRuns}
+                />
+
                 <Route
                   path={paths.importResources()}
                   component={ImportResources}
                 />
+                <Route path={paths.secrets.all()} exact component={Secrets} />
+
                 <Route
                   path={paths.extensions.all()}
                   exact
@@ -205,6 +208,12 @@ export /* istanbul ignore next */ class App extends Component {
                       )}
                     />
                   ))}
+
+                <Route
+                  path={paths.kubernetesResources.all()}
+                  exact
+                  component={ResourceList}
+                />
                 <Route
                   path={paths.kubernetesResources.byNamespace()}
                   exact
@@ -221,11 +230,6 @@ export /* istanbul ignore next */ class App extends Component {
                   component={CustomResourceDefinition}
                 />
                 <Route
-                  path={paths.kubernetesResources.all()}
-                  exact
-                  component={ResourceList}
-                />
-                <Route
                   path={paths.rawCRD.byNamespace()}
                   exact
                   component={CustomResourceDefinition}
@@ -235,6 +239,7 @@ export /* istanbul ignore next */ class App extends Component {
                   exact
                   component={CustomResourceDefinition}
                 />
+
                 <Redirect to={urls.pipelineRuns.all()} />
               </Switch>
             </Content>

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -152,7 +152,6 @@ export class ImportResources extends Component {
 
             const finalURL = urls.pipelineRuns.byName({
               namespace: installNamespace,
-              pipelineName: 'pipeline0',
               pipelineRunName
             });
 

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -122,7 +122,6 @@ describe('ImportResources component', () => {
     ).toContain(
       urls.pipelineRuns.byName({
         namespace: installNamespace,
-        pipelineName: 'pipeline0',
         pipelineRunName
       })
     );

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -152,7 +152,6 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 PipelineRunContainer.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
-      pipelineName: PropTypes.string.isRequired,
       pipelineRunName: PropTypes.string.isRequired
     }).isRequired
   }).isRequired

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -202,14 +202,10 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
 
   handleCreatePipelineRunSuccess(newPipelineRun) {
     const {
-      metadata: { namespace, name },
-      spec: {
-        pipelineRef: { name: pipelineName }
-      }
+      metadata: { namespace, name }
     } = newPipelineRun;
     const url = urls.pipelineRuns.byName({
       namespace,
-      pipelineName,
       pipelineRunName: name
     });
     this.toggleModal(false);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/142

Update the URL used for the PipelineRun details page to match
the pattern used for other resources, i.e.:
`/namespaces/:namespace/pipelineruns/:pipelineRunName`

This has the added benefit of finally marking the PipelineRuns
item in the left nav as active when on this page, instead of
the Pipelines item as before.

This change does not touch the various TaskRun pages, which
should be addressed separately.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
