### PR TITLE
Fix empty timeout error

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -161,7 +161,9 @@ class CreatePipelineRun extends React.Component {
 
     // Timeout is a number and less than 1 year in minutes
     const timeoutTest =
-      !Number.isNaN(this.state.timeout) && this.state.timeout < 525600;
+      !Number.isNaN(this.state.timeout) &&
+      this.state.timeout < 525600 &&
+      this.state.timeout.trim() !== '';
     if (!timeoutTest) {
       this.setState({ validTimeout: false });
     } else {

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -631,6 +631,12 @@ it('CreatePipelineRun validates inputs', () => {
   });
   fireEvent.click(submitButton(getAllByText));
   expect(queryByText(timeoutValidationErrorRegExp)).toBeTruthy();
+  // Test invalid timeouts for empty Timeout
+  fireEvent.change(document.getElementById('create-pipelinerun--timeout'), {
+    target: { value: ' ' }
+  });
+  fireEvent.click(submitButton(getAllByText));
+  expect(queryByText(timeoutValidationErrorRegExp)).toBeTruthy();
   fireEvent.change(document.getElementById('create-pipelinerun--timeout'), {
     target: { value: '525600' }
   });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

References issue #854 
Instead of being able to submit and receiving the original error it now brings up an error on the modal 
Added a test to ensure if it is empty then the error appears in the modal

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
