### PR TITLE
Kaniko task changes as latest is breaking integration test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -50,11 +50,14 @@ function dump_extra_cluster_state() {
   echo ">>> Dashboard backend log:"
   kubectl -n tekton-pipelines logs $(get_app_pod tekton-dashboard tekton-pipelines)
 
+  echo "Task info"
+  kubectl -n tekton-pipelines get Task -o yaml
+
   echo "TaskRun info"
-  kubectl -n tekton-pipelines get TaskRun -o json
+  kubectl -n tekton-pipelines get TaskRun -o yaml
 
   echo "PipelineRun info"
-  kubectl -n tekton-pipelines get PipelineRun -o json
+  kubectl -n tekton-pipelines get PipelineRun -o yaml
 
   echo "PipelineRun container info"
   kubectl -n tekton-pipelines logs -l app=e2e-pipelinerun --all-containers

--- a/test/resources/static/kaniko-build-task.yaml
+++ b/test/resources/static/kaniko-build-task.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
@@ -6,31 +7,33 @@ metadata:
 spec:
   inputs:
     params:
-    - name: pathToDockerFile
-      description: The path to the dockerfile to build
-      default: /workspace/git-source/Dockerfile
-    - name: pathToContext
-      description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
-      default: /workspace/git-source
+      - name: pathToDockerFile
+        description: The path to the dockerfile to build
+        default: /workspace/git-source/Dockerfile
+      - name: pathToContext
+        description: The build context used by Kaniko
+        default: /workspace/git-source
 
     resources:
-    - name: git-source
-      type: git
+      - name: git-source
+        type: git
 
   outputs:
     resources:
-    - name: builtImage
-      type: image
+      - name: builtImage
+        type: image
 
   steps:
-  - name: build-and-push
-    securityContext:
-      runAsUser: 0
-    env:
-    - name: "DOCKER_CONFIG"
-      value: "/builder/home/.docker"
-    image: gcr.io/kaniko-project/executor:latest
-    args:
-    - --dockerfile=$(inputs.params.pathToDockerFile)
-    - --destination=$(outputs.resources.builtImage.url)
-    - --context=$(inputs.params.pathToContext)
+    - name: build-and-push
+      workingdir: /workspace/git-source
+      image: gcr.io/kaniko-project/executor:v0.16.0
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: "DOCKER_CONFIG"
+          value: "/tekton/home/.docker"
+      command:
+        - /kaniko/executor
+        - --dockerfile=$(inputs.params.pathToDockerFile)
+        - --destination=$(outputs.resources.builtImage.url)
+        - --context=$(inputs.params.pathToContext)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Instead of using `latest`, try with `v0.16.0`. For https://github.com/tektoncd/dashboard/issues/1001

We currently see 

```
I0204 12:11:42.757] PipelineRun container info
I0204 12:11:42.921] {"level":"info","ts":1580818282.2961466,"logger":"fallback-logger","caller":"logging/config.go:69","msg":"Fetch GitHub commit ID from kodata failed: \"KO_DATA_PATH\" does not exist or is empty"}
I0204 12:11:42.934] {"level":"info","ts":1580818284.8766327,"logger":"fallback-logger","caller":"logging/config.go:69","msg":"Fetch GitHub commit ID from kodata failed: open /var/run/ko/refs/heads/master: no such file or directory"}
I0204 12:11:42.935] {"level":"info","ts":1580818290.8876646,"logger":"fallback-logger","caller":"logging/config.go:69","msg":"Fetch GitHub commit ID from kodata failed: open /var/run/ko/refs/heads/master: no such file or directory"}
I0204 12:11:42.935] {"level":"info","ts":1580818291.2240348,"logger":"fallback-logger","caller":"git/git.go:102","msg":"Successfully cloned https://github.com/ncskier/go-hello-world @ master in path /workspace/git-source"}
I0204 12:11:42.935] {"level":"warn","ts":1580818291.2241433,"logger":"fallback-logger","caller":"git/git.go:149","msg":"Unexpected error: creating symlink: symlink /tekton/home/.ssh /root/.ssh: file exists"}
I0204 12:11:42.935] {"level":"info","ts":1580818291.267475,"logger":"fallback-logger","caller":"git/git.go:130","msg":"Successfully initialized and updated submodules in path /workspace/git-source"}
I0204 12:11:42.946] ERROR: logging before flag.Parse: E0204 12:11:31.394636      10 metadata.go:159] while reading 'google-dockercfg-url' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
I0204 12:11:42.947] INFO[0000] Resolved base name golang to golang          
I0204 12:11:42.947] INFO[0000] Resolved base name golang to golang          
I0204 12:11:42.947] INFO[0000] Retrieving image manifest golang             
I0204 12:11:42.947] INFO[0000] Retrieving image manifest golang             
I0204 12:11:42.947] INFO[0001] Built cross stage deps: map[]                
I0204 12:11:42.948] INFO[0001] Retrieving image manifest golang             
I0204 12:11:42.948] INFO[0001] Retrieving image manifest golang             
I0204 12:11:42.948] INFO[0002] Unpacking rootfs as cmd ADD . /go/src/github.com/ncskier/go-hello-world requires it. 
I0204 12:11:42.948] error building image: error building stage: failed to get filesystem from image: error removing var/run to make way for new symlink: unlinkat /var/run/secrets/kubernetes.io/serviceaccount/..2020_02_04_12_11_19.931887167: read-only file system
I0204 12:11:42.960] {"level":"info","ts":1580818288.4537482,"logger":"fallback-logger","caller":"logging/config.go:69","msg":"Fetch GitHub commit ID from kodata failed: open /var/run/ko/HEAD: no such file or directory"}
I0204 12:11:42.961] 2020/02/04 12:11:36 Skipping step because a previous step failed
I0204 12:11:48.151] Error from server (NotFound): deployments.extensions "go-hello-world" not found
I0204 12:11:48.156] About to sleep, getting and describing pod info
I0204 12:11:48.335] apiVersion: v1
```

Nothing else has changed. The key part being

```
I0204 12:11:42.948] INFO[0002] Unpacking rootfs as cmd ADD . /go/src/github.com/ncskier/go-hello-world requires it. 
I0204 12:11:42.948] error building image: error building stage: failed to get filesystem from image: error removing var/run to make way for new symlink: unlinkat /var/run/secrets/kubernetes.io/serviceaccount/..2020_02_04_12_11_19.931887167: read-only file system
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Use v0.16.0

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
