### PR TITLE
Change radio buttons on secrets page to horizontal alignment

### DIFF
--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -371,7 +371,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
                 defaultMessage: 'Type'
               })}
               name="secret-type"
-              orientation="vertical"
+              orientation="horizontal"
               labelPosition="right"
               valueSelected={selectedType}
               onChange={this.handleSelectedType}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Very small change to make the radio buttons on the secrets page horizontal instead of vertical, with regard to @AlanGreene's comment here: https://github.com/tektoncd/dashboard/pull/1117#pullrequestreview-369695300
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
