### PR TITLE
Fix alignment of Table checkboxes when row contains overflow menu

### DIFF
--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -35,6 +35,12 @@ limitations under the License.
       vertical-align: middle;
     }
 
+    &.bx--table-column-checkbox {
+      padding-top: 0;
+      padding-bottom: 0;
+      vertical-align: middle;
+    }
+
     &.cell-status {
       vertical-align: middle;
     }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When a row contains both a checkbox (for selecting the row) and
an overflow menu, the checkbox is not correctly aligned.

Fix this by vertically aligning the checkbox and ensuring this
still works on tables using checkboxes but no overflow menu.

Before:
![image](https://user-images.githubusercontent.com/2829095/75271585-59e46b00-57f4-11ea-90b2-11f63a0c6d7e.png)

After:
![image](https://user-images.githubusercontent.com/2829095/75271592-5d77f200-57f4-11ea-81a6-115c0e131d7f.png)

Only checkbox (secrets table):
![image](https://user-images.githubusercontent.com/2829095/75271608-636dd300-57f4-11ea-9bcb-50b61e549ed5.png)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
