### PR TITLE
Namespace on the left overwriting namespace in the create secret modal

### DIFF
--- a/src/components/SecretsModal/BasicAuthFields.js
+++ b/src/components/SecretsModal/BasicAuthFields.js
@@ -26,15 +26,13 @@ const BasicAuthFields = props => {
     serviceAccounts
   } = props;
 
-  const saItems = serviceAccounts
-    .filter(sa => sa.metadata.namespace === namespace)
-    .map(sa => (
-      <SelectItem
-        value={sa.metadata.name}
-        text={sa.metadata.name}
-        key={`${sa.metadata.namespace}:${sa.metadata.name}`}
-      />
-    ));
+  const saItems = serviceAccounts.map(sa => (
+    <SelectItem
+      value={sa.metadata.name}
+      text={sa.metadata.name}
+      key={`${sa.metadata.namespace}:${sa.metadata.name}`}
+    />
+  ));
 
   return (
     <>

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -19,7 +19,7 @@ import Annotations from '../../components/SecretsModal/Annotations';
 import BasicAuthFields from '../../components/SecretsModal/BasicAuthFields';
 import '../../components/SecretsModal/SecretsModal.scss';
 import { createSecret } from '../../actions/secrets';
-import { getServiceAccounts, isWebSocketConnected } from '../../reducers';
+import { isWebSocketConnected } from '../../reducers';
 import { fetchServiceAccounts } from '../../actions/serviceAccounts';
 
 /* istanbul ignore next */
@@ -67,12 +67,9 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
             .substring(2, 11)
         }
       ],
-      invalidFields: []
+      invalidFields: [],
+      serviceAccounts: []
     };
-  }
-
-  componentDidMount() {
-    this.props.fetchServiceAccounts();
   }
 
   componentDidUpdate(prevProps) {
@@ -196,7 +193,13 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       } else if (idIndex === -1) {
         newInvalidFields.push(stateVar);
       }
-      return { [stateVar]: stateValue, invalidFields: newInvalidFields };
+      this.props.fetchServiceAccounts({ namespace: stateValue }).then(data => {
+        this.setState({ serviceAccounts: data });
+      });
+      return {
+        [stateVar]: stateValue,
+        invalidFields: newInvalidFields
+      };
     });
   };
 
@@ -302,7 +305,8 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
   };
 
   render() {
-    const { open, handleNew, serviceAccounts } = this.props;
+    const { open, handleNew } = this.props;
+    const { serviceAccounts } = this.state;
     const {
       name,
       namespace,
@@ -365,7 +369,6 @@ SecretsModal.defaultProps = {
 
 function mapStateToProps(state) {
   return {
-    serviceAccounts: getServiceAccounts(state),
     webSocketConnected: isWebSocketConnected(state)
   };
 }


### PR DESCRIPTION
issue: #549 

# Changes

the action `fetchServiceAccounts` was not being used correctly. Was fetching them when the component mounted without passing the selected namespace as a parameter. Changed it to make the fetch after namespace is selected.


