### PR TITLE
Always show namespace column on list views

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -21,12 +21,7 @@ import {
   StructuredListRow,
   StructuredListWrapper
 } from 'carbon-components-react';
-import {
-  ALL_NAMESPACES,
-  getStatus,
-  getStatusIcon,
-  urls
-} from '@tektoncd/dashboard-utils';
+import { getStatus, getStatusIcon, urls } from '@tektoncd/dashboard-utils';
 
 import { FormattedDate, RunDropdown } from '..';
 
@@ -39,10 +34,10 @@ const PipelineRuns = ({
   createPipelineRunTimestamp = pipelineRun =>
     getStatus(pipelineRun).lastTransitionTime,
   createPipelineRunsByPipelineURL = urls.pipelineRuns.byPipeline,
+  hideNamespace,
   intl,
   pipelineName,
   pipelineRuns,
-  selectedNamespace,
   pipelineRunActions
 }) => (
   <StructuredListWrapper border selection>
@@ -52,7 +47,7 @@ const PipelineRuns = ({
         {!pipelineName && (
           <StructuredListCell head>Pipeline</StructuredListCell>
         )}
-        {selectedNamespace === ALL_NAMESPACES && (
+        {!hideNamespace && (
           <StructuredListCell head>Namespace</StructuredListCell>
         )}
         <StructuredListCell head>
@@ -128,7 +123,7 @@ const PipelineRuns = ({
                 </Link>
               </StructuredListCell>
             )}
-            {selectedNamespace === ALL_NAMESPACES && (
+            {!hideNamespace && (
               <StructuredListCell>{namespace}</StructuredListCell>
             )}
             <StructuredListCell

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import React from 'react';
-import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import PipelineRuns from './PipelineRuns';
@@ -20,18 +19,18 @@ import PipelineRuns from './PipelineRuns';
 it('PipelineRuns renders empty state', () => {
   const { queryByText } = renderWithIntl(<PipelineRuns pipelineRuns={[]} />);
   expect(queryByText(/no pipelineruns/i)).toBeTruthy();
-  expect(queryByText(/namespace/i)).toBeFalsy();
+  expect(queryByText(/namespace/i)).toBeTruthy();
 });
 
-it('PipelineRuns renders optional columns', () => {
+it('PipelineRuns hides namespace when hideNamespace set', () => {
   const { queryByText } = renderWithIntl(
     <PipelineRuns
       pipelineName="some-pipeline"
       pipelineRuns={[]}
-      selectedNamespace={ALL_NAMESPACES}
+      hideNamespace
     />
   );
-  expect(queryByText(/namespace/i)).toBeTruthy();
+  expect(queryByText(/namespace/i)).toBeFalsy();
   expect(queryByText(/pipeline/i)).toBeTruthy();
   expect(queryByText(/no pipelineruns for some-pipeline/i)).toBeTruthy();
 });

--- a/src/components/SecretsTable/SecretsTable.js
+++ b/src/components/SecretsTable/SecretsTable.js
@@ -50,12 +50,9 @@ const SecretsTable = props => {
 
   const initialHeaders = [
     { key: 'secret', header: 'Secret' },
+    { key: 'namespace', header: 'Namespace' },
     { key: 'annotations', header: 'Annotations' }
   ];
-
-  if (selectedNamespace === ALL_NAMESPACES) {
-    initialHeaders.splice(1, 0, { key: 'namespace', header: 'Namespace' });
-  }
 
   const secretsFormatted = secrets.map(secret => {
     let annotations = '';
@@ -65,14 +62,11 @@ const SecretsTable = props => {
       }
     });
     const formattedSecret = {
+      annotations,
       id: `${secret.namespace}:${secret.name}`,
-      secret: secret.name,
-      annotations
+      namespace: secret.namespace,
+      secret: secret.name
     };
-
-    if (selectedNamespace === ALL_NAMESPACES) {
-      formattedSecret.namespace = secret.namespace;
-    }
 
     return formattedSecret;
   });

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -23,11 +23,7 @@ import {
   StructuredListSkeleton,
   StructuredListWrapper
 } from 'carbon-components-react';
-import {
-  ALL_NAMESPACES,
-  getErrorMessage,
-  urls
-} from '@tektoncd/dashboard-utils';
+import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
 
 import { fetchPipelineResources } from '../../actions/pipelineResources';
 
@@ -67,12 +63,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
   }
 
   render() {
-    const {
-      error,
-      loading,
-      namespace: selectedNamespace,
-      pipelineResources
-    } = this.props;
+    const { error, loading, pipelineResources } = this.props;
 
     if (loading) {
       return <StructuredListSkeleton border />;
@@ -95,9 +86,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
         <StructuredListHead>
           <StructuredListRow head>
             <StructuredListCell head>PipelineResource</StructuredListCell>
-            {selectedNamespace === ALL_NAMESPACES && (
-              <StructuredListCell head>Namespace</StructuredListCell>
-            )}
+            <StructuredListCell head>Namespace</StructuredListCell>
             <StructuredListCell head>Type</StructuredListCell>
           </StructuredListRow>
         </StructuredListHead>
@@ -130,9 +119,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
                     {pipelineResourceName}
                   </Link>
                 </StructuredListCell>
-                {selectedNamespace === ALL_NAMESPACES && (
-                  <StructuredListCell>{namespace}</StructuredListCell>
-                )}
+                <StructuredListCell>{namespace}</StructuredListCell>
                 <StructuredListCell>
                   {pipelineResource.spec.type}
                 </StructuredListCell>

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -25,11 +25,7 @@ import {
   StructuredListSkeleton,
   StructuredListWrapper
 } from 'carbon-components-react';
-import {
-  ALL_NAMESPACES,
-  getErrorMessage,
-  urls
-} from '@tektoncd/dashboard-utils';
+import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
 
 import { fetchPipelines } from '../../actions/pipelines';
 import {
@@ -59,12 +55,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
   }
 
   render() {
-    const {
-      error,
-      loading,
-      namespace: selectedNamespace,
-      pipelines
-    } = this.props;
+    const { error, loading, pipelines } = this.props;
 
     if (loading && !pipelines.length) {
       return <StructuredListSkeleton border />;
@@ -87,9 +78,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
         <StructuredListHead>
           <StructuredListRow head>
             <StructuredListCell head>Pipeline</StructuredListCell>
-            {selectedNamespace === ALL_NAMESPACES && (
-              <StructuredListCell head>Namespace</StructuredListCell>
-            )}
+            <StructuredListCell head>Namespace</StructuredListCell>
             <StructuredListCell head />
           </StructuredListRow>
         </StructuredListHead>
@@ -113,9 +102,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
                     {name}
                   </Link>
                 </StructuredListCell>
-                {selectedNamespace === ALL_NAMESPACES && (
-                  <StructuredListCell>{namespace}</StructuredListCell>
-                )}
+                <StructuredListCell>{namespace}</StructuredListCell>
                 <StructuredListCell>
                   <Link
                     title="Pipeline definition"

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -24,11 +24,7 @@ import {
 } from 'carbon-components-react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import {
-  ALL_NAMESPACES,
-  getErrorMessage,
-  urls
-} from '@tektoncd/dashboard-utils';
+import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
 import { FormattedDate } from '@tektoncd/dashboard-components';
 
 import { getCustomResources } from '../../api';
@@ -83,7 +79,7 @@ export /* istanbul ignore next */ class ResourceListContainer extends Component 
   }
 
   render() {
-    const { match, namespace: selectedNamespace } = this.props;
+    const { match } = this.props;
     const { group, version, type } = match.params;
     const { error, loading, resources } = this.state;
 
@@ -108,9 +104,7 @@ export /* istanbul ignore next */ class ResourceListContainer extends Component 
         <StructuredListHead>
           <StructuredListRow head>
             <StructuredListCell head>Resource</StructuredListCell>
-            {selectedNamespace === ALL_NAMESPACES && (
-              <StructuredListCell head>Namespace</StructuredListCell>
-            )}
+            <StructuredListCell head>Namespace</StructuredListCell>
             <StructuredListCell head>Created</StructuredListCell>
           </StructuredListRow>
         </StructuredListHead>
@@ -153,9 +147,7 @@ export /* istanbul ignore next */ class ResourceListContainer extends Component 
                     {name}
                   </Link>
                 </StructuredListCell>
-                {selectedNamespace === ALL_NAMESPACES && (
-                  <StructuredListCell>{namespace}</StructuredListCell>
-                )}
+                <StructuredListCell>{namespace}</StructuredListCell>
                 <StructuredListCell>
                   <FormattedDate date={creationTimestamp} relative />
                 </StructuredListCell>

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -25,7 +25,6 @@ import {
   StructuredListWrapper
 } from 'carbon-components-react';
 import {
-  ALL_NAMESPACES,
   getErrorMessage,
   getStatus,
   getStatusIcon,
@@ -110,13 +109,7 @@ export /* istanbul ignore next */ class TaskRuns extends Component {
   }
 
   render() {
-    const {
-      error,
-      filters,
-      loading,
-      namespace: selectedNamespace,
-      taskRuns
-    } = this.props;
+    const { error, filters, loading, taskRuns } = this.props;
 
     if (loading) {
       return <StructuredListSkeleton border />;
@@ -149,9 +142,7 @@ export /* istanbul ignore next */ class TaskRuns extends Component {
             <StructuredListRow head>
               <StructuredListCell head>TaskRun</StructuredListCell>
               <StructuredListCell head>Task</StructuredListCell>
-              {selectedNamespace === ALL_NAMESPACES && (
-                <StructuredListCell head>Namespace</StructuredListCell>
-              )}
+              <StructuredListCell head>Namespace</StructuredListCell>
               <StructuredListCell head>Status</StructuredListCell>
               <StructuredListCell head>Last Transition Time</StructuredListCell>
               <StructuredListCell head />
@@ -211,9 +202,7 @@ export /* istanbul ignore next */ class TaskRuns extends Component {
                       </Link>
                     )}
                   </StructuredListCell>
-                  {selectedNamespace === ALL_NAMESPACES && (
-                    <StructuredListCell>{namespace}</StructuredListCell>
-                  )}
+                  <StructuredListCell>{namespace}</StructuredListCell>
                   <StructuredListCell
                     className="status"
                     data-reason={reason}
@@ -253,6 +242,7 @@ TaskRuns.defaultProps = {
   filters: []
 };
 
+/* istanbul ignore next */
 export function fetchFilters(searchQuery) {
   const queryParams = new URLSearchParams(searchQuery);
   let filters = [];

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -23,11 +23,7 @@ import {
   StructuredListSkeleton,
   StructuredListWrapper
 } from 'carbon-components-react';
-import {
-  ALL_NAMESPACES,
-  getErrorMessage,
-  urls
-} from '@tektoncd/dashboard-utils';
+import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
 
 import Information16 from '@carbon/icons-react/lib/information/16';
 import { fetchTasks } from '../../actions/tasks';
@@ -58,7 +54,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
   }
 
   render() {
-    const { error, loading, namespace: selectedNamespace, tasks } = this.props;
+    const { error, loading, tasks } = this.props;
 
     if (loading && !tasks.length) {
       return <StructuredListSkeleton border />;
@@ -81,9 +77,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
         <StructuredListHead>
           <StructuredListRow head>
             <StructuredListCell head>Task</StructuredListCell>
-            {selectedNamespace === ALL_NAMESPACES && (
-              <StructuredListCell head>Namespace</StructuredListCell>
-            )}
+            <StructuredListCell head>Namespace</StructuredListCell>
             <StructuredListCell head />
           </StructuredListRow>
         </StructuredListHead>
@@ -108,9 +102,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
                     {taskName}
                   </Link>
                 </StructuredListCell>
-                {selectedNamespace === ALL_NAMESPACES && (
-                  <StructuredListCell>{namespace}</StructuredListCell>
-                )}
+                <StructuredListCell>{namespace}</StructuredListCell>
                 <StructuredListCell>
                   <Link
                     title="Task definition"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/717

Previously we hid the namespace column when a specific
namespace was selected from the namespaces dropdown, and only
displayed the namespace column when 'All Namespaces' was selected.

Update all list components so that namespace is always shown,
with the exception of the PipelineRuns component which will show
the column by default, but provides a prop allowing consumers
to override this behaviour.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
