### PR TITLE
Only selectDefaultStep in componentDidMount

### DIFF
--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -28,10 +28,6 @@ class Task extends Component {
     this.selectDefaultStep();
   }
 
-  componentDidUpdate() {
-    this.selectDefaultStep();
-  }
-
   handleClick = event => {
     if (event) {
       event.preventDefault();


### PR DESCRIPTION
Fix for https://github.com/tektoncd/dashboard/issues/693

Prevents infinite loop occurring, initially raised in Slack https://tektoncd.slack.com/archives/CHTHGRQBC/p1572780310027400

Tested with the pipeline provided (renders fine, we get no logs because the PipelineRun never really kicks off owing to the intentionally unsatisfied volume claim)

I also ran pipeline0 with the same code and observed the pipeline0-task kubectl apply was selected anyway, so I'm expecting this code here wasn't really necessary but definitely problematic for this scenario