### PR TITLE
[WIP] If type isn't known, don't error for individual SA page

### DIFF
--- a/src/containers/ServiceAccount/ServiceAccount.js
+++ b/src/containers/ServiceAccount/ServiceAccount.js
@@ -209,7 +209,9 @@ export /* istanbul ignore next */ class ServiceAccountContainer extends Componen
     let rowsForImgPull = [];
     if (serviceAccount.imagePullSecrets && !loading) {
       rowsForImgPull = serviceAccount.imagePullSecrets.map(({ name }) => {
-        const { type } = secrets.find(secret => secret.name === name);
+        const { type } = secrets.find(secret => secret.name === name) || {
+          type: 'unknown-type'
+        };
         return {
           id: name,
           name,


### PR DESCRIPTION
For https://github.com/tektoncd/dashboard/issues/981

# Changes

This is the "bare minimum" PR that allows the page to load instead of the fatal error we're seeing

I'm going to try and get it displaying the correct type next

Interestingly I don't see any data for the secrets either (regardless of this change):

![image](https://user-images.githubusercontent.com/12814972/73665569-3a489f80-4699-11ea-9fd9-214847dd499e.png)

The YAML for this particular ServiceAccount is

```
kind: ServiceAccount
apiVersion: v1
metadata:
  name: default
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/serviceaccounts/default
  uid: b804a234-3c47-11ea-b749-00000a1012bb
  resourceVersion: '11010'
  creationTimestamp: '2020-01-21T12:15:31Z'
secrets:
  - name: default-token-jmjd2
  - name: default-dockercfg-2lk5b
imagePullSecrets:
  - name: default-dockercfg-2lk5b
```


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
