### PR TITLE
Populate Secret Annotation Fields with Default Value

### DIFF
--- a/src/components/SecretsModal/Annotations.js
+++ b/src/components/SecretsModal/Annotations.js
@@ -14,7 +14,8 @@ limitations under the License.
 import React from 'react';
 import { TextInput } from 'carbon-components-react';
 import Add from '@carbon/icons-react/lib/add--alt/24';
-import Remove from '@carbon/icons-react/lib/misuse/24';
+import Remove from '@carbon/icons-react/lib/subtract--alt/24';
+import Delete from '@carbon/icons-react/lib/misuse/16';
 import './SecretsModal.scss';
 
 const Annotations = props => {
@@ -54,6 +55,15 @@ const Annotations = props => {
           invalid={invalidFields.indexOf(`annotation-value${index}`) > -1}
           autoComplete="off"
         />
+        {annotation.value && (
+          <Delete
+            className="deleteInputIcon"
+            aria-label={`Delete Button#${index}. Deletes entire entry in current text field.`}
+            onClick={() => {
+              handleChange({ key: 'value', index, value: '' });
+            }}
+          />
+        )}
       </div>
     );
   });
@@ -62,8 +72,18 @@ const Annotations = props => {
     <div className="annotations">
       <div className="labelAndButtons">
         <p className="label">Server URL:</p>
-        <Remove className="removeIcon" onClick={handleRemove} />
-        <Add className="addIcon" onClick={handleAdd} />
+        <Remove
+          className={
+            annotationFields.length === 1 ? 'removeIconDisabled' : 'removeIcon'
+          }
+          onClick={handleRemove}
+          aria-label="Remove Button. Removes a Server URL entry."
+        />
+        <Add
+          className="addIcon"
+          onClick={handleAdd}
+          aria-label="Add Button. Adds another Server URL entry."
+        />
       </div>
       {invalidFields.find(field => field.includes('annotation-value')) !==
         undefined && <p className="invalidAnnotation">Server URL required.</p>}

--- a/src/components/SecretsModal/Annotations.test.js
+++ b/src/components/SecretsModal/Annotations.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { render } from 'react-testing-library';
+import { fireEvent, render } from 'react-testing-library';
 import Annotations from './Annotations';
 
 it('Annotations shows blank fields', () => {
@@ -72,4 +72,63 @@ it('Annotations incorrect fields', () => {
   expect(annotationValue1.getAttribute('data-invalid')).toBeFalsy();
   expect(annotationValue2.getAttribute('data-invalid')).toBeTruthy();
   expect(annotationValue3.getAttribute('data-invalid')).toBeFalsy();
+});
+
+it('Annotations delete button works', () => {
+  const props = {
+    handleChange: jest.fn(),
+    invalidFields: [],
+    annotations: [
+      { label: `tekton.dev/git-0`, value: 'https://domain.com', id: 'aaaa' },
+      { label: `tekton.dev/git-1`, value: '', id: 'bbbb' },
+      { label: `tekton.dev/git-2`, value: 'https://domain.com', id: 'cccc' },
+      { label: `tekton.dev/git-3`, value: 'https://domain.com', id: 'dddd' }
+    ],
+    handleAdd() {},
+    handleRemove() {}
+  };
+  const { getByLabelText } = render(<Annotations {...props} />);
+
+  const deleteButton0 = getByLabelText(/Delete Button#0/i);
+
+  fireEvent.click(deleteButton0);
+
+  expect(props.handleChange).toHaveBeenCalledTimes(1);
+  expect(props.handleChange).toBeCalledWith({
+    index: 0,
+    key: 'value',
+    value: ''
+  });
+});
+
+it('Annotations add and remove buttons works', () => {
+  const props = {
+    handleChange() {},
+    invalidFields: [],
+    annotations: [
+      { label: `tekton.dev/git-0`, value: 'https://domain.com', id: 'aaaa' },
+      { label: `tekton.dev/git-1`, value: '', id: 'bbbb' },
+      { label: `tekton.dev/git-2`, value: 'https://domain.com', id: 'cccc' },
+      { label: `tekton.dev/git-3`, value: 'https://domain.com', id: 'dddd' }
+    ],
+    handleAdd: jest.fn(),
+    handleRemove: jest.fn()
+  };
+  const { getByLabelText } = render(<Annotations {...props} />);
+
+  const removeButton = getByLabelText(/Remove Button/i);
+  const addButton = getByLabelText(/Add Button/i);
+
+  fireEvent.click(addButton);
+  fireEvent.click(addButton);
+  fireEvent.click(addButton);
+  fireEvent.click(addButton);
+  fireEvent.click(addButton);
+
+  fireEvent.click(removeButton);
+  fireEvent.click(removeButton);
+  fireEvent.click(removeButton);
+
+  expect(props.handleAdd).toHaveBeenCalledTimes(5);
+  expect(props.handleRemove).toHaveBeenCalledTimes(3);
 });

--- a/src/components/SecretsModal/SecretsModal.scss
+++ b/src/components/SecretsModal/SecretsModal.scss
@@ -30,7 +30,7 @@ limitations under the License.
     min-width: 100%;
   }
 
-  .bx--select svg{
+  .bx--select svg {
     display: none;
   }
 
@@ -67,6 +67,9 @@ limitations under the License.
           fill: $hover-danger;
         }
       }
+      .removeIconDisabled {
+        fill: $disabled-02;
+      }
       .addIcon {
         fill: $support-02;
         &:hover {
@@ -75,15 +78,26 @@ limitations under the License.
       }
     }
     .annotationRow {
+      position: relative;
+      display: flex;
+      align-items: center;
+      margin-bottom: 5px;
       .bx--form-item.bx--text-input-wrapper {
         width: 48%;
         display: inline-flex;
-        vertical-align: middle;
+        margin-bottom: 0;
       }
       .colon {
         display: inline-block;
         width: 4%;
         text-align: center;
+      }
+      .deleteInputIcon {
+        position: absolute;
+        right: 1rem;
+        &:hover {
+          fill: $hover-secondary;
+        }
       }
     }
   }

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -60,7 +60,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       annotations: [
         {
           label: `tekton.dev/git-0`,
-          value: '',
+          value: 'https://github.com',
           placeholder: 'https://github.com',
           id: Math.random()
             .toString(36)
@@ -237,18 +237,30 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
         newInvalidFields.push(stateVar);
       }
       const annotations = prevState.annotations.map(annotation => {
+        const gitExampleText = 'https://github.com';
+        const dockerExampleText = 'https://index.docker.io/v1/';
         let toSearch;
         let toExampleText;
+        let annotationValue;
         if (stateValue === 'git') {
           toSearch = 'docker';
-          toExampleText = 'https://github.com';
+          toExampleText = gitExampleText;
         } else {
           toSearch = 'git';
-          toExampleText = 'https://index.docker.io/v1/';
+          toExampleText = dockerExampleText;
+        }
+        if (
+          annotation.value === gitExampleText ||
+          annotation.value === dockerExampleText ||
+          annotation.value.trim() === ''
+        ) {
+          annotationValue = toExampleText;
+        } else {
+          annotationValue = annotation.value;
         }
         return {
           label: annotation.label.split(toSearch).join(stateValue),
-          value: annotation.value,
+          value: annotationValue,
           id: annotation.id,
           placeholder: toExampleText
         };
@@ -256,7 +268,9 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       return {
         [stateVar]: stateValue,
         annotations,
-        invalidFields: newInvalidFields
+        invalidFields: newInvalidFields.filter(
+          field => field.indexOf('annotation') === -1
+        )
       };
     });
   };
@@ -296,7 +310,7 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       }
       annotations.push({
         label: `tekton.dev/${accessTo}-${annotations.length}`,
-        value: '',
+        value: example,
         placeholder: example,
         id: Math.random()
           .toString(36)

--- a/src/containers/SecretsModal/SecretsModal.test.js
+++ b/src/containers/SecretsModal/SecretsModal.test.js
@@ -158,7 +158,7 @@ it('Create Secret validates all empty inputs', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret errors when starting with a "-"', () => {
@@ -176,7 +176,7 @@ it('Create Secret errors when starting with a "-"', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret errors when ends with a "-"', () => {
@@ -194,7 +194,7 @@ it('Create Secret errors when ends with a "-"', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret errors when contains "."', () => {
@@ -212,7 +212,7 @@ it('Create Secret errors when contains "."', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret errors when contains spaces', () => {
@@ -230,7 +230,7 @@ it('Create Secret errors when contains spaces', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret errors when contains capital letters', () => {
@@ -248,7 +248,7 @@ it('Create Secret errors when contains capital letters', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret doesn\'t error when contains "-" in the middle of the secret', () => {
@@ -266,7 +266,7 @@ it('Create Secret doesn\'t error when contains "-" in the middle of the secret',
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when contains 0", () => {
@@ -284,7 +284,7 @@ it("Create Secret doesn't error when contains 0", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when contains 9", () => {
@@ -302,7 +302,7 @@ it("Create Secret doesn't error when contains 9", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it('Create Secret errors when contains 253 characters', () => {
@@ -323,7 +323,7 @@ it('Create Secret errors when contains 253 characters', () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when contains 252 characters", () => {
@@ -344,7 +344,7 @@ it("Create Secret doesn't error when contains 252 characters", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when contains a valid namespace", () => {
@@ -364,7 +364,7 @@ it("Create Secret doesn't error when contains a valid namespace", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when Docker Registry is selected", () => {
@@ -388,7 +388,7 @@ it("Create Secret doesn't error when Docker Registry is selected", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when a username is entered", () => {
@@ -413,7 +413,7 @@ it("Create Secret doesn't error when a username is entered", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeFalsy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeTruthy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });
 
 it("Create Secret doesn't error when a password is entered", () => {
@@ -442,5 +442,5 @@ it("Create Secret doesn't error when a password is entered", () => {
   expect(queryByText(usernameValidationErrorRegExp)).toBeFalsy();
   expect(queryByText(passwordValidationErrorRegExp)).toBeFalsy();
   expect(queryByText(serviceAccountValidationErrorRegExp)).toBeTruthy();
-  expect(queryByText(serverurlValidationErrorRegExp)).toBeTruthy();
+  expect(queryByText(serverurlValidationErrorRegExp)).toBeFalsy();
 });


### PR DESCRIPTION
issue: #543 

# Changes
With this PR, the default value will not only the be in placeholder but will also be the initial value in the text input when it is rendered. If given the case that the user wants to use a value that is not the default one then he can just click the `X` icon to delete the whole entry. Now, if the user decides to change the access credentials from Git to Docker or vice-versa,  the default value is populated accordingly (if and only if the current value is a default value or blank) in each Annotation Field currently present in the modal.  In addition, I added some logic to disable the `Remove` icon if only one annotation is present. Finally, CSS styles and test cases were added and/or updated.

# Before
<img width="526" alt="Screen Shot 2019-10-31 at 2 08 12 PM" src="https://user-images.githubusercontent.com/49996607/67974028-01a3b080-fbe8-11e9-8732-2eecdaf5a04a.png">

# After 
<img width="518" alt="Screen Shot 2019-10-31 at 2 02 18 PM" src="https://user-images.githubusercontent.com/49996607/67974063-0ff1cc80-fbe8-11e9-8095-712ff07fbe59.png">

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
