### PR TITLE
make timestamp configurable

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -36,6 +36,8 @@ const PipelineRuns = ({
   createPipelineRunURL = urls.pipelineRuns.byName,
   createPipelineRunDisplayName = ({ pipelineRunMetadata }) =>
     pipelineRunMetadata.name,
+  createPipelineRunTimestamp = pipelineRun =>
+    getStatus(pipelineRun).lastTransitionTime,
   createPipelineRunsByPipelineURL = urls.pipelineRuns.byPipeline,
   intl,
   pipelineName,
@@ -99,7 +101,7 @@ const PipelineRuns = ({
           pipelineRunMetadata: pipelineRun.metadata
         });
         const pipelineRefName = pipelineRun.spec.pipelineRef.name;
-        const { lastTransitionTime, reason, status } = getStatus(pipelineRun);
+        const { reason, status } = getStatus(pipelineRun);
         const url = createPipelineRunURL({
           namespace,
           pipelineRunName,
@@ -143,7 +145,10 @@ const PipelineRuns = ({
                   })}
             </StructuredListCell>
             <StructuredListCell>
-              <FormattedDate date={lastTransitionTime} relative />
+              <FormattedDate
+                date={createPipelineRunTimestamp(pipelineRun)}
+                relative
+              />
             </StructuredListCell>
             {pipelineRunActions && (
               <StructuredListCell>

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
@@ -15,6 +15,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import StoryRouter from 'storybook-react-router';
 
+import { getStatus } from '@tektoncd/dashboard-utils';
 import PipelineRuns from '.';
 
 storiesOf('PipelineRuns', module)
@@ -31,6 +32,10 @@ storiesOf('PipelineRuns', module)
         pipelineName,
         pipelineRunName
       }) => `to-pipeline-${namespace}/${pipelineName}/${pipelineRunName}`}
+      createPipelineRunTimestamp={pipelineRun =>
+        getStatus(pipelineRun).lastTransitionTime ||
+        pipelineRun.metadata.creationTimestamp
+      }
       pipelineName="Pipeline Name"
       selectedNamespace="default"
       pipelineRunActions={[
@@ -99,7 +104,8 @@ storiesOf('PipelineRuns', module)
           apiVersion: 'tekton.dev/v1alpha1',
           kind: 'PipelineRun',
           metadata: {
-            name: 'output-pipeline-run'
+            name: 'output-pipeline-run',
+            creationTimestamp: '2019-10-09T17:10:49Z'
           },
           spec: {
             pipelineRef: {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Allows a consumer to get the timestamp from else where in the run (creation time for example)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
