### PR TITLE
Namespaces changed to all Namespaces doesn't change page

### DIFF
--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -73,6 +73,19 @@ export class SideNav extends Component {
 
     if (namespace === ALL_NAMESPACES) {
       this.props.selectNamespace(namespace);
+      const currentURL = this.props.match.url;
+      if (currentURL.includes(urls.taskRuns.all())) {
+        history.push(urls.taskRuns.all());
+        return;
+      }
+      if (currentURL.includes(urls.pipelineResources.all())) {
+        history.push(urls.pipelineResources.all());
+        return;
+      }
+      if (currentURL.includes(urls.pipelines.all())) {
+        history.push(urls.pipelines.all());
+        return;
+      }
       history.push('/');
       return;
     }

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -16,7 +16,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fireEvent } from 'react-testing-library';
-import { ALL_NAMESPACES, paths } from '@tektoncd/dashboard-utils';
+import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import SideNavContainer, { SideNav } from './SideNav';
@@ -142,7 +142,7 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
       <SideNav
         extensions={[]}
         history={{ push }}
-        match={{ params: { namespace } }}
+        match={{ params: { namespace }, url: urls.secrets.all() }}
         namespace={namespace}
         selectNamespace={selectNamespace}
       />
@@ -152,6 +152,108 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith('/');
+});
+
+it('SideNav redirects to TaskRuns page when all namespaces selected on namespaced URL on TaskRuns', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const push = jest.fn();
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        history={{ push }}
+        match={{ params: { namespace }, url: urls.taskRuns.all() }}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByText(/all namespaces/i));
+  expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
+  expect(push).toHaveBeenCalledWith(urls.taskRuns.all());
+});
+
+it('SideNav redirects to PipelineResources page when all namespaces selected on namespaced URL on PipelineResources', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const push = jest.fn();
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        history={{ push }}
+        match={{
+          params: { namespace },
+          url: urls.pipelineResources.all()
+        }}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByText(/all namespaces/i));
+  expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
+  expect(push).toHaveBeenCalledWith(urls.pipelineResources.all());
+});
+
+it('SideNav redirects to Pipelines page when all namespaces selected on namespaced URL on Pipelines', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const push = jest.fn();
+  const { getByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        history={{ push }}
+        match={{
+          params: { namespace },
+          url: urls.pipelines.all()
+        }}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByText(/all namespaces/i));
+  expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
+  expect(push).toHaveBeenCalledWith(urls.pipelines.all());
 });
 
 it('SideNav updates namespace in URL', async () => {


### PR DESCRIPTION
References issue #758 
References issue #759 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes bug where pipelineresource,  taskrun and pipelines pages get changed to pipelineruns page on change to all namespaces
Added tests to make sure it does as expected on TaskRun, PipelineResources and pipelines pages 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
