### PR TITLE
Preserve newlines in copy-pasted logs

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -21,7 +21,7 @@ import './Log.scss';
 
 const LogLine = ({ data, index, style }) => (
   <div style={style}>
-    <Ansi>{data[index]}</Ansi>
+    <Ansi>{`${data[index]}\n`}</Ansi>
   </div>
 );
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/933
This has no visible impact to rendering of logs, but ensures that when content is copy-pasted from the log container that it preserves newlines as expected.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
