### PR TITLE
Batch action bar doesn't display if there are no secrets

### DIFF
--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -290,6 +290,20 @@ export /* istanbul ignore next */ class Secrets extends Component {
       return formattedSecret;
     });
 
+    const batchActionButtons =
+      secretsToUse.length === 0
+        ? []
+        : [
+            {
+              onClick: this.handleDeleteSecretClick,
+              text: intl.formatMessage({
+                id: 'dashboard.actions.deleteButton',
+                defaultMessage: 'Delete'
+              }),
+              icon: Delete
+            }
+          ];
+
     return (
       <>
         {patchSuccess && (
@@ -401,16 +415,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
                 },
                 { kind: 'Secrets', selectedNamespace }
               )}
-              batchActionButtons={[
-                {
-                  onClick: this.handleDeleteSecretClick,
-                  text: intl.formatMessage({
-                    id: 'dashboard.actions.deleteButton',
-                    defaultMessage: 'Delete'
-                  }),
-                  icon: Delete
-                }
-              ]}
+              batchActionButtons={batchActionButtons}
               toolbarButtons={[
                 {
                   onClick: this.handleNewSecretClick,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1101
- Disables the batch-action bar for the secrets table if there are no secrets to display, therefore removing the ability to delete secrets when there are none to delete.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
