### PR TITLE
Remove duplicate lerna 'prepare' step in dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER root
 WORKDIR /go/src/github.com/tektoncd/dashboard
 COPY . .
 RUN npm install
-RUN npm run bootstrap
+RUN npm run bootstrap:ci
 RUN npm run build
 
 FROM golang:1.12-alpine as goBuilder

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap && lerna run prepare",
+    "bootstrap": "lerna bootstrap",
+    "bootstrap:ci": "lerna bootstrap && lerna run prepare",
     "build": "webpack --config webpack.prod.js",
     "build_ko": "webpack --config webpack.prod.js --output-path='./cmd/dashboard/kodata/web' ",
     "clean": "lerna clean --yes && lerna run clean && rimraf node_modules",
@@ -13,6 +14,7 @@
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",
     "postinstall": "npm run bootstrap",
+    "prepare": "lerna run prepare",
     "start": "webpack-dev-server --hot --config webpack.dev.js",
     "storybook": "start-storybook -p 5000",
     "storybook:build": "build-storybook",

--- a/tekton/build.yml
+++ b/tekton/build.yml
@@ -37,7 +37,7 @@ spec:
           npm config set prefix '~/.npm-global'
           export PATH=$PATH:$HOME/.npm-global/bin
           npm ci
-          npm run bootstrap
+          npm run bootstrap:ci
           npm run build_ko
           dep ensure -v
     - name: copy-files-to-output-resource

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -75,7 +75,7 @@ function node_npm_install() {
   npm config set prefix '~/.npm-global'
   export PATH=$PATH:$HOME/.npm-global/bin
   npm ci || failed=1 # similar to `npm install` but ensures all versions from lock file
-  npm run bootstrap || failed=1
+  npm run bootstrap:ci || failed=1
   return ${failed}
 }
 

--- a/test/publish-images.sh
+++ b/test/publish-images.sh
@@ -33,7 +33,7 @@ mkdir ~/.npm-global
 npm config set prefix '~/.npm-global'
 export PATH=$PATH:$HOME/.npm-global/bin
 npm ci
-npm run bootstrap
+npm run bootstrap:ci
 npm run build_ko
 
 export KO_DOCKER_REPO=gcr.io/tekton-nightly


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
We previously ran `lerna run prepare` multiple times in dev
as a result of a workaround for our CI config which blocks
npm postinstall (breaking default lerna behaviour) due to
security concerns with postinstall scripts on shared infra.

Create a CI-specific script which keeps the existing behaviour.
Update the `bootstrap` script to split out the `prepare` step so
it is now only executed once in local dev environments meaning
it should only cause a single webpack build instead of the 2 or 3
previously seen with the repeated 'prepare' scripts depending on
timing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
