### PR TITLE
Update Carbon icon imports to remove references to the CommonJS exports

### DIFF
--- a/packages/components/src/components/CancelButton/CancelButton.js
+++ b/packages/components/src/components/CancelButton/CancelButton.js
@@ -15,7 +15,7 @@ import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 
 import { Modal } from 'carbon-components-react';
-import StopFilled16 from '@carbon/icons-react/lib/stop--filled/16';
+import { StopFilled16 } from '@carbon/icons-react';
 
 import './CancelButton.scss';
 

--- a/packages/components/src/components/Graph/Node.js
+++ b/packages/components/src/components/Graph/Node.js
@@ -14,11 +14,13 @@ limitations under the License.
 import React, { Component } from 'react';
 import classNames from 'classnames';
 
-import CheckmarkFilled from '@carbon/icons-react/lib/checkmark--filled/20';
-import ChevronDown from '@carbon/icons-react/lib/chevron--down/20';
-import ChevronUp from '@carbon/icons-react/lib/chevron--up/20';
-import CloseFilled from '@carbon/icons-react/lib/close--filled/20';
-import Undefined from '@carbon/icons-react/lib/undefined/20';
+import {
+  CheckmarkFilled20 as CheckmarkFilled,
+  ChevronDown20 as ChevronDown,
+  ChevronUp20 as ChevronUp,
+  CloseFilled20 as CloseFilled,
+  Undefined20 as Undefined
+} from '@carbon/icons-react';
 
 import Graph from './Graph'; // eslint-disable-line import/no-cycle
 import InlineLoading from './InlineLoading';

