### PR TITLE
Issue: 1051 - Do not expose URL in v1/extensions

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -157,13 +157,27 @@ func (h *Handler) registerExtensions() {
 	h.extensionWebService = extensionWebService
 }
 
+type RedactedExtension struct {
+	Name           string `json:"name"`
+	DisplayName    string `json:"displayname"`
+	BundleLocation string `json:"bundlelocation"`
+	endpoints      []string
+}
+
 // getExtensions gets all of the registered extensions on the handler
-func (h *Handler) getExtensions() []Extension {
+func (h *Handler) getExtensions() []RedactedExtension {
 	h.RLock()
 	defer h.RUnlock()
-	extensions := []Extension{}
+
+	extensions := []RedactedExtension{}
 	for _, e := range h.uidExtensionMap {
-		extensions = append(extensions, *e)
+		redactedExtension := RedactedExtension{
+			Name:           e.Name,
+			DisplayName:    e.DisplayName,
+			BundleLocation: e.BundleLocation,
+			endpoints:      e.endpoints,
+		}
+		extensions = append(extensions, redactedExtension)
 	}
 	return extensions
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -380,11 +380,10 @@ export async function getExtensions() {
   let extensions = await get(uri);
   const resourceExtensions = await get(resourceExtensionsUri);
   extensions = (extensions || []).map(
-    ({ bundlelocation, displayname, name, url }) => ({
+    ({ bundlelocation, displayname, name }) => ({
       displayName: displayname,
       name,
-      source: getExtensionBundleURL(name, bundlelocation),
-      url
+      source: getExtensionBundleURL(name, bundlelocation)
     })
   );
   return extensions.concat(

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -540,9 +540,8 @@ it('getExtensions', () => {
   const name = 'name';
   const bundlelocation = 'bundlelocation';
   const source = index.getExtensionBundleURL(name, bundlelocation);
-  const url = 'url';
-  const extensions = [{ displayname: displayName, name, bundlelocation, url }];
-  const transformedExtensions = [{ displayName, name, source, url }];
+  const extensions = [{ displayname: displayName, name, bundlelocation }];
+  const transformedExtensions = [{ displayName, name, source }];
   fetchMock.get(/extensions/, extensions);
   return index.getExtensions().then(response => {
     expect(response).toEqual(transformedExtensions);


### PR DESCRIPTION
# Changes

For Issue 1051 - Changed returning Extension struct to redactedExtension struct which has URL and Port removed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
