### PR TITLE
Table component should hide batch actions when rows is empty

### DIFF
--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -130,6 +130,9 @@ const Table = props => {
     toolbarButtons
   } = props;
 
+  const shouldRenderBatchActions = !!(
+    dataRows.length && batchActionButtons.length
+  );
   const translateWithId = getTranslateWithId(intl);
 
   return (
@@ -150,28 +153,29 @@ const Table = props => {
           selectedRows
         }) => (
           <TableContainer title={title}>
-            {(toolbarButtons.length !== 0 ||
-              batchActionButtons.length !== 0) && (
+            {(toolbarButtons.length || shouldRenderBatchActions) && (
               <TableToolbar>
-                <TableBatchActions
-                  {...getBatchActionProps()}
-                  translateWithId={translateWithId}
-                >
-                  {batchActionButtons.map(button => (
-                    <TableBatchAction
-                      renderIcon={button.icon}
-                      key={`${button.text}Button`}
-                      onClick={() => {
-                        button.onClick(
-                          selectedRows,
-                          getBatchActionProps().onCancel
-                        );
-                      }}
-                    >
-                      {button.text}
-                    </TableBatchAction>
-                  ))}
-                </TableBatchActions>
+                {shouldRenderBatchActions && (
+                  <TableBatchActions
+                    {...getBatchActionProps()}
+                    translateWithId={translateWithId}
+                  >
+                    {batchActionButtons.map(button => (
+                      <TableBatchAction
+                        renderIcon={button.icon}
+                        key={`${button.text}Button`}
+                        onClick={() => {
+                          button.onClick(
+                            selectedRows,
+                            getBatchActionProps().onCancel
+                          );
+                        }}
+                      >
+                        {button.text}
+                      </TableBatchAction>
+                    ))}
+                  </TableBatchActions>
+                )}
                 <TableToolbarContent>
                   {toolbarButtons.map(button => (
                     <Button
@@ -195,7 +199,7 @@ const Table = props => {
               <CarbonTable {...getTableProps()}>
                 <TableHead>
                   <TableRow>
-                    {batchActionButtons.length > 0 && (
+                    {shouldRenderBatchActions && (
                       <TableSelectAll {...getSelectionProps()} />
                     )}
                     {headers.map(header => {
@@ -217,7 +221,7 @@ const Table = props => {
                     <TableRow>
                       <TableCell
                         colSpan={
-                          headers.length + (batchActionButtons.length ? 1 : 0)
+                          headers.length + (shouldRenderBatchActions ? 1 : 0)
                         }
                       >
                         <div className="noRows">
@@ -231,7 +235,7 @@ const Table = props => {
                   {rows.map(row => {
                     return (
                       <TableRow {...getRowProps({ row })} key={row.id}>
-                        {batchActionButtons.length > 0 && (
+                        {shouldRenderBatchActions && (
                           <TableSelectRow {...getSelectionProps({ row })} />
                         )}
                         {row.cells.map(cell => (
@@ -258,23 +262,23 @@ const Table = props => {
 
 Table.defaultProps = {
   batchActionButtons: [],
-  toolbarButtons: [],
-  loading: false,
   isSortable: false,
+  loading: false,
   selectedNamespace: null,
-  title: null
+  title: null,
+  toolbarButtons: []
 };
 
 Table.propTypes = {
+  batchActionButtons: PropTypes.arrayOf(PropTypes.object),
   emptyTextAllNamespaces: PropTypes.string.isRequired,
   emptyTextSelectedNamespace: PropTypes.string.isRequired,
   headers: PropTypes.arrayOf(PropTypes.object).isRequired,
-  loading: PropTypes.bool,
   isSortable: PropTypes.bool,
+  loading: PropTypes.bool,
   rows: PropTypes.arrayOf(PropTypes.object).isRequired,
   selectedNamespace: PropTypes.string,
   title: PropTypes.string,
-  batchActionButtons: PropTypes.arrayOf(PropTypes.object),
   toolbarButtons: PropTypes.arrayOf(PropTypes.object)
 };
 

--- a/packages/components/src/components/Table/Table.test.js
+++ b/packages/components/src/components/Table/Table.test.js
@@ -100,12 +100,12 @@ it('Table renders title with no rows, selected namespace, 1 batch and 1 toolbar 
   expect(
     queryByText(/Name/i).parentNode.className.includes('sort')
   ).toBeFalsy();
-  expect(queryByText(/Delete/i)).toBeTruthy();
+  expect(queryByText(/Delete/i)).toBeFalsy();
   expect(queryByText(/Add/i)).toBeTruthy();
-  expect(queryByLabelText('Select all rows')).toBeTruthy();
-  expect(queryByLabelText('Select row')).toBeNull();
+  expect(queryByLabelText('Select all rows')).toBeFalsy();
+  expect(queryByLabelText('Select row')).toBeFalsy();
   expect(queryByText(emptyTextSelectedNamespace)).toBeTruthy();
-  expect(queryByText(emptyTextAllNamespaces)).toBeNull();
+  expect(queryByText(emptyTextAllNamespaces)).toBeFalsy();
 });
 
 it('Table renders plain with one row, ALL_NAMESPACES', () => {

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -69,8 +69,8 @@ import { fetchInstallProperties } from '../../actions/properties';
 import {
   getExtensions,
   getLocale,
-  getReadOnly,
   getSelectedNamespace,
+  isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
 import messages from '../../nls/messages_en.json';
@@ -348,7 +348,7 @@ const mapStateToProps = state => ({
   extensions: getExtensions(state),
   namespace: getSelectedNamespace(state),
   lang: getLocale(state),
-  isReadOnly: getReadOnly(state),
+  isReadOnly: isReadOnly(state),
   webSocketConnected: isWebSocketConnected(state)
 });
 

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,11 +19,11 @@ import thunk from 'redux-thunk';
 
 import { App } from './App';
 import * as API from '../../api';
-import * as Reducers from '../../reducers';
+import * as selectors from '../../reducers';
 
 beforeEach(() => {
   jest.spyOn(API, 'getPipelines').mockImplementation(() => {});
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
 });
 
 it('App renders successfully', () => {

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -34,9 +34,9 @@ import PipelineResourcesModal from '../PipelineResourcesModal';
 import {
   getPipelineResources,
   getPipelineResourcesErrorMessage,
-  getReadOnly,
   getSelectedNamespace,
   isFetchingPipelineResources,
+  isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
 
@@ -138,8 +138,8 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
   };
 
   pipelineResourceActions = () => {
-    const { intl, isReadOnly } = this.props;
-    if (isReadOnly) {
+    const { intl } = this.props;
+    if (this.props.isReadOnly) {
       return [];
     }
 
@@ -203,7 +203,6 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
       error,
       loading,
       namespace: selectedNamespace,
-      isReadOnly,
       pipelineResources,
       intl
     } = this.props;
@@ -225,7 +224,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
       );
     }
 
-    const toolbarButtons = isReadOnly
+    const toolbarButtons = this.props.isReadOnly
       ? []
       : [
           {
@@ -238,7 +237,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
           }
         ];
 
-    const batchActionButtons = isReadOnly
+    const batchActionButtons = this.props.isReadOnly
       ? []
       : [
           {
@@ -288,7 +287,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
         )}
         <h1>PipelineResources</h1>
         <LabelFilter {...this.props} />
-        {!isReadOnly && (
+        {!this.props.isReadOnly && (
           <PipelineResourcesModal
             open={this.state.showCreatePipelineResourceModal}
             handleCreatePipelineResource={
@@ -353,7 +352,7 @@ function mapStateToProps(state, props) {
 
   return {
     error: getPipelineResourcesErrorMessage(state),
-    isReadOnly: getReadOnly(state),
+    isReadOnly: isReadOnly(state),
     filters,
     loading: isFetchingPipelineResources(state),
     namespace,

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,11 +23,11 @@ import {
   getClusterTasks,
   getPipelineRun,
   getPipelineRunsErrorMessage,
-  getReadOnly,
   getTaskRunsByPipelineRunName,
   getTaskRunsErrorMessage,
   getTasks,
   getTasksErrorMessage,
+  isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
 import { LogDownloadButton } from '..';
@@ -94,15 +94,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   }
 
   render() {
-    const {
-      error,
-      intl,
-      isReadOnly,
-      match,
-      pipelineRun,
-      tasks,
-      taskRuns
-    } = this.props;
+    const { error, intl, match, pipelineRun, tasks, taskRuns } = this.props;
 
     if (!pipelineRun) {
       return (
@@ -128,7 +120,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     const { loading, showRerunNotification } = this.state;
     const { pipelineRunName } = match.params;
 
-    const rerun = !isReadOnly && (
+    const rerun = !this.props.isReadOnly && (
       <Rerun
         pipelineRun={pipelineRun}
         rerunPipelineRun={rerunPipelineRun}
@@ -193,7 +185,7 @@ function mapStateToProps(state, ownProps) {
   const { namespace } = match.params;
 
   return {
-    isReadOnly: getReadOnly(state),
+    isReadOnly: isReadOnly(state),
     error:
       getPipelineRunsErrorMessage(state) ||
       getTasksErrorMessage(state) ||

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -34,9 +34,9 @@ import { fetchPipelineRuns } from '../../actions/pipelineRuns';
 import {
   getPipelineRuns,
   getPipelineRunsErrorMessage,
-  getReadOnly,
   getSelectedNamespace,
   isFetchingPipelineRuns,
+  isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
 import {
@@ -115,9 +115,9 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
   };
 
   pipelineRunActions = () => {
-    const { intl, isReadOnly } = this.props;
+    const { intl } = this.props;
 
-    if (isReadOnly) {
+    if (this.props.isReadOnly) {
       return [];
     }
     return [
@@ -231,8 +231,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
       loading,
       namespace: selectedNamespace,
       pipelineRuns,
-      intl,
-      isReadOnly
+      intl
     } = this.props;
 
     if (error) {
@@ -252,7 +251,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
     const pipelineRunActions = this.pipelineRunActions();
     sortRunsByStartTime(pipelineRuns);
 
-    const toolbarButtons = isReadOnly
+    const toolbarButtons = this.props.isReadOnly
       ? []
       : [
           {
@@ -302,7 +301,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
         )}
         <h1>PipelineRuns</h1>
         <LabelFilter {...this.props} />
-        {!isReadOnly && (
+        {!this.props.isReadOnly && (
           <CreatePipelineRun
             open={this.state.showCreatePipelineRunModal}
             onClose={() => this.toggleModal(false)}
@@ -338,7 +337,7 @@ function mapStateToProps(state, props) {
   const pipelineName = pipelineFilter.replace('tekton.dev/pipeline=', '');
 
   return {
-    isReadOnly: getReadOnly(state),
+    isReadOnly: isReadOnly(state),
     error: getPipelineRunsErrorMessage(state),
     loading: isFetchingPipelineRuns(state),
     namespace,

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -20,7 +20,7 @@ import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
 import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api';
-import * as Reducers from '../../reducers';
+import * as selectors from '../../reducers';
 import PipelineRunsContainer from './PipelineRuns';
 
 const namespacesTestStore = {
@@ -163,7 +163,7 @@ beforeEach(() => {
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
   jest.spyOn(API, 'getPipelines').mockImplementation(() => []);
   jest.spyOn(API, 'getPipelineResources').mockImplementation(() => []);
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
 });
 
 it('PipelineRuns can be filtered on a single label filter', async () => {
@@ -367,7 +367,7 @@ it('An invalid filter value is disallowed and reported', async () => {
 });
 
 it('Creation, deletion and stop events are possible when not in read-only mode', async () => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => false);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
 
   const mockTestStore = mockStore(testStore);
   const match = {
@@ -408,7 +408,7 @@ it('Creation, deletion and stop events are possible when not in read-only mode',
 });
 
 it('Creation, deletion and stop events are not possible when in read-only mode', async () => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
 
   const mockTestStore = mockStore(testStore);
   const match = {
@@ -447,7 +447,7 @@ it('Creation, deletion and stop events are not possible when in read-only mode',
 
 it('TaskTree handles rerun event in PipelineRuns page', async () => {
   const mockTestStore = mockStore(testStore);
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => false);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
   jest.spyOn(API, 'rerunPipelineRun').mockImplementation(() => []);
   const { getByTestId, getByText } = renderWithRouter(
     <Provider store={mockTestStore}>

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -37,13 +37,13 @@ import {
   getDeleteSecretsErrorMessage,
   getDeleteSecretsSuccessMessage,
   getPatchSecretsSuccessMessage,
-  getReadOnly,
   getSecrets,
   getSecretsErrorMessage,
   getSelectedNamespace,
   getServiceAccounts,
   isFetchingSecrets,
   isFetchingServiceAccounts,
+  isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
 
@@ -143,7 +143,6 @@ export /* istanbul ignore next */ class Secrets extends Component {
     const {
       loading,
       deleteSuccess,
-      isReadOnly,
       secrets,
       selectedNamespace,
       serviceAccounts,
@@ -159,7 +158,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
       selectedType
     } = this.state;
 
-    const toolbarButtons = isReadOnly
+    const toolbarButtons = this.props.isReadOnly
       ? []
       : [
           {
@@ -242,19 +241,18 @@ export /* istanbul ignore next */ class Secrets extends Component {
       })
     });
 
-    const batchActionButtons =
-      !isReadOnly && secretsToUse.length > 0
-        ? [
-            {
-              onClick: this.handleDeleteSecretClick,
-              text: intl.formatMessage({
-                id: 'dashboard.actions.deleteButton',
-                defaultMessage: 'Delete'
-              }),
-              icon: Delete
-            }
-          ]
-        : [];
+    const batchActionButtons = this.props.isReadOnly
+      ? []
+      : [
+          {
+            onClick: this.handleDeleteSecretClick,
+            text: intl.formatMessage({
+              id: 'dashboard.actions.deleteButton',
+              defaultMessage: 'Delete'
+            }),
+            icon: Delete
+          }
+        ];
 
     const secretsFormatted = secretsToUse.map(secret => {
       let annotations = '';
@@ -433,14 +431,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
               batchActionButtons={batchActionButtons}
               toolbarButtons={toolbarButtons}
             />
-            <DeleteModal
-              open={openDeleteSecret}
-              handleClick={this.handleHideDeleteSecret}
-              handleDelete={this.delete}
-              toBeDeleted={toBeDeleted}
-              toolbarButtons={toolbarButtons}
-            />
-            {!isReadOnly && (
+            {!this.props.isReadOnly && (
               <DeleteModal
                 open={openDeleteSecret}
                 handleClick={this.handleHideDeleteSecret}
@@ -474,7 +465,7 @@ function mapStateToProps(state, props) {
     errorMessage:
       getDeleteSecretsErrorMessage(state) || getSecretsErrorMessage(state),
     deleteSuccess: getDeleteSecretsSuccessMessage(state),
-    isReadOnly: getReadOnly(state),
+    isReadOnly: isReadOnly(state),
     patchSuccess: getPatchSecretsSuccessMessage(state),
     filters,
     loading: isFetchingSecrets(state) || isFetchingServiceAccounts(state),

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -22,7 +22,7 @@ import thunk from 'redux-thunk';
 import { renderWithRouter } from '../../utils/test';
 import Secrets from '.';
 import * as API from '../../api';
-import * as Reducers from '../../reducers';
+import * as selectors from '../../reducers';
 
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
@@ -34,7 +34,7 @@ const intl = createIntl({
 
 beforeEach(() => {
   jest.spyOn(API, 'getPipelines').mockImplementation(() => {});
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => false);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
 });
 
 const byNamespace = {
@@ -312,7 +312,7 @@ it('Secrets can be filtered on a single label filter', async () => {
 });
 
 it('Secrets can not be created when in read-only mode', async () => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
 
   const currentProps = {
     loading: false,
@@ -334,7 +334,7 @@ it('Secrets can not be created when in read-only mode', async () => {
 });
 
 it('Secrets can be created when not in read-only mode', async () => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => false);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
 
   const currentProps = {
     loading: false,

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -29,8 +29,8 @@ import { NamespacesDropdown } from '..';
 import { selectNamespace } from '../../actions/namespaces';
 import {
   getExtensions,
-  getReadOnly,
-  getSelectedNamespace
+  getSelectedNamespace,
+  isReadOnly
 } from '../../reducers';
 import { getCustomResource } from '../../api';
 
@@ -143,7 +143,7 @@ class SideNav extends Component {
   }
 
   render() {
-    const { extensions, intl, isReadOnly, namespace } = this.props;
+    const { extensions, intl, namespace } = this.props;
     const { isTriggersInstalled } = this.state;
 
     return (
@@ -252,7 +252,7 @@ class SideNav extends Component {
             })}
           </SideNavLink>
 
-          {!isReadOnly && (
+          {!this.props.isReadOnly && (
             <SideNavLink
               element={NavLink}
               icon={<span />}
@@ -320,7 +320,7 @@ class SideNav extends Component {
 /* istanbul ignore next */
 const mapStateToProps = state => ({
   extensions: getExtensions(state),
-  isReadOnly: getReadOnly(state),
+  isReadOnly: isReadOnly(state),
   namespace: getSelectedNamespace(state)
 });
 

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,10 +21,10 @@ import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 import { renderWithRouter } from '../../utils/test';
 import SideNavContainer, { SideNavWithIntl as SideNav } from './SideNav';
 import * as API from '../../api';
-import * as Reducers from '../../reducers';
+import * as selectors from '../../reducers';
 
 beforeEach(() => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
 });
 
 it('SideNav renders with extensions', () => {
@@ -62,7 +62,7 @@ it('SideNav renders with extensions', () => {
 });
 
 it('SideNav renders with triggers', async () => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => false);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
 
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
@@ -475,7 +475,7 @@ it('SideNav updates namespace in URL', async () => {
 });
 
 it('SideNav renders import in not read-only mode', async () => {
-  jest.spyOn(Reducers, 'getReadOnly').mockImplementation(() => false);
+  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
 
   const middleware = [thunk];
   const mockStore = configureStore(middleware);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -475,6 +475,6 @@ export function isFetchingEventListeners(state) {
   return eventListenersSelectors.isFetchingEventListeners(state.eventListeners);
 }
 
-export function getReadOnly(state) {
-  return propertiesSelectors.getReadOnly(state.properties);
+export function isReadOnly(state) {
+  return propertiesSelectors.isReadOnly(state.properties);
 }

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -48,7 +48,8 @@ import {
   isFetchingPipelines,
   isFetchingSecrets,
   isFetchingTaskRuns,
-  isFetchingTasks
+  isFetchingTasks,
+  isReadOnly
 } from '.';
 import * as clusterTaskSelectors from './clusterTasks';
 import * as extensionSelectors from './extensions';
@@ -57,6 +58,7 @@ import * as namespaceSelectors from './namespaces';
 import * as pipelineResourcesSelectors from './pipelineResources';
 import * as pipelineSelectors from './pipelines';
 import * as pipelineRunsSelectors from './pipelineRuns';
+import * as propertiesSelectors from './properties';
 import * as secretSelectors from './secrets';
 import * as serviceAccountSelectors from './serviceAccounts';
 import * as taskSelectors from './tasks';
@@ -495,4 +497,10 @@ it('isFetchingTaskRuns', () => {
   expect(taskRunsSelectors.isFetchingTaskRuns).toHaveBeenCalledWith(
     state.taskRuns
   );
+});
+
+it('isReadOnly', () => {
+  jest.spyOn(propertiesSelectors, 'isReadOnly').mockImplementation(() => true);
+  expect(isReadOnly(state)).toBe(true);
+  expect(propertiesSelectors.isReadOnly).toHaveBeenCalledWith(state.properties);
 });

--- a/src/reducers/properties.test.js
+++ b/src/reducers/properties.test.js
@@ -11,18 +11,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const defaultState = { ReadOnly: true };
-function properties(state = defaultState, action) {
-  switch (action.type) {
-    case 'INSTALL_PROPERTIES_SUCCESS':
-      return action.data;
-    default:
-      return state;
-  }
-}
+import propertiesReducer, * as selectors from './properties';
 
-export function isReadOnly(state) {
-  return state.ReadOnly;
-}
+it('handles init or unknown actions', () => {
+  expect(propertiesReducer(undefined, { type: 'does_not_exist' })).toEqual({
+    ReadOnly: true
+  });
+});
 
-export default properties;
+it('INSTALL_PROPERTIES_SUCCESS', () => {
+  const installProperties = { fake: 'installProperties', ReadOnly: false };
+  const action = {
+    type: 'INSTALL_PROPERTIES_SUCCESS',
+    data: installProperties
+  };
+
+  const state = propertiesReducer({}, action);
+  expect(selectors.isReadOnly(state)).toBe(false);
+});


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Follow up to https://github.com/tektoncd/dashboard/issues/1101
- Update Table component to control when batch actions are displayed
  This will reduce code duplication relating to table empty states.
- Update `isReadOnly` selector naming for consistency

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
