### PR TITLE
Include ClusterTasks in set of tasks provided to PipelineRun component

### DIFF
--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -94,7 +94,15 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   }
 
   render() {
-    const { error, intl, match, pipelineRun, tasks, taskRuns } = this.props;
+    const {
+      clusterTasks,
+      error,
+      intl,
+      match,
+      pipelineRun,
+      tasks,
+      taskRuns
+    } = this.props;
 
     if (!pipelineRun) {
       return (
@@ -163,7 +171,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           pipelineRun={pipelineRun}
           showIO
           sortTaskRuns
-          tasks={tasks}
+          tasks={tasks.concat(clusterTasks)}
           taskRuns={taskRuns}
           rerun={rerun}
         />


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
If a Pipeline references a ClusterTask, the resulting TaskRun
should be displayed in the PipelineRun UI.

This was not the case as we were not passing the ClusterTask
definitions to the PipelineRun component and they were being
excluded from the rendered results, even though we were actually
fetching the ClusterTasks data in the container.

Concatenate both the Tasks and ClusterTasks arrays and pass them
to the PipelineRun component so we avoid the dreaded
'No TaskRuns found for this PipelineRun yet…' message for these
PipelineRuns.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
