### PR TITLE
Fix error showing TaskRun steps that have not run

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -23,7 +23,8 @@ import {
   selectedTask,
   selectedTaskRun,
   stepsStatus,
-  taskRunStep
+  taskRunStep,
+  updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
 import { Log, RunHeader, StepDetails, TaskTree } from '..';
@@ -245,7 +246,10 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
     const { definition, reason, status, stepName, stepStatus } = taskRunStep(
       selectedStepId,
-      taskRun
+      {
+        ...taskRun,
+        steps: updateUnexecutedSteps(taskRun.steps)
+      }
     );
 
     const logContainer = (

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -17,6 +17,8 @@ import ChevronRight from '@carbon/icons-react/lib/chevron--right/16';
 import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
 import { Spinner, Step } from '@tektoncd/dashboard-components';
 
+import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
+
 import './Task.scss';
 
 class Task extends Component {
@@ -89,24 +91,26 @@ class Task extends Component {
         </a>
         {expanded && (
           <ol className="step-list">
-            {steps.map(({ id, reason: stepReason, status, stepName }) => {
-              const selected = selectedStepId === id;
-              const stepStatus =
-                reason === 'TaskRunCancelled' && status !== 'terminated'
-                  ? 'cancelled'
-                  : status;
-              return (
-                <Step
-                  id={id}
-                  key={id}
-                  onSelect={this.handleStepSelected}
-                  reason={stepReason}
-                  selected={selected}
-                  status={stepStatus}
-                  stepName={stepName}
-                />
-              );
-            })}
+            {updateUnexecutedSteps(steps).map(
+              ({ id, reason: stepReason, status, stepName }) => {
+                const selected = selectedStepId === id;
+                const stepStatus =
+                  reason === 'TaskRunCancelled' && status !== 'terminated'
+                    ? 'cancelled'
+                    : status;
+                return (
+                  <Step
+                    id={id}
+                    key={id}
+                    onSelect={this.handleStepSelected}
+                    reason={stepReason}
+                    selected={selected}
+                    status={stepStatus}
+                    stepName={stepName}
+                  />
+                );
+              }
+            )}
           </ol>
         )}
       </li>

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -23,8 +23,8 @@ const props = {
 };
 
 const steps = [
-  { id: 'build', stepName: 'build' },
-  { id: 'test', stepName: 'test' }
+  { id: 'build', stepName: 'build', reason: 'Completed' },
+  { id: 'test', stepName: 'test', reason: 'Completed' }
 ];
 
 storiesOf('Task', module)

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -40,6 +40,20 @@ it('Task renders steps in expanded state', () => {
   expect(queryByText(/a step/i)).toBeTruthy();
 });
 
+it('Task renders completed steps in expanded state', () => {
+  const steps = [
+    { id: 'step1', stepName: 'step 1', reason: 'Completed' },
+    { id: 'step2', stepName: 'step 2', reason: 'Error' },
+    { id: 'step3', stepName: 'step 3', reason: 'Completed' }
+  ];
+  const { queryByText } = renderWithIntl(
+    <Task {...props} expanded steps={steps} />
+  );
+  expect(queryByText(/step 1/i)).toBeTruthy();
+  expect(queryByText(/step 2/i)).toBeTruthy();
+  expect(queryByText(/step 3/i)).toBeTruthy();
+});
+
 it('Task renders success state', () => {
   renderWithIntl(<Task {...props} succeeded="True" />);
 });

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -139,3 +139,33 @@ export function getStatusIcon({ reason, status }) {
 
   return Icon ? <Icon className="status-icon" /> : null;
 }
+
+// Update the status of steps that follow a step with an error
+export function updateUnexecutedSteps(steps) {
+  if (!steps) {
+    return steps;
+  }
+  let errorIndex = steps.length - 1;
+  return steps.map((step, index) => {
+    // Update errorIndex
+    if (step.reason !== 'Completed') {
+      errorIndex = Math.min(index, errorIndex);
+    }
+    // Update step
+    if (index > errorIndex) {
+      const s = {
+        ...step,
+        reason: '',
+        status: ''
+      };
+      if (step.stepStatus && step.stepStatus.terminated) {
+        s.stepStatus = {
+          ...step.stepStatus,
+          terminated: { ...step.stepStatus.terminated, reason: '' }
+        };
+      }
+      return s;
+    }
+    return step;
+  });
+}

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -18,7 +18,8 @@ import {
   isRunning,
   selectedTask,
   stepsStatus,
-  taskRunStep
+  taskRunStep,
+  updateUnexecutedSteps
 } from '.';
 
 it('taskRunSteps with no taskRun', () => {
@@ -238,4 +239,72 @@ it('stepsStatus step is terminated with error', () => {
   expect(returnedStep.status).toEqual('terminated');
   expect(returnedStep.stepName).toEqual(stepName);
   expect(returnedStep.reason).toEqual(reason);
+});
+
+it('updateUnexecutedSteps no steps', () => {
+  const steps = [];
+  const wantUpdatedSteps = [];
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+});
+
+it('updateUnexecutedSteps undefined steps', () => {
+  let steps;
+  let wantUpdatedSteps;
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+});
+
+it('updateUnexecutedSteps no error steps', () => {
+  const steps = [
+    { reason: 'Completed', status: 'Terminated' },
+    {
+      reason: 'Running',
+      status: 'Unknown',
+      stepStatus: {}
+    }
+  ];
+  const wantUpdatedSteps = [...steps];
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+});
+
+it('updateUnexecutedSteps error step', () => {
+  const steps = [
+    {
+      reason: 'Completed',
+      status: 'Terminated',
+      stepStatus: { terminated: { reason: 'Completed' } }
+    },
+    {
+      reason: 'Error',
+      status: 'Error',
+      stepStatus: { terminated: { reason: 'Error' } }
+    },
+    {
+      reason: 'Completed',
+      status: 'Terminated',
+      stepStatus: { terminated: { reason: 'Completed' } }
+    }
+  ];
+  const wantUpdatedSteps = [
+    {
+      reason: 'Completed',
+      status: 'Terminated',
+      stepStatus: { terminated: { reason: 'Completed' } }
+    },
+    {
+      reason: 'Error',
+      status: 'Error',
+      stepStatus: { terminated: { reason: 'Error' } }
+    },
+    {
+      reason: '',
+      status: '',
+      stepStatus: { terminated: { reason: '' } }
+    }
+  ];
+
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
 });

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -24,7 +24,12 @@ import {
   StepDetails,
   TaskTree
 } from '@tektoncd/dashboard-components';
-import { getStatus, stepsStatus, taskRunStep } from '@tektoncd/dashboard-utils';
+import {
+  getStatus,
+  stepsStatus,
+  taskRunStep,
+  updateUnexecutedSteps
+} from '@tektoncd/dashboard-utils';
 
 import { fetchLogs } from '../../utils';
 
@@ -170,7 +175,10 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
 
     const { definition, reason, status, stepName, stepStatus } = taskRunStep(
       selectedStepId,
-      taskRun
+      {
+        ...taskRun,
+        steps: updateUnexecutedSteps(taskRun.steps)
+      }
     );
 
     const logContainer = (


### PR DESCRIPTION
# Changes

Fixes #644
This fix shows a neutral "Not run" status for steps that follow a step with an
error. Previously, these steps showed a misleading green "Completed" status.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
