### PR TITLE
Display EventListener name in tooltip on list view

### DIFF
--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -133,6 +133,7 @@ export /* istanbul ignore next */ class EventListeners extends Component {
             namespace: listener.metadata.namespace,
             eventListenerName: listener.metadata.name
           })}
+          title={listener.metadata.name}
         >
           {listener.metadata.name}
         </Link>

--- a/src/containers/EventListeners/EventListeners.test.js
+++ b/src/containers/EventListeners/EventListeners.test.js
@@ -98,7 +98,7 @@ it('EventListeners renders with one binding', () => {
     notifications: {}
   });
 
-  const { queryByText } = renderWithRouter(
+  const { queryByText, queryByTitle } = renderWithRouter(
     <Provider store={store}>
       <Route
         path="/eventlisteners"
@@ -111,6 +111,7 @@ it('EventListeners renders with one binding', () => {
   expect(queryByText('EventListeners')).toBeTruthy();
   expect(queryByText('No EventListeners under any namespace.')).toBeFalsy();
   expect(queryByText('event-listener')).toBeTruthy();
+  expect(queryByTitle('event-listener')).toBeTruthy();
 });
 
 it('EventListeners can be filtered on a single label filter', async () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Display tooltip on hover of EventListener name on EventListeners
list view. This matches the behaviour of other pages, and is
important when long names are truncated.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
