### PR TITLE
Add created time column on all resource list pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5049,6 +5049,7 @@
         "elkjs": "^0.5.1",
         "js-yaml": "^3.13.0",
         "prop-types": "^15.7.2",
+        "react-intl-formatted-duration": "^3.1.0",
         "react-window": "^1.8.5"
       },
       "dependencies": {
@@ -13067,6 +13068,11 @@
       "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.0.7.tgz",
       "integrity": "sha512-L16VbbV3NFaiZV65XwOIH9fBe52TS2EkOR0k8Y4ratsgTE7KPEbcUCUrz/iEQwJo7BcWY4ohkZbeYZRgAiPR1Q=="
     },
+    "intl-unofficial-duration-unit-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/intl-unofficial-duration-unit-format/-/intl-unofficial-duration-unit-format-1.1.0.tgz",
+      "integrity": "sha512-xAwjaUZql3cSx+oYjKUve+lqu6vh6sGQ9X4OIWPA0uxedvBFpH+deHgcUYdafXliTHgSV6G6nXIgM/SLozXr5g=="
+    },
     "into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -20329,6 +20335,14 @@
         "invariant": "^2.1.1",
         "react": "^16.3.0",
         "shallow-equal": "^1.1.0"
+      }
+    },
+    "react-intl-formatted-duration": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-intl-formatted-duration/-/react-intl-formatted-duration-3.1.0.tgz",
+      "integrity": "sha512-sOim1afR8Rmb82DQgXitxxQJlZ6WKW1ZSzg4/ajr/dv2s5e3pF9ulo1vn2LzfG4EGQrzwhQoNG5r5XAxKC4e7A==",
+      "requires": {
+        "intl-unofficial-duration-unit-format": "1.1.0"
       }
     },
     "react-is": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,6 +23,7 @@
     "elkjs": "^0.5.1",
     "js-yaml": "^3.13.0",
     "prop-types": "^15.7.2",
