### PR TITLE
Prevent Safari wrapping and overlapping text in Log component

### DIFF
--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -28,6 +28,7 @@ limitations under the License.
 
   code {
     white-space: pre;
+    overflow-wrap: normal;
   }
 
   .log-trailer {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Safari applies word-wrap / overflow-wrap even when white-space: pre
is applied to an element (other than `<pre>`).

Set `overflow-wrap: normal` to prevent content from wrapping
and overlapping the line(s) below.

Before:
![image](https://user-images.githubusercontent.com/2829095/72284268-7d829600-3638-11ea-95ab-635be25d4fab.png)

After:
![image](https://user-images.githubusercontent.com/2829095/72284275-82dfe080-3638-11ea-9a90-226434c43f55.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
