### PR TITLE
Add RBAC for getting CRD info, used to detect Triggers installation

### DIFF
--- a/config/dev-tekton-dashboard.yaml
+++ b/config/dev-tekton-dashboard.yaml
@@ -1,5 +1,5 @@
 # ------------------- Dashboard Service Account ------------------- #
-
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,6 +35,9 @@ metadata:
   name: tekton-dashboard-minimal
   namespace: tekton-pipelines
 rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
@@ -60,20 +63,24 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines",
+                "pipelineruns", "pipelineresources", "conditions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status",
+                "pipelines/status", "pipelineruns/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["dashboard.tekton.dev"]
     resources: ["extensions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch", "add"]
+    resources: ["eventlisteners", "triggerbindings",
+                "triggertemplates"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch",
+            "add"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -109,30 +116,29 @@ spec:
     spec:
       serviceAccountName: tekton-dashboard
       containers:
-      - name: tekton-dashboard
-        image: github.com/tektoncd/dashboard/cmd/dashboard
-        ports:
-        - containerPort: 9097
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 9097
-        readinessProbe:
-          httpGet:
-            path: /readiness
-            port: 9097
-        resources:
-        env:
-        - name: PORT
-          value: "9097"
-        - name: WEB_RESOURCES_DIR
-          value: /var/run/ko/web
-        - name: PIPELINE_RUN_SERVICE_ACCOUNT
-          value: ""
-        - name: INSTALLED_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+        - name: tekton-dashboard
+          image: github.com/tektoncd/dashboard/cmd/dashboard
+          ports:
+            - containerPort: 9097
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9097
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9097
+          env:
+            - name: PORT
+              value: "9097"
+            - name: WEB_RESOURCES_DIR
+              value: /var/run/ko/web
+            - name: PIPELINE_RUN_SERVICE_ACCOUNT
+              value: ""
+            - name: INSTALLED_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 ---
 # ------------------- Dashboard Service ------------------- #
 kind: Service

--- a/config/openshift/openshift-tekton-dashboard.yaml
+++ b/config/openshift/openshift-tekton-dashboard.yaml
@@ -1,5 +1,5 @@
 # ------------------- Dashboard Service Account ------------------- #
-
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,7 +8,9 @@ metadata:
   name: tekton-dashboard
   namespace: tekton-pipelines
   annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"tekton-dashboard"}}'
+    serviceaccounts.openshift.io/oauth-redirectreference.primary:
+      '{"kind":"OAuthRedirectReference","apiVersion":"v1",
+      "reference":{"kind":"Route","name":"tekton-dashboard"}}'
 ---
 # ------------------- Extension Resource Definition ------------------- #
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -37,6 +39,9 @@ metadata:
   name: tekton-dashboard-minimal
   namespace: tekton-pipelines
 rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
@@ -62,20 +67,24 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines",
+                "pipelineruns", "pipelineresources", "conditions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status",
+                "pipelines/status", "pipelineruns/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["dashboard.tekton.dev"]
     resources: ["extensions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch", "add"]
+    resources: ["eventlisteners", "triggerbindings",
+                "triggertemplates"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch",
+            "add"]
 ---
 
 # ------------------- Dashboard Role & Role Binding ------------------- #
@@ -112,53 +121,52 @@ spec:
         app: tekton-dashboard
     spec:
       containers:
