### PR TITLE
Display decoded secret usernames instead of base64 form

### DIFF
--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -226,6 +226,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
         });
       });
       const serviceAccountsString = serviceAccountsWithSecret.join(', ');
+      const secretUsernameToDisplay = atob(secret.username);
       const formattedSecret = {
         annotations: <span title={annotations}>{annotations}</span>,
         id: `${secret.namespace}:${secret.name}`,
@@ -236,9 +237,10 @@ export /* istanbul ignore next */ class Secrets extends Component {
           <span title={serviceAccountsString}>{serviceAccountsString}</span>
         ),
         type: <span title={secret.type}>{secret.type}</span>,
-        username: <span title={secret.username}>{secret.username}</span>
+        username: (
+          <span title={secretUsernameToDisplay}>{secretUsernameToDisplay}</span>
+        )
       };
-
       return formattedSecret;
     });
 

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -37,6 +37,7 @@ const byNamespace = {
       uid: '0',
       name: 'github-repo-access-secret',
       type: 'userpass',
+      username: 'bXl1c2VybmFtZQ==', // This is "myusername"
       annotations: {
         'tekton.dev/git-0': 'https://github.ibm.com',
         badannotation: 'badcontent'
@@ -49,6 +50,7 @@ const byNamespace = {
       annotations: {
         'tekton.dev/git-0': 'https://github.com'
       },
+      username: 'bXl1c2VybmFtZQ==', // This is "myusername"
       labels: {
         baz: 'bam'
       }
@@ -250,6 +252,20 @@ it('SecretsTable only renders tekton.dev annotations', () => {
   expect(queryByText(/badannotation/i)).toBeFalsy();
 
   expect(queryByText(/badcontent/i)).toBeFalsy();
+});
+
+it('SecretsTable renders username in regular form (not encoded)', () => {
+  const { queryByText, getByText } = renderWithRouter(
+    <Provider store={store}>
+      <Route
+        path={urls.secrets.all()}
+        render={props => <Secrets {...props} />}
+      />
+    </Provider>,
+    { route: urls.secrets.all() }
+  );
+  expect(queryByText(/github-repo-access-secret/i)).toBeTruthy();
+  expect(getByText(/myusername/i)).toBeTruthy();
 });
 
 it('Secrets can be filtered on a single label filter', async () => {

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -151,8 +151,6 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
       invalidFields.name = true;
     }
 
-    // If the data isn't base64 encoded, you'll confusingly get back a 404 from the secrets API
-
     if (validateInputs(username, 'username')) {
       const encodedUsername = Buffer.from(username).toString('base64');
       postData.data.username = encodedUsername;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
For https://github.com/tektoncd/dashboard/issues/974

Note that I did attempt this in the action but then had massive difficulty in writing a test for it - so do so when displaying the data instead

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
