### PR TITLE
Allow consumers of the components to disable the byPipeline link on PipelineRuns page

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -50,7 +50,6 @@ const PipelineRuns = ({
     return `${reason}: ${message}`;
   },
   hideNamespace,
-  hidePipeline,
   intl,
   loading,
   selectedNamespace,
@@ -72,7 +71,7 @@ const PipelineRuns = ({
         defaultMessage: 'Name'
       })
     },
-    !hidePipeline && {
+    {
       key: 'pipeline',
       header: intl.formatMessage({
         id: 'dashboard.tableHeader.pipeline',
@@ -118,15 +117,22 @@ const PipelineRuns = ({
     const pipelineRunName = createPipelineRunDisplayName({
       pipelineRunMetadata: pipelineRun.metadata
     });
-    const pipelineRefName = pipelineRun.spec.pipelineRef.name;
+    const pipelineRefName =
+      pipelineRun.spec.pipelineRef && pipelineRun.spec.pipelineRef.name;
     const pipelineRunType = pipelineRun.spec.type;
     const { lastTransitionTime, reason, status } = getStatus(pipelineRun);
     const statusIcon = getPipelineRunStatusIcon(pipelineRun);
-    const url = createPipelineRunURL({
+    const pipelineRunURL = createPipelineRunURL({
       namespace,
       pipelineRunName,
       annotations
     });
+    const pipelineRunsByPipelineURL =
+      pipelineRefName &&
+      createPipelineRunsByPipelineURL({
+        namespace,
+        pipelineName: pipelineRefName
+      });
 
     let endTime = Date.now();
     if (status === 'False' || status === 'True') {
@@ -141,27 +147,21 @@ const PipelineRuns = ({
 
     return {
       id: `${namespace}:${pipelineRunName}`,
-      name: url ? (
-        <Link to={url} title={pipelineRunName}>
+      name: pipelineRunURL ? (
+        <Link to={pipelineRunURL} title={pipelineRunName}>
           {pipelineRunName}
         </Link>
       ) : (
         pipelineRunName
       ),
       pipeline:
-        !hidePipeline &&
-        (pipelineRefName ? (
-          <Link
-            to={createPipelineRunsByPipelineURL({
-              namespace,
-              pipelineName: pipelineRefName
-            })}
-            title={pipelineRefName}
-          >
+        pipelineRefName &&
+        (pipelineRunsByPipelineURL ? (
+          <Link to={pipelineRunsByPipelineURL} title={pipelineRefName}>
             {pipelineRefName}
           </Link>
         ) : (
-          ''
+          pipelineRefName
         )),
       namespace: !hideNamespace && namespace,
       status: (

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
@@ -55,7 +55,8 @@ storiesOf('PipelineRuns', module)
           metadata: {
             name: 'pipeline-run-20190816124708',
             namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
-            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e'
+            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e',
+            creationTimestamp: '2019-08-16T12:48:00Z'
           },
           spec: {
             pipelineRef: {
@@ -78,7 +79,8 @@ storiesOf('PipelineRuns', module)
           metadata: {
             name: 'pipeline-run-20190816170431',
             namespace: '21cf1eac-7392-4e67-a4d0-f654506fe04d',
-            uid: 'a7812005-f766-4877-abd4-b3d418b04f66'
+            uid: 'a7812005-f766-4877-abd4-b3d418b04f66',
+            creationTimestamp: '2019-08-16T17:09:12Z'
           },
           spec: {
             pipelineRef: {
@@ -108,6 +110,80 @@ storiesOf('PipelineRuns', module)
             pipelineRef: {
               name: 'output-pipeline'
             },
+            serviceAccountName: 'default',
+            resources: [
+              {
+                name: 'source-repo',
+                resourceRef: {
+                  name: 'skaffold-git'
+                }
+              }
+            ]
+          }
+        }
+      ]}
+      cancelPipelineRun={() => {}}
+    />
+  ))
+  .add('no pipeline link', () => (
+    <PipelineRuns
+      createPipelineRunURL={({ namespace, pipelineRunName }) =>
+        namespace ? `to-pipelineRun-${namespace}/${pipelineRunName}` : null
+      }
+      createPipelineRunsByPipelineURL={() => null}
+      createPipelineRunTimestamp={pipelineRun =>
+        getStatus(pipelineRun).lastTransitionTime ||
+        pipelineRun.metadata.creationTimestamp
+      }
+      selectedNamespace="default"
+      pipelineRunActions={[
+        {
+          actionText: 'Cancel',
+          action: resource => resource,
+          disable: resource =>
+            resource.status &&
+            resource.status.conditions[0].reason !== 'Running',
+          modalProperties: {
+            heading: 'cancel',
+            primaryButtonText: 'ok',
+            secondaryButtonText: 'no',
+            body: resource => `cancel pipelineRun ${resource.metadata.name}`
+          }
+        }
+      ]}
+      pipelineRuns={[
+        {
+          metadata: {
+            name: 'pipeline-run-20190816124708',
+            namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
+            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e',
+            creationTimestamp: '2019-08-16T12:48:00Z'
+          },
+          spec: {
+            pipelineRef: {
+              name: 'pipeline'
+            }
+          },
+          status: {
+            conditions: [
+              {
+                lastTransitionTime: '2019-08-16T12:49:28Z',
+                message: 'All Tasks have completed executing',
+                reason: 'Succeeded',
+                status: 'True',
+                type: 'Succeeded'
+              }
+            ]
+          }
+        },
+        {
+          apiVersion: 'tekton.dev/v1alpha1',
+          kind: 'PipelineRun',
+          metadata: {
+            name: 'output-pipeline-run',
+            creationTimestamp: '2019-10-09T17:10:49Z'
+          },
+          spec: {
             serviceAccountName: 'default',
             resources: [
               {

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
@@ -70,10 +70,7 @@ it('PipelineRuns renders data', () => {
       ]}
       pipelineRunActions={[
         {
-          actionText: intl.formatMessage({
-            id: 'test.actionText',
-            defaultMessage: 'TestAction'
-          })
+          actionText: 'TestAction'
         }
       ]}
     />
@@ -81,4 +78,48 @@ it('PipelineRuns renders data', () => {
   expect(queryByText(pipelineRunName)).toBeTruthy();
   expect(queryByTitle(/FAKE_REASON/i)).toBeTruthy();
   expect(queryByTitle(/FAKE_MESSAGE/i)).toBeTruthy();
+});
+
+it('PipelineRuns renders with custom link creators', () => {
+  const pipelineName = 'pipeline-12345';
+  const pipelineRunName = 'pipeline-run-20190816124708';
+  const { queryByText } = renderWithRouter(
+    <PipelineRuns
+      intl={intl}
+      pipelineRuns={[
+        {
+          metadata: {
+            name: pipelineRunName,
+            namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
+            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e'
+          },
+          spec: {
+            pipelineRef: {
+              name: pipelineName
+            }
+          },
+          status: {
+            conditions: [
+              {
+                lastTransitionTime: '2019-08-16T12:49:28Z',
+                message: 'FAKE_MESSAGE',
+                reason: 'FAKE_REASON',
+                status: 'True',
+                type: 'Succeeded'
+              }
+            ]
+          }
+        }
+      ]}
+      pipelineRunActions={[
+        {
+          actionText: 'TestAction'
+        }
+      ]}
+      createPipelineRunURL={() => null}
+      createPipelineRunsByPipelineURL={() => null}
+    />
+  );
+  expect(queryByText(pipelineRunName)).toBeTruthy();
+  expect(queryByText(pipelineName)).toBeTruthy();
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Allow consumers of the PipelineRuns component to disable the
link to the filtered list of PipelineRuns by pipelineName.

Previously we supported hiding the Pipeline column entirely but
this is not desirable. Instead we want to allow consumers to
render the Pipeline name as plain text instead of a clickable
link.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
