### PR TITLE
Only display one notification on secrets page (clear error if success)

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -166,9 +166,8 @@ export function createSecret(postData, namespace) {
         namespace: serviceAccount.metadata.namespace,
         secretName: postData.metadata.name
       });
-      dispatch({
-        type: 'SECRET_CREATE_SUCCESS'
-      });
+      dispatch({ type: 'CLEAR_SECRET_ERROR_NOTIFICATION' });
+      dispatch({ type: 'SECRET_CREATE_SUCCESS' });
     } catch (error) {
       error.response.text().then(message => {
         dispatch({ type: 'SECRET_CREATE_FAILURE', error: message });


### PR DESCRIPTION
Fix for https://github.com/tektoncd/dashboard/issues/679

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
considering

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