-      - name: oauth-proxy
-        image: openshift/oauth-proxy:latest
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8443
-          name: public
-        args:
-        - --https-address=:8443
-        - --provider=openshift
-        - --openshift-service-account=tekton-dashboard
-        - --upstream=http://localhost:9097
-        - --tls-cert=/etc/tls/private/tls.crt
-        - --tls-key=/etc/tls/private/tls.key
-        - --cookie-secret=SECRET
-        - --skip-auth-regex=^/v1/extensions/.*\.js
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: proxy-tls
-      - name: tekton-dashboard
-        image: github.com/tektoncd/dashboard/cmd/dashboard
-        ports:
-        - containerPort: 9097
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 9097
-        readinessProbe:
-          httpGet:
-            path: /readiness
-            port: 9097
-        resources:
-        env:
-        - name: PORT
-          value: "9097"
-        - name: WEB_RESOURCES_DIR
-          value: /var/run/ko/web
-        - name: PIPELINE_RUN_SERVICE_ACCOUNT
-          value: ""
-        - name: INSTALLED_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+        - name: oauth-proxy
+          image: openshift/oauth-proxy:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: public
+              containerPort: 8443
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=tekton-dashboard
+            - --upstream=http://localhost:9097
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - --skip-auth-regex=^/v1/extensions/.*\.js
+          volumeMounts:
+            - name: proxy-tls
+              mountPath: /etc/tls/private
+        - name: tekton-dashboard
+          image: github.com/tektoncd/dashboard/cmd/dashboard
+          ports:
+            - containerPort: 9097
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9097
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9097
+          env:
+            - name: PORT
+              value: "9097"
+            - name: WEB_RESOURCES_DIR
+              value: /var/run/ko/web
+            - name: PIPELINE_RUN_SERVICE_ACCOUNT
+              value: ""
+            - name: INSTALLED_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       serviceAccountName: tekton-dashboard
       volumes:
-      - name: proxy-tls
-        secret:
-          secretName: proxy-tls
+        - name: proxy-tls
+          secret:
+            secretName: proxy-tls
 ---
 # ------------------- Dashboard Route ------------------- #
 apiVersion: route.openshift.io/v1
@@ -218,36 +226,36 @@ metadata:
   namespace: tekton-pipelines
 spec:
   resources:
-  - name: git-source
-    type: git
+    - name: git-source
+      type: git
   params:
-  - name: pathToResourceFiles
-    description: The path to the resource files to apply
-    default: /workspace/git-source
-    type: string
-  - name: apply-directory
-    description: The directory from which resources are to be applied
-    default: "."
-    type: string
-  - name: target-namespace
-    description: The namespace in which to create the resources being imported
-    default: tekton-pipelines
-    type: string
-  tasks:
-  - name: pipeline0-task
-    taskRef:
-      name: pipeline0-task
-    params:
     - name: pathToResourceFiles
-      value: $(params.pathToResourceFiles)
+      description: The path to the resource files to apply
+      default: /workspace/git-source
+      type: string
     - name: apply-directory
-      value: $(params.apply-directory)
+      description: The directory from which resources are to be applied
+      default: "."
+      type: string
     - name: target-namespace
-      value: $(params.target-namespace)
-    resources:
-      inputs:
-      - name: git-source
-        resource: git-source
+      description: The namespace where created resources will go
+      default: tekton-pipelines
+      type: string
+  tasks:
+    - name: pipeline0-task
+      taskRef:
+        name: pipeline0-task
+      params:
+        - name: pathToResourceFiles
+          value: $(params.pathToResourceFiles)
+        - name: apply-directory
+          value: $(params.apply-directory)
+        - name: target-namespace
+          value: $(params.target-namespace)
+      resources:
+        inputs:
+          - name: git-source
+            resource: git-source
 ---
 # ------------------- Pipeline0 task ---------------------- #
 apiVersion: tekton.dev/v1alpha1
@@ -258,29 +266,29 @@ metadata:
 spec:
   inputs:
     resources:
-    - name: git-source
-      type: git
+      - name: git-source
+        type: git
     params:
-    - name: pathToResourceFiles
-      description: The path to the resource files to apply
-      default: /workspace/git-source
-      type: string
-    - name: apply-directory
-      description: The directory from which resources are to be applied
-      default: "."
-      type: string
-    - name: target-namespace
-      description: The namespace in which to create the resources being imported
-      default: tekton-pipelines
-      type: string
+      - name: pathToResourceFiles
+        description: The path to the resource files to apply
+        default: /workspace/git-source
+        type: string
+      - name: apply-directory
+        description: The directory from which resources are to be applied
+        default: "."
+        type: string
+      - name: target-namespace
+        description: The namespace where created resources will go
+        default: tekton-pipelines
+        type: string
   steps:
