### PR TITLE
Add secret details page

### DIFF
--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -86,6 +86,12 @@ export const paths = {
   secrets: {
     all() {
       return '/secrets';
+    },
+    byName() {
+      return byNamespace({ path: '/secrets/:secretName' });
+    },
+    byNamespace() {
+      return byNamespace({ path: '/secrets' });
     }
   },
   serviceAccounts: {

--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -14,13 +14,17 @@ limitations under the License.
 import {
   createCredential,
   deleteCredential,
+  getCredential,
   getCredentials,
   getServiceAccounts,
   patchServiceAccount,
   updateServiceAccountSecrets
 } from '../api';
 
-import { fetchNamespacedCollection } from './actionCreators';
+import {
+  fetchNamespacedCollection,
+  fetchNamespacedResource
+} from './actionCreators';
 
 export function fetchSecretsSuccess(data) {
   return {
@@ -33,6 +37,14 @@ export function fetchSecrets({ namespace } = {}) {
   return fetchNamespacedCollection('Secret', getCredentials, {
     namespace
   });
+}
+
+export function fetchSecret({ name, namespace } = {}) {
+  const secret = fetchNamespacedResource('Secret', getCredential, {
+    namespace,
+    name
+  });
+  return secret;
 }
 
 export function deleteSecret(secrets, cancelMethod) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -301,8 +301,8 @@ export function getAllCredentials(namespace) {
   return get(uri);
 }
 
-export function getCredential(id, namespace) {
-  const uri = getKubeAPI('secrets', { name: id, namespace });
+export function getCredential(name, namespace) {
+  const uri = getKubeAPI('secrets', name, namespace);
   return get(uri);
 }
 

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -483,9 +483,10 @@ it('getAllCredentials', () => {
 
 it('getCredential', () => {
   const credentialId = 'foo';
+  const namespace = 'default';
   const data = { fake: 'credential' };
-  fetchMock.get(`end:${credentialId}`, data);
-  return index.getCredential(credentialId).then(credential => {
+  fetchMock.get(/secrets/, data);
+  return index.getCredential(credentialId, namespace).then(credential => {
     expect(credential).toEqual(data);
     fetchMock.restore();
   });
@@ -582,16 +583,6 @@ it('getServiceAccounts returns the correct data', () => {
   fetchMock.get(/serviceaccounts/, data);
   return index.getServiceAccounts().then(response => {
     expect(response).toEqual(data.items);
-    fetchMock.restore();
-  });
-});
-
-it('getCredential', () => {
-  const credentialId = 'foo';
-  const data = { fake: 'credential' };
-  fetchMock.get(`end:${credentialId}`, data);
-  return index.getCredential(credentialId).then(credential => {
-    expect(credential).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -48,6 +48,7 @@ import {
   PipelineRuns,
   Pipelines,
   ResourceList,
+  Secret,
   Secrets,
   ServiceAccount,
   ServiceAccounts,
@@ -205,6 +206,16 @@ export /* istanbul ignore next */ class App extends Component {
                   )}
 
                   <Route path={paths.secrets.all()} exact component={Secrets} />
+                  <Route
+                    path={paths.secrets.byName()}
+                    exact
+                    component={Secret}
+                  />
+                  <Route
+                    path={paths.secrets.byNamespace()}
+                    exact
+                    component={Secrets}
+                  />
                   <Route
                     path={paths.serviceAccounts.byName()}
                     exact

--- a/src/containers/Secret/Secret.js
+++ b/src/containers/Secret/Secret.js
@@ -1,0 +1,268 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Component } from 'react';
+import '../../scss/Triggers.scss';
+import { injectIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { InlineNotification, Tag } from 'carbon-components-react';
+import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { formatLabels, getErrorMessage, urls } from '@tektoncd/dashboard-utils';
+import { fetchServiceAccounts } from '../../actions/serviceAccounts';
+
+import {
+  getSecret,
+  getSecretsErrorMessage,
+  getServiceAccounts,
+  isFetchingSecrets,
+  isWebSocketConnected
+} from '../../reducers';
+
+import { fetchSecret } from '../../actions/secrets';
+
+export /* istanbul ignore next */ class SecretContainer extends Component {
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { match, webSocketConnected } = this.props;
+    const { namespace, secretName } = match.params;
+    const {
+      match: prevMatch,
+      webSocketConnected: prevWebSocketConnected
+    } = prevProps;
+    const {
+      namespace: prevNamespace,
+      secretName: prevSecretName
+    } = prevMatch.params;
+
+    if (
+      namespace !== prevNamespace ||
+      secretName !== prevSecretName ||
+      (webSocketConnected && prevWebSocketConnected === false)
+    ) {
+      this.fetchData();
+    }
+  }
+
+  async fetchData() {
+    const { match } = this.props;
+    const { namespace, secretName } = match.params;
+    await this.props.fetchSecret({ name: secretName, namespace });
+    await this.props.fetchServiceAccounts();
+  }
+
+  render() {
+    const { error, intl, match, secret, loading, serviceAccounts } = this.props;
+    const { secretName, namespace } = match.params;
+    const serviceAccountsWithSecret = [];
+
+    if (serviceAccounts) {
+      serviceAccounts.forEach(serviceAccount => {
+        serviceAccount.secrets.forEach(secretInServiceAccount => {
+          if (secretInServiceAccount.name === secret.metadata.name) {
+            serviceAccountsWithSecret.push(serviceAccount.metadata.name);
+          }
+        });
+      });
+    }
+
+    const emptyTextMessageSAs = intl.formatMessage({
+      id: 'dashboard.secret.noServiceAccounts',
+      defaultMessage: 'No ServiceAccounts found for this Secret.'
+    });
+
+    const headersForServiceAccounts = [
+      {
+        key: 'name',
+        header: intl.formatMessage({
+          id: 'dashboard.tableHeader.name',
+          defaultMessage: 'Name'
+        })
+      }
+    ];
+
+    const rowsForServiceAccounts = serviceAccountsWithSecret.map(
+      serviceAccount => {
+        return {
+          id: serviceAccount,
+          name: (
+            <Link
+              to={urls.serviceAccounts.byName({
+                namespace,
+                serviceAccountName: serviceAccount
+              })}
+              title={serviceAccount}
+            >
+              {serviceAccount}
+            </Link>
+          )
+        };
+      }
+    );
+
+    if (error) {
+      return (
+        <InlineNotification
+          kind="error"
+          hideCloseButton
+          lowContrast
+          title={intl.formatMessage({
+            id: 'dashboard.secret.errorLoading',
+            defaultMessage: 'Error loading Secret'
+          })}
+          subtitle={getErrorMessage(error)}
+        />
+      );
+    }
+
+    if (!secret) {
+      return (
+        <InlineNotification
+          kind="info"
+          hideCloseButton
+          lowContrast
+          title={intl.formatMessage({
+            id: 'dashboard.secret.failed',
+            defaultMessage: 'Cannot load Secret'
+          })}
+          subtitle={intl.formatMessage(
+            {
+              id: 'dashboard.secret.failedSubtitle',
+              defaultMessage: 'Secret {secretName} not found'
+            },
+            { secretName }
+          )}
+        />
+      );
+    }
+
+    const { type } = secret;
+    let formattedLabelsToRender = [];
+    if (secret.metadata.labels) {
+      formattedLabelsToRender = formatLabels(secret.metadata.labels);
+    }
+
+    return (
+      <>
+        <h1>{secretName}</h1>
+        <div className="trigger">
+          <div className="details">
+            <div className="resource--detail-block">
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.metadata.dateCreated',
+                    defaultMessage: 'Date Created:'
+                  })}
+                </span>
+                <FormattedDate
+                  date={secret.metadata.creationTimestamp}
+                  relative
+                />
+              </p>
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.metadata.labels',
+                    defaultMessage: 'Labels:'
+                  })}
+                </span>
+                {formattedLabelsToRender.length
+                  ? formattedLabelsToRender.map(label => (
+                      <Tag type="blue" key={label}>
+                        {label}
+                      </Tag>
+                    ))
+                  : intl.formatMessage({
+                      id: 'dashboard.metadata.none',
+                      defaultMessage: 'None'
+                    })}
+              </p>
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.metadata.namespace',
+                    defaultMessage: 'Namespace:'
+                  })}
+                </span>
+                {secret.metadata.namespace}
+              </p>
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.secret.type',
+                    defaultMessage: 'Type:'
+                  })}
+                </span>
+                {type}
+              </p>
+            </div>
+            <Table
+              title={intl.formatMessage({
+                id: 'dashboard.secret.serviceAccountTableTitle',
+                defaultMessage: 'ServiceAccounts'
+              })}
+              headers={headersForServiceAccounts}
+              rows={rowsForServiceAccounts}
+              loading={loading}
+              selectedNamespace={namespace}
+              emptyTextAllNamespaces={emptyTextMessageSAs}
+              emptyTextSelectedNamespace={emptyTextMessageSAs}
+            />
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+SecretContainer.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      namespace: PropTypes.string.isRequired,
+      secretName: PropTypes.string.isRequired
+    }).isRequired
+  }).isRequired
+};
+
+/* istanbul ignore next */
+function mapStateToProps(state, ownProps) {
+  const { match } = ownProps;
+  const { namespace, secretName: name } = match.params;
+
+  return {
+    error: getSecretsErrorMessage(state),
+    loading: isFetchingSecrets(state),
+    namespace,
+    secret: getSecret(state, {
+      name,
+      namespace
+    }),
+    webSocketConnected: isWebSocketConnected(state),
+    serviceAccounts: getServiceAccounts(state)
+  };
+}
+
+const mapDispatchToProps = {
+  fetchSecret,
+  fetchServiceAccounts
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(SecretContainer));

