### PR TITLE
Access token secrets can be viewed in the secrets table

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -292,10 +292,7 @@ export function rerunPipelineRun(namespace, payload) {
 }
 
 export function getCredentials({ namespace } = {}) {
-  const queryParams = {
-    fieldSelector: 'type=kubernetes.io/basic-auth'
-  };
-  const uri = getKubeAPI('secrets', { namespace }, queryParams);
+  const uri = getKubeAPI('secrets', { namespace });
   return get(uri).then(checkData);
 }
 

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -42,7 +42,7 @@ const byNamespace = {
           badannotation: 'badcontent'
         }
       },
-      type: 'userpass',
+      type: 'kubernetes.io/basic-auth',
       data: {
         username: 'bXl1c2VybmFtZQ==' // This is "myusername"
       }
@@ -58,7 +58,7 @@ const byNamespace = {
           baz: 'bam'
         }
       },
-      type: 'userpass',
+      type: 'kubernetes.io/basic-auth',
       data: {
         username: 'bXl1c2VybmFtZQ==' // This is "myusername"
       }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1102
- Adds the ability to view access token secrets in the Secrets table view
- Adds radio buttons to switch between viewing access token secrets and password secrets, as they have different fields in the table.

<img width="1693" alt="Screenshot 2020-03-05 at 14 43 08" src="https://user-images.githubusercontent.com/52741262/75992309-acf2a800-5eef-11ea-9e20-7b6d354885e6.png">
<img width="1697" alt="Screenshot 2020-03-05 at 14 42 56" src="https://user-images.githubusercontent.com/52741262/75992326-b11ec580-5eef-11ea-9240-352d168eed4f.png">

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
