### PR TITLE
Fix rebuild of cancelled PipelineRuns

### DIFF
--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -219,6 +219,7 @@ func (r Resource) rebuildRun(name, namespace string) (*v1alpha1.PipelineRun, err
 
 	newPipelineRunData := pipelineRun
 	newPipelineRunData.Name = ""
+	newPipelineRunData.Spec.Status = ""
 	theName := generateNewNameForRebuild(name)
 	newPipelineRunData.GenerateName = theName
 	newPipelineRunData.ResourceVersion = ""


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

For https://github.com/tektoncd/dashboard/issues/577

Resets the status of a rebuilt PipelineRun so that it does not get copied over as cancelled, which was causing the rebuilds to fail.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
