### PR TITLE
Password is selected as default secret type

### DIFF
--- a/src/containers/CreateSecret/CreateSecret.js
+++ b/src/containers/CreateSecret/CreateSecret.js
@@ -65,7 +65,7 @@ export /* istanbul ignore next */ class CreateSecret extends Component {
       username: '',
       password: '',
       accessToken: '',
-      secretType: '',
+      secretType: 'password',
       annotations: [
         {
           access: 'git',


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1106

- Makes a secret have a 'password' type as default, to avoid the issue of being able to create secrets with no password or access token.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
