### PR TITLE
GKE Ingress requires 200 OK

### DIFF
--- a/pkg/endpoints/health.go
+++ b/pkg/endpoints/health.go
@@ -21,5 +21,5 @@ import (
 
 func (r Resource) CheckHealth(request *restful.Request, response *restful.Response) {
 	// A method here so there's scope for doing anything fancy e.g. checking anything else
-	response.WriteHeader(http.StatusNoContent)
+	response.WriteHeader(http.StatusOK)
 }

--- a/pkg/endpoints/health_test.go
+++ b/pkg/endpoints/health_test.go
@@ -25,7 +25,7 @@ func TestGETHealthEndpoint(t *testing.T) {
 	defer server.Close()
 	httpReq := testutils.DummyHTTPRequest("GET", fmt.Sprintf("%s/health", server.URL), nil)
 	response, _ := http.DefaultClient.Do(httpReq)
-	expectedStatus := http.StatusNoContent
+	expectedStatus := http.StatusOK
 	if response.StatusCode != expectedStatus {
 		t.Fatalf("Health check failed: expected statusCode %d, actual %d", expectedStatus, response.StatusCode)
 	}


### PR DESCRIPTION
# Changes

The GKE Ingress uses an external loadbalancer with healthchecks that expect 200 OK back instead of 204 no content. What healthcheck expects may very much vary, so we may want to make this configurable, or have multiple endpoints.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
