### PR TITLE
Add default value of 60 for pipelinerun timeout

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -272,7 +272,7 @@ class CreatePipelineRun extends React.Component {
       ),
       [NAMESPACE]: namespace !== ALL_NAMESPACES ? namespace : '',
       serviceAccount: '',
-      timeout: '',
+      timeout: '60',
       validationError: false,
       submitError: '',
       validTimeout: true
@@ -430,7 +430,7 @@ class CreatePipelineRun extends React.Component {
             />
             <TextInput
               id="create-pipelinerun--timeout"
-              labelText="Timeout (optional)"
+              labelText="Timeout"
               helperText="PipelineRun timeout in minutes"
               invalid={validationError && !validTimeout}
               invalidText="Timeout must be a valid number less than 525600"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For #607 
Added a default value of 60 for the timeout box in CreatePipelineRun.
Also removed the text saying the timeout is optional as with the current functionality the timeout is required.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