-  - name: kubectl-apply
-    image: lachlanevenson/k8s-kubectl:latest
-    command:
-    - kubectl
-    args:
-    - apply
-    - -f
-    - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
-    - -n
-    - $(inputs.params.target-namespace)
+    - name: kubectl-apply
+      image: lachlanevenson/k8s-kubectl:latest
+      command:
+        - kubectl
+      args:
+        - apply
+        - -f
+        - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
+        - -n
+        - $(inputs.params.target-namespace)

--- a/config/pipeline0-task.yaml
+++ b/config/pipeline0-task.yaml
@@ -1,6 +1,6 @@
-# The contents of this file should be included in both the Tekton dashboard config directory
-# and config/release/gcr-tekton-dashboard.yaml
-
+# The contents of this file should be included in both the Tekton dashboard
+# config directory and config/release/gcr-tekton-dashboard.yaml
+---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
@@ -9,29 +9,29 @@ metadata:
 spec:
   inputs:
     resources:
-    - name: git-source
-      type: git
+      - name: git-source
+        type: git
     params:
-    - name: pathToResourceFiles
-      description: The path to the resource files to apply
-      default: /workspace/git-source
-      type: string
-    - name: apply-directory
-      description: The directory from which resources are to be applied
-      default: "."
-      type: string
-    - name: target-namespace
-      description: The namespace in which to create the resources being imported
-      default: tekton-pipelines
-      type: string
+      - name: pathToResourceFiles
+        description: The path to the resource files to apply
+        default: /workspace/git-source
+        type: string
+      - name: apply-directory
+        description: The directory from which resources are to be applied
+        default: "."
+        type: string
+      - name: target-namespace
+        description: The namespace where created resources will go
+        default: tekton-pipelines
+        type: string
   steps:
-  - name: kubectl-apply
-    image: lachlanevenson/k8s-kubectl:latest
-    command:
-    - kubectl
-    args:
-    - apply
-    - -f
-    - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
-    - -n
-    - $(inputs.params.target-namespace)
+    - name: kubectl-apply
+      image: lachlanevenson/k8s-kubectl:latest
+      command:
+        - kubectl
+      args:
+        - apply
+        - -f
+        - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
+        - -n
+        - $(inputs.params.target-namespace)

--- a/config/release/gcr-tekton-dashboard.yaml
+++ b/config/release/gcr-tekton-dashboard.yaml
@@ -1,5 +1,5 @@
 # ------------------- Dashboard Service Account ------------------- #
-
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,6 +35,9 @@ metadata:
   name: tekton-dashboard-minimal
   namespace: tekton-pipelines
 rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
@@ -60,20 +63,24 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines",
+                "pipelineruns", "pipelineresources", "conditions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status",
+                "pipelines/status", "pipelineruns/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["dashboard.tekton.dev"]
     resources: ["extensions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch", "add"]
