### PR TITLE
Fix lockdown.py curl URL in publish pipeline

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -83,7 +83,7 @@ spec:
     args:
     - -ce
     - |
-      curl https://raw.githubusercontent.com/tektoncd/dashboard/tekton/scripts/lockdown.py --output lockdown.py
+      curl https://raw.githubusercontent.com/tektoncd/dashboard/master/tekton/scripts/lockdown.py --output lockdown.py
       chmod +x lockdown.py
       pip install docker
       ./lockdown.py --omit dashboard --path /workspace/bucket/dashboard/previous/${inputs.params.versionTag}/release.yaml


### PR DESCRIPTION
Fixes ./lockdown.py: 1: ./lockdown.py: 404:: not found used in publish pipeline

https://raw.githubusercontent.com/tektoncd/dashboard/tekton/scripts/lockdown.py returns a 404

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
