### PR TITLE
Changed icon from x to trash bin on secrets modal

### DIFF
--- a/src/components/SecretsModal/Annotations.js
+++ b/src/components/SecretsModal/Annotations.js
@@ -15,7 +15,7 @@ import React from 'react';
 import { TextInput } from 'carbon-components-react';
 import Add from '@carbon/icons-react/lib/add--alt/24';
 import Remove from '@carbon/icons-react/lib/subtract--alt/24';
-import Delete from '@carbon/icons-react/lib/misuse/16';
+import Delete from '@carbon/icons-react/lib/delete/16';
 import './SecretsModal.scss';
 
 const Annotations = props => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For: https://github.com/tektoncd/dashboard/issues/715
Changes an icon on the secrets modal to a trash bin to keep in line with the other delete icon within the secrets panel, as well as avoid confusion with previous icon also being used for failed pipelineruns/taskruns.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
