### PR TITLE
Fix overflow issue on step details

### DIFF
--- a/packages/components/src/components/StepDefinition/StepDefinition.scss
+++ b/packages/components/src/components/StepDefinition/StepDefinition.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,8 +12,6 @@ limitations under the License.
 */
 
 .step-definition {
-  padding: 1.3rem 1.6rem;
-
   > .title {
     font-weight: bold;
     font-size: 0.75rem;

--- a/packages/components/src/components/StepDetails/StepDetails.scss
+++ b/packages/components/src/components/StepDetails/StepDetails.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,6 +16,7 @@ limitations under the License.
   flex-direction: column;
   flex-wrap: nowrap;
   align-items: stretch;
+  overflow: hidden;
 
   .bx--tabs {
     margin-top: 0.4rem;

--- a/packages/components/src/components/StepStatus/StepStatus.scss
+++ b/packages/components/src/components/StepStatus/StepStatus.scss
@@ -1,6 +1,17 @@
-.step-status {
-  padding: 1.3rem 1.6rem;
+/*
+Copyright 2019-2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
+.step-status {
   > .title {
     font-weight: bold;
     font-size: 0.75rem;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Prevent status and details tab content overflowing the `.step-details`
container by setting `overflow: hidden`. This forces a horizontal
scrollbar on the codeblock when needed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