+    resources: ["eventlisteners", "triggerbindings",
+                "triggertemplates"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch",
+            "add"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -108,30 +115,29 @@ spec:
         app: tekton-dashboard
     spec:
       containers:
-      - name: tekton-dashboard
-        image: gcr.io/tekton-nightly/dashboard:latest
-        ports:
-        - containerPort: 9097
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 9097
-        readinessProbe:
-          httpGet:
-            path: /readiness
-            port: 9097
-        resources:
-        env:
-        - name: PORT
-          value: "9097"
-        - name: WEB_RESOURCES_DIR
-          value: /var/run/ko/web
-        - name: PIPELINE_RUN_SERVICE_ACCOUNT
-          value: ""
-        - name: INSTALLED_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+        - name: tekton-dashboard
+          image: gcr.io/tekton-nightly/dashboard:latest
+          ports:
+            - containerPort: 9097
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9097
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9097
+          env:
+            - name: PORT
+              value: "9097"
+            - name: WEB_RESOURCES_DIR
+              value: /var/run/ko/web
+            - name: PIPELINE_RUN_SERVICE_ACCOUNT
+              value: ""
+            - name: INSTALLED_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       serviceAccountName: tekton-dashboard
 ---
 # ------------------- Dashboard Service ------------------- #
@@ -159,36 +165,36 @@ metadata:
   namespace: tekton-pipelines
 spec:
   resources:
-  - name: git-source
-    type: git
+    - name: git-source
+      type: git
   params:
-  - name: pathToResourceFiles
-    description: The path to the resource files to apply
-    default: /workspace/git-source
-    type: string
-  - name: apply-directory
-    description: The directory from which resources are to be applied
-    default: "."
-    type: string
-  - name: target-namespace
-    description: The namespace in which to create the resources being imported
-    default: tekton-pipelines
-    type: string
-  tasks:
-  - name: pipeline0-task
-    taskRef:
-      name: pipeline0-task
-    params:
     - name: pathToResourceFiles
-      value: $(params.pathToResourceFiles)
+      description: The path to the resource files to apply
+      default: /workspace/git-source
+      type: string
     - name: apply-directory
-      value: $(params.apply-directory)
+      description: The directory from which resources are to be applied
+      default: "."
+      type: string
     - name: target-namespace
-      value: $(params.target-namespace)
-    resources:
-      inputs:
-      - name: git-source
-        resource: git-source
+      description: The namespace where created resources will go
+      default: tekton-pipelines
+      type: string
+  tasks:
+    - name: pipeline0-task
+      taskRef:
+        name: pipeline0-task
+      params:
+        - name: pathToResourceFiles
+          value: $(params.pathToResourceFiles)
+        - name: apply-directory
+          value: $(params.apply-directory)
+        - name: target-namespace
+          value: $(params.target-namespace)
+      resources:
+        inputs:
+          - name: git-source
+            resource: git-source
 ---
 # ------------------- Pipeline0 task ---------------------- #
 apiVersion: tekton.dev/v1alpha1
@@ -199,29 +205,29 @@ metadata:
 spec:
   inputs:
     resources:
-    - name: git-source
-      type: git
+      - name: git-source
+        type: git
     params:
-    - name: pathToResourceFiles
-      description: The path to the resource files to apply
-      default: /workspace/git-source
-      type: string
-    - name: apply-directory
-      description: The directory from which resources are to be applied
-      default: "."
-      type: string
-    - name: target-namespace
-      description: The namespace in which to create the resources being imported
-      default: tekton-pipelines
-      type: string
+      - name: pathToResourceFiles
+        description: The path to the resource files to apply
+        default: /workspace/git-source
+        type: string
+      - name: apply-directory
+        description: The directory from which resources are to be applied
+        default: "."
+        type: string
+      - name: target-namespace
+        description: The namespace where created resources will go
+        default: tekton-pipelines
+        type: string
   steps:
-  - name: kubectl-apply
-    image: lachlanevenson/k8s-kubectl:latest
-    command:
-    - kubectl
-    args:
-    - apply
-    - -f
-    - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
-    - -n
-    - $(inputs.params.target-namespace)
+    - name: kubectl-apply
+      image: lachlanevenson/k8s-kubectl:latest
+      command:
+        - kubectl
+      args:
+        - apply
+        - -f
+        - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
+        - -n
+        - $(inputs.params.target-namespace)


### PR DESCRIPTION
For https://github.com/tektoncd/dashboard/issues/919

Without it we get a cryptic unknown error from the proxy and Trigger resources aren't displayed on master (including the 0.4.0 release)

Fixed about 30 linter errors too