+    "react-intl-formatted-duration": "^3.1.0",
     "react-window": "^1.8.5"
   },
   "peerDependencies": {

--- a/packages/components/src/components/FormattedDuration/FormattedDuration.js
+++ b/packages/components/src/components/FormattedDuration/FormattedDuration.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2019-2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import FormattedDuration from 'react-intl-formatted-duration';
+
+defineMessages({
+  duration: {
+    id: 'react-intl-formatted-duration.duration',
+    defaultMessage: '{value} {unit}'
+  },
+  daysUnit: {
+    id: 'react-intl-formatted-duration.daysUnit',
+    defaultMessage: '{value, plural, one {day} other {days}}'
+  },
+  hoursUnit: {
+    id: 'react-intl-formatted-duration.hoursUnit',
+    defaultMessage: '{value, plural, one {hour} other {hours}}'
+  },
+  minutesUnit: {
+    id: 'react-intl-formatted-duration.minutesUnit',
+    defaultMessage: '{value, plural, one {minute} other {minutes}}'
+  },
+  secondsUnit: {
+    id: 'react-intl-formatted-duration.secondsUnit',
+    defaultMessage: '{value, plural, one {second} other {seconds}}'
+  }
+});
+
+const FormattedDurationWrapper = ({ milliseconds }) => {
+  return (
+    <FormattedDuration
+      seconds={milliseconds / 1000}
+      format="{days} {hours} {minutes} {seconds}"
+    />
+  );
+};
+
+export default FormattedDurationWrapper;

--- a/packages/components/src/components/FormattedDuration/FormattedDuration.stories.js
+++ b/packages/components/src/components/FormattedDuration/FormattedDuration.stories.js
@@ -12,27 +12,19 @@ limitations under the License.
 */
 
 import React from 'react';
-import { IntlProvider } from "react-intl";
+import { storiesOf } from '@storybook/react';
+import { number } from '@storybook/addon-knobs';
 
-import messages from '../src/nls/messages_en.json';
+import FormattedDuration from './FormattedDuration';
 
-import './Container.scss';
-
-export default function Container({ story }) {
-  return (
-    <IntlProvider locale="en" defaultLocale="en" messages={messages['en']}>
-      <div
-        data-floating-menu-container
-        role="main"
-        style={{
-          padding: '3em',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center'
-        }}
-      >
-        {story()}
-      </div>
-    </IntlProvider>
-  );
-}
+storiesOf('FormattedDuration', module)
+  .add('1 second', () => <FormattedDuration milliseconds={1000} />)
+  .add('1 minute 1 second', () => <FormattedDuration milliseconds={61000} />)
+  .add('other', () => (
+    <FormattedDuration
+      milliseconds={number(
+        'milliseconds',
+        2 * 60 * 60 * 1000 + 1 * 60 * 1000 + 10 * 1000 // 2h 1m 10s
+      )}
+    />
+  ));

--- a/packages/components/src/components/FormattedDuration/index.js
+++ b/packages/components/src/components/FormattedDuration/index.js
@@ -11,28 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
-import { IntlProvider } from "react-intl";
-
-import messages from '../src/nls/messages_en.json';
-
-import './Container.scss';
-
-export default function Container({ story }) {
-  return (
-    <IntlProvider locale="en" defaultLocale="en" messages={messages['en']}>
-      <div
-        data-floating-menu-container
-        role="main"
-        style={{
-          padding: '3em',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center'
-        }}
-      >
-        {story()}
-      </div>
-    </IntlProvider>
-  );
-}
+export { default } from './FormattedDuration';

--- a/packages/components/src/components/PipelineResources/PipelineResources.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
 
-import { RunDropdown, Table } from '..';
+import { FormattedDate, RunDropdown, Table } from '..';
 
 const PipelineResources = ({
   createPipelineResourcesURL = urls.pipelineResources.byName,
@@ -51,6 +51,13 @@ const PipelineResources = ({
       })
     },
     {
+      key: 'createdTime',
+      header: intl.formatMessage({
+        id: 'dashboard.tableHeader.createdTime',
+        defaultMessage: 'Created'
+      })
+    },
+    {
       key: 'dropdown',
       header: ''
     }
@@ -75,6 +82,12 @@ const PipelineResources = ({
       ),
       namespace,
       type: pipelineResource.spec.type,
+      createdTime: (
+        <FormattedDate
+          date={pipelineResource.metadata.creationTimestamp}
+          relative
+        />
+      ),
       dropdown: (
         <RunDropdown
           items={pipelineResourceActions}

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import { Table } from '@tektoncd/dashboard-components';
 import 'carbon-components-react';
 import { getStatus, getStatusIcon, urls } from '@tektoncd/dashboard-utils';
 
-import { FormattedDate, RunDropdown } from '..';
+import { FormattedDate, FormattedDuration, RunDropdown } from '..';
 
 import './PipelineRuns.scss';
 
@@ -26,8 +26,6 @@ const PipelineRuns = ({
   createPipelineRunURL = urls.pipelineRuns.byName,
   createPipelineRunDisplayName = ({ pipelineRunMetadata }) =>
     pipelineRunMetadata.name,
-  createPipelineRunTimestamp = pipelineRun =>
-    getStatus(pipelineRun).lastTransitionTime,
   createPipelineRunsByPipelineURL = urls.pipelineRuns.byPipeline,
   getPipelineRunStatus = (pipelineRun, intl) =>
     pipelineRun.status && pipelineRun.status.conditions
@@ -78,10 +76,17 @@ const PipelineRuns = ({
       })
     },
     {
-      key: 'transitionTime',
+      key: 'createdTime',
       header: intl.formatMessage({
-        id: 'dashboard.tableHeader.transitionTime',
-        defaultMessage: 'Last Transition Time'
+        id: 'dashboard.tableHeader.createdTime',
+        defaultMessage: 'Created'
+      })
+    },
+    {
+      key: 'duration',
+      header: intl.formatMessage({
+        id: 'dashboard.tableHeader.duration',
+        defaultMessage: 'Duration'
       })
     },
     {
@@ -98,13 +103,13 @@ const PipelineRuns = ({
   });
 
   const pipelineRunsFormatted = pipelineRuns.map(pipelineRun => {
-    const { namespace, annotations } = pipelineRun.metadata;
+    const { annotations, creationTimestamp, namespace } = pipelineRun.metadata;
     const pipelineRunName = createPipelineRunDisplayName({
       pipelineRunMetadata: pipelineRun.metadata
     });
     const pipelineRefName = pipelineRun.spec.pipelineRef.name;
     const pipelineRunType = pipelineRun.spec.type;
-    const { reason, status } = getStatus(pipelineRun);
+    const { lastTransitionTime, reason, status } = getStatus(pipelineRun);
     const statusIcon = getPipelineRunStatusIcon(pipelineRun);
     const pipelineRunStatus = getPipelineRunStatus(pipelineRun, intl);
     const url = createPipelineRunURL({
@@ -112,6 +117,18 @@ const PipelineRuns = ({
       pipelineRunName,
       annotations
     });
+
+    let endTime = Date.now();
+    if (status === 'False' || status === 'True') {
+      endTime = new Date(lastTransitionTime).getTime();
+    }
+
+    const duration = (
+      <FormattedDuration
+        milliseconds={endTime - new Date(creationTimestamp).getTime()}
+      />
+    );
+
     return {
       id: `${namespace}:${pipelineRunName}`,
       name: url ? <Link to={url}>{pipelineRunName}</Link> : pipelineRunName,
@@ -138,12 +155,8 @@ const PipelineRuns = ({
           </div>
         </div>
       ),
-      transitionTime: (
-        <FormattedDate
-          date={createPipelineRunTimestamp(pipelineRun)}
-          relative
-        />
-      ),
+      createdTime: <FormattedDate date={creationTimestamp} relative />,
+      duration,
       type: pipelineRunType,
       dropdown: (
         <RunDropdown items={pipelineRunActions} resource={pipelineRun} />

--- a/packages/components/src/components/TaskRuns/TaskRuns.test.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -32,7 +32,8 @@ it('TaskRuns renders headers state', () => {
   expect(queryByText(/task/i)).toBeTruthy();
   expect(queryByText(/namespace/i)).toBeTruthy();
   expect(queryByText(/status/i)).toBeTruthy();
-  expect(queryByText(/last transition time/i)).toBeTruthy();
+  expect(queryByText(/created/i)).toBeTruthy();
+  expect(queryByText(/duration/i)).toBeTruthy();
   expect(document.getElementsByClassName('bx--overflow-menu')).toBeTruthy();
 });
 

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,6 +15,7 @@ export { default as Breadcrumbs } from './Breadcrumbs';
 export { default as CancelButton } from './CancelButton';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as FormattedDate } from './FormattedDate';
+export { default as FormattedDuration } from './FormattedDuration';
 export { default as Graph } from './Graph/Graph';
 export { default as Header } from './Header';
 export { default as LabelFilter } from './LabelFilter';

--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -40,6 +40,7 @@ export function fetchSecrets({ namespace } = {}) {
       const secretsFormatted = [];
       secrets.items.forEach(secret => {
         const object = {
+          creationTimestamp: secret.metadata.creationTimestamp,
           name: secret.metadata.name,
           namespace: secret.metadata.namespace,
           annotations: secret.metadata.annotations,
@@ -71,10 +72,10 @@ export function deleteSecret(secrets, cancelMethod) {
       namespacesToSecretsMap.set(secret.namespace, foundSecretInfo);
     });
 
-    /* Now we know the secrets for each namespace, iterate and determine which secrets 
-    should be removed from the SA. With the list of known secrets that stay, 
-    we finally do a replace type PATCH on the entire service account at once. 
-    This is used to ensure all data is still correct regardless of things like indexes changing 
+    /* Now we know the secrets for each namespace, iterate and determine which secrets
+    should be removed from the SA. With the list of known secrets that stay,
+    we finally do a replace type PATCH on the entire service account at once.
+    This is used to ensure all data is still correct regardless of things like indexes changing
     which is the only way to remove secrets otherwise using the patch API */
 
     // For each namespace there are secrets in

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
-import { Table } from '@tektoncd/dashboard-components';
+import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 import { InlineNotification } from 'carbon-components-react';
 import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
 
@@ -57,6 +57,13 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
           id: 'dashboard.tableHeader.name',
           defaultMessage: 'Name'
         })
+      },
+      {
+        key: 'createdTime',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
+        })
       }
     ];
 
@@ -70,6 +77,9 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
         >
           {clusterTask.metadata.name}
         </Link>
+      ),
+      createdTime: (
+        <FormattedDate date={clusterTask.metadata.creationTimestamp} relative />
       )
     }));
 

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -109,17 +109,17 @@ export /* istanbul ignore next */ class EventListeners extends Component {
         })
       },
       {
-        key: 'date',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.dateCreated',
-          defaultMessage: 'Date Created'
-        })
-      },
-      {
         key: 'namespace',
         header: intl.formatMessage({
           id: 'dashboard.tableHeader.namespace',
           defaultMessage: 'Namespace'
+        })
+      },
+      {
+        key: 'date',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
         })
       }
     ];

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import { injectIntl } from 'react-intl';
 
 import { InlineNotification } from 'carbon-components-react';
 import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
