### PR TITLE
Bypass createPipelineRunsByPipelineURL method when Pipeline is Embedded

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -110,14 +110,18 @@ const PipelineRuns = ({
               {url ? <Link to={url}>{pipelineRunName}</Link> : pipelineRunName}
             </StructuredListCell>
             <StructuredListCell>
-              <Link
-                to={createPipelineRunsByPipelineURL({
-                  namespace,
-                  pipelineName: pipelineRefName
-                })}
-              >
-                {pipelineRefName}
-              </Link>
+              {pipelineRefName ? (
+                <Link
+                  to={createPipelineRunsByPipelineURL({
+                    namespace,
+                    pipelineName: pipelineRefName
+                  })}
+                >
+                  {pipelineRefName}
+                </Link>
+              ) : (
+                ''
+              )}
             </StructuredListCell>
             {!hideNamespace && (
               <StructuredListCell>{namespace}</StructuredListCell>


### PR DESCRIPTION
as per issue: #688 

# Changes

With the new feature to embed pipeline inside the pipelineRuns yaml, the `PipelineRun` component was erroring out because it couldn't reference the "pipeline" used when trying to create the url that when clicked, applies the `tekton.dev/pipeline:{PIPELINE_NAME}` filter. 
<img width="1402" alt="Screen Shot 2019-11-20 at 3 08 52 PM" src="https://user-images.githubusercontent.com/49996607/69274374-3cc24f80-0ba8-11ea-88fb-b4c7f2a8e724.png">

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