--- a/src/containers/Secret/Secret.test.js
+++ b/src/containers/Secret/Secret.test.js
@@ -1,0 +1,130 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { waitForElement } from 'react-testing-library';
+import 'jest-dom/extend-expect';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { createIntl } from 'react-intl';
+import { SecretContainer } from './Secret';
+import { renderWithRouter } from '../../utils/test';
+
+const intl = createIntl({
+  locale: 'en',
+  defaultLocale: 'en'
+});
+
+const serviceAccounts = [
+  {
+    metadata: {
+      name: 'serviceAccount1'
+    },
+    secrets: [
+      {
+        name: 'secret-simple'
+      }
+    ]
+  }
+];
+
+const secret = {
+  apiVersion: 'tekton.dev/v1alpha1',
+  kind: 'Secret',
+  metadata: {
+    creationTimestamp: '2019-11-19T19:44:43Z',
+    name: 'secret-simple',
+    namespace: 'tekton-pipelines',
+    uid: '49243595-0c72-11ea-ae12-025000000001'
+  }
+};
+
+it('SecretContainer renders', async () => {
+  const secretName = 'bar';
+  const match = {
+    params: {
+      secretName
+    }
+  };
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const testStore = mockStore({
+    namespaces: {
+      selected: 'default'
+    },
+    Secrets: {
+      byId: {},
+      byNamespace: { default: {} },
+      errorMessage: null,
+      isFetching: false
+    }
+  });
+
+  const { getByText } = renderWithRouter(
+    <Provider store={testStore}>
+      <SecretContainer
+        intl={intl}
+        match={match}
+        fetchSecret={() => Promise.resolve()}
+        fetchServiceAccounts={() => Promise.resolve()}
+        error={null}
+        loading={false}
+      />
+    </Provider>
+  );
+  await waitForElement(() => getByText(`Secret bar not found`));
+});
+
+it('SecretContainer renders service accounts', async () => {
+  const match = {
+    params: {
+      secretName: 'secret-simple',
+      namespace: 'tekton-pipelines'
+    }
+  };
+
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+
+  const testStore = mockStore({
+    namespaces: {
+      selected: 'tekton-pipelines'
+    },
+    Secrets: {
+      byId: 'secret-simple',
+      byNamespace: { default: 'tekton-pipelines' },
+      errorMessage: null,
+      isFetching: false
+    }
+  });
+
+  const { getByText } = renderWithRouter(
+    <Provider store={testStore}>
+      <SecretContainer
+        intl={intl}
+        match={match}
+        error={null}
+        fetchSecret={() => Promise.resolve(secret)}
+        fetchServiceAccounts={() => Promise.resolve(serviceAccounts)}
+        serviceAccounts={serviceAccounts}
+        secret={secret}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => getByText('secret-simple'));
+  await waitForElement(() => getByText('tekton-pipelines'));
+  await waitForElement(() => getByText('None'));
+  await waitForElement(() => getByText('serviceAccount1'));
+});