-import { Table } from '@tektoncd/dashboard-components';
+import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 
 import { fetchPipelines } from '../../actions/pipelines';
 import {
@@ -73,6 +73,13 @@ export /* istanbul ignore next */ class Pipelines extends Component {
         })
       },
       {
+        key: 'createdTime',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
+        })
+      },
+      {
         key: 'link',
         header: ''
       }
@@ -91,6 +98,9 @@ export /* istanbul ignore next */ class Pipelines extends Component {
         </Link>
       ),
       namespace: pipeline.metadata.namespace,
+      createdTime: (
+        <FormattedDate date={pipeline.metadata.creationTimestamp} relative />
+      ),
       link: (
         <Link
           to={urls.rawCRD.byNamespace({

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { InlineNotification } from 'carbon-components-react';
-import { Table } from '@tektoncd/dashboard-components';
+import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 import Add from '@carbon/icons-react/lib/add/16';
 import Delete from '@carbon/icons-react/lib/delete/16';
 import Modal from '../SecretsModal';
@@ -142,6 +142,13 @@ export /* istanbul ignore next */ class Secrets extends Component {
           id: 'dashboard.tableHeader.annotations',
           defaultMessage: 'Annotations'
         })
+      },
+      {
+        key: 'created',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
+        })
       }
     ];
 
