### PR TITLE
Fix Scrolling Bug when Modal is Closed

### DIFF
--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.js
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.js
@@ -22,6 +22,7 @@ const SecretsDeleteModal = props => {
     <Modal
       open={open}
       className="deleteModal"
+      data-testid="deleteModal"
       primaryButtonText="Delete"
       secondaryButtonText="Cancel"
       modalHeading="Delete Secret"

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -343,15 +343,13 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
             </Tag>
           ))}
         </div>
-        {this.state.showCreatePipelineRunModal && (
-          <CreatePipelineRun
-            open={this.state.showCreatePipelineRunModal}
-            onClose={() => this.toggleModal(false)}
-            onSuccess={this.handleCreatePipelineRunSuccess}
-            pipelineRef={pipelineName}
-            namespace={selectedNamespace}
-          />
-        )}
+        <CreatePipelineRun
+          open={this.state.showCreatePipelineRunModal}
+          onClose={() => this.toggleModal(false)}
+          onSuccess={this.handleCreatePipelineRunSuccess}
+          pipelineRef={pipelineName}
+          namespace={selectedNamespace}
+        />
         <PipelineRunsList
           pipelineName={pipelineName}
           selectedNamespace={selectedNamespace}

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -38,7 +38,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
     this.state = {
       openNewSecret: false,
       openDeleteSecret: false,
-      toBeDeleted: null
+      toBeDeleted: []
     };
   }
 
@@ -65,7 +65,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
   handleDeleteSecretToggle = () => {
     this.setState({
       openDeleteSecret: false,
-      toBeDeleted: null
+      toBeDeleted: []
     });
   };
 
@@ -106,17 +106,13 @@ export /* istanbul ignore next */ class Secrets extends Component {
           secrets={secrets}
           selectedNamespace={selectedNamespace}
         />
-        {openNewSecret && (
-          <Modal open={openNewSecret} handleNew={this.handleNewSecretClick} />
-        )}
-        {openDeleteSecret && (
-          <DeleteModal
-            open={openDeleteSecret}
-            handleClick={this.handleDeleteSecretToggle}
-            handleDelete={this.delete}
-            toBeDeleted={toBeDeleted}
-          />
-        )}
+        <Modal open={openNewSecret} handleNew={this.handleNewSecretClick} />
+        <DeleteModal
+          open={openDeleteSecret}
+          handleClick={this.handleDeleteSecretToggle}
+          handleDelete={this.delete}
+          toBeDeleted={toBeDeleted}
+        />
       </>
     );
   }

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -127,21 +127,17 @@ it('click add new secret & modal appears', () => {
 
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
 
-  const { getByTestId, queryByText } = render(
+  const { getByTestId } = render(
     <Provider store={store}>
       <Secrets {...props} />
     </Provider>
   );
 
-  expect(queryByText('Create Secret')).toBeFalsy();
-  expect(queryByText('Close')).toBeFalsy();
-  expect(queryByText('Submit')).toBeFalsy();
+  expect(getByTestId('modal').className.includes('is-visible')).toBeFalsy();
 
   fireEvent.click(getByTestId('addButton'));
 
-  expect(queryByText('Create Secret')).toBeTruthy();
-  expect(queryByText('Close')).toBeTruthy();
-  expect(queryByText('Submit')).toBeTruthy();
+  expect(getByTestId('modal').className.includes('is-visible')).toBeTruthy();
 });
 
 it('click add delete secret & modal appears', () => {
@@ -158,19 +154,21 @@ it('click add delete secret & modal appears', () => {
     error: null
   };
 
-  const { getByTestId, queryByText } = render(
+  const { getByTestId } = render(
     <Provider store={store}>
       <Secrets {...props} />
     </Provider>
   );
 
-  expect(queryByText('Delete Secret')).toBeFalsy();
+  expect(
+    getByTestId('deleteModal').className.includes('is-visible')
+  ).toBeFalsy();
 
   fireEvent.click(getByTestId('deleteButton'));
 
-  expect(queryByText('Delete Secret')).toBeTruthy();
-  expect(queryByText('Cancel')).toBeTruthy();
-  expect(queryByText('Delete')).toBeTruthy();
+  expect(
+    getByTestId('deleteModal').className.includes('is-visible')
+  ).toBeTruthy();
 });
 
 it('error notification appears', () => {
@@ -187,8 +185,16 @@ it('error notification appears', () => {
       errorMessage: 'Some error message'
     },
     namespaces,
-    notifications: {}
+    notifications: {},
+    serviceAccounts: {
+      byId: serviceAccountsById,
+      byNamespace: serviceAccountsByNamespace,
+      isFetching: false
+    }
   });
+
+  jest.spyOn(API, 'getCredentials').mockImplementation(() => []);
+
   const { getByTestId } = render(
     <Provider store={store}>
       <Secrets {...props} />

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -318,6 +318,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       <Modal
         open={open}
         className="modal"
+        data-testid="modal"
         primaryButtonText="Submit"
         secondaryButtonText="Close"
         modalHeading="Create Secret"


### PR DESCRIPTION
issue: #581

# Changes

Apparently, with the new update of Carbon Components, Modals are not "unmounting" properly when you render them inside some inline logic. i.e: {booleanVariable && `component`}. Thus removing the inline logic for each modal fixed the scrolling problem. With that said, when the page is loading without the logic, one can see for a split second how the modals appear & disappear as soon as the container is finished mounting. Probably adding some lazy rending might fix this harmless behavior. Lastly I updated some test cases for the Secret container.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
