### PR TITLE
Increase log / details font size to improve legibility of ideographic languages

### DIFF
--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -16,7 +16,11 @@ limitations under the License.
 .log {
   padding: 1.3rem 1.6rem;
   font-family: ibm-plex-mono, monospace;
-  font-size: 0.68rem;
+  font-size: 0.75rem;
+  @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
+    font-size: 0.6875rem;
+  }
+
   line-height: 0.95rem; // Update the react-window List itemSize if changing this
   overflow: hidden;
   text-shadow: 0.1px 0.1px 0 #272d3340;
@@ -28,7 +32,6 @@ limitations under the License.
 
   .log-trailer {
     font-family: ibm-plex-sans, sans-serif;
-    font-size: 0.73rem;
     font-weight: bold;
 
     &[data-status='Completed'] {

--- a/packages/components/src/components/StepDefinition/StepDefinition.scss
+++ b/packages/components/src/components/StepDefinition/StepDefinition.scss
@@ -22,7 +22,10 @@ limitations under the License.
 
   > pre {
     font-family: ibm-plex-mono, monospace;
-    font-size: 0.68rem;
+    font-size: 0.75rem;
+    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
+      font-size: 0.6875rem;
+    }
     line-height: 0.95rem;
     white-space: pre-wrap;
     word-break: break-all;

--- a/packages/components/src/components/StepStatus/StepStatus.scss
+++ b/packages/components/src/components/StepStatus/StepStatus.scss
@@ -9,7 +9,10 @@
 
   > pre {
     font-family: ibm-plex-mono, monospace;
-    font-size: 0.68rem;
+    font-size: 0.75rem;
+    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
+      font-size: 0.6875rem;
+    }
     line-height: 0.95rem;
     white-space: pre-wrap;
     word-break: break-all;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
For ideographic languages (e.g. Japanese) the font size of
0.68rem (10.88px) was causing some issues with legibility.

Increasing to 12px (11px for high density displays) resolves this.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
