### PR TITLE
Notifications stretch entire width of page

### DIFF
--- a/src/components/Definitions/Definitions.scss
+++ b/src/components/Definitions/Definitions.scss
@@ -34,6 +34,10 @@ main {
   .bx--data-table-header {
     background-color: transparent;
   }
+
+  .bx--inline-notification {
+    max-width: 100%;
+  }
 }
 
 .definition .status {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
For: https://github.com/tektoncd/dashboard/issues/807

Adds CSS to ensure that notifications for successes/errors stretch the width of their container.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
