### PR TITLE
Secret create error doesn't show on modal and secrets page

### DIFF
--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -38,9 +38,9 @@ import {
 import { fetchServiceAccounts } from '../../actions/serviceAccounts';
 import {
   getCreateSecretsSuccessMessage,
+  getDeleteSecretsErrorMessage,
   getDeleteSecretsSuccessMessage,
   getSecrets,
-  getSecretsErrorMessage,
   getSelectedNamespace,
   getServiceAccounts,
   isFetchingSecrets,
@@ -370,7 +370,6 @@ export /* istanbul ignore next */ class Secrets extends Component {
           ]}
         />
         <Modal
-          errorMessage={errorMessage}
           open={openNewSecret}
           key={openNewSecret}
           handleCreateSecret={this.handleCreateSecretClick}
@@ -398,7 +397,7 @@ function mapStateToProps(state, props) {
   const namespace = namespaceParam || getSelectedNamespace(state);
 
   return {
-    errorMessage: getSecretsErrorMessage(state),
+    errorMessage: getDeleteSecretsErrorMessage(state),
     createSuccess: getCreateSecretsSuccessMessage(state),
     deleteSuccess: getDeleteSecretsSuccessMessage(state),
     filters,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -313,6 +313,10 @@ export function getSecretsErrorMessage(state) {
   return secretSelectors.getSecretsErrorMessage(state.secrets);
 }
 
+export function getDeleteSecretsErrorMessage(state) {
+  return secretSelectors.getDeleteSecretsErrorMessage(state.secrets);
+}
+
 export function getCreateSecretsSuccessMessage(state) {
   return secretSelectors.getCreateSecretsSuccessMessage(state.secrets);
 }

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -15,6 +15,7 @@ import {
   getClusterTask,
   getClusterTasks,
   getClusterTasksErrorMessage,
+  getDeleteSecretsErrorMessage,
   getExtensions,
   getExtensionsErrorMessage,
   getLocale,
@@ -299,6 +300,17 @@ it('getSecretsErrorMessage', () => {
     .mockImplementation(() => errorMessage);
   expect(getSecretsErrorMessage(state)).toEqual(errorMessage);
   expect(secretSelectors.getSecretsErrorMessage).toHaveBeenCalledWith(
+    state.secrets
+  );
+});
+
+it('getDeleteSecretsErrorMessage', () => {
+  const errorMessage = 'fake error message';
+  jest
+    .spyOn(secretSelectors, 'getDeleteSecretsErrorMessage')
+    .mockImplementation(() => errorMessage);
+  expect(getDeleteSecretsErrorMessage(state)).toEqual(errorMessage);
+  expect(secretSelectors.getDeleteSecretsErrorMessage).toHaveBeenCalledWith(
     state.secrets
   );
 });

--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -85,7 +85,21 @@ function errorMessage(state = false, action) {
     case 'SECRET_CREATE_FAILURE':
       return action.error;
     case 'SECRET_DELETE_FAILURE':
+    case 'SECRETS_FETCH_REQUEST':
+    case 'SECRETS_FETCH_SUCCESS':
+    case 'CLEAR_SECRET_ERROR_NOTIFICATION':
+      return null;
+    default:
+      return state;
+  }
+}
+
+function deleteErrorMessage(state = false, action) {
+  switch (action.type) {
+    case 'SECRETS_FETCH_FAILURE':
+    case 'SECRET_DELETE_FAILURE':
       return action.error;
+    case 'SECRET_CREATE_FAILURE':
     case 'SECRETS_FETCH_REQUEST':
     case 'SECRETS_FETCH_SUCCESS':
     case 'CLEAR_SECRET_ERROR_NOTIFICATION':
@@ -128,6 +142,7 @@ function deleteSuccessMessage(state = null, action) {
 export default combineReducers({
   byNamespace,
   errorMessage,
+  deleteErrorMessage,
   createSuccessMessage,
   deleteSuccessMessage,
   isFetching
@@ -147,6 +162,10 @@ export function getSecrets(state, namespace) {
 
 export function getSecretsErrorMessage(state) {
   return state.errorMessage;
+}
+
+export function getDeleteSecretsErrorMessage(state) {
+  return state.deleteErrorMessage;
 }
 
 export function getCreateSecretsSuccessMessage(state) {

--- a/src/reducers/secrets.test.js
+++ b/src/reducers/secrets.test.js
@@ -17,6 +17,7 @@ it('handles init or unknown actions', () => {
   expect(secretsReducer(undefined, { type: 'does_not_exist' })).toEqual({
     byNamespace: {},
     errorMessage: false,
+    deleteErrorMessage: false,
     createSuccessMessage: null,
     deleteSuccessMessage: null,
     isFetching: false


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1014

- Fixes issue where the error notification for creating a secret would appear both on the secrets modal and on the secrets page behind it.
- Splits the secrets creation/deletion error notifications into separate reducers so they are handled separately.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
