### PR TITLE
Add wait for deployment so timing error for pods doesnt happen

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -63,6 +63,16 @@ function dump_extra_cluster_state() {
 function install_dashboard_backend() {
   echo ">> Deploying the Dashboard backend"
   ko apply -f config/ || fail_test "Dashboard backend installation failed"
+  # Wait until deployment is running before checking pods, stops timing error
+  for i in {1..30}
+  do
+    wait=$(kubectl wait --namespace tekton-pipelines --for=condition=available deployments/tekton-dashboard --timeout=30s)
+    if [ "$wait" = "deployment.extensions/tekton-dashboard condition met" ]; then
+      break
+    else
+      sleep 5
+    fi
+  done
   # Wait for pods to be running in the namespaces we are deploying to
   wait_until_pods_running tekton-pipelines || fail_test "Dashboard backend did not come up"
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
References issue #888 
Stops the timing issue of pods not being ready in the tekton-pipelines namespace as it checks the deployment and wont continue until the deployment is running. 
Instead of just waiting for the all pods in the tekton-pipelines namespace to be running which . the dashboard pod can sometimes not come up until this check is done 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
