### PR TITLE
Prevent PipelineRuns page from resetting on websocket reconnect

### DIFF
--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -75,12 +75,10 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
       webSocketConnected: prevWebSocketConnected
     } = prevProps;
 
-    if (
-      namespace !== prevNamespace ||
-      !isEqual(filters, prevFilters) ||
-      (webSocketConnected && prevWebSocketConnected === false)
-    ) {
+    if (namespace !== prevNamespace || !isEqual(filters, prevFilters)) {
       this.reset();
+      this.fetchPipelineRuns();
+    } else if (webSocketConnected && prevWebSocketConnected === false) {
       this.fetchPipelineRuns();
     }
   }
@@ -236,7 +234,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
       intl
     } = this.props;
 
-    if (loading) {
+    if ((!pipelineRuns || !pipelineRuns.length) && loading) {
       return <StructuredListSkeleton border />;
     }
 

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -118,7 +118,7 @@ export /* istanbul ignore next */ class TaskRuns extends Component {
       taskRuns
     } = this.props;
 
-    if (loading) {
+    if ((!taskRuns || !taskRuns.length) && loading) {
       return <StructuredListSkeleton border />;
     }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/736

In `componentDidUpdate` we were calling `reset` on websocket
reconnect. This resulted in the component's state being reset,
closing the 'Create PipelineRun' dialog if open, among other effects.

Update the logic so we no longer call reset in this case, and
also prevent displaying the loading state unless there are no
existing PipelineRuns displayed. Also update the TaskRuns
loading state to match this.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
