### PR TITLE
Show Errored Task as Default in TaskRun/PipelineRun View

### DIFF
--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -26,6 +26,12 @@ class Task extends Component {
     this.selectDefaultStep();
   }
 
+  componentDidUpdate(prevState) {
+    if (!prevState.selectedStepId) {
+      this.selectDefaultStep();
+    }
+  }
+
   handleClick = event => {
     if (event) {
       event.preventDefault();
@@ -46,7 +52,10 @@ class Task extends Component {
     const { expanded, steps } = this.props;
     const { selectedStepId } = this.state;
     if (expanded && !selectedStepId) {
-      const { id } = steps[0] || {};
+      const erroredStep = steps.find(
+        step => step.reason === 'Error' || step.reason === undefined
+      );
+      const { id } = erroredStep || steps[0] || {};
       this.handleStepSelected(id);
     }
   }

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -40,6 +40,49 @@ it('Task renders steps in expanded state', () => {
   expect(queryByText(/a step/i)).toBeTruthy();
 });
 
+it('Task renders first step in expanded Task with no error', () => {
+  const steps = [
+    { id: 'step', stepName: 'a step', reason: 'Completed' },
+    { id: 'step-two', stepName: 'a step two', reason: 'Completed' }
+  ];
+  const { queryByText } = renderWithIntl(
+    <Task {...props} expanded steps={steps} />
+  );
+  expect(
+    queryByText('a step').parentNode.parentNode.getAttribute('data-selected')
+  ).toBeTruthy();
+});
+
+it('Task renders error step in expanded Task', () => {
+  const steps = [
+    { id: 'step', stepName: 'a step', reason: 'Completed' },
+    { id: 'step-two', stepName: 'a step two', reason: 'Error' }
+  ];
+  const { queryByText } = renderWithIntl(
+    <Task {...props} expanded steps={steps} />
+  );
+  expect(
+    queryByText('a step two').parentNode.parentNode.getAttribute(
+      'data-selected'
+    )
+  ).toBeTruthy();
+});
+
+it('Task renders cancelled step in expanded Task', () => {
+  const steps = [
+    { id: 'step', stepName: 'a step', reason: 'Completed' },
+    { id: 'step-two', stepName: 'a step two', reason: undefined }
+  ];
+  const { queryByText } = renderWithIntl(
+    <Task {...props} expanded steps={steps} />
+  );
+  expect(
+    queryByText('a step two').parentNode.parentNode.getAttribute(
+      'data-selected'
+    )
+  ).toBeTruthy();
+});
+
 it('Task renders success state', () => {
   renderWithIntl(<Task {...props} succeeded="True" />);
 });

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -35,8 +35,11 @@ class TaskTree extends Component {
             return null;
           }
           const { id, reason, steps, succeeded, pipelineTaskName } = taskRun;
+          const erroredTask = taskRuns.find(task => task.succeeded === 'False');
           const expanded =
-            selectedTaskId === id || (!selectedTaskId && index === 0);
+            (!selectedTaskId && erroredTask && erroredTask.id === id) ||
+            selectedTaskId === id ||
+            (!erroredTask && !selectedTaskId && index === 0);
           return (
             <Task
               id={id}

--- a/packages/components/src/components/TaskTree/TaskTree.test.js
+++ b/packages/components/src/components/TaskTree/TaskTree.test.js
@@ -22,6 +22,25 @@ const props = {
     {
       id: 'task',
       pipelineTaskName: 'A Task',
+      succeeded: 'True',
+      steps: [
+        { id: 'build', stepName: 'build' },
+        { id: 'test', stepName: 'test' }
+      ]
+    },
+    {
+      id: 'task2',
+      succeeded: 'True',
+      pipelineTaskName: 'A Second Task',
+      steps: [
+        { id: 'build', stepName: 'build' },
+        { id: 'test', stepName: 'test' }
+      ]
+    },
+    {
+      id: 'task3',
+      succeeded: 'True',
+      pipelineTaskName: 'A Third Task',
       steps: [
         { id: 'build', stepName: 'build' },
         { id: 'test', stepName: 'test' }
@@ -40,6 +59,38 @@ it('TaskTree renders when taskRuns is falsy', () => {
 
 it('TaskTree renders when taskRuns contains a falsy run', () => {
   renderWithIntl(<TaskTree {...props} taskRuns={[null]} />);
+});
+
+it('TaskTree renders and expands first Task in TaskRun with no error', () => {
+  const { queryByText } = renderWithIntl(<TaskTree {...props} />);
+  // Selected Task should have two child elements. The anchor and ordered list
+  // of steps in expanded task
+  expect(queryByText('A Task').parentNode.childNodes).toHaveLength(2);
+  expect(queryByText('A Second Task').parentNode.childNodes).toHaveLength(1);
+  expect(queryByText('A Third Task').parentNode.childNodes).toHaveLength(1);
+});
+
+it('TaskTree renders and expands error Task in TaskRun', () => {
+  props.taskRuns[1].succeeded = 'False';
+
+  const { queryByText } = renderWithIntl(<TaskTree {...props} />);
+  // Selected Task should have two child elements. The anchor and ordered list
+  // of steps in expanded task
+  expect(queryByText('A Task').parentNode.childNodes).toHaveLength(1);
+  expect(queryByText('A Second Task').parentNode.childNodes).toHaveLength(2);
+  expect(queryByText('A Third Task').parentNode.childNodes).toHaveLength(1);
+});
+
+it('TaskTree renders and expands first error Task in TaskRun', () => {
+  props.taskRuns[1].succeeded = 'False';
+  props.taskRuns[2].succeeded = 'False';
+
+  const { queryByText } = renderWithIntl(<TaskTree {...props} />);
+  // Selected Task should have two child elements. The anchor and ordered list
+  // of steps in expanded task
+  expect(queryByText('A Task').parentNode.childNodes).toHaveLength(1);
+  expect(queryByText('A Second Task').parentNode.childNodes).toHaveLength(2);
+  expect(queryByText('A Third Task').parentNode.childNodes).toHaveLength(1);
 });
 
 it('TaskTree handles click event on Task', () => {


### PR DESCRIPTION
issue: https://github.com/tektoncd/dashboard/issues/488#issuecomment-528371488

# Changes
Show errored task as default, if present, when viewing the steps in a TaskRun or PipelineRun. Tests included. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._

/cc @AlanGreene 
