### PR TITLE
Hide trigger nav items when triggers not installed

### DIFF
--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -26,16 +26,23 @@ import { NamespacesDropdown } from '..';
 
 import { selectNamespace } from '../../actions/namespaces';
 import { getExtensions, getSelectedNamespace } from '../../reducers';
+import { getCustomResource } from '../../api';
 
 import './SideNav.scss';
 
 export class SideNav extends Component {
+  state = {
+    isTriggersInstalled: false
+  };
+
   componentDidMount() {
     const { match } = this.props;
 
     if (match && match.params.namespace) {
       this.props.selectNamespace(match.params.namespace);
     }
+
+    this.checkTriggersInstalled();
   }
 
   componentDidUpdate(prevProps) {
@@ -94,8 +101,22 @@ export class SideNav extends Component {
     history.push(newURL);
   };
 
+  checkTriggersInstalled() {
+    getCustomResource({
+      group: 'apiextensions.k8s.io',
+      version: 'v1beta1',
+      type: 'customresourcedefinitions',
+      name: 'eventlisteners.tekton.dev'
+    })
+      .then(() => {
+        this.setState({ isTriggersInstalled: true });
+      })
+      .catch(() => {});
+  }
+
   render() {
     const { extensions, namespace } = this.props;
+    const { isTriggersInstalled } = this.state;
 
     return (
       <CarbonSideNav
@@ -148,27 +169,31 @@ export class SideNav extends Component {
             >
               TaskRuns
             </SideNavMenuItem>
-            <SideNavMenuItem
-              element={NavLink}
-              icon={<span />}
-              to={urls.eventListeners.all()}
-            >
-              EventListeners
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              element={NavLink}
-              icon={<span />}
-              to={urls.triggerBindings.all()}
-            >
-              TriggerBindings
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              element={NavLink}
-              icon={<span />}
-              to={urls.triggerTemplates.all()}
-            >
-              TriggerTemplates
-            </SideNavMenuItem>
+            {isTriggersInstalled && (
+              <>
+                <SideNavMenuItem
+                  element={NavLink}
+                  icon={<span />}
+                  to={urls.eventListeners.all()}
+                >
+                  EventListeners
+                </SideNavMenuItem>
+                <SideNavMenuItem
+                  element={NavLink}
+                  icon={<span />}
+                  to={urls.triggerBindings.all()}
+                >
+                  TriggerBindings
+                </SideNavMenuItem>
+                <SideNavMenuItem
+                  element={NavLink}
+                  icon={<span />}
+                  to={urls.triggerTemplates.all()}
+                >
+                  TriggerTemplates
+                </SideNavMenuItem>
+              </>
+            )}
           </SideNavMenu>
           <SideNavMenuItem
             element={NamespacesDropdown}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/815

Check for presence of one of the triggers CRDs, and use this
to determine whether or not the triggers nav items should be
displayed in the left nav.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