--- a/src/containers/Secret/index.js
+++ b/src/containers/Secret/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './Secret';

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -15,13 +15,14 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import isEqual from 'lodash.isequal';
+import { Link } from 'react-router-dom';
 import {
   InlineNotification,
   RadioButton,
   RadioButtonGroup
 } from 'carbon-components-react';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { getErrorMessage, getFilters } from '@tektoncd/dashboard-utils';
+import { getErrorMessage, getFilters, urls } from '@tektoncd/dashboard-utils';
 import { Add16 as Add, Delete16 as Delete } from '@carbon/icons-react';
 import { LabelFilter } from '..';
 import CreateSecret from '../CreateSecret';
@@ -299,7 +300,17 @@ export /* istanbul ignore next */ class Secrets extends Component {
       const formattedSecret = {
         annotations: <span title={annotations}>{annotations}</span>,
         id: `${secret.metadata.namespace}:${secret.metadata.name}`,
-        name: <span title={secret.metadata.name}>{secret.metadata.name}</span>,
+        name: (
+          <Link
+            to={urls.secrets.byName({
+              namespace: secret.metadata.namespace,
+              secretName: secret.metadata.name
+            })}
+            title={secret.metadata.name}
+          >
+            {secret.metadata.name}
+          </Link>
+        ),
         namespace: (
           <span title={secret.metadata.namespace}>
             {secret.metadata.namespace}

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -43,6 +43,7 @@ const byNamespace = {
       metadata: {
         uid: '0',
         name: 'github-repo-access-secret',
+        namespace: 'default',
         annotations: {
           'tekton.dev/git-0': 'https://github.ibm.com',
           badannotation: 'badcontent'
@@ -57,6 +58,7 @@ const byNamespace = {
       metadata: {
         uid: '0',
         name: 'another-secret-with-label',
+        namespace: 'default',
         annotations: {
           'tekton.dev/git-0': 'https://github.com'
         },

--- a/src/containers/ServiceAccount/ServiceAccount.js
+++ b/src/containers/ServiceAccount/ServiceAccount.js
@@ -14,6 +14,7 @@ limitations under the License.
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import '../../scss/Triggers.scss';
 import { injectIntl } from 'react-intl';
 import { InlineNotification, Tag } from 'carbon-components-react';
@@ -24,7 +25,7 @@ import {
   Tabs,
   ViewYAML
 } from '@tektoncd/dashboard-components';
-import { formatLabels } from '@tektoncd/dashboard-utils';
+import { formatLabels, urls } from '@tektoncd/dashboard-utils';
 import {
   getSecrets,
   getSelectedNamespace,
@@ -102,7 +103,7 @@ export /* istanbul ignore next */ class ServiceAccountContainer extends Componen
       selectedNamespace,
       serviceAccount
     } = this.props;
-    const { serviceAccountName } = match.params;
+    const { serviceAccountName, namespace } = match.params;
 
     if (error) {
       return ServiceAccountContainer.notification({
@@ -137,7 +138,18 @@ export /* istanbul ignore next */ class ServiceAccountContainer extends Componen
       rowsForSecrets = serviceAccount.secrets.map(({ name }) => {
         return {
           id: name,
-          name
+          name: (
+            <Link
+              to={urls.secrets.byName({
+                namespace,
+                secretName: name
+              })}
+              title={name}
+            >
+              {' '}
+              {name}
+            </Link>
+          )
         };
       });
     }

--- a/src/containers/ServiceAccount/ServiceAccount.test.js
+++ b/src/containers/ServiceAccount/ServiceAccount.test.js
@@ -28,10 +28,12 @@ const intl = createIntl({
 
 const secrets = [
   {
-    name: 'secret1'
+    name: 'secret1',
+    namespace: 'tekton-pipelines'
   },
   {
-    name: 'imagePull1'
+    name: 'imagePull1',
+    namespace: 'tekton-pipelines'
   }
 ];
 
@@ -358,7 +360,8 @@ it('ServiceAccountContainer renders details with no secret nor imagePullSecrets 
 it('ServiceAccountContainer renders secrets', async () => {
   const match = {
     params: {
-      serviceAccountName: 'service-account-simple'
+      serviceAccountName: 'service-account-simple',
+      namespace: 'tekton-pipelines'
     }
   };
 

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -268,7 +268,7 @@ class SideNav extends Component {
           <SideNavLink
             element={NavLink}
             icon={<span />}
-            to={urls.secrets.all()}
+            to={this.getPath(urls.secrets.all())}
           >
             Secrets
           </SideNavLink>

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -38,6 +38,7 @@ export { default as Pipelines } from './Pipelines';
 export { default as PipelinesDropdown } from './PipelinesDropdown';
 export { default as ResourceList } from './ResourceList';
 export { default as Secrets } from './Secrets';
+export { default as Secret } from './Secret';
 export { default as ServiceAccount } from './ServiceAccount';
 export { default as ServiceAccounts } from './ServiceAccounts';
 export { default as ServiceAccountsDropdown } from './ServiceAccountsDropdown';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -313,6 +313,10 @@ export function getSecrets(
   });
 }
 
+export function getSecret(state, { name, namespace }) {
+  return secretSelectors.getSecret(state.secrets, name, namespace);
+}
+
 export function getSecretsErrorMessage(state) {
   return secretSelectors.getSecretsErrorMessage(state.secrets);
 }

--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -173,6 +173,11 @@ export function getSecrets(state, namespace) {
   return Object.values(state.byNamespace[namespace] || []);
 }
 
+export function getSecret(state, name, namespace) {
+  const resources = state.byNamespace[namespace] || {};
+  return resources[name];
+}
+
 export function getPatchSecretsErrorMessage(state) {
   return state.patchErrorMessage;
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For: https://github.com/tektoncd/dashboard/issues/1009
- Adds a secret details page for individual secrets, showing basic data as well as a complete list of service accounts, as well as tests for this file
- Introduces links from individual service accounts to secrets and vice versa
- Updates tests to account for links and also removes a duplicate test for `getCredential`

<img width="960" alt="Screenshot 2020-03-12 at 10 09 29" src="https://user-images.githubusercontent.com/52741262/76510481-9bf2eb00-6449-11ea-8811-b83718fb817f.png">


<img width="974" alt="Screenshot 2020-03-12 at 10 09 36" src="https://user-images.githubusercontent.com/52741262/76510495-a1e8cc00-6449-11ea-9830-f6142562497b.png">
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
