### PR TITLE
Fix infinite loop error in TaskTree

### DIFF
--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -26,8 +26,8 @@ class Task extends Component {
     this.selectDefaultStep();
   }
 
-  componentDidUpdate(prevState) {
-    if (!prevState.selectedStepId) {
+  componentDidUpdate() {
+    if (!this.state.selectedStepId && this.props.steps.length > 0) {
       this.selectDefaultStep();
     }
   }


### PR DESCRIPTION
When there are no steps in the Task selected by default, PipelineRun/TaskRun errors out with an infinite loop.
<img width="1348" alt="Screen Shot 2020-01-14 at 11 44 12 AM" src="https://user-images.githubusercontent.com/49996607/72387194-f1807500-36f0-11ea-985d-f456987a889c.png">

# Changes 

Check if there are steps present in Task before calling `selectDefaultStep`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._

/cc @AlanGreene 