### PR TITLE
Fix log line positioning issue in Safari

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -139,7 +139,7 @@ export class LogContainer extends Component {
     const { downloadButton } = this.props;
     const { loading } = this.state;
     return (
-      <pre className="log">
+      <pre className="tkn-log">
         {loading ? (
           <SkeletonText paragraph width="60%" />
         ) : (

--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -13,7 +13,7 @@ limitations under the License.
 
 @import '~@tektoncd/dashboard-components/dist/scss/vars';
 
-.log {
+pre.tkn-log {
   position: relative;
   padding: 2rem 1.6rem 1.3rem 1.6rem;
   font-family: ibm-plex-mono, monospace;
@@ -26,6 +26,9 @@ limitations under the License.
   overflow: hidden;
   text-shadow: 0.1px 0.1px 0 #272d3340;
   background-color: #f1f2f4;
+
+  word-break: normal;
+  word-wrap: normal;
 
   code {
     white-space: pre;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Prevent log lines from wrapping and overlapping while scrolling
in Safari by ensuring the default word-break and word-wrap
rules are applied regardless of the host page's styles.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
