### PR TITLE
Update usage of fetch to send credentials

### DIFF
--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -12,7 +12,8 @@ limitations under the License.
 */
 
 const defaultOptions = {
-  method: 'get'
+  method: 'get',
+  credentials: 'same-origin'
 };
 
 export function getHeaders(headers = {}) {
@@ -43,8 +44,9 @@ export function checkStatus(response = {}) {
   throw error;
 }
 
-export function request(uri, options = defaultOptions) {
+export function request(uri, options) {
   return fetch(uri, {
+    ...defaultOptions,
     ...options
   }).then(checkStatus);
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/528

Ensure we set `credentials: 'same-origin'` so that all
browsers send credentials on fetch requests, but only for
same-origin requests. This is to address an issue with
FF ESR (60) which was not sending credentials.

Other browser default to 'same-origin', but FF ESR requires
it explicitly. This behaviour was changed to match other
browsers from FF61: https://github.com/whatwg/fetch/pull/585#issuecomment-403487602

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
