### PR TITLE
Sort Tasks for PipelineRuns by their Task's earliest startedAt time

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -62,6 +62,34 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     };
   };
 
+  sortTaskRuns = taskRuns => {
+    const toReturn = taskRuns.sort((taskRunA, taskRunB) => {
+      if (!taskRunA || !taskRunB) {
+        return 0;
+      }
+
+      const firstStepA = taskRunA.steps[0];
+      const firstStepB = taskRunB.steps[0];
+
+      if (!firstStepA || !firstStepB) {
+        // shouldn't be able to reach this state (both tasks requiring at least one step)
+        return 0;
+      }
+
+      const { startedAt: startedAtA } =
+        firstStepA.terminated || firstStepA.running || {};
+      const { startedAt: startedAtB } =
+        firstStepB.terminated || firstStepB.running || {};
+
+      if (!startedAtA || !startedAtB) {
+        return 0;
+      }
+
+      return new Date(startedAtA).getTime() - new Date(startedAtB).getTime();
+    });
+    return toReturn;
+  };
+
   loadTaskRuns = pipelineRun => {
     if (!pipelineRun || !pipelineRun.status || !pipelineRun.status.taskRuns) {
       return [];
@@ -249,6 +277,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       );
     }
     const taskRuns = this.loadTaskRuns(pipelineRun, taskRunNames);
+
+    this.sortTaskRuns(taskRuns);
 
     if (taskRuns.length === 0) {
       return (

--- a/testdata/ordering/pipeline.yaml
+++ b/testdata/ordering/pipeline.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: test-pipeline
+  namespace: tekton-pipelines
+spec:
+  tasks:
+    - name: b-task
+      taskRef:
+        kind: Task
+        name: step-b-task
+    - name: c-task
+      taskRef:
+        kind: Task
+        name: step-c-task
+    - name: a-task
+      taskRef:
+        kind: Task
+        name: step-a-task

--- a/testdata/ordering/pipelinerun.yaml
+++ b/testdata/ordering/pipelinerun.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: test-pipelinerun
+  namespace: tekton-pipelines
+spec:
+  pipelineRef:
+    name: test-pipeline

--- a/testdata/ordering/tasks.yaml
+++ b/testdata/ordering/tasks.yaml
@@ -1,0 +1,43 @@
+# Test file used for PipelineRun/TaskRun rendering of Tasks by started time
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: step-b-task
+  namespace: tekton-pipelines
+spec:
+  steps:
+    - name: step-b-task-step
+      image: ubuntu
+      script: ls
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: step-a-task
+  namespace: tekton-pipelines
+spec:
+  steps:
+    - name: step-a-task-step-1
+      image: ubuntu
+      script: sleep 10
+    - name: step-a-task-step-2
+      image: ubuntu
+      script: sleep 1
+    - name: step-a-task-step-3
+      image: ubuntu
+      script: sleep 5
+    - name: step-a-task-step-4
+      image: ubuntu
+      script: sleep 5
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: step-c-task
+  namespace: tekton-pipelines
+spec:
+  steps:
+    - name: step-c-task-step
+      image: ubuntu
+      script: ls


### PR DESCRIPTION
For https://github.com/tektoncd/dashboard/issues/932 which definitely requires a good read through, particularly @AlanGreene's comment:

This approach does satisfy the requirement from Kabanero (in that the `validate` step will appear first as that starts first).

This is also missing unit tests and I want to check this is the approach we want to take, doing things via their order in the Pipeline definition itself proved non-trivial (when we get the data using `getTektonAPI` for example, it's mysteriously sorted by Task name).

More notes:
1) I want to make this code much neater
2) Note that `moment` has been introduced too (MIT license)

3) I'm using `steps[0]` - although there may be multiple steps for a Task.

If one of the steps much sooner than the very first in that array; our sorting will be incorrect so this is a bug. 

Perhaps we advocate for a `startTime` in the Task field for each TaskRun that's not under `running` or `completed`. Alternatively we could implement a `getEarliestStep` method and use that in the sort, sorting against the earliest step for the other tasks.

@AlanGreene what do you think? Perhaps it is easier to display them as defined in the Pipeline but I couldn't figure it out.