### PR TITLE
Add support for taskSpec in PipelineRun

### DIFF
--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -204,7 +204,7 @@ function mapStateToProps(state, ownProps) {
       {
         namespace
       }
-    ).filter(taskRun => 'taskRef' in taskRun.spec),
+    ),
     clusterTasks: getClusterTasks(state),
     webSocketConnected: isWebSocketConnected(state)
   };


### PR DESCRIPTION
This PR adds support for `TaskRuns` based on taskSpec rather than taskRef in `PipelineRun`.

This solves the issue #1159.