### PR TITLE
Stop clearing the global selected namespace when cancelling create secret dialog

### DIFF
--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -138,8 +138,10 @@ export /* istanbul ignore next */ class Secrets extends Component {
     this.setState({
       openNewSecret: false
     });
-    this.props.selectNamespace(namespace);
-    this.fetchData();
+    if (namespace) {
+      this.props.selectNamespace(namespace);
+      this.fetchData();
+    }
   };
 
   delete = () => {
@@ -411,10 +413,10 @@ export /* istanbul ignore next */ class Secrets extends Component {
                   id: 'dashboard.secretType.helper',
                   defaultMessage: `Use Password if you plan to
                 have a PipelineRun that clones from a Git
-                repository or image registry that requires authentication. 
+                repository or image registry that requires authentication.
 
-                Use Access Token when interacting with webhooks or PullRequest resources. 
-                
+                Use Access Token when interacting with webhooks or PullRequest resources.
+
                 Check the official Tekton Pipelines documentation for more details.`
                 })}
               </div>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1186

When closing the CreateSecret dialog, we pass the selected
namespace back to the container so it can update the globally
selected namespace and ensure the user sees their newly created
secret. In the case of cancelling the dialog without creating
the secret, the `namespace` is not set.

Detect this state and avoid unnecessary API calls and leave
the current global selected namespace as-is.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
