### PR TITLE
Fix step name wrapping

### DIFF
--- a/packages/components/src/components/Step/Step.scss
+++ b/packages/components/src/components/Step/Step.scss
@@ -67,6 +67,7 @@ limitations under the License.
   }
 
   .status-label {
+    flex-shrink: 0;
     margin-left: 0.5rem;
     font-size: 0.7rem;
     letter-spacing: 0.01rem;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Prevent step name from wrapping onto multiple lines, often happens in 'Not run' state, with longer step names.

Before:
![image](https://user-images.githubusercontent.com/2829095/69868722-84309600-12a2-11ea-8542-793c21dffb5b.png)

After:
![image](https://user-images.githubusercontent.com/2829095/69868727-885cb380-12a2-11ea-9ae3-e4287124dfa6.png)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