@@ -157,8 +164,9 @@ export /* istanbul ignore next */ class Secrets extends Component {
       const formattedSecret = {
         annotations,
         id: `${secret.namespace}:${secret.name}`,
+        name: secret.name,
         namespace: secret.namespace,
-        name: secret.name
+        created: <FormattedDate date={secret.creationTimestamp} relative />
       };
 
       return formattedSecret;

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { InlineNotification } from 'carbon-components-react';
 import { getErrorMessage, urls } from '@tektoncd/dashboard-utils';
-import { Table } from '@tektoncd/dashboard-components';
+import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 import Information16 from '@carbon/icons-react/lib/information/16';
 import { fetchTasks } from '../../actions/tasks';
 import {
@@ -71,6 +71,13 @@ export /* istanbul ignore next */ class Tasks extends Component {
         })
       },
       {
+        key: 'createdTime',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
+        })
+      },
+      {
         key: 'link',
         header: ''
       }
@@ -89,6 +96,9 @@ export /* istanbul ignore next */ class Tasks extends Component {
         </Link>
       ),
       namespace: task.metadata.namespace,
+      createdTime: (
+        <FormattedDate date={task.metadata.creationTimestamp} relative />
+      ),
       link: (
         <Link
           to={urls.rawCRD.byNamespace({

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -110,17 +110,17 @@ export /* istanbul ignore next */ class TriggerBindings extends Component {
         })
       },
       {
-        key: 'date',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.dateCreated',
-          defaultMessage: 'Date Created'
-        })
-      },
-      {
         key: 'namespace',
         header: intl.formatMessage({
           id: 'dashboard.tableHeader.namespace',
           defaultMessage: 'Namespace'
+        })
+      },
+      {
+        key: 'date',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
         })
       }
     ];

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -110,17 +110,17 @@ export /* istanbul ignore next */ class TriggerTemplates extends Component {
         })
       },
       {
-        key: 'date',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.dateCreated',
-          defaultMessage: 'Date Created'
-        })
-      },
-      {
         key: 'namespace',
         header: intl.formatMessage({
           id: 'dashboard.tableHeader.namespace',
           defaultMessage: 'Namespace'
+        })
+      },
+      {
+        key: 'date',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.createdTime',
+          defaultMessage: 'Created'
         })
       }
     ];

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -84,13 +84,13 @@
     "dashboard.step.statusNotAvailable": "No status available",
     "dashboard.step.stepDefinition": "Step definition",
     "dashboard.tableHeader.annotations": "Annotations",
