### PR TITLE
fix readme apply -f link for v0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tekton Dashboard is a general purpose, web-based UI for Tekton Pipelines. It all
    and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/tektoncd/dashboard/releases/download/v0.4.0/dashboard-latest-release.yaml
+   kubectl apply --filename https://github.com/tektoncd/dashboard/releases/download/v0.4.0/dashboard_latest_release.yaml
    ```
 
    Previous versions will be available at `previous/$VERSION_NUMBER`, e.g.
@@ -89,7 +89,7 @@ You can then access the Tekton Dashboard at `tekton-dashboard.${ip}.nip.io`. Thi
 1. Assuming you want to install the Dashboard into the `tekton-pipelines` namespace:
 
    ```bash
-   kubectl apply --filename https://github.com/tektoncd/dashboard/releases/download/v0.4.0/dashboard-latest-openshift-tekton-dashboard-release.yaml --validate=false
+   kubectl apply --filename https://github.com/tektoncd/dashboard/releases/download/v0.4.0/dashboard_latest_openshift-tekton-dashboard-release.yaml --validate=false
    ```
 
 2. Access the dashboard by determining its route with `kubectl get route tekton-dashboard -n tekton-pipelines`


### PR DESCRIPTION
# Changes
Apparently `dashboard-latest-release.yaml` was renamed `dashboard_latest_release.yaml` on v0.4.0, here is the fix 😁

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
