### PR TITLE
Use selectedNamespace as key for Table component

### DIFF
--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -138,6 +138,7 @@ const Table = props => {
   return (
     <div className="tableComponent">
       <DataTable
+        key={selectedNamespace}
         rows={dataRows}
         headers={dataHeaders}
         isSortable={isSortable}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1147

Carbon Table component tracks selected rows in internal state
with no clean way to reset these from the consumer. By setting
the `key` prop to the `selectedNamespace` we ensure that React
will render a new component when this changes, giving us a clean
Table state and avoiding selections persisting when they shouldn't.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
