### PR TITLE
Fix EventListener Storybook Entry

### DIFF
--- a/src/containers/EventListener/EventListener.stories.js
+++ b/src/containers/EventListener/EventListener.stories.js
@@ -35,7 +35,6 @@ const eventListener = {
     serviceAccountName: 'my-serviceaccount',
     triggers: [
       {
-        eventListenerNamespace: 'default',
         name: 'my-trigger',
         bindings: [
           { name: 'triggerbinding0' },
@@ -50,11 +49,11 @@ const eventListener = {
             webhook: {
               header: [
                 {
-                  name: 'header0',
+                  name: 'Header0',
                   value: 'value0'
                 },
                 {
-                  name: 'header1',
+                  name: 'Header1',
                   value: ['value1-0', 'value1-1', 'value1-2']
                 }
               ],
@@ -69,7 +68,6 @@ const eventListener = {
         ]
       },
       {
-        eventListenerNamespace: 'foo',
         name: 'my-trigger-1',
         bindings: [{ name: 'triggerbinding1' }],
         template: {
@@ -94,7 +92,6 @@ const eventListener = {
         ]
       },
       {
-        eventListenerNamespace: 'foo',
         name: 'my-trigger-2',
         bindings: [{ name: 'triggerbinding2' }],
         template: {
@@ -113,7 +110,6 @@ const eventListener = {
         ]
       },
       {
-        eventListenerNamespace: 'foo',
         name: 'my-trigger-3',
         bindings: [{ name: 'triggerbinding3' }],
         template: {


### PR DESCRIPTION
# Changes

I copied the Triggers from Trigger.stories.js, and forgot to remove the
`eventListenerNamespace` prop. So, this PR removes `eventListenerNamespace` from EventListener.stories.js.

Also, header names should be capitalized.

/cc @a-roberts 
/cc @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
