### PR TITLE
Secrets with names the same as a namespace can be created

### DIFF
--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -21,11 +21,12 @@ function byNamespace(state = {}, action) {
     case 'SECRETS_FETCH_SUCCESS':
       const namespaces = action.data.reduce((accumulator, secret) => {
         const { metadata } = secret;
-        if (isStale({ metadata }, state, 'name')) {
+        const { name, namespace } = metadata;
+        const secretsState = state[namespace] || {};
+        if (isStale({ metadata }, secretsState, 'name')) {
           return state;
         }
 
-        const { name, namespace } = metadata;
         return merge(accumulator, {
           [namespace]: {
             [name]: { ...secret }
@@ -35,8 +36,9 @@ function byNamespace(state = {}, action) {
       return merge({}, state, namespaces);
     case 'SecretCreated':
     case 'SecretUpdated':
+      const secretsState = state[action.payload.metadata.namespace] || {};
       if (
-        isStale(action.payload, state, 'name') ||
+        isStale(action.payload, secretsState, 'name') ||
         action.payload.type !== 'kubernetes.io/basic-auth'
       ) {
         return state;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1164
- The secrets reducer now has it's own `isSecretStale` function as secrets were not working with the `isStale` function in utils. 
- Should be a temporary fix while we work to introduce `byId()` to secrets, so that it can share the `isStale` function in utils.
- This means that secrets with the same name as their namespace do not now cause errors in the dashboard

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
