### PR TITLE
Change PipelineRun tooltip from cancel to stop

### DIFF
--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -132,7 +132,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
     const { intl } = this.props;
     return [
       {
-        actionText: 'Cancel',
+        actionText: 'Stop',
         action: this.cancel,
         disable: resource => {
           const { reason, status } = getStatus(resource);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For https://github.com/tektoncd/dashboard/issues/655

Changed the tooltip for a PipelineRun to say 'Stop' instead of 'Cancel' in order to be consistent with other references to this action.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
