### PR TITLE
Convert getStatusIcon to a component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5498,8 +5498,7 @@
     "@tektoncd/dashboard-utils": {
       "version": "file:packages/utils",
       "requires": {
-        "@babel/cli": "^7.5.5",
-        "@carbon/icons-react": "^10.6.0"
+        "@babel/cli": "^7.5.5"
       }
     },
     "@types/babel__core": {

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -14,8 +14,8 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { Table } from '@tektoncd/dashboard-components';
-import { getStatus, getStatusIcon, urls } from '@tektoncd/dashboard-utils';
+import { StatusIcon, Table } from '@tektoncd/dashboard-components';
+import { getStatus, urls } from '@tektoncd/dashboard-utils';
 
 import { FormattedDate, FormattedDuration, RunDropdown } from '..';
 
@@ -38,7 +38,7 @@ const PipelineRuns = ({
   },
   getPipelineRunStatusIcon = pipelineRun => {
     const { reason, status } = getStatus(pipelineRun);
-    return getStatusIcon({ reason, status });
+    return <StatusIcon reason={reason} status={status} />;
   },
   getPipelineRunStatusTooltip = (pipelineRun, intl) => {
     const { message } = getStatus(pipelineRun);

--- a/packages/components/src/components/StatusIcon/StatusIcon.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+import React from 'react';
+import {
+  CheckmarkFilled20 as CheckmarkFilled,
+  CloseFilled20 as CloseFilled,
+  Time20 as Time
+} from '@carbon/icons-react';
+import { isRunning } from '@tektoncd/dashboard-utils';
+
+import { Spinner } from '..';
+
+export default function StatusIcon({ reason, status }) {
+  if (!status || (status === 'Unknown' && reason === 'Pending')) {
+    return <Time className="status-icon" />;
+  }
+
+  if (isRunning(reason, status)) {
+    return <Spinner className="status-icon" />;
+  }
+
+  let Icon;
+  if (status === 'True') {
+    Icon = CheckmarkFilled;
+  } else if (status === 'False') {
+    Icon = CloseFilled;
+  }
+
+  return Icon ? <Icon className="status-icon" /> : null;
+}

--- a/packages/components/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.stories.js
@@ -1,0 +1,24 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import StatusIcon from './StatusIcon';
+
+storiesOf('StatusIcon', module)
+  .add('queued', () => <StatusIcon />)
+  .add('pending', () => <StatusIcon reason="Pending" status="Unknown" />)
+  .add('running', () => <StatusIcon reason="Running" status="Unknown" />)
+  .add('succeeded', () => <StatusIcon status="True" />)
+  .add('failed', () => <StatusIcon status="False" />);

--- a/packages/components/src/components/StatusIcon/index.js
+++ b/packages/components/src/components/StatusIcon/index.js
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+export { default } from './StatusIcon';

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -67,7 +67,7 @@ class Task extends Component {
   icon() {
     const { reason, succeeded } = this.props;
 
-    if (succeeded === 'Unknown' && reason === 'Pending') {
+    if (succeeded === 'Unknown' && reason === 'Running') {
       return <Spinner className="task-icon" />;
     }
 

--- a/packages/components/src/components/Task/Task.scss
+++ b/packages/components/src/components/Task/Task.scss
@@ -64,7 +64,7 @@ limitations under the License.
       fill: $failed-fg;
     }
   }
-  &[data-succeeded='Unknown'][data-reason='Pending'] > a.task-link {
+  &[data-succeeded='Unknown'][data-reason='Running'] > a.task-link {
     background-color: $running-bg;
     color: $running-fg;
     &:focus, &:hover {

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -28,11 +28,13 @@ const steps = [
 ];
 
 storiesOf('Task', module)
-  .add('default', () => <Task {...props} />)
   .add('succeeded', () => <Task {...props} succeeded="True" />)
   .add('failed', () => <Task {...props} succeeded="False" />)
   .add('unknown', () => <Task {...props} succeeded="Unknown" />)
   .add('pending', () => (
     <Task {...props} succeeded="Unknown" reason="Pending" />
+  ))
+  .add('running', () => (
+    <Task {...props} succeeded="Unknown" reason="Running" />
   ))
   .add('expanded', () => <Task {...props} expanded steps={steps} />);

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -14,7 +14,8 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { getStatus, getStatusIcon, urls } from '@tektoncd/dashboard-utils';
+import { StatusIcon } from '@tektoncd/dashboard-components';
+import { getStatus, urls } from '@tektoncd/dashboard-utils';
 
 import { FormattedDate, FormattedDuration, RunDropdown, Table } from '..';
 
@@ -34,7 +35,7 @@ const TaskRuns = ({
   },
   getTaskRunStatusIcon = taskRun => {
     const { reason, status } = getStatus(taskRun);
-    return getStatusIcon({ reason, status });
+    return <StatusIcon reason={reason} status={status} />;
   },
   getTaskRunStatusTooltip = (taskRun, intl) => {
     const { message } = getStatus(taskRun);

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -31,6 +31,7 @@ export { default as ResourceTable } from './ResourceTable';
 export { default as RunDropdown } from './RunDropdown';
 export { default as RunHeader } from './RunHeader';
 export { default as Spinner } from './Spinner';
+export { default as StatusIcon } from './StatusIcon';
 export { default as Step } from './Step';
 export { default as StepDefinition } from './StepDefinition';
 export { default as StepDetails } from './StepDetails';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,8 +9,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@babel/cli": "^7.5.5",
-    "@carbon/icons-react": "^10.6.0"
+    "@babel/cli": "^7.5.5"
   },
   "peerDependencies": {
     "history": "^4.9.0",

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -11,14 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
-import {
-  CheckmarkFilled20 as CheckmarkFilled,
-  CloseFilled20 as CloseFilled,
-  Time20 as Time
-} from '@carbon/icons-react';
-import { Spinner } from '@tektoncd/dashboard-components';
-
 export { default as buildGraphData } from './buildGraphData';
 export { paths, urls } from './router';
 export { getStatus } from './status';
@@ -155,25 +147,6 @@ export function reorderSteps(unorderedSteps, orderedSteps) {
 
 export function isRunning(reason, status) {
   return status === 'Unknown' && reason === 'Running';
-}
-
-export function getStatusIcon({ reason, status }) {
-  if (!status) {
-    return <Time className="status-icon" />;
-  }
-
-  if (isRunning(reason, status)) {
-    return <Spinner className="status-icon" />;
-  }
-
-  let Icon;
-  if (status === 'True') {
-    Icon = CheckmarkFilled;
-  } else if (status === 'False') {
-    Icon = CloseFilled;
-  }
-
-  return Icon ? <Icon className="status-icon" /> : null;
 }
 
 // Generates a unique id

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import {
   getErrorMessage,
   getFilters,
   getStatus,
-  getStatusIcon,
   isRunning,
   reorderSteps,
   selectedTask,
@@ -166,17 +165,6 @@ it('isRunning', () => {
   expect(isRunning('Running', 'Unknown')).toBe(true);
   expect(isRunning('?', 'Unknown')).toBe(false);
   expect(isRunning('Running', '?')).toBe(false);
-});
-
-it('getStatusIcon', () => {
-  let icon = getStatusIcon({ reason: 'Running', status: 'Unknown' });
-  expect(icon).not.toBeNull();
-  icon = getStatusIcon({ status: 'True' });
-  expect(icon).not.toBeNull();
-  icon = getStatusIcon({ status: 'False' });
-  expect(icon).not.toBeNull();
-  icon = getStatusIcon({});
-  expect(icon).not.toBeNull();
 });
 
 it('stepsStatus step is waiting', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Remove getStatusIcon from @tektoncd/dashboard-utils and replace
it with a component in @tektoncd/dashboard-components

This allows us to remove the dependency on @carbon/icons-react
from the utils package that was causing odd module resolution
issues for some consumers.

It will also allow us to clean up the styles for the status icon
used across a number of components / containers. This change will
come in a separate PR.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