-    "dashboard.tableHeader.dateCreated": "Date Created",
+    "dashboard.tableHeader.createdTime": "Created",
+    "dashboard.tableHeader.duration": "Duration",
     "dashboard.tableHeader.name": "Name",
     "dashboard.tableHeader.namespace": "Namespace",
     "dashboard.tableHeader.pipeline": "Pipeline",
     "dashboard.tableHeader.status": "Status",
     "dashboard.tableHeader.task": "Task",
-    "dashboard.tableHeader.transitionTime": "Last Transition Time",
     "dashboard.tableHeader.type": "Type",
     "dashboard.tableHeader.value": "Value",
     "dashboard.taskRun.details": "Details",
@@ -117,6 +117,11 @@
     "dashboard.triggerTemplate.paramaters": "Parameters",
     "dashboard.triggerTemplate.resourceNameHeader": "Resource name to create",
     "dashboard.triggerTemplate.resourceTemplates": "Resource Templates",
-    "dashboard.triggerTemplate.unavailable": "TriggerTemplate not available"
+    "dashboard.triggerTemplate.unavailable": "TriggerTemplate not available",
+    "react-intl-formatted-duration.daysUnit": "{value, plural, one {day} other {days}}",
+    "react-intl-formatted-duration.duration": "{value} {unit}",
+    "react-intl-formatted-duration.hoursUnit": "{value, plural, one {hour} other {hours}}",
+    "react-intl-formatted-duration.minutesUnit": "{value, plural, one {minute} other {minutes}}",
+    "react-intl-formatted-duration.secondsUnit": "{value, plural, one {second} other {seconds}}"
   }
 }

--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,6 +23,7 @@ function byNamespace(state = {}, action) {
         if (isStale({ metadata: secret }, state, 'name')) {
           return state;
         }
+
         const { namespace, name } = secret;
         return merge(accumulator, {
           [namespace]: {
@@ -42,6 +43,7 @@ function byNamespace(state = {}, action) {
       const secret = {
         [action.payload.metadata.namespace]: {
           [action.payload.metadata.name]: {
+            creationTimestamp: action.payload.metadata.creationTimestamp || '',
             name: action.payload.metadata.name || '',
             namespace: action.payload.metadata.namespace || '',
             annotations: action.payload.metadata.annotations || ''

--- a/src/reducers/secrets.test.js
+++ b/src/reducers/secrets.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -120,6 +120,7 @@ it('SECRET_DELETE_SUCCESS for multiple secrets', () => {
 it('SecretCreated', () => {
   const secret = {
     metadata: {
+      creationTimestamp: 'some timestamp',
       name: 'github-repo-access-secret',
       namespace: 'default',
       annotations: {}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/850

- Add column showing creationTimestamp on all list views
- Add column showing duration on PipelineRuns and TaskRuns views
  - `now - creationTimestamp` for in progress runs
  - `lastUpdate - creationTimestamp` for completed runs

![image](https://user-images.githubusercontent.com/2829095/71033942-3627e900-2110-11ea-96f6-d8a669485765.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
