### PR TITLE
Skip Conditional Step when Loading PipelineRun page

### DIFF
--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -195,7 +195,7 @@ function mapStateToProps(state, ownProps) {
       {
         namespace
       }
-    ),
+    ).filter(taskRun => 'taskRef' in taskRun.spec),
     clusterTasks: getClusterTasks(state),
     webSocketConnected: isWebSocketConnected(state)
   };


### PR DESCRIPTION
issue: #638 

The reason behind the page break was due to the new conditional step added to the Pipeline where it determines if the new changes in the repo should be deployed. 

# Changes
The only thing needed was to skip this step when loading the `TaskRuns` data to be displayed. 

# Additional Info.
In line 239, variables `pipelineRun` & `taskRunNames` are passed to the`loadTaskRuns` method but this method is defined with only the `pipelineRun` parameter in line 63. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
