### PR TITLE
Fix display of step details

### DIFF
--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -106,6 +106,15 @@ class StepDefinition extends Component {
 
   render() {
     const { definition, intl } = this.props;
+    const { container, imageID, terminated, ...stepDefinition } =
+      definition || {};
+
+    const resource = definition
+      ? stepDefinition
+      : intl.formatMessage({
+          id: 'dashboard.step.definitionNotAvailable',
+          defaultMessage: 'description: step definition not available'
+        });
 
     const paramsResources = this.getIOTables();
     return (
@@ -117,15 +126,7 @@ class StepDefinition extends Component {
           />
           :
         </div>
-        <ViewYAML
-          resource={
-            definition ||
-            intl.formatMessage({
-              id: 'dashboard.step.definitionNotAvailable',
-              defaultMessage: 'description: step definition not available'
-            })
-          }
-        />
+        <ViewYAML resource={resource} />
         {paramsResources}
       </div>
     );

--- a/packages/components/src/components/StepStatus/StepStatus.js
+++ b/packages/components/src/components/StepStatus/StepStatus.js
@@ -19,6 +19,14 @@ import { ViewYAML } from '..';
 import './StepStatus.scss';
 
 const StepStatus = ({ intl, status }) => {
+  const { container, imageID, name, terminated } = status || {};
+  const resource = status
+    ? { container, imageID, name, terminated }
+    : intl.formatMessage({
+        id: 'dashboard.step.statusNotAvailable',
+        defaultMessage: 'No status available'
+      });
+
   return (
     <div className="step-status">
       <div className="title">
@@ -28,15 +36,7 @@ const StepStatus = ({ intl, status }) => {
         })}
         :
       </div>
-      <ViewYAML
-        resource={
-          status ||
-          intl.formatMessage({
-            id: 'dashboard.step.statusNotAvailable',
-            defaultMessage: 'No status available'
-          })
-        }
-      />
+      <ViewYAML resource={resource} />
     </div>
   );
 };

--- a/packages/components/src/components/StepStatus/StepStatus.test.js
+++ b/packages/components/src/components/StepStatus/StepStatus.test.js
@@ -23,7 +23,15 @@ it('StepStatus renders default content', () => {
 });
 
 it('StepStatus renders the provided content', () => {
-  const { queryByText } = renderWithIntl(<StepStatus status="testing" />);
+  const container = 'fake_container';
+  const imageID = 'fake_imageID';
+  const name = 'fake_name';
+  const terminated = 'fake_terminated';
+  const status = { container, imageID, name, terminated };
+  const { queryByText } = renderWithIntl(<StepStatus status={status} />);
 
-  expect(queryByText(/testing/i)).toBeTruthy();
+  expect(queryByText(new RegExp(container, 'i'))).toBeTruthy();
+  expect(queryByText(new RegExp(imageID, 'i'))).toBeTruthy();
+  expect(queryByText(new RegExp(name, 'i'))).toBeTruthy();
+  expect(queryByText(new RegExp(terminated, 'i'))).toBeTruthy();
 });

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -106,7 +106,7 @@ class Task extends Component {
                 return (
                   <Step
                     id={id}
-                    key={id}
+                    key={stepName}
                     onSelect={this.handleStepSelected}
                     reason={stepReason}
                     selected={selected}

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -137,12 +137,17 @@ export function reorderSteps(unorderedSteps, orderedSteps) {
   if (!unorderedSteps || !orderedSteps) {
     return [];
   }
-  return orderedSteps.map(({ name }, idx) => {
+  return orderedSteps.map(({ name, ...rest }, idx) => {
     let findName = name;
     if (name === '') {
       findName = `unnamed-${idx}`;
     }
-    return unorderedSteps.find(step => step.name === findName);
+    const orderedStep = unorderedSteps.find(step => step.name === findName);
+    return {
+      name,
+      ...rest,
+      ...orderedStep
+    };
   });
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/961

Update logic for display of step status and step details tabs
so the correct information (command, args, script, etc.) are
available to display in the step details tab.

This is a temporary measure to fix a recent regression, and
this code will undergo significant refactoring as part of the
updated designs which remove the status tab entirely.

Before:
![image](https://user-images.githubusercontent.com/2829095/73181030-5cc54080-410e-11ea-829f-65c24141e4c7.png)

After:
![image](https://user-images.githubusercontent.com/2829095/73180968-41f2cc00-410e-11ea-8878-818d0ebc5659.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
