### PR TITLE
Remove Carbon style imports from Table.scss

### DIFF
--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -14,10 +14,6 @@ limitations under the License.
 @import '~@tektoncd/dashboard-components/dist/scss/vars';
 
 .tableComponent {
-  $css--reset: false;
-  @import '~carbon-components/scss/components/data-table/data-table-core';
-  @import '~carbon-components/scss/components/overflow-menu/overflow-menu';
-
   .bx--table-toolbar {
     background: transparent;
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The table and overflow menu styles were previously imported
inside the `.tableComponent` scope to resolve an issue on pages
where Carbon 9 and Carbon 10 styles were both present.

This is no longer required so we can remove them and enjoy a
slightly smaller SCSS bundle as a result.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
