### PR TITLE
Add suport for custom columns to the PipelineRuns component

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
@@ -14,10 +14,11 @@ limitations under the License.
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import StoryRouter from 'storybook-react-router';
-
 import { getStatus } from '@tektoncd/dashboard-utils';
 import { action } from '@storybook/addon-actions';
 import { Delete16 as Delete } from '@carbon/icons-react';
+
+import { StatusIcon } from '..';
 import PipelineRuns from '.';
 
 storiesOf('PipelineRuns', module)
@@ -201,32 +202,21 @@ storiesOf('PipelineRuns', module)
       cancelPipelineRun={() => {}}
     />
   ))
-  .add('Batch Actions', () => (
+  .add('batch actions', () => (
     <PipelineRuns
       batchActionButtons={[
         { onClick: action('handleDelete'), text: 'Delete', icon: Delete }
       ]}
-      createPipelineRunURL={({ namespace, pipelineRunName }) =>
-        namespace ? `to-pipelineRun-${namespace}/${pipelineRunName}` : null
-      }
-      createPipelineRunsByPipelineURL={() => null}
-      createPipelineRunTimestamp={pipelineRun =>
-        getStatus(pipelineRun).lastTransitionTime ||
-        pipelineRun.metadata.creationTimestamp
-      }
       selectedNamespace="default"
       pipelineRunActions={[
         {
-          actionText: 'Cancel',
+          actionText: 'An Action',
           action: resource => resource,
-          disable: resource =>
-            resource.status &&
-            resource.status.conditions[0].reason !== 'Running',
           modalProperties: {
-            heading: 'cancel',
-            primaryButtonText: 'ok',
-            secondaryButtonText: 'no',
-            body: resource => `cancel pipelineRun ${resource.metadata.name}`
+            heading: 'An Action',
+            primaryButtonText: 'OK',
+            secondaryButtonText: 'Cancel',
+            body: () => 'Do something interesting'
           }
         }
       ]}
@@ -235,24 +225,12 @@ storiesOf('PipelineRuns', module)
           metadata: {
             name: 'pipeline-run-20190816124708',
             namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
-            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e',
             creationTimestamp: '2019-08-16T12:48:00Z'
           },
           spec: {
             pipelineRef: {
               name: 'pipeline'
             }
-          },
-          status: {
-            conditions: [
-              {
-                lastTransitionTime: '2019-08-16T12:49:28Z',
-                message: 'All Tasks have completed executing',
-                reason: 'Succeeded',
-                status: 'True',
-                type: 'Succeeded'
-              }
-            ]
           }
         },
         {
@@ -260,6 +238,7 @@ storiesOf('PipelineRuns', module)
           kind: 'PipelineRun',
           metadata: {
             name: 'output-pipeline-run',
+            namespace: 'default',
             creationTimestamp: '2019-10-09T17:10:49Z'
           },
           spec: {
@@ -275,7 +254,67 @@ storiesOf('PipelineRuns', module)
           }
         }
       ]}
-      cancelPipelineRun={() => {}}
+    />
+  ))
+  .add('custom columns', () => (
+    <PipelineRuns
+      columns={[
+        'status',
+        'name',
+        'pipeline',
+        'trigger',
+        'createdTime',
+        'duration'
+      ]}
+      customColumns={{
+        status: {
+          getValue() {
+            return (
+              <div className="definition">
+                <div className="status">
+                  <StatusIcon /> Pending
+                </div>
+              </div>
+            );
+          }
+        },
+        trigger: {
+          header: 'Trigger',
+          getValue({ pipelineRun }) {
+            const trigger = pipelineRun.metadata.labels['tekton.dev/trigger'];
+            return <span title={trigger}>{trigger}</span>;
+          }
+        }
+      }}
+      pipelineRunActions={[
+        {
+          actionText: 'An Action',
+          action: resource => resource,
+          modalProperties: {
+            heading: 'An Action',
+            primaryButtonText: 'OK',
+            secondaryButtonText: 'Cancel',
+            body: () => 'Do something interesting'
+          }
+        }
+      ]}
+      pipelineRuns={[
+        {
+          metadata: {
+            name: 'pipeline-run-20190816124708',
+            namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
+            creationTimestamp: '2019-08-16T12:48:00Z',
+            labels: {
+              'tekton.dev/trigger': 'my-trigger'
+            }
+          },
+          spec: {
+            pipelineRef: {
+              name: 'pipeline'
+            }
+          }
+        }
+      ]}
     />
   ))
   .add('empty', () => (

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
@@ -22,104 +22,190 @@ const intl = createIntl({
   defaultLocale: 'en'
 });
 
-it('PipelineRuns renders empty state', () => {
-  const { queryByText } = renderWithIntl(<PipelineRuns pipelineRuns={[]} />);
-  expect(queryByText(/no pipelineruns/i)).toBeTruthy();
-  expect(queryByText(/namespace/i)).toBeTruthy();
-});
+describe('PipelineRuns', () => {
+  it('renders empty state', () => {
+    const { queryByText } = renderWithIntl(<PipelineRuns pipelineRuns={[]} />);
+    expect(queryByText(/no pipelineruns/i)).toBeTruthy();
+    expect(queryByText(/namespace/i)).toBeTruthy();
+  });
 
-it('PipelineRuns hides namespace when hideNamespace set', () => {
-  const { queryByText } = renderWithIntl(
-    <PipelineRuns pipelineRuns={[]} hideNamespace />
-  );
+  it('hides namespace when omitted from the list of columns', () => {
+    const { queryByText } = renderWithIntl(
+      <PipelineRuns
+        columns={['status', 'name', 'pipeline']}
+        pipelineRuns={[]}
+      />
+    );
 
-  expect(queryByText(/Namespace/)).toBeFalsy();
-  expect(queryByText(/pipeline/i)).toBeTruthy();
-  expect(queryByText(/no pipelineruns/i)).toBeTruthy();
-});
+    expect(queryByText(/Namespacei/)).toBeFalsy();
+    expect(queryByText(/pipeline/i)).toBeTruthy();
+    expect(queryByText(/no pipelineruns/i)).toBeTruthy();
+  });
 
-it('PipelineRuns renders data', () => {
-  const pipelineRunName = 'pipeline-run-20190816124708';
-  const { queryByText, queryByTitle } = renderWithRouter(
-    <PipelineRuns
-      intl={intl}
-      pipelineRuns={[
-        {
-          metadata: {
-            name: pipelineRunName,
-            namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
-            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e'
-          },
-          spec: {
-            pipelineRef: {
-              name: 'pipeline'
+  it('renders custom columns', () => {
+    const { queryByText } = renderWithIntl(
+      <PipelineRuns
+        columns={['aCustomColumn']}
+        customColumns={{
+          aCustomColumn: {
+            header: 'Custom Column',
+            getValue({ pipelineRun }) {
+              return pipelineRun.metadata.someField;
             }
-          },
-          status: {
-            conditions: [
-              {
-                lastTransitionTime: '2019-08-16T12:49:28Z',
-                message: 'FAKE_MESSAGE',
-                reason: 'FAKE_REASON',
-                status: 'True',
-                type: 'Succeeded'
-              }
-            ]
           }
-        }
-      ]}
-      pipelineRunActions={[
-        {
-          actionText: 'TestAction'
-        }
-      ]}
-    />
-  );
-  expect(queryByText(pipelineRunName)).toBeTruthy();
-  expect(queryByTitle(/FAKE_REASON/i)).toBeTruthy();
-  expect(queryByTitle(/FAKE_MESSAGE/i)).toBeTruthy();
-});
+        }}
+        pipelineRuns={[
+          {
+            metadata: {
+              name: 'pipelineRunName',
+              namespace: 'default',
+              someField: 'A custom value'
+            },
+            spec: {}
+          }
+        ]}
+      />
+    );
 
-it('PipelineRuns renders with custom link creators', () => {
-  const pipelineName = 'pipeline-12345';
-  const pipelineRunName = 'pipeline-run-20190816124708';
-  const { queryByText } = renderWithRouter(
-    <PipelineRuns
-      intl={intl}
-      pipelineRuns={[
-        {
-          metadata: {
-            name: pipelineRunName,
-            namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
-            uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e'
-          },
-          spec: {
-            pipelineRef: {
-              name: pipelineName
-            }
-          },
+    expect(queryByText(/Custom Column/i)).toBeTruthy();
+    expect(queryByText(/A custom value/i)).toBeTruthy();
+  });
+
+  it('renders custom column headers', () => {
+    const { queryByText } = renderWithIntl(
+      <PipelineRuns
+        columns={['status']}
+        customColumns={{
           status: {
-            conditions: [
-              {
-                lastTransitionTime: '2019-08-16T12:49:28Z',
-                message: 'FAKE_MESSAGE',
-                reason: 'FAKE_REASON',
-                status: 'True',
-                type: 'Succeeded'
-              }
-            ]
+            header: 'Custom Column Header'
           }
-        }
-      ]}
-      pipelineRunActions={[
-        {
-          actionText: 'TestAction'
-        }
-      ]}
-      createPipelineRunURL={() => null}
-      createPipelineRunsByPipelineURL={() => null}
-    />
-  );
-  expect(queryByText(pipelineRunName)).toBeTruthy();
-  expect(queryByText(pipelineName)).toBeTruthy();
+        }}
+        pipelineRuns={[
+          {
+            metadata: {
+              name: 'pipelineRunName',
+              namespace: 'default'
+            },
+            spec: {}
+          }
+        ]}
+      />
+    );
+
+    expect(queryByText(/Status/i)).toBeFalsy();
+    expect(queryByText(/Custom Column Header/i)).toBeTruthy();
+  });
+
+  it('renders custom column values', () => {
+    const { queryByText } = renderWithIntl(
+      <PipelineRuns
+        columns={['status']}
+        customColumns={{
+          status: {
+            getValue() {
+              return 'Custom Column Value';
+            }
+          }
+        }}
+        pipelineRuns={[
+          {
+            metadata: {
+              name: 'pipelineRunName',
+              namespace: 'default'
+            },
+            spec: {}
+          }
+        ]}
+      />
+    );
+
+    expect(queryByText(/Status/i)).toBeTruthy();
+    expect(queryByText(/Custom Column Value/i)).toBeTruthy();
+  });
+
+  it('renders data', () => {
+    const pipelineRunName = 'pipeline-run-20190816124708';
+    const { queryByText, queryByTitle } = renderWithRouter(
+      <PipelineRuns
+        intl={intl}
+        pipelineRuns={[
+          {
+            metadata: {
+              name: pipelineRunName,
+              namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
+              uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e'
+            },
+            spec: {
+              pipelineRef: {
+                name: 'pipeline'
+              }
+            },
+            status: {
+              conditions: [
+                {
+                  lastTransitionTime: '2019-08-16T12:49:28Z',
+                  message: 'FAKE_MESSAGE',
+                  reason: 'FAKE_REASON',
+                  status: 'True',
+                  type: 'Succeeded'
+                }
+              ]
+            }
+          }
+        ]}
+        pipelineRunActions={[
+          {
+            actionText: 'TestAction'
+          }
+        ]}
+      />
+    );
+    expect(queryByText(pipelineRunName)).toBeTruthy();
+    expect(queryByTitle(/FAKE_REASON/i)).toBeTruthy();
+    expect(queryByTitle(/FAKE_MESSAGE/i)).toBeTruthy();
+  });
+
+  it('renders with custom link creators', () => {
+    const pipelineName = 'pipeline-12345';
+    const pipelineRunName = 'pipeline-run-20190816124708';
+    const { queryByText } = renderWithRouter(
+      <PipelineRuns
+        intl={intl}
+        pipelineRuns={[
+          {
+            metadata: {
+              name: pipelineRunName,
+              namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
+              uid: '7c266264-4d4d-45e3-ace0-041be8f7d06e'
+            },
+            spec: {
+              pipelineRef: {
+                name: pipelineName
+              }
+            },
+            status: {
+              conditions: [
+                {
+                  lastTransitionTime: '2019-08-16T12:49:28Z',
+                  message: 'FAKE_MESSAGE',
+                  reason: 'FAKE_REASON',
+                  status: 'True',
+                  type: 'Succeeded'
+                }
+              ]
+            }
+          }
+        ]}
+        pipelineRunActions={[
+          {
+            actionText: 'TestAction'
+          }
+        ]}
+        createPipelineRunURL={() => null}
+        createPipelineRunsByPipelineURL={() => null}
+      />
+    );
+    expect(queryByText(pipelineRunName)).toBeTruthy();
+    expect(queryByText(pipelineName)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/861

Consumers may want to hide certain columns, add new columns,
or modify the header / value of other columns. So far we've done
this on a case by case basis with slightly different approaches, e.g.:
- `hideNamespace` prop to hide the namespace column
- optional function props to customise value used for created time
- etc.

Introduce 2 new props that replace the `hideNamespace` and some
other combinations:
- `columns` - an array of column keys (default value matching
  current columns displayed in the dashboard is provided). If
  a value is specified for this prop, it replaces the default
  columns, allowing consumers to change the order, omit default
  columns, or add their own custom ones.
- `customColumns` - this can be provided as an object where the
  keys match entries from the `columns` prop, and the values are objects of the format `{ header: 'Column Header', getValue({ pipelineRun }) { return 'value to display'; } }`

Using the `customColumns` prop, consumers can override the default column headers, values, or both.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
