### PR TITLE
Secrets table display changes based one what type of secret has been created

### DIFF
--- a/src/containers/CreateSecret/CreateSecret.js
+++ b/src/containers/CreateSecret/CreateSecret.js
@@ -197,7 +197,7 @@ export /* istanbul ignore next */ class CreateSecret extends Component {
     });
   };
 
-  handleSubmit = namespace => {
+  handleSubmit = async namespace => {
     this.props.selectNamespace(namespace);
     const invalidFields = {};
     let postData;
@@ -311,7 +311,8 @@ export /* istanbul ignore next */ class CreateSecret extends Component {
         this.setState({
           errorMessageDuplicate: null
         });
-        this.props.createSecret(postData, namespace);
+        await this.props.createSecret(postData, namespace);
+        this.props.handleSelectedType(secretType);
       }
     } else {
       this.setState({ invalidFields });

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -484,6 +484,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
         {openNewSecret && (
           <CreateSecret
             handleClose={this.handleCloseNewSecret}
+            handleSelectedType={this.handleSelectedType}
             secrets={secrets}
           />
         )}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1148
- Adds a property in `CreateSecret.js` that changes the type of secret displayed on the secrets table to match the type of the secret being created

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
