### PR TITLE
Change instances of 'date modified' to 'date created' for trigger resources

### DIFF
--- a/packages/components/src/components/Table/Table.stories.js
+++ b/packages/components/src/components/Table/Table.stories.js
@@ -27,7 +27,7 @@ storiesOf('Table', module)
     const headers = [
       { key: 'name', header: text('header1', 'Name') },
       { key: 'namespace', header: text('header2', 'Namespace') },
-      { key: 'date', header: text('header3', 'Date Modified') }
+      { key: 'date', header: text('header3', 'Date Created') }
     ];
 
     return (
@@ -65,7 +65,7 @@ storiesOf('Table', module)
         headers={[
           { key: 'name', header: 'Name' },
           { key: 'namespace', header: 'Namespace' },
-          { key: 'date', header: 'Date Modified' }
+          { key: 'date', header: 'Date Created' }
         ]}
         selectedNamespace="*"
         loading={boolean('loading', false)}
@@ -94,7 +94,7 @@ storiesOf('Table', module)
         headers={[
           { key: 'name', header: 'Name' },
           { key: 'namespace', header: 'Namespace' },
-          { key: 'date', header: 'Date Modified' }
+          { key: 'date', header: 'Created' }
         ]}
         selectedNamespace="*"
         loading={boolean('loading', false)}
@@ -135,7 +135,7 @@ storiesOf('Table', module)
           headers={[
             { key: 'name', header: 'Name' },
             { key: 'namespace', header: 'Namespace' },
-            { key: 'date', header: 'Date Modified' }
+            { key: 'date', header: 'Date Created' }
           ]}
           selectedNamespace="*"
           isSortable={boolean('isSortable', true)}

--- a/packages/components/src/components/Table/Table.test.js
+++ b/packages/components/src/components/Table/Table.test.js
@@ -33,7 +33,7 @@ const rows = [
 const headers = [
   { key: 'name', header: 'Name' },
   { key: 'namespace', header: 'Namespace' },
-  { key: 'date', header: 'Date Modified' }
+  { key: 'date', header: 'Date Created' }
 ];
 
 const toolbarButtons = [
@@ -67,7 +67,7 @@ it('Table renders plain with ALL_NAMESPACES no rows', () => {
   ).toBeFalsy();
   expect(queryByText(/Name/i)).toBeTruthy();
   expect(queryByText(/Namespace/i)).toBeTruthy();
-  expect(queryByText(/Date Modified/i)).toBeTruthy();
+  expect(queryByText(/Date Created/i)).toBeTruthy();
   expect(queryByText(/Delete/i)).toBeFalsy();
   expect(queryByText(/Add/i)).toBeFalsy();
   expect(queryByText(emptyTextAllNamespaces)).toBeTruthy();
@@ -270,7 +270,7 @@ it('Table loading plain with one row and ALL_NAMESPACES', () => {
   expect(queryByText(/Resources/i)).toBeNull();
   expect(queryByText(/Name/i)).toBeNull();
   expect(queryByText(/Namespace/i)).toBeNull();
-  expect(queryByText(/Date Modified/i)).toBeNull();
+  expect(queryByText(/Date Created/i)).toBeNull();
   expect(queryByText(/Delete/i)).toBeNull();
   expect(queryByText(/Add/i)).toBeNull();
   expect(queryByLabelText('Select all rows')).toBeNull();

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -113,8 +113,8 @@ export /* istanbul ignore next */ class EventListeners extends Component {
       {
         key: 'date',
         header: intl.formatMessage({
-          id: 'dashboard.tableHeader.date',
-          defaultMessage: 'Date Modified'
+          id: 'dashboard.tableHeader.dateCreated',
+          defaultMessage: 'Date Created'
         })
       },
       {

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -113,8 +113,8 @@ export /* istanbul ignore next */ class TriggerBindings extends Component {
       {
         key: 'date',
         header: intl.formatMessage({
-          id: 'dashboard.tableHeader.date',
-          defaultMessage: 'Date Modified'
+          id: 'dashboard.tableHeader.dateCreated',
+          defaultMessage: 'Date Created'
         })
       },
       {

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -113,8 +113,8 @@ export /* istanbul ignore next */ class TriggerTemplates extends Component {
       {
         key: 'date',
         header: intl.formatMessage({
-          id: 'dashboard.tableHeader.date',
-          defaultMessage: 'Date Modified'
+          id: 'dashboard.tableHeader.dateCreated',
+          defaultMessage: 'Date Created'
         })
       },
       {

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -52,7 +52,7 @@
     "dashboard.step.definitionNotAvailable": "description: step definition not available",
     "dashboard.step.statusNotAvailable": "No status available",
     "dashboard.step.stepDefinition": "Step definition",
-    "dashboard.tableHeader.date": "Date Modified",
+    "dashboard.tableHeader.dateCreated": "Date Created",
     "dashboard.tableHeader.name": "Name",
     "dashboard.tableHeader.namespace": "Namespace",
     "dashboard.tableHeader.value": "Value",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

For: https://github.com/tektoncd/dashboard/issues/771

Changes table headers for trigger templates, trigger bindings and event listeners to be 'Date Created' instead of 'Date Modified'.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
