### PR TITLE
Move default pollingInterval to defaultProps

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -90,7 +90,7 @@ export class LogContainer extends Component {
   initPolling = () => {
     const { stepStatus, pollingInterval } = this.props;
     if (!this.timer && stepStatus && !stepStatus.terminated) {
-      this.timer = setInterval(() => this.loadLog(), pollingInterval || 4000);
+      this.timer = setInterval(() => this.loadLog(), pollingInterval);
     }
     if (this.timer && stepStatus && stepStatus.terminated) {
       clearInterval(this.timer);
@@ -151,5 +151,9 @@ export class LogContainer extends Component {
     );
   }
 }
+
+LogContainer.defaultProps = {
+  pollingInterval: 4000
+};
 
 export default injectIntl(LogContainer);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/pull/643
Move default value to defaultProps to ensure consistency instead of doing it inline.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
