### PR TITLE
Show logs when no step name is provided

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -20,6 +20,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import {
   getErrorMessage,
   getStatus,
+  reorderSteps,
   selectedTask,
   selectedTaskRun,
   stepsStatus,
@@ -118,7 +119,11 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           };
           taskRun = theRun; // eslint-disable-line no-param-reassign
         } else {
-          steps = stepsStatus(task.spec.steps, taskRun.status.steps);
+          const reorderedSteps = reorderSteps(
+            taskRun.status.steps,
+            task.spec.steps
+          );
+          steps = stepsStatus(reorderedSteps, reorderedSteps);
         }
 
         return {

--- a/packages/components/src/components/TaskTree/TaskTree.stories.js
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.js
@@ -22,10 +22,18 @@ storiesOf('TaskTree', module).add('default', () => {
     taskRuns: [
       {
         id: 'task',
-        pipelineTaskName: text('Task name', 'default task name'),
+        pipelineTaskName: text('Task 1 name', 'Task 1'),
         steps: [
           { id: 'build', stepName: 'build' },
           { id: 'test', stepName: 'test' }
+        ]
+      },
+      {
+        id: 'task2',
+        pipelineTaskName: text('Task 2 name', 'Task 2'),
+        steps: [
+          { id: 'step 1', stepName: 'step 1' },
+          { id: 'step 2', stepName: 'step 2' }
         ]
       }
     ]

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -112,6 +112,27 @@ export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
   return steps;
 }
 
+/*
+  When steps are retreived from a TaskRun's status, their order is not guaranteed.
+  This function reorders the given unorderedSteps to match the order specified by the given orderedSteps.
+  Each step in unorderedSteps must have the same name as a step in the orderedSteps.
+  Unnamed steps are automatically given the name 'unnamed-NUM' where NUM is the step number starting from 1.
+    ex: 'unnamed-3' is the 3rd step
+  None of the unorderedSteps will have an empty name, but some of the orderedSteps may have empty names.
+*/
+export function reorderSteps(unorderedSteps, orderedSteps) {
+  if (!unorderedSteps || !orderedSteps) {
+    return [];
+  }
+  return orderedSteps.map(({ name }, idx) => {
+    let findName = name;
+    if (name === '') {
+      findName = `unnamed-${idx + 1}`;
+    }
+    return unorderedSteps.find(step => step.name === findName);
+  });
+}
+
 export function isRunning(reason, status) {
   return status === 'Unknown' && reason === 'Running';
 }

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -18,6 +18,7 @@ import {
   getStatus,
   getStatusIcon,
   isRunning,
+  reorderSteps,
   selectedTask,
   stepsStatus,
   taskRunStep
@@ -239,6 +240,83 @@ it('stepsStatus step is terminated with error', () => {
   expect(returnedStep.status).toEqual('terminated');
   expect(returnedStep.stepName).toEqual(stepName);
   expect(returnedStep.reason).toEqual(reason);
+});
+
+it('reorderSteps returns empty array for undefined unorderedSteps', () => {
+  const unorderedSteps = undefined;
+  const orderedSteps = [{ name: 'a' }];
+  const want = [];
+  const got = reorderSteps(unorderedSteps, orderedSteps);
+  expect(got).toEqual(want);
+});
+
+it('reorderSteps returns empty array for undefined ordered', () => {
+  const unorderedSteps = [{ name: 'a' }];
+  const orderedSteps = undefined;
+  const want = [];
+  const got = reorderSteps(unorderedSteps, orderedSteps);
+  expect(got).toEqual(want);
+});
+
+it('reorderSteps works on empty steps', () => {
+  const unorderedSteps = [];
+  const orderedSteps = [];
+  const want = [];
+  const got = reorderSteps(unorderedSteps, orderedSteps);
+  expect(got).toEqual(want);
+});
+
+it('reorderSteps works on ordered steps', () => {
+  const unorderedSteps = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+  const orderedSteps = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+  const want = [...unorderedSteps];
+  const got = reorderSteps(unorderedSteps, orderedSteps);
+  expect(got).toEqual(want);
+});
+
+it('reorderSteps properly reorders unnamed steps', () => {
+  const unorderedSteps = [
+    { name: 'unnamed-2' },
+    { name: 'unnamed-3' },
+    { name: 'unnamed-1' }
+  ];
+  const orderedSteps = [{ name: '' }, { name: '' }, { name: '' }];
+  const want = [
+    { name: 'unnamed-1' },
+    { name: 'unnamed-2' },
+    { name: 'unnamed-3' }
+  ];
+  const got = reorderSteps(unorderedSteps, orderedSteps);
+  expect(got).toEqual(want);
+});
+
+it('reorderSteps properly reorders unnamed and named steps', () => {
+  const unorderedSteps = [
+    { name: 'c' },
+    { name: 'unnamed-5' },
+    { name: 'a' },
+    { name: 'unnamed-1' },
+    { name: 'b' },
+    { name: 'unnamed-6' }
+  ];
+  const orderedSteps = [
+    { name: '' },
+    { name: 'a' },
+    { name: 'b' },
+    { name: 'c' },
+    { name: '' },
+    { name: '' }
+  ];
+  const want = [
+    { name: 'unnamed-1' },
+    { name: 'a' },
+    { name: 'b' },
+    { name: 'c' },
+    { name: 'unnamed-5' },
+    { name: 'unnamed-6' }
+  ];
+  const got = reorderSteps(unorderedSteps, orderedSteps);
+  expect(got).toEqual(want);
 });
 
 it('generateId', () => {

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -24,7 +24,12 @@ import {
   StepDetails,
   TaskTree
 } from '@tektoncd/dashboard-components';
-import { getStatus, stepsStatus, taskRunStep } from '@tektoncd/dashboard-utils';
+import {
+  getStatus,
+  reorderSteps,
+  stepsStatus,
+  taskRunStep
+} from '@tektoncd/dashboard-utils';
 
 import { fetchLogs } from '../../utils';
 
@@ -101,14 +106,16 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     if (!taskRun) {
       return null;
     }
-    let { steps } = taskRun.status;
-    if (task) {
-      steps = task.spec.steps; // eslint-disable-line
-    }
+
+    const { steps } = taskRun.status;
+    const stepDefinitions = taskRun.spec.taskSpec
+      ? taskRun.spec.taskSpec.steps
+      : task.spec.steps;
+    const reorderedSteps = reorderSteps(steps, stepDefinitions);
     const taskRunName = taskRun.metadata.name;
     const taskRunNamespace = taskRun.metadata.namespace;
     const { reason, status: succeeded } = getStatus(taskRun);
-    const runSteps = stepsStatus(steps, taskRun.status.steps);
+    const runSteps = stepsStatus(reorderedSteps, reorderedSteps);
     const { params, resources: inputResources } = taskRun.spec.inputs;
     const { resources: outputResources } = taskRun.spec.outputs;
     const { startTime } = taskRun.status;


### PR DESCRIPTION
# Changes
Fixes #709
A TaskRun has all of the information about the steps in its status
(including the default step names when no name is provided). So, I
changed the TaskRun container and PipelineRun component to only use the
TaskRun's status for retreiving information about the TaskRun
(previously they were using the Task definition as well).

Here's an example of the default step names when no name is provided:
<img width="862" alt="Screen Shot 2020-01-08 at 2 18 45 PM" src="https://user-images.githubusercontent.com/16961496/72008454-dcec3a80-3221-11ea-9a1d-34ab4a89b1bd.png">


I also updated the TaskTree's Storybook entry to be more descriptive.

/cc @AlanGreene 
/cc @a-roberts 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
