### PR TITLE
Fix error showing TaskRun steps that have not run (again)

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -24,7 +24,8 @@ import {
   selectedTask,
   selectedTaskRun,
   stepsStatus,
-  taskRunStep
+  taskRunStep,
+  updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
 import { Log, RunHeader, StepDetails, TaskTree } from '..';
@@ -261,7 +262,10 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
     const { definition, reason, status, stepName, stepStatus } = taskRunStep(
       selectedStepId,
-      taskRun
+      {
+        ...taskRun,
+        steps: updateUnexecutedSteps(taskRun.steps)
+      }
     );
 
     const logContainer = (

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -17,6 +17,8 @@ import ChevronRight from '@carbon/icons-react/lib/chevron--right/16';
 import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
 import { Spinner, Step } from '@tektoncd/dashboard-components';
 
+import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
+
 import './Task.scss';
 
 class Task extends Component {
@@ -94,24 +96,26 @@ class Task extends Component {
         </a>
         {expanded && (
           <ol className="step-list">
-            {steps.map(({ id, reason: stepReason, status, stepName }) => {
-              const selected = selectedStepId === id;
-              const stepStatus =
-                reason === 'TaskRunCancelled' && status !== 'terminated'
-                  ? 'cancelled'
-                  : status;
-              return (
-                <Step
-                  id={id}
-                  key={id}
-                  onSelect={this.handleStepSelected}
-                  reason={stepReason}
-                  selected={selected}
-                  status={stepStatus}
-                  stepName={stepName}
-                />
-              );
-            })}
+            {updateUnexecutedSteps(steps).map(
+              ({ id, reason: stepReason, status, stepName }) => {
+                const selected = selectedStepId === id;
+                const stepStatus =
+                  reason === 'TaskRunCancelled' && status !== 'terminated'
+                    ? 'cancelled'
+                    : status;
+                return (
+                  <Step
+                    id={id}
+                    key={id}
+                    onSelect={this.handleStepSelected}
+                    reason={stepReason}
+                    selected={selected}
+                    status={stepStatus}
+                    stepName={stepName}
+                  />
+                );
+              }
+            )}
           </ol>
         )}
       </li>

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -23,8 +23,8 @@ const props = {
 };
 
 const steps = [
-  { id: 'build', stepName: 'build' },
-  { id: 'test', stepName: 'test' }
+  { id: 'build', stepName: 'build', reason: 'Completed' },
+  { id: 'test', stepName: 'test', reason: 'Completed' }
 ];
 
 storiesOf('Task', module)

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -83,6 +83,20 @@ it('Task renders cancelled step in expanded Task', () => {
   ).toBeTruthy();
 });
 
+it('Task renders completed steps in expanded state', () => {
+  const steps = [
+    { id: 'step1', stepName: 'step 1', reason: 'Completed' },
+    { id: 'step2', stepName: 'step 2', reason: 'Error' },
+    { id: 'step3', stepName: 'step 3', reason: 'Completed' }
+  ];
+  const { queryByText } = renderWithIntl(
+    <Task {...props} expanded steps={steps} />
+  );
+  expect(queryByText(/step 1/i)).toBeTruthy();
+  expect(queryByText(/step 2/i)).toBeTruthy();
+  expect(queryByText(/step 3/i)).toBeTruthy();
+});
+
 it('Task renders success state', () => {
   renderWithIntl(<Task {...props} succeeded="True" />);
 });

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -192,3 +192,33 @@ export function formatLabels(labelsRaw) {
 
   return formattedLabelsToRender;
 }
+
+// Update the status of steps that follow a step with an error
+export function updateUnexecutedSteps(steps) {
+  if (!steps) {
+    return steps;
+  }
+  let errorIndex = steps.length - 1;
+  return steps.map((step, index) => {
+    // Update errorIndex
+    if (step.reason !== 'Completed') {
+      errorIndex = Math.min(index, errorIndex);
+    }
+    // Update step
+    if (index > errorIndex) {
+      const s = {
+        ...step,
+        reason: '',
+        status: ''
+      };
+      if (step.stepStatus && step.stepStatus.terminated) {
+        s.stepStatus = {
+          ...step.stepStatus,
+          terminated: { ...step.stepStatus.terminated, reason: '' }
+        };
+      }
+      return s;
+    }
+    return step;
+  });
+}

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -21,7 +21,8 @@ import {
   reorderSteps,
   selectedTask,
   stepsStatus,
-  taskRunStep
+  taskRunStep,
+  updateUnexecutedSteps
 } from '.';
 
 it('taskRunSteps with no taskRun', () => {
@@ -343,4 +344,72 @@ it('formatLabels', () => {
     'gitServer: github.com',
     'tekton.dev/pipeline: pipeline0'
   ]);
+});
+
+it('updateUnexecutedSteps no steps', () => {
+  const steps = [];
+  const wantUpdatedSteps = [];
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+});
+
+it('updateUnexecutedSteps undefined steps', () => {
+  let steps;
+  let wantUpdatedSteps;
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+});
+
+it('updateUnexecutedSteps no error steps', () => {
+  const steps = [
+    { reason: 'Completed', status: 'Terminated' },
+    {
+      reason: 'Running',
+      status: 'Unknown',
+      stepStatus: {}
+    }
+  ];
+  const wantUpdatedSteps = [...steps];
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+});
+
+it('updateUnexecutedSteps error step', () => {
+  const steps = [
+    {
+      reason: 'Completed',
+      status: 'Terminated',
+      stepStatus: { terminated: { reason: 'Completed' } }
+    },
+    {
+      reason: 'Error',
+      status: 'Error',
+      stepStatus: { terminated: { reason: 'Error' } }
+    },
+    {
+      reason: 'Completed',
+      status: 'Terminated',
+      stepStatus: { terminated: { reason: 'Completed' } }
+    }
+  ];
+  const wantUpdatedSteps = [
+    {
+      reason: 'Completed',
+      status: 'Terminated',
+      stepStatus: { terminated: { reason: 'Completed' } }
+    },
+    {
+      reason: 'Error',
+      status: 'Error',
+      stepStatus: { terminated: { reason: 'Error' } }
+    },
+    {
+      reason: '',
+      status: '',
+      stepStatus: { terminated: { reason: '' } }
+    }
+  ];
+
+  const gotUpdatedSteps = updateUnexecutedSteps(steps);
+  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
 });

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -28,7 +28,8 @@ import {
   getStatus,
   reorderSteps,
   stepsStatus,
-  taskRunStep
+  taskRunStep,
+  updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
 import { fetchLogs } from '../../utils';
@@ -177,7 +178,10 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
 
     const { definition, reason, status, stepName, stepStatus } = taskRunStep(
       selectedStepId,
-      taskRun
+      {
+        ...taskRun,
+        steps: updateUnexecutedSteps(taskRun.steps)
+      }
     );
 
     const {


### PR DESCRIPTION
# Changes

This fixes an error seen when using the Tekton Dashboard with Tekton
Pipelines v0.8.0. In order to support users on Tekton Pipelines v0.8.0
and earlier, the fix from https://github.com/tektoncd/dashboard/pull/653 is going back into the Dashboard codebase.
The fix was previously reverted when Tekton Pipelines v0.9.0 fixed the
root cause of the issue (https://github.com/tektoncd/dashboard/pull/795/files).

![Screen Shot 2020-01-16 at 3 15 54 PM](https://user-images.githubusercontent.com/16961496/72559588-24527680-3873-11ea-8ace-cc91630f0edb.png)

This issue was brought to my attention by a user running the Dashboard v0.3.0 with Tekton Pipelines v0.8.0: https://github.com/kabanero-io/kabanero-pipelines/issues/86#issuecomment-574892024

Note, we don't want to reintroduce issue https://github.com/tektoncd/dashboard/issues/782 with this change.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