--- a/packages/components/src/components/KeyValueList/KeyValueList.js
+++ b/packages/components/src/components/KeyValueList/KeyValueList.js
@@ -13,8 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Button, TextInput } from 'carbon-components-react';
-import Add from '@carbon/icons-react/lib/add--alt/24';
-import Remove from '@carbon/icons-react/lib/subtract--alt/24';
+import { AddAlt24 as Add, SubtractAlt24 as Remove } from '@carbon/icons-react';
 import './KeyValueList.scss';
 
 const KeyValueList = props => {

--- a/packages/components/src/components/LabelFilter/LabelFilter.js
+++ b/packages/components/src/components/LabelFilter/LabelFilter.js
@@ -22,7 +22,7 @@ import {
   Tag
 } from 'carbon-components-react';
 
-import Add from '@carbon/icons-react/lib/add/16';
+import { Add16 as Add } from '@carbon/icons-react';
 
 import './LabelFilter.scss';
 

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -15,7 +15,6 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { Table } from '@tektoncd/dashboard-components';
-import 'carbon-components-react';
 import { getStatus, getStatusIcon, urls } from '@tektoncd/dashboard-utils';
 
 import { FormattedDate, FormattedDuration, RunDropdown } from '..';

--- a/packages/components/src/components/Rerun/Rerun.js
+++ b/packages/components/src/components/Rerun/Rerun.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React, { Component } from 'react';
 import { Button } from 'carbon-components-react';
 import { urls } from '@tektoncd/dashboard-utils';
-import Restart from '@carbon/icons-react/lib/restart/32';
+import { Restart32 as Restart } from '@carbon/icons-react';
 import './Rerun.scss';
 
 export class Rerun extends Component {

--- a/packages/components/src/components/Step/Step.js
+++ b/packages/components/src/components/Step/Step.js
@@ -13,9 +13,11 @@ limitations under the License.
 
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
-import CheckmarkFilled from '@carbon/icons-react/lib/checkmark--filled/16';
-import ChevronRight from '@carbon/icons-react/lib/chevron--right/16';
-import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
+import {
+  CheckmarkFilled16 as CheckmarkFilled,
+  ChevronRight16 as ChevronRight,
+  CloseFilled16 as CloseFilled
+} from '@carbon/icons-react';
 
 import Spinner from '../Spinner';
 

--- a/packages/components/src/components/StepDetailsHeader/StepDetailsHeader.js
+++ b/packages/components/src/components/StepDetailsHeader/StepDetailsHeader.js
@@ -12,9 +12,11 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
-import CheckmarkFilled from '@carbon/icons-react/lib/checkmark--filled/24';
-import ChevronRight from '@carbon/icons-react/lib/chevron--right/24';
-import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
+import {
+  CheckmarkFilled24 as CheckmarkFilled,
+  ChevronRight24 as ChevronRight,
+  CloseFilled16 as CloseFilled
+} from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
 import { getStatus } from '@tektoncd/dashboard-utils';
 

--- a/packages/components/src/components/Table/Table.stories.js
+++ b/packages/components/src/components/Table/Table.stories.js
@@ -15,10 +15,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import Add from '@carbon/icons-react/lib/add/16';
-import Delete from '@carbon/icons-react/lib/delete/16';
-import Rerun from '@carbon/icons-react/lib/restart/16';
-import RerunAll from '@carbon/icons-react/lib/renew/16';
+import {
+  Add16 as Add,
+  Delete16 as Delete,
+  Restart16 as Rerun,
+  Renew16 as RerunAll
+} from '@carbon/icons-react';
 
 import Table from './Table';
 

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -12,9 +12,11 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
-import CheckmarkFilled from '@carbon/icons-react/lib/checkmark--filled/16';
-import ChevronRight from '@carbon/icons-react/lib/chevron--right/16';
-import CloseFilled from '@carbon/icons-react/lib/close--filled/16';
+import {
+  CheckmarkFilled16 as CheckmarkFilled,
+  ChevronRight16 as ChevronRight,
+  CloseFilled16 as CloseFilled
+} from '@carbon/icons-react';
 import { Spinner, Step } from '@tektoncd/dashboard-components';
 
 import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';

--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import LinkIcon from '@carbon/icons-react/lib/launch/16';
+import { Launch16 as LinkIcon } from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
 import React from 'react';
 import { urls } from '@tektoncd/dashboard-utils';

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -12,9 +12,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import CheckmarkFilled from '@carbon/icons-react/lib/checkmark--filled/20';
-import Time from '@carbon/icons-react/lib/time/20';
-import CloseFilled from '@carbon/icons-react/lib/close--filled/20';
+import {
+  CheckmarkFilled20 as CheckmarkFilled,
+  CloseFilled20 as CloseFilled,
+  Time20 as Time
+} from '@carbon/icons-react';
 import { Spinner } from '@tektoncd/dashboard-components';
 
 export { default as buildGraphData } from './buildGraphData';

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -28,7 +28,7 @@ import {
   PipelineResources as PipelineResourcesList
 } from '@tektoncd/dashboard-components';
 import { Button, InlineNotification } from 'carbon-components-react';
-import Add from '@carbon/icons-react/lib/add/16';
+import { Add16 as Add } from '@carbon/icons-react';
 import { fetchPipelineResources } from '../../actions/pipelineResources';
 import { deletePipelineResource } from '../../api';
 import PipelineResourcesModal from '../PipelineResourcesModal';

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -30,7 +30,7 @@ import {
   isRunning,
   urls
 } from '@tektoncd/dashboard-utils';
-import Add from '@carbon/icons-react/lib/add/16';
+import { Add16 as Add } from '@carbon/icons-react';
 
 import { CreatePipelineRun } from '..';
 

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import Information16 from '@carbon/icons-react/lib/information/16';
+import { Information16 } from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
 import isEqual from 'lodash.isequal';
 import { InlineNotification } from 'carbon-components-react';

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -27,8 +27,7 @@ import {
   getErrorMessage,
   getFilters
 } from '@tektoncd/dashboard-utils';
-import Add from '@carbon/icons-react/lib/add/16';
-import Delete from '@carbon/icons-react/lib/delete/16';
+import { Add16 as Add, Delete16 as Delete } from '@carbon/icons-react';
 import Modal from '../SecretsModal';
 import DeleteModal from '../../components/SecretsDeleteModal';
 import {

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -29,7 +29,7 @@ import {
   LabelFilter,
   Table
 } from '@tektoncd/dashboard-components';
-import Information16 from '@carbon/icons-react/lib/information/16';
+import { Information16 } from '@carbon/icons-react';
 import { fetchTasks } from '../../actions/tasks';
 import {
   getSelectedNamespace,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update import statements for Carbon icons to remove references
to the 'lib' folder (CommonJS) to ensure that tree-shaking/
dead code elimination can take place correctly, especially for
3rd party consumers of the @tektoncd/dashboard-components package.

Also remove an errant `import 'carbon-components-react';` from
the PipelineRuns component. 🙈 

These changes result in a consistent ~1 minute savings on the production build time
(`npm run build`), from ~2m30s to ~1m30s.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
