### PR TITLE
Update secrets error message to indicate where a secret is already created

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -14,6 +14,7 @@ limitations under the License.
 import {
   createCredential,
   deleteCredential,
+  getAllCredentials,
   getCredentials,
   getServiceAccount,
   getServiceAccounts,
@@ -176,9 +177,20 @@ export function createSecret(postData, namespace) {
       });
       return false;
     } catch (error) {
-      error.response.text().then(message => {
-        dispatch({ type: 'SECRET_CREATE_FAILURE', error: message });
+      const secrets = await getAllCredentials(namespace);
+      secrets.items.forEach(secret => {
+        if (secret.metadata.name === postData.metadata.name) {
+          const message = `A secret already exists in namespace ${namespace} with name ${
+            secret.metadata.name
+          }`;
+          dispatch({ type: 'SECRET_CREATE_FAILURE', error: message });
+        }
       });
+      if (!error.response) {
+        error.response.text().then(message => {
+          dispatch({ type: 'SECRET_CREATE_FAILURE', error: message });
+        });
+      }
       return true;
     }
   };

--- a/src/actions/secrets.test.js
+++ b/src/actions/secrets.test.js
@@ -246,7 +246,7 @@ it('createSecret error', async () => {
     response: {
       text: () => {
         return Promise.resolve(
-          'Could not create secret "secret-name" in namespace default'
+          'A secret already exists in namespace default with name default-token-kbn7j'
         );
       }
     }
@@ -256,11 +256,14 @@ it('createSecret error', async () => {
     throw error;
   });
 
+  jest.spyOn(API, 'getAllCredentials').mockImplementation(() => data);
+
   const expectedActions = [
     { type: 'SECRET_CREATE_REQUEST' },
     {
       type: 'SECRET_CREATE_FAILURE',
-      error: 'Could not create secret "secret-name" in namespace default'
+      error:
+        'A secret already exists in namespace default with name default-token-kbn7j'
     }
   ];
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -290,6 +290,11 @@ export function getCredentials(namespace) {
   return get(uri);
 }
 
+export function getAllCredentials(namespace) {
+  const uri = getKubeAPI('secrets', namespace);
+  return get(uri);
+}
+
 export function getCredential(id, namespace) {
   const uri = getKubeAPI('secrets', { name: id, namespace });
   return get(uri);

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -472,6 +472,17 @@ it('getCredentials', () => {
   });
 });
 
+it('getAllCredentials', () => {
+  const data = {
+    items: 'credentials'
+  };
+  fetchMock.get(/secrets/, data);
+  return index.getAllCredentials().then(response => {
+    expect(response).toEqual(data);
+    fetchMock.restore();
+  });
+});
+
 it('getCredential', () => {
   const credentialId = 'foo';
   const data = { fake: 'credential' };


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For: https://github.com/tektoncd/dashboard/issues/806

- Updates the `createSecret` function to specify where a create fails because a secret is already created with the chosen name in the chosen namespace.

- Updates the test for a `createSecret` failure

- Adds a new function `getAllCredentials` to retrieve all secrets (user created or otherwise) from a single namespace, as well as a test for this function.

<img width="627" alt="Screenshot 2020-01-07 at 11 14 24" src="https://user-images.githubusercontent.com/52741262/71891625-eea8e180-313e-11ea-99e4-0eb51266d725.png">


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
