### PR TITLE
Override the default base image to run as non-root user

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/base:nonroot


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

By default, `ko` makes use of `gcr.io/distroless/base:latest` as the base image for containers.
This change overrides the default base image to make the dashboard run as a non-privileged user.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
