### PR TITLE
Fix unnamed steps bug

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -140,7 +140,7 @@ export function reorderSteps(unorderedSteps, orderedSteps) {
   return orderedSteps.map(({ name }, idx) => {
     let findName = name;
     if (name === '') {
-      findName = `unnamed-${idx + 1}`;
+      findName = `unnamed-${idx}`;
     }
     return unorderedSteps.find(step => step.name === findName);
   });

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -277,15 +277,15 @@ it('reorderSteps works on ordered steps', () => {
 
 it('reorderSteps properly reorders unnamed steps', () => {
   const unorderedSteps = [
+    { name: 'unnamed-1' },
     { name: 'unnamed-2' },
-    { name: 'unnamed-3' },
-    { name: 'unnamed-1' }
+    { name: 'unnamed-0' }
   ];
   const orderedSteps = [{ name: '' }, { name: '' }, { name: '' }];
   const want = [
+    { name: 'unnamed-0' },
     { name: 'unnamed-1' },
-    { name: 'unnamed-2' },
-    { name: 'unnamed-3' }
+    { name: 'unnamed-2' }
   ];
   const got = reorderSteps(unorderedSteps, orderedSteps);
   expect(got).toEqual(want);
@@ -294,11 +294,11 @@ it('reorderSteps properly reorders unnamed steps', () => {
 it('reorderSteps properly reorders unnamed and named steps', () => {
   const unorderedSteps = [
     { name: 'c' },
-    { name: 'unnamed-5' },
+    { name: 'unnamed-4' },
     { name: 'a' },
-    { name: 'unnamed-1' },
+    { name: 'unnamed-0' },
     { name: 'b' },
-    { name: 'unnamed-6' }
+    { name: 'unnamed-5' }
   ];
   const orderedSteps = [
     { name: '' },
@@ -309,12 +309,12 @@ it('reorderSteps properly reorders unnamed and named steps', () => {
     { name: '' }
   ];
   const want = [
-    { name: 'unnamed-1' },
+    { name: 'unnamed-0' },
     { name: 'a' },
     { name: 'b' },
     { name: 'c' },
-    { name: 'unnamed-5' },
-    { name: 'unnamed-6' }
+    { name: 'unnamed-4' },
+    { name: 'unnamed-5' }
   ];
   const got = reorderSteps(unorderedSteps, orderedSteps);
   expect(got).toEqual(want);


### PR DESCRIPTION
# Changes

Seeing "Cannot read property 'name' of undefined" error for Tasks with
unnamed steps. This was supposed to be fixed in PR #878
https://github.com/tektoncd/dashboard/pull/878)

The bug appears to be with the step names starting from 0 instead of 1.

### Breaking Change
This fixes a bug related to the Tekton Pipelines version. Tekton Pipelines v0.8.0 names unnamed steps starting from `1`. On the other hand, Tekton Pipelines v0.9.0 and up name unnamed steps starting from `0`. So, this PR will _**"break" the Dashboard for Tekton Pipelines v0.8.0**_. However, this PR will _**"fix" the Dashboard for Tekton Pipelines v0.9.0 and up**_.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes
```
When using Tekton Pipelines v0.8.0 or lower, TaskRuns & PipelineRuns that run
unnamed steps will no longer be displayed properly on the Dashboard.
```