### PR TITLE
Display init containers in TaskTree when failed

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -105,10 +105,6 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       status: { taskRuns: taskRunDetails }
     } = pipelineRun;
 
-    if (!pipelineRun.status || !pipelineRun.status.taskRuns) {
-      return [];
-    }
-
     return taskRuns
       .map(taskRun => {
         let taskSpec;
@@ -166,7 +162,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
             taskRun.status.steps,
             taskSpec.steps
           );
-          steps = stepsStatus(reorderedSteps, reorderedSteps);
+          steps = stepsStatus(reorderedSteps, taskRun.status.steps);
         }
 
         return {

--- a/packages/components/src/components/PipelineRun/PipelineRun.test.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.js
@@ -13,147 +13,57 @@ limitations under the License.
 
 import React from 'react';
 import { waitForElement } from 'react-testing-library';
-import { Provider } from 'react-redux';
-import thunk from 'redux-thunk';
-import configureStore from 'redux-mock-store';
 import PipelineRun from './PipelineRun';
 import { renderWithIntl } from '../../utils/test';
 
 it('PipelineRunContainer renders', async () => {
-  const pipelineRunName = 'bar';
-  const match = {
-    params: {
-      pipelineName: 'foo',
-      pipelineRunName
-    }
-  };
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const testStore = mockStore({
-    tasks: {
-      byNamespace: { default: {} }
-    },
-    namespaces: {
-      selected: 'default'
-    },
-    pipelineRuns: {
-      byId: {},
-      byNamespace: { default: {} },
-      errorMessage: null,
-      isFetching: false
-    }
-  });
-
   const { getByText } = renderWithIntl(
-    <Provider store={testStore}>
-      <PipelineRun
-        match={match}
-        fetchTaskRuns={() => Promise.resolve()}
-        fetchPipelineRun={() => Promise.resolve()}
-        fetchTasks={() => Promise.resolve()}
-        fetchClusterTasks={() => Promise.resolve()}
-        error={null}
-        loading={false}
-      />
-    </Provider>
+    <PipelineRun error={null} loading={false} />
   );
   await waitForElement(() => getByText('PipelineRun not found'));
 });
 
 it('PipelineRunContainer handles error state', async () => {
-  const match = {
-    params: {
-      pipelineName: 'foo',
-      pipelineRunName: 'bar'
-    }
-  };
-
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-
-  const testStore = mockStore({
-    tasks: {
-      byNamespace: { default: {} }
-    },
-    taskRuns: {
-      byId: {},
-      byNamespace: { default: {} },
-      errorMessage: null,
-      isFetching: false
-    },
-    namespaces: {
-      selected: 'default'
-    },
-    pipelineRuns: {
-      byId: {},
-      byNamespace: { default: {} },
-      errorMessage: 'Error',
-      isFetching: false
-    }
-  });
-
-  const { getByText } = renderWithIntl(
-    <Provider store={testStore}>
-      <PipelineRun
-        match={match}
-        error="Error"
-        fetchTaskRuns={() => Promise.resolve()}
-        fetchPipelineRun={() => Promise.resolve()}
-        fetchTasks={() => Promise.resolve()}
-        fetchClusterTasks={() => Promise.resolve()}
-      />
-    </Provider>
-  );
+  const { getByText } = renderWithIntl(<PipelineRun error="Error" />);
   await waitForElement(() => getByText('Error loading PipelineRun'));
 });
 
-// A scenario exists (typically with rerun) where all PipelineRun data
-// is not yet available. Verify that the container still renders OK
-it('PipelineRunContainer handles no TaskRuns found yet', async () => {
-  const match = {
-    params: {
-      pipelineName: 'foo',
-      pipelineRunName: 'bar'
+it('PipelineRunContainer handles init step failures', async () => {
+  const initStepName = 'my-failed-init-step';
+  const pipelineRunName = 'fake_pipelineRunName';
+  const taskRunName = 'fake_taskRunName';
+
+  const taskRun = {
+    metadata: {
+      name: taskRunName,
+      labels: {}
+    },
+    spec: {
+      inputs: {},
+      outputs: {},
+      taskSpec: {}
+    },
+    status: {
+      steps: [
+        {
+          terminated: {},
+          name: initStepName
+        }
+      ]
     }
   };
 
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-
-  const testStore = mockStore({
-    tasks: {
-      byNamespace: {}
+  const pipelineRun = {
+    metadata: {
+      name: pipelineRunName
     },
-    taskRuns: {
-      // Nothing here
-      byId: {},
-      byNamespace: {},
-      errorMessage: null,
-      isFetching: false
-    },
-    namespaces: {
-      selected: 'default'
-    },
-    pipelineRuns: {
-      byId: {},
-      byNamespace: { default: {} },
-      errorMessage: null,
-      isFetching: false
+    status: {
+      taskRuns: []
     }
-  });
+  };
 
   const { getByText } = renderWithIntl(
-    <Provider store={testStore}>
-      <PipelineRun
-        match={match}
-        error={null}
-        fetchTaskRuns={() => Promise.resolve()}
-        fetchPipelineRun={() => Promise.resolve()}
-        fetchTasks={() => Promise.resolve()}
-        fetchClusterTasks={() => Promise.resolve()}
-      />
-    </Provider>
+    <PipelineRun pipelineRun={pipelineRun} taskRuns={[taskRun]} tasks={[]} />
   );
-  // But it still renders and all is well
-  await waitForElement(() => getByText('PipelineRun not found'));
+  await waitForElement(() => getByText(initStepName));
 });

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -102,11 +102,12 @@ export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
     include that step in the displayed list so we can surface status
     and logs to aid the user in debugging.
    */
+  const failedInitSteps = [];
   taskRunStepsStatus.forEach(stepStatus => {
     const { name: stepName, terminated } = stepStatus;
     const step = taskSteps.find(taskStep => taskStep.name === stepName);
     if (!step && terminated && terminated.exitCode !== 0) {
-      steps.push({
+      failedInitSteps.push({
         reason: terminated.reason,
         status: 'terminated',
         stepStatus,
@@ -116,7 +117,7 @@ export function stepsStatus(taskSteps, taskRunStepsStatus = []) {
     }
   });
 
-  return steps;
+  return failedInitSteps.concat(steps);
 }
 
 /*


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1155

Ensure we display details of init container failures in the
TaskRun and PipelineRun details pages, to aid users in
debugging failures (often related to missing / misconfigured
secrets, etc.)

Also update unit tests to ensure we're actually testing what
we think we are... (previous tests were populating the redux
store which is not used by the PipelineRun UI component)

Example:
Import resources without creating a secret for the target git host
![image](https://user-images.githubusercontent.com/2829095/77447702-df553e00-6de7-11ea-8307-bde1da7b9f0b.png)

See the init container is now displayed, and viewing its logs shows the reason
![image](https://user-images.githubusercontent.com/2829095/77447761-f09e4a80-6de7-11ea-95fd-086ebedba59a.png)

Also verified that unnamed steps are still handled correctly (both order and display of logs https://github.com/tektoncd/dashboard/issues/709)

@a-roberts @ncskier fyi

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
