### PR TITLE
Update RunDropdown to ensure menu gets focus for keyboard nav

### DIFF
--- a/packages/components/src/components/RunDropdown/RunDropdown.js
+++ b/packages/components/src/components/RunDropdown/RunDropdown.js
@@ -52,14 +52,16 @@ class RunDropdown extends Component {
         >
           {items.map(item => {
             const { actionText, action, disable, modalProperties } = item;
+            const disabled = disable && disable(resource);
             return (
               <OverflowMenuItem
                 key={actionText}
                 itemText={actionText}
-                disabled={disable && disable(resource)}
+                disabled={disabled}
                 onClick={() =>
                   this.handleShow(() => action(resource), modalProperties)
                 }
+                primaryFocus={!disabled}
               />
             );
           })}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Set `primaryFocus` prop on first enabled OverflowMenuItem to
ensure it gets focus when the menu is opened.

If there are no enabled items, Carbon will automatically set
focus to the menu body.

This change ensures keyboard nav works as expected for the dropdown.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
