### PR TITLE
Update TooltipDropdown to use ComboBox internally

### DIFF
--- a/src/components/PipelineResourcesModal/UniversalFields.js
+++ b/src/components/PipelineResourcesModal/UniversalFields.js
@@ -69,6 +69,7 @@ const UniversalFields = props => {
           id: 'dashboard.createPipelineResource.namespaceError',
           defaultMessage: 'Namespace required'
         })}
+        light
       />
       <Dropdown
         id="type"

--- a/src/components/SecretsModal/SecretsModal.scss
+++ b/src/components/SecretsModal/SecretsModal.scss
@@ -15,7 +15,7 @@ limitations under the License.
 
 .modal.bx--modal.is-visible {
   .bx--modal-content > form > .bx--form-item,
-  .bx--dropdown__wrapper {
+  .bx--list-box__wrapper {
     margin-bottom: $spacing-03;
   }
 
@@ -28,10 +28,6 @@ limitations under the License.
 
   .bx--select svg {
     display: none;
-  }
-
-  .bx--dropdown {
-    background-color: $ui-background;
   }
 
   .bx--modal-content {

--- a/src/components/SecretsModal/UniversalFields.js
+++ b/src/components/SecretsModal/UniversalFields.js
@@ -51,6 +51,7 @@ const UniversalFields = props => {
       />
       <NamespacesDropdown
         id="namespace"
+        light
         selectedItem={
           selectedNamespace
             ? {

--- a/src/components/SecretsModal/UniversalFields.test.js
+++ b/src/components/SecretsModal/UniversalFields.test.js
@@ -91,7 +91,12 @@ it('UniversalFields renders with blank inputs', () => {
     selectedNamespace: 'default',
     invalidFields: {}
   };
-  const { getByLabelText, getAllByDisplayValue, getByText } = renderWithIntl(
+  const {
+    getByLabelText,
+    getAllByDisplayValue,
+    getByText,
+    getByDisplayValue
+  } = renderWithIntl(
     <Provider store={store}>
       <UniversalFields {...props} />
     </Provider>
@@ -100,7 +105,7 @@ it('UniversalFields renders with blank inputs', () => {
   expect(getByLabelText(/Namespace/i)).toBeTruthy();
   expect(getByLabelText(/Access To/i)).toBeTruthy();
   expect(getByText(/Git Server/i)).toBeTruthy();
-  expect(getByText(/default/i)).toBeTruthy();
+  expect(getByDisplayValue(/default/i)).toBeTruthy();
   expect(getAllByDisplayValue('').length).toEqual(1);
 });
 

--- a/src/components/TooltipDropdown/TooltipDropdown.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Dropdown, DropdownSkeleton } from 'carbon-components-react';
+import { ComboBox, DropdownSkeleton } from 'carbon-components-react';
 
 const itemToElement = ({ id, text }) => {
   return (
@@ -34,28 +34,40 @@ const itemToObject = item => {
 
 const TooltipDropdown = ({
   className,
+  disabled,
+  emptyText,
   id,
   inline,
   items,
-  loading,
   label,
-  emptyText,
-  ...dropdownProps
+  light,
+  loading,
+  onChange,
+  selectedItem,
+  titleText,
+  ...rest
 }) => {
   if (loading) {
     return <DropdownSkeleton className={className} id={id} inline={inline} />;
   }
   const options = items.map(itemToObject);
+
   return (
-    <Dropdown
-      {...dropdownProps}
+    <ComboBox
       className={className}
+      disabled={disabled}
       id={id}
       inline={inline}
-      itemToElement={itemToElement}
       items={options}
+      itemToElement={itemToElement}
       itemToString={itemToString}
       label={options.length === 0 ? emptyText : label}
+      light={light}
+      onChange={onChange}
+      placeholder={options.length === 0 ? emptyText : label}
+      selectedItem={selectedItem}
+      titleText={titleText}
+      {...rest}
     />
   );
 };

--- a/src/components/TooltipDropdown/TooltipDropdown.test.js
+++ b/src/components/TooltipDropdown/TooltipDropdown.test.js
@@ -25,41 +25,45 @@ const props = {
 const initialTextRegExp = new RegExp('select an item', 'i');
 
 it('TooltipDropdown renders', () => {
-  const { getByText, queryByText } = render(<TooltipDropdown {...props} />);
-  expect(queryByText(initialTextRegExp)).toBeTruthy();
-  fireEvent.click(getByText(initialTextRegExp));
+  const { getByText, getByPlaceholderText, queryByText, queryByValue } = render(
+    <TooltipDropdown {...props} />
+  );
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   props.items.forEach(item => {
     expect(queryByText(new RegExp(item, 'i'))).toBeTruthy();
   });
   fireEvent.click(getByText(/item 1/i));
-  expect(queryByText(/item 1/i)).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByValue(/item 1/i)).toBeTruthy();
 });
 
 it('TooltipDropdown renders selected item', () => {
-  const { queryByText } = render(
+  const { queryByValue } = render(
     <TooltipDropdown {...props} selectedItem={{ text: 'item 1' }} />
   );
-  expect(queryByText(/item 1/i)).toBeTruthy();
+  expect(queryByValue(/item 1/i)).toBeTruthy();
 });
 
 it('TooltipDropdown renders empty', () => {
-  const { queryByText } = render(<TooltipDropdown {...props} items={[]} />);
-  expect(queryByText(/no items found/i)).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  const { queryByPlaceholderText } = render(
+    <TooltipDropdown {...props} items={[]} />
+  );
+  expect(queryByPlaceholderText(/no items found/i)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('TooltipDropdown renders loading skeleton', () => {
-  const { queryByText } = render(<TooltipDropdown {...props} loading />);
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  const { queryByPlaceholderText } = render(
+    <TooltipDropdown {...props} loading />
+  );
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('TooltipDropdown handles onChange event', () => {
   const onChange = jest.fn();
-  const { getByText } = render(
+  const { getByPlaceholderText, getByText } = render(
     <TooltipDropdown {...props} onChange={onChange} />
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   fireEvent.click(getByText(/item 1/i));
   expect(onChange).toHaveBeenCalledTimes(1);
 });

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -253,7 +253,8 @@ class CreatePipelineRun extends React.Component {
     });
   };
 
-  handleNamespaceChange = ({ selectedItem: { text } }) => {
+  handleNamespaceChange = ({ selectedItem }) => {
+    const { text = '' } = selectedItem || {};
     // Reset pipeline and service account when namespace changes
     if (text !== this.state[NAMESPACE]) {
       this.setState({
@@ -273,7 +274,8 @@ class CreatePipelineRun extends React.Component {
     }));
   };
 
-  handlePipelineChange = ({ selectedItem: { text } }) => {
+  handlePipelineChange = ({ selectedItem }) => {
+    const { text } = selectedItem || {};
     if (text !== this.state[PIPELINE_REF]) {
       this.setState((state, props) => {
         const pipelineInfo = parsePipelineInfo(
@@ -550,9 +552,10 @@ class CreatePipelineRun extends React.Component {
                     const value = this.state.resources[resourceSpec.name];
                     return value ? { id: value, text: value } : '';
                   })()}
-                  onChange={({ selectedItem: { text } }) =>
-                    this.handleResourceChange(resourceSpec.name, text)
-                  }
+                  onChange={({ selectedItem }) => {
+                    const { text } = selectedItem || {};
+                    this.handleResourceChange(resourceSpec.name, text);
+                  }}
                 />
               ))}
             </FormGroup>
@@ -600,9 +603,10 @@ class CreatePipelineRun extends React.Component {
                   : ''
               }
               disabled={this.isDisabled()}
-              onChange={({ selectedItem: { text } }) =>
-                this.setState({ serviceAccount: text })
-              }
+              onChange={({ selectedItem }) => {
+                const { text } = selectedItem || {};
+                this.setState({ serviceAccount: text });
+              }}
             />
             <TextInput
               id="create-pipelinerun--timeout"

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.scss
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.scss
@@ -18,7 +18,7 @@ limitations under the License.
     width: 100%;
   }
 
-  .bx--dropdown__wrapper,
+  .bx--list-box__wrapper,
   .bx--form-item {
     margin-bottom: $carbon--spacing-06;
   }

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -104,12 +104,16 @@ export class ImportResources extends Component {
   };
 
   handleNamespace = ({ selectedItem }) => {
-    this.setState({ invalidNamespace: false, namespace: selectedItem.id });
+    if (selectedItem) {
+      this.setState({ invalidNamespace: false, namespace: selectedItem.id });
+    } else {
+      this.setState({ invalidNamespace: true });
+    }
   };
 
-  handleServiceAccount = data => {
+  handleServiceAccount = ({ selectedItem }) => {
     this.setState({
-      serviceAccount: data.selectedItem.text
+      serviceAccount: selectedItem ? selectedItem.text : null
     });
   };
 

--- a/src/containers/ImportResources/ImportResources.scss
+++ b/src/containers/ImportResources/ImportResources.scss
@@ -23,17 +23,15 @@ limitations under the License.
   background-color: white;
   min-height: 46rem;
 
-  .bx--dropdown.bx--list-box {
-    margin: 0rem;
+  .bx--combo-box.bx--list-box {
     width: 30%;
-    border-bottom: 1px solid $ui-04;
   }
 
   .bx--toast-notification {
     margin: 2.8rem;
   }
 
-  .bx--dropdown__wrapper {
+  .bx--list-box__wrapper {
     margin-left: 2.8rem;
   }
 

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -65,15 +65,14 @@ describe('ImportResources component', () => {
   });
 
   it('Displays an error when Repository URL is empty', async () => {
-    const { getByLabelText, getByText } = await renderWithIntl(
+    const { getByPlaceholderText, getByText } = await renderWithIntl(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
     );
     const namespace = 'default';
 
-    fireEvent.click(getByLabelText(/namespace/i));
-    fireEvent.click(getByText(/select namespace/i));
+    fireEvent.click(getByPlaceholderText(/select namespace/i));
     fireEvent.click(getByText(namespace));
 
     fireEvent.click(getByText('Import and Apply'));
@@ -189,7 +188,11 @@ describe('ImportResources component', () => {
       .spyOn(API, 'determineInstallNamespace')
       .mockImplementation(() => installNamespace);
 
-    const { getByLabelText, getByTestId, getByText } = await renderWithRouter(
+    const {
+      getByPlaceholderText,
+      getByTestId,
+      getByText
+    } = await renderWithRouter(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -200,8 +203,7 @@ describe('ImportResources component', () => {
       target: { value: 'https://github.com/test/testing' }
     });
 
-    fireEvent.click(getByLabelText(/namespace/i));
-    fireEvent.click(getByText(/select namespace/i));
+    fireEvent.click(getByPlaceholderText(/select namespace/i));
     fireEvent.click(getByText(namespace));
 
     fireEvent.click(getByText('Import and Apply'));
@@ -237,7 +239,11 @@ describe('ImportResources component', () => {
       .spyOn(API, 'determineInstallNamespace')
       .mockImplementation(() => 'namespace1');
 
-    const { getByLabelText, getByTestId, getByText } = await renderWithIntl(
+    const {
+      getByPlaceholderText,
+      getByTestId,
+      getByText
+    } = await renderWithIntl(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -246,8 +252,7 @@ describe('ImportResources component', () => {
     const repoURLField = getByTestId('repository-url-field');
     fireEvent.change(repoURLField, { target: { value: 'URL' } });
 
-    fireEvent.click(getByLabelText(/namespace/i));
-    fireEvent.click(getByText(/select namespace/i));
+    fireEvent.click(getByPlaceholderText(/select namespace/i));
     fireEvent.click(getByText('namespace1'));
 
     fireEvent.click(getByText('Import and Apply'));

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -18,7 +18,14 @@ import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import TooltipDropdown from '../../components/TooltipDropdown';
 import { getNamespaces, isFetchingNamespaces } from '../../reducers';
 
-const NamespacesDropdown = ({ showAllNamespaces, ...rest }) => {
+const NamespacesDropdown = ({
+  allNamespacesLabel, // extract props that are not valid for the dropdown
+  children,
+  isSideNavExpanded,
+  dispatch,
+  showAllNamespaces,
+  ...rest
+}) => {
   return <TooltipDropdown {...rest} />;
 };
 

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
@@ -40,12 +40,12 @@ it('NamespacesDropdown renders items based on Redux state', () => {
       isFetching: false
     }
   });
-  const { getByText, getAllByText, queryByText } = render(
+  const { getAllByText, getByPlaceholderText, queryByText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   Object.keys(byName).forEach(item => {
     expect(queryByText(new RegExp(item, 'i'))).toBeTruthy();
   });
@@ -62,12 +62,12 @@ it('NamespacesDropdown renders controlled selection', () => {
     }
   });
   // Select item 'namespace-1'
-  const { container, queryByText } = render(
+  const { container, queryByPlaceholderText, queryByValue } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} selectedItem={{ text: 'namespace-1' }} />
     </Provider>
   );
-  expect(queryByText(/namespace-1/i)).toBeTruthy();
+  expect(queryByValue(/namespace-1/i)).toBeTruthy();
   // Select item 'namespace-2'
   render(
     <Provider store={store}>
@@ -75,7 +75,7 @@ it('NamespacesDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(/namespace-2/i)).toBeTruthy();
+  expect(queryByValue(/namespace-2/i)).toBeTruthy();
   // No selected item (select item '')
   render(
     <Provider store={store}>
@@ -83,7 +83,7 @@ it('NamespacesDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(initialTextRegExp)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
 });
 
 it('NamespacesDropdown renders empty', () => {
@@ -94,12 +94,12 @@ it('NamespacesDropdown renders empty', () => {
     }
   });
 
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>
   );
-  expect(queryByText(/no namespaces found/i)).toBeTruthy();
+  expect(queryByPlaceholderText(/no namespaces found/i)).toBeTruthy();
 });
 
 it('NamespacesDropdown renders loading skeleton based on Redux state', () => {
@@ -110,12 +110,12 @@ it('NamespacesDropdown renders loading skeleton based on Redux state', () => {
     }
   });
 
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>
   );
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('NamespacesDropdown handles onChange event', () => {
@@ -126,12 +126,12 @@ it('NamespacesDropdown handles onChange event', () => {
     }
   });
   const onChange = jest.fn();
-  const { getByText } = render(
+  const { getByPlaceholderText, getByText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} onChange={onChange} />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   fireEvent.click(getByText(/namespace-1/i));
   expect(onChange).toHaveBeenCalledTimes(1);
 });

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
@@ -42,7 +42,13 @@ class PipelineResourcesDropdown extends React.Component {
   }
 
   render() {
-    const { namespace, type, ...rest } = this.props;
+    const {
+      fetchPipelineResources: _fetchPipelineResources, // extract props that are not valid for the dropdown
+      namespace,
+      type,
+      webSocketConnected,
+      ...rest
+    } = this.props;
     let emptyText = 'No PipelineResources found';
     if (type && namespace !== ALL_NAMESPACES) {
       emptyText = `No PipelineResources found of type '${type}' in the '${namespace}' namespace`;

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -134,13 +134,13 @@ it('PipelineResourcesDropdown renders items based on Redux state', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { getByText, getAllByText, queryByText } = render(
+  const { getByPlaceholderText, getAllByText, queryByText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -154,16 +154,16 @@ it('PipelineResourcesDropdown renders items based on type', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { container, getByText, queryByText } = render(
+  const { container, getByPlaceholderText, queryByText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} type="type-1" />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   expect(queryByText(/pipeline-resource-1/i)).toBeTruthy();
   expect(queryByText(/pipeline-resource-2/i)).toBeFalsy();
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} type="type-2" />
@@ -171,7 +171,7 @@ it('PipelineResourcesDropdown renders items based on type', () => {
     { container }
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   expect(queryByText(/pipeline-resource-1/i)).toBeFalsy();
   expect(queryByText(/pipeline-resource-2/i)).toBeTruthy();
 });
@@ -182,19 +182,19 @@ it('PipelineResourcesDropdown renders items based on Redux state when namespace 
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { container, getByText, getAllByText, queryByText } = render(
+  const { container, getByPlaceholderText, getAllByText, queryByText } = render(
     <Provider store={blueStore}>
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
     testDict: pipelineResourcesByNamespace.blue
   });
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
 
   // Change selected namespace from 'blue' to 'green'
   const greenStore = mockStore({
@@ -209,7 +209,7 @@ it('PipelineResourcesDropdown renders items based on Redux state when namespace 
     { container }
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -224,7 +224,7 @@ it('PipelineResourcesDropdown renders controlled selection', () => {
     notifications: {}
   });
   // Select item 'pipeline-resource-1'
-  const { container, queryByText } = render(
+  const { container, queryByPlaceholderText, queryByValue } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown
         {...props}
@@ -232,7 +232,7 @@ it('PipelineResourcesDropdown renders controlled selection', () => {
       />
     </Provider>
   );
-  expect(queryByText(/pipeline-resource-1/i)).toBeTruthy();
+  expect(queryByValue(/pipeline-resource-1/i)).toBeTruthy();
   // Select item 'pipeline-resource-2'
   render(
     <Provider store={store}>
@@ -243,7 +243,7 @@ it('PipelineResourcesDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(/pipeline-resource-2/i)).toBeTruthy();
+  expect(queryByValue(/pipeline-resource-2/i)).toBeTruthy();
   // No selected item (select item '')
   render(
     <Provider store={store}>
@@ -251,7 +251,7 @@ it('PipelineResourcesDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(initialTextRegExp)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
 });
 
 it('PipelineResourcesDropdown renders controlled namespace', () => {
@@ -261,12 +261,12 @@ it('PipelineResourcesDropdown renders controlled namespace', () => {
     notifications: {}
   });
   // Select namespace 'green'
-  const { queryByText, getByText, getAllByText } = render(
+  const { queryByText, getByPlaceholderText, getAllByText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} namespace="green" />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -284,15 +284,17 @@ it('PipelineResourcesDropdown renders empty', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
   expect(
-    queryByText(/no pipelineresources found in the 'blue' namespace/i)
+    queryByPlaceholderText(
+      /no pipelineresources found in the 'blue' namespace/i
+    )
   ).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelineResourcesDropdown renders empty all namespaces', () => {
@@ -305,13 +307,13 @@ it('PipelineResourcesDropdown renders empty all namespaces', () => {
     ...namespacesStoreAll,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
-  expect(queryByText(/no pipelineresources found/i)).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(/no pipelineresources found/i)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelineResourcesDropdown renders empty with type', () => {
@@ -324,17 +326,17 @@ it('PipelineResourcesDropdown renders empty with type', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} type="bogus" />
     </Provider>
   );
   expect(
-    queryByText(
+    queryByPlaceholderText(
       /no pipelineresources found of type 'bogus' in the 'blue' namespace/i
     )
   ).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelineResourcesDropdown renders empty with type and all namespaces', () => {
@@ -347,15 +349,15 @@ it('PipelineResourcesDropdown renders empty with type and all namespaces', () =>
     ...namespacesStoreAll,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} type="bogus" />
     </Provider>
   );
   expect(
-    queryByText(/no pipelineresources found of type 'bogus'/i)
+    queryByPlaceholderText(/no pipelineresources found of type 'bogus'/i)
   ).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelineResourcesDropdown renders loading skeleton based on Redux state', () => {
@@ -364,12 +366,12 @@ it('PipelineResourcesDropdown renders loading skeleton based on Redux state', ()
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} />
     </Provider>
   );
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelineResourcesDropdown handles onChange event', () => {
@@ -379,12 +381,12 @@ it('PipelineResourcesDropdown handles onChange event', () => {
     notifications: {}
   });
   const onChange = jest.fn();
-  const { getByText } = render(
+  const { getByPlaceholderText, getByText } = render(
     <Provider store={store}>
       <PipelineResourcesDropdown {...props} onChange={onChange} />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   fireEvent.click(getByText(/pipeline-resource-1/i));
   expect(onChange).toHaveBeenCalledTimes(1);
 });

--- a/src/containers/PipelineResourcesModal/PipelineResourcesModal.js
+++ b/src/containers/PipelineResourcesModal/PipelineResourcesModal.js
@@ -199,9 +199,9 @@ export /* istanbul ignore next */ class PipelineResourcesModal extends Component
     });
   };
 
-  handleChangeNamespace = e => {
+  handleChangeNamespace = ({ selectedItem }) => {
     const stateVar = 'namespace';
-    const stateValue = e.selectedItem.text;
+    const { text: stateValue = '' } = selectedItem || {};
     this.setState(prevState => {
       const newInvalidFields = prevState.invalidFields;
       if (validateInputs(stateValue, stateVar)) {

--- a/src/containers/PipelineResourcesModal/PipelineResourcesModal.test.js
+++ b/src/containers/PipelineResourcesModal/PipelineResourcesModal.test.js
@@ -293,7 +293,7 @@ it("Create PipelineResource doesn't error when contains a valid namespace", () =
   fireEvent.change(getByPlaceholderText(/pipeline-resource-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
   fireEvent.click(queryByText('Create'));
   expect(queryByText(nameValidationErrorMsgRegExp)).toBeFalsy();
@@ -311,7 +311,7 @@ it("Create PipelineResource doesn't error when a url is entered", () => {
   fireEvent.change(getByPlaceholderText(/pipeline-resource-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
 
   fireEvent.change(getByPlaceholderText(/pipeline-resource-url/i), {
@@ -334,7 +334,7 @@ it("Create PipelineResource doesn't error when a revision is entered", () => {
   fireEvent.change(getByPlaceholderText(/pipeline-resource-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
 
   fireEvent.change(getByPlaceholderText(/pipeline-resource-revision/i), {

--- a/src/containers/PipelineResourcesModal/PipelineResourcesModalErrorNotification.test.js
+++ b/src/containers/PipelineResourcesModal/PipelineResourcesModalErrorNotification.test.js
@@ -83,7 +83,7 @@ it('error notification appears', async () => {
   fireEvent.change(getByPlaceholderText(/pipeline-resource-name/i), {
     target: { value: 'test-pipeline-resource' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   await waitForElement(() => getByText(/default/i));
   fireEvent.click(getByText(/default/i));
 

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -42,7 +42,12 @@ class PipelinesDropdown extends React.Component {
   }
 
   render() {
-    const { namespace, ...rest } = this.props;
+    const {
+      fetchPipelines: _fetchPipelines, // extract props that are not valid for the dropdown
+      namespace,
+      webSocketConnected,
+      ...rest
+    } = this.props;
     const emptyText =
       namespace === ALL_NAMESPACES
         ? `No Pipelines found`

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
@@ -124,13 +124,13 @@ it('PipelinesDropdown renders items based on Redux state', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { getByText, getAllByText, queryByText } = render(
+  const { getByPlaceholderText, getAllByText, queryByText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -144,19 +144,19 @@ it('PipelinesDropdown renders items based on Redux state when namespace changes'
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { container, getByText, getAllByText, queryByText } = render(
+  const { container, getByPlaceholderText, getAllByText, queryByText } = render(
     <Provider store={blueStore}>
       <PipelinesDropdown {...props} />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
     testDict: pipelinesByNamespace.blue
   });
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
 
   // Change selected namespace from 'blue' to 'green'
   const greenStore = mockStore({
@@ -171,7 +171,7 @@ it('PipelinesDropdown renders items based on Redux state when namespace changes'
     { container }
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -186,12 +186,12 @@ it('PipelinesDropdown renders controlled selection', () => {
     notifications: {}
   });
   // Select item 'pipeline-1'
-  const { container, queryByText } = render(
+  const { container, queryByDisplayValue, queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} selectedItem={{ text: 'pipeline-1' }} />
     </Provider>
   );
-  expect(queryByText(/pipeline-1/i)).toBeTruthy();
+  expect(queryByDisplayValue(/pipeline-1/i)).toBeTruthy();
   // Select item 'pipeline-2'
   render(
     <Provider store={store}>
@@ -199,7 +199,7 @@ it('PipelinesDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(/pipeline-2/i)).toBeTruthy();
+  expect(queryByDisplayValue(/pipeline-2/i)).toBeTruthy();
   // No selected item (select item '')
   render(
     <Provider store={store}>
@@ -207,7 +207,7 @@ it('PipelinesDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(initialTextRegExp)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
 });
 
 it('PipelinesDropdown renders controlled namespace', () => {
@@ -217,12 +217,12 @@ it('PipelinesDropdown renders controlled namespace', () => {
     notifications: {}
   });
   // Select namespace 'green'
-  const { queryByText, getByText, getAllByText } = render(
+  const { queryByText, getByPlaceholderText, getAllByText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} namespace="green" />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -240,15 +240,15 @@ it('PipelinesDropdown renders empty', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} />
     </Provider>
   );
   expect(
-    queryByText(/no pipelines found in the 'blue' namespace/i)
+    queryByPlaceholderText(/no pipelines found in the 'blue' namespace/i)
   ).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelinesDropdown for all namespaces renders empty', () => {
@@ -261,13 +261,13 @@ it('PipelinesDropdown for all namespaces renders empty', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} namespace={ALL_NAMESPACES} />
     </Provider>
   );
-  expect(queryByText(/no pipelines found/i)).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(/no pipelines found/i)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelinesDropdown renders loading skeleton based on Redux state', () => {
@@ -276,12 +276,12 @@ it('PipelinesDropdown renders loading skeleton based on Redux state', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} />
     </Provider>
   );
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('PipelinesDropdown handles onChange event', () => {
@@ -291,12 +291,12 @@ it('PipelinesDropdown handles onChange event', () => {
     notifications: {}
   });
   const onChange = jest.fn();
-  const { getByText } = render(
+  const { getByPlaceholderText, getByText } = render(
     <Provider store={store}>
       <PipelinesDropdown {...props} onChange={onChange} />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   fireEvent.click(getByText(/pipeline-1/i));
   expect(onChange).toHaveBeenCalledTimes(1);
 });

--- a/src/containers/SecretsModal/SecretsModal.js
+++ b/src/containers/SecretsModal/SecretsModal.js
@@ -221,9 +221,9 @@ export /* istanbul ignore next */ class SecretsModal extends Component {
     });
   };
 
-  handleChangeNamespace = e => {
+  handleChangeNamespace = ({ selectedItem }) => {
     const stateVar = 'namespace';
-    const stateValue = e.selectedItem.text;
+    const { text: stateValue = '' } = selectedItem || {};
     this.setState(prevState => {
       const newInvalidFields = prevState.invalidFields;
       if (validateInputs(stateValue, stateVar)) {

--- a/src/containers/SecretsModal/SecretsModal.test.js
+++ b/src/containers/SecretsModal/SecretsModal.test.js
@@ -359,7 +359,7 @@ it("Create Secret doesn't error when contains a valid namespace", () => {
   fireEvent.change(getByPlaceholderText(/secret-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
   fireEvent.click(queryByText('Create'));
   expect(queryByText(nameValidationErrorMsgRegExp)).toBeFalsy();
@@ -379,7 +379,7 @@ it("Create Secret doesn't error when Docker Registry is selected", () => {
   fireEvent.change(getByPlaceholderText(/secret-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
 
   fireEvent.click(getByText(/git server/i));
@@ -403,7 +403,7 @@ it("Create Secret doesn't error when a username is entered", () => {
   fireEvent.change(getByPlaceholderText(/secret-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
 
   fireEvent.change(getByPlaceholderText(/username/i), {
@@ -428,7 +428,7 @@ it("Create Secret doesn't error when a password is entered", () => {
   fireEvent.change(getByPlaceholderText(/secret-name/i), {
     target: { value: 'the-cat-goes-meow' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText(/default/i));
 
   fireEvent.change(getByPlaceholderText(/username/i), {

--- a/src/containers/SecretsModal/SecretsModalErrorNotification.test.js
+++ b/src/containers/SecretsModal/SecretsModalErrorNotification.test.js
@@ -126,7 +126,7 @@ it('error notification appears', async () => {
   fireEvent.change(getByPlaceholderText(/secret-name/i), {
     target: { value: 'test-secret' }
   });
-  fireEvent.click(getByText(/select namespace/i));
+  fireEvent.click(getByPlaceholderText(/select namespace/i));
   await waitForElement(() => getByText(/default/i));
   fireEvent.click(getByText(/default/i));
 

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -42,7 +42,12 @@ class ServiceAccountsDropdown extends React.Component {
   }
 
   render() {
-    const { namespace, ...rest } = this.props;
+    const {
+      fetchServiceAccounts: _fetchServiceAccounts, // extract props that are not valid for the dropdown
+      namespace,
+      webSocketConnected,
+      ...rest
+    } = this.props;
     const emptyText =
       namespace === ALL_NAMESPACES
         ? `No Service Accounts found`

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -123,13 +123,13 @@ it('ServiceAccountsDropdown renders items based on Redux state', () => {
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { getByText, getAllByText, queryByText } = render(
+  const { getByPlaceholderText, getAllByText, queryByText } = render(
     <Provider store={store}>
       <ServiceAccountsDropdown {...props} />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -143,19 +143,19 @@ it('ServiceAccountsDropdown renders items based on Redux state when namespace ch
     ...namespacesStoreBlue,
     notifications: {}
   });
-  const { container, getByText, getAllByText, queryByText } = render(
+  const { container, getByPlaceholderText, getAllByText, queryByText } = render(
     <Provider store={blueStore}>
       <ServiceAccountsDropdown {...props} />
     </Provider>
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
     testDict: serviceAccountsByNamespace.blue
   });
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
 
   // Change selected namespace from 'blue' to 'green'
   const greenStore = mockStore({
@@ -170,7 +170,7 @@ it('ServiceAccountsDropdown renders items based on Redux state when namespace ch
     { container }
   );
   // View items
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -185,7 +185,7 @@ it('ServiceAccountsDropdown renders controlled selection', () => {
     notifications: {}
   });
   // Select item 'service-account-1'
-  const { container, queryByText } = render(
+  const { container, queryByPlaceholderText, queryByValue } = render(
     <Provider store={store}>
       <ServiceAccountsDropdown
         {...props}
@@ -193,7 +193,7 @@ it('ServiceAccountsDropdown renders controlled selection', () => {
       />
     </Provider>
   );
-  expect(queryByText(/service-account-1/i)).toBeTruthy();
+  expect(queryByValue(/service-account-1/i)).toBeTruthy();
   // Select item 'service-account-2'
   render(
     <Provider store={store}>
@@ -204,7 +204,7 @@ it('ServiceAccountsDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(/service-account-2/i)).toBeTruthy();
+  expect(queryByValue(/service-account-2/i)).toBeTruthy();
   // No selected item (select item '')
   render(
     <Provider store={store}>
@@ -212,7 +212,7 @@ it('ServiceAccountsDropdown renders controlled selection', () => {
     </Provider>,
     { container }
   );
-  expect(queryByText(initialTextRegExp)).toBeTruthy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
 });
 
 it('ServiceAccountsDropdown renders controlled namespace', () => {
@@ -222,12 +222,12 @@ it('ServiceAccountsDropdown renders controlled namespace', () => {
     notifications: {}
   });
   // Select namespace 'green'
-  const { queryByText, getByText, getAllByText } = render(
+  const { queryByText, getByPlaceholderText, getAllByText } = render(
     <Provider store={store}>
       <ServiceAccountsDropdown {...props} namespace="green" />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   checkDropdownItems({
     getAllByText,
     queryByText,
@@ -246,15 +246,15 @@ it('ServiceAccountsDropdown renders empty', () => {
     notifications: {}
   });
   // Select item 'service-account-1'
-  const { queryByText } = render(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <ServiceAccountsDropdown {...props} />
     </Provider>
   );
   expect(
-    queryByText(/no service accounts found in the 'blue' namespace/i)
+    queryByPlaceholderText(/no service accounts found in the 'blue' namespace/i)
   ).toBeTruthy();
-  expect(queryByText(initialTextRegExp)).toBeFalsy();
+  expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
 });
 
 it('ServiceAccountsDropdown renders loading skeleton based on Redux state', () => {
@@ -278,12 +278,12 @@ it('ServiceAccountsDropdown handles onChange event', () => {
     notifications: {}
   });
   const onChange = jest.fn();
-  const { getByText } = render(
+  const { getByPlaceholderText, getByText } = render(
     <Provider store={store}>
       <ServiceAccountsDropdown {...props} onChange={onChange} />
     </Provider>
   );
-  fireEvent.click(getByText(initialTextRegExp));
+  fireEvent.click(getByPlaceholderText(initialTextRegExp));
   fireEvent.click(getByText(/service-account-1/i));
   expect(onChange).toHaveBeenCalledTimes(1);
 });

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -72,7 +72,9 @@ class SideNav extends Component {
   }
 
   selectNamespace = event => {
-    const namespace = event.selectedItem.id;
+    const namespace = event.selectedItem
+      ? event.selectedItem.id
+      : ALL_NAMESPACES;
     const { history, match } = this.props;
 
     if (!match) {

--- a/src/containers/SideNav/SideNav.scss
+++ b/src/containers/SideNav/SideNav.scss
@@ -15,7 +15,7 @@ limitations under the License.
 
 .bx--header ~ {
   nav.bx--side-nav {
-    .bx--dropdown__wrapper {
+    .bx--list-box__wrapper {
       margin-top: 1rem;
       padding: 0 1rem;
 
@@ -26,10 +26,14 @@ limitations under the License.
         letter-spacing: 0.16px;
       }
 
-      .bx--dropdown.bx--list-box {
+      .bx--combo-box.bx--list-box {
         border: none;
         margin-bottom: 1.5em;
         width: auto;
+      }
+
+      .bx--text-input {
+        border: none;
       }
     }
   }

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -140,7 +140,7 @@ it('SideNav selects namespace when no namespace in URL', async () => {
     }
   });
   const selectNamespace = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -149,7 +149,7 @@ it('SideNav selects namespace when no namespace in URL', async () => {
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(otherNamespace));
   expect(selectNamespace).toHaveBeenCalledWith(otherNamespace);
 });
@@ -169,7 +169,7 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -180,7 +180,7 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith('/');
@@ -201,7 +201,7 @@ it('SideNav redirects to TaskRuns page when all namespaces selected on namespace
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -212,7 +212,7 @@ it('SideNav redirects to TaskRuns page when all namespaces selected on namespace
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.taskRuns.all());
@@ -233,7 +233,7 @@ it('SideNav redirects to PipelineResources page when all namespaces selected on 
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -247,7 +247,7 @@ it('SideNav redirects to PipelineResources page when all namespaces selected on 
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.pipelineResources.all());
@@ -268,7 +268,7 @@ it('SideNav redirects to Pipelines page when all namespaces selected on namespac
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -282,7 +282,7 @@ it('SideNav redirects to Pipelines page when all namespaces selected on namespac
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.pipelines.all());
@@ -303,7 +303,7 @@ it('SideNav redirects to ServiceAccounts page when all namespaces selected on na
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -317,7 +317,7 @@ it('SideNav redirects to ServiceAccounts page when all namespaces selected on na
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.serviceAccounts.all());
@@ -338,7 +338,7 @@ it('SideNav redirects to EventListeners page when all namespaces selected on nam
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -352,7 +352,7 @@ it('SideNav redirects to EventListeners page when all namespaces selected on nam
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.eventListeners.all());
@@ -373,7 +373,7 @@ it('SideNav redirects to TriggerBindings page when all namespaces selected on na
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -387,7 +387,7 @@ it('SideNav redirects to TriggerBindings page when all namespaces selected on na
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.triggerBindings.all());
@@ -408,7 +408,7 @@ it('SideNav redirects to TriggerTemplates page when all namespaces selected on n
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -422,7 +422,7 @@ it('SideNav redirects to TriggerTemplates page when all namespaces selected on n
       />
     </Provider>
   );
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith(urls.triggerTemplates.all());
@@ -445,7 +445,7 @@ it('SideNav updates namespace in URL', async () => {
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
-  const { getByText } = renderWithRouter(
+  const { getByText, getByValue } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -460,7 +460,7 @@ it('SideNav updates namespace in URL', async () => {
     </Provider>
   );
   selectNamespace.mockClear();
-  fireEvent.click(getByText(namespace));
+  fireEvent.click(getByValue(namespace));
   fireEvent.click(getByText(otherNamespace));
   expect(selectNamespace).not.toHaveBeenCalled();
   expect(push).toHaveBeenCalledWith(expect.stringContaining(otherNamespace));


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Switch the implmentation of TooltipDropdown from the Carbon
DropDown to the ComboBox component.

This enables typeahead for namespaces, pipelines, service accounts,
and pipeline resources.

https://github.com/tektoncd/dashboard/issues/711

Depends on https://github.com/tektoncd/dashboard/pull/1039

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
