### PR TITLE
Fix for secrets timeout error when deleting multiple secrets

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -48,13 +48,14 @@ export function fetchSecrets({ namespace } = {}) {
 export function deleteSecret(secrets) {
   return async dispatch => {
     dispatch({ type: 'SECRET_DELETE_REQUEST' });
+    const timeoutLength = secrets.length * 1000;
     const deletePromises = secrets.map(secret => {
       const { name, namespace } = secret;
       const response = deleteCredential(name, namespace);
       const timeout = new Promise((resolve, reject) => {
         setTimeout(() => {
           reject(new Error('An error occured deleting the secret(s).'));
-        }, 1000);
+        }, timeoutLength);
       });
       const deleteWithinTimePromise = Promise.race([response, timeout]);
       return deleteWithinTimePromise;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Stops the timeout error from occurring when deleting multiple secrets 
Changes the timeout for secrets being deleted from 1000 to 1000 * the amount of secrets being deleted 


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
