### PR TITLE
Use ViewYAML component anywhere YAML is rendered in the UI

### DIFF
--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -15,11 +15,10 @@ limitations under the License.
 
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import jsYaml from 'js-yaml';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { urls } from '@tektoncd/dashboard-utils';
 
-import { ResourceTable } from '..';
+import { ResourceTable, ViewYAML } from '..';
 import './StepDefinition.scss';
 
 const resourceTable = (title, namespace, resources, intl) => {
@@ -40,7 +39,7 @@ const resourceTable = (title, namespace, resources, intl) => {
               {resourceRef.name}
             </Link>
           ) : (
-            <pre>{jsYaml.dump(resourceSpec)}</pre>
+            <ViewYAML resource={resourceSpec} />
           )
       }))}
       headers={[
@@ -107,13 +106,6 @@ class StepDefinition extends Component {
 
   render() {
     const { definition, intl } = this.props;
-    const yaml = jsYaml.dump(
-      definition ||
-        intl.formatMessage({
-          id: 'dashboard.step.definitionNotAvailable',
-          defaultMessage: 'description: step definition not available'
-        })
-    );
 
     const paramsResources = this.getIOTables();
     return (
@@ -125,7 +117,15 @@ class StepDefinition extends Component {
           />
           :
         </div>
-        <pre>{yaml}</pre>
+        <ViewYAML
+          resource={
+            definition ||
+            intl.formatMessage({
+              id: 'dashboard.step.definitionNotAvailable',
+              defaultMessage: 'description: step definition not available'
+            })
+          }
+        />
         {paramsResources}
       </div>
     );

--- a/packages/components/src/components/StepStatus/StepStatus.js
+++ b/packages/components/src/components/StepStatus/StepStatus.js
@@ -12,19 +12,13 @@ limitations under the License.
 */
 
 import React from 'react';
-import jsYaml from 'js-yaml';
-
-import './StepStatus.scss';
 import { injectIntl } from 'react-intl';
 
+import { ViewYAML } from '..';
+
+import './StepStatus.scss';
+
 const StepStatus = ({ intl, status }) => {
-  const yaml = jsYaml.dump(
-    status ||
-      intl.formatMessage({
-        id: 'dashboard.step.statusNotAvailable',
-        defaultMessage: 'No status available'
-      })
-  );
   return (
     <div className="step-status">
       <div className="title">
@@ -34,7 +28,15 @@ const StepStatus = ({ intl, status }) => {
         })}
         :
       </div>
-      <pre>{yaml}</pre>
+      <ViewYAML
+        resource={
+          status ||
+          intl.formatMessage({
+            id: 'dashboard.step.statusNotAvailable',
+            defaultMessage: 'No status available'
+          })
+        }
+      />
     </div>
   );
 };

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -44,5 +44,5 @@ export { default as TaskRuns } from './TaskRuns';
 export { default as TaskSkeleton } from './TaskSkeleton';
 export { default as TaskTree } from './TaskTree';
 export { default as KeyValueList } from './KeyValueList';
-export { default as ViewYaml } from './ViewYAML';
+export { default as ViewYAML } from './ViewYAML';
 export { default as Trigger } from './Trigger';

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -17,8 +17,8 @@ import {
   CodeSnippetSkeleton,
   InlineNotification
 } from 'carbon-components-react';
-import jsYaml from 'js-yaml';
 import { getErrorMessage } from '@tektoncd/dashboard-utils';
+import { ViewYAML } from '@tektoncd/dashboard-components';
 
 import { fetchClusterTask, fetchTask } from '../../actions/tasks';
 import { fetchPipeline } from '../../actions/pipelines';
@@ -116,13 +116,8 @@ export /* istanbul ignore next */ class CustomResourceDefinition extends Compone
         />
       );
     }
-    return (
-      <div className="bx--snippet--multi">
-        <code>
-          <pre>{jsYaml.dump(resource)}</pre>
-        </code>
-      </div>
-    );
+
+    return <ViewYAML resource={resource} />;
   }
 }
 

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -22,7 +22,7 @@ import { formatLabels } from '@tektoncd/dashboard-utils';
 import {
   FormattedDate,
   Trigger,
-  ViewYaml
+  ViewYAML
 } from '@tektoncd/dashboard-components';
 import {
   getEventListener,
@@ -175,7 +175,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
             </div>
           </Tab>
           <Tab label="YAML">
-            <ViewYaml resource={eventListener} />
+            <ViewYAML resource={eventListener} />
           </Tab>
         </Tabs>
       </div>

--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
 import '../../scss/Triggers.scss';
 import { injectIntl } from 'react-intl';
 import { InlineNotification, Tab, Tabs, Tag } from 'carbon-components-react';
-import { FormattedDate, Table, ViewYaml } from '@tektoncd/dashboard-components';
+import { FormattedDate, Table, ViewYAML } from '@tektoncd/dashboard-components';
 import { formatLabels } from '@tektoncd/dashboard-utils';
 import {
   getSelectedNamespace,
@@ -204,7 +204,7 @@ export /* istanbul ignore next */ class TriggerBindingContainer extends Componen
             </div>
           </Tab>
           <Tab label="YAML">
-            <ViewYaml resource={triggerBinding} />
+            <ViewYAML resource={triggerBinding} />
           </Tab>
         </Tabs>
       </div>

--- a/src/containers/TriggerBinding/TriggerBinding.test.js
+++ b/src/containers/TriggerBinding/TriggerBinding.test.js
@@ -139,7 +139,7 @@ it('TriggerBindingContainer toggles between tabs correctly', async () => {
   await waitForElement(() => getByText('trigger-binding-simple'));
 
   await waitForElement(() => getByText('Date Created:'));
-  let yamlTab = getByText(/Yaml/i);
+  let yamlTab = getByText('YAML');
   expect(yamlTab.getAttribute('aria-selected')).toBe('false');
 
   fireEvent.click(yamlTab);
@@ -148,7 +148,7 @@ it('TriggerBindingContainer toggles between tabs correctly', async () => {
   expect(detailsTab.getAttribute('aria-selected')).toBe('false');
 
   fireEvent.click(detailsTab);
-  yamlTab = getByText(/Yaml/i);
+  yamlTab = getByText('YAML');
   expect(yamlTab.getAttribute('aria-selected')).toBe('false');
 });
 
@@ -265,7 +265,7 @@ it('TriggerBindingContainer renders YAML', async () => {
   );
 
   await waitForElement(() => getByText('trigger-binding-simple'));
-  const yamlTab = getByText(/yaml/i);
+  const yamlTab = getByText('YAML');
   fireEvent.click(yamlTab);
   await waitForElement(() => getByText(/creationTimestamp/i));
   await waitForElement(() => getByText(/spec/i));

--- a/src/containers/TriggerTemplate/TriggerTemplate.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.js
@@ -26,7 +26,7 @@ import {
 import {
   Table as DashboardTable,
   FormattedDate,
-  ViewYaml
+  ViewYAML
 } from '@tektoncd/dashboard-components';
 import { formatLabels } from '@tektoncd/dashboard-utils';
 import {
@@ -300,7 +300,7 @@ export /* istanbul ignore next */ class TriggerTemplateContainer extends Compone
                               </TableExpandRow>
                               {row.isExpanded && (
                                 <TableExpandedRow colSpan={headers.length + 1}>
-                                  <ViewYaml
+                                  <ViewYAML
                                     resource={
                                       triggerTemplate.spec.resourcetemplates[
                                         index
@@ -320,7 +320,7 @@ export /* istanbul ignore next */ class TriggerTemplateContainer extends Compone
             </div>
           </Tab>
           <Tab label="YAML">
-            <ViewYaml resource={triggerTemplate} />
+            <ViewYAML resource={triggerTemplate} />
           </Tab>
         </Tabs>
       </div>

--- a/src/containers/TriggerTemplate/TriggerTemplate.test.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.test.js
@@ -504,7 +504,7 @@ it('TriggerTemplateContainer contains YAML tab with accurate information', async
   );
 
   await waitForElement(() => getByText('pipeline-template'));
-  const yamlTab = getByText(/yaml/i);
+  const yamlTab = getByText('YAML');
   fireEvent.click(yamlTab);
   await waitForElement(() => getByText(/creationtimestamp/i));
   await waitForElement(() => getByText(/selflink/i));


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
To ensure consistency and reduce maintenance / testing overhead
we should make sure the ViewYAML component is always used when
we want to render YAML (whether a resource, or a fragment) in
the UI.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
