### PR TITLE
Fix issue preventing secrets modal from rendering correctly

### DIFF
--- a/src/components/SecretsTable/SecretsTable.js
+++ b/src/components/SecretsTable/SecretsTable.js
@@ -56,11 +56,13 @@ const SecretsTable = props => {
 
   const secretsFormatted = secrets.map(secret => {
     let annotations = '';
-    Object.keys(secret.annotations).forEach(function annotationSetup(key) {
-      if (key.includes('tekton.dev')) {
-        annotations += `${key}: ${secret.annotations[key]}\n`;
-      }
-    });
+    if (secret.annotations !== undefined) {
+      Object.keys(secret.annotations).forEach(function annotationSetup(key) {
+        if (key.includes('tekton.dev')) {
+          annotations += `${key}: ${secret.annotations[key]}\n`;
+        }
+      });
+    }
     const formattedSecret = {
       annotations,
       id: `${secret.namespace}:${secret.name}`,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

For: https://github.com/tektoncd/dashboard/issues/731

Adds an if statement to check if annotations for each secret are defined when rendering the secrets table, as secrets can be manually configured to not contain annotations.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
