### PR TITLE
Format Metadata Label Util Method

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -74,3 +74,20 @@ export function getGitValues(url) {
 
   return { gitServer, gitOrg, gitRepo: `${gitRepo}.git` };
 }
+
+export function formatLabels(labelsRaw) {
+  const labels = JSON.stringify(labelsRaw)
+    .replace('{', '')
+    .replace('}', '')
+    .replace(/['"]+/g, '')
+    .replace('$', '');
+
+  const formattedLabelsToRender = [];
+  const labelsSplitOnComma = labels.split(',');
+  labelsSplitOnComma.forEach(label => {
+    const [key, value] = label.split(':');
+    formattedLabelsToRender.push(`${key}: ${value}`);
+  });
+
+  return formattedLabelsToRender;
+}

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -15,6 +15,7 @@ import * as API from '../api';
 
 import {
   fetchLogs,
+  formatLabels,
   getGitValues,
   isStale,
   sortRunsByStartTime,
@@ -97,4 +98,24 @@ it('getGitValues', () => {
     gitRepo: 'repo.git',
     gitServer: 'github.com'
   });
+});
+
+it('formatLabels', () => {
+  const labels = {
+    app: 'tekton-app',
+    gitOrg: 'foo',
+    gitRepo: 'bar.git',
+    gitServer: 'github.com',
+    'tekton.dev/pipeline': 'pipeline0'
+  };
+
+  const returnedLabels = formatLabels(labels);
+
+  expect(returnedLabels).toStrictEqual([
+    'app: tekton-app',
+    'gitOrg: foo',
+    'gitRepo: bar.git',
+    'gitServer: github.com',
+    'tekton.dev/pipeline: pipeline0'
+  ]);
 });


### PR DESCRIPTION
# Changes
Since all Trigger pages will use labels, the code to format label for the Ticks component has been added to the utils folder for reuse. Test included.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/cc @AlanGreene @a-roberts 
