### PR TITLE
Add websocket events for ServiceAccounts

### DIFF
--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -49,6 +49,9 @@ const (
 	SecretCreated           messageType = "SecretCreated"
 	SecretDeleted           messageType = "SecretDeleted"
 	SecretUpdated           messageType = "SecretUpdated"
+	ServiceAccountCreated   messageType = "ServiceAccountCreated"
+	ServiceAccountDeleted   messageType = "ServiceAccountDeleted"
+	ServiceAccountUpdated   messageType = "ServiceAccountUpdated"
 )
 
 type SocketData struct {

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2019-2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (
@@ -41,6 +54,7 @@ func StartKubeControllers(clientset k8sclientset.Interface, resyncDur time.Durat
 	kubecontroller.NewExtensionController(kubeInformerFactory, installNamespace, handler)
 	kubecontroller.NewNamespaceController(kubeInformerFactory)
 	kubecontroller.NewSecretController(kubeInformerFactory)
+	kubecontroller.NewServiceAccountController(kubeInformerFactory)
 	// Started once all controllers have been registered
 	logging.Log.Info("Starting Kube controllers")
 	kubeInformerFactory.Start(stopCh)

--- a/pkg/controllers/kubernetes/serviceAccount.go
+++ b/pkg/controllers/kubernetes/serviceAccount.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/endpoints"
+	logging "github.com/tektoncd/dashboard/pkg/logging"
+	v1 "k8s.io/api/core/v1"
+	k8sinformer "k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewServiceAccountController registers the K8s shared informer that reacts to
+// create, update and delete events for ServiceAccounts
+func NewServiceAccountController(sharedK8sInformerFactory k8sinformer.SharedInformerFactory) {
+	logging.Log.Debug("In NewServiceAccountController")
+	k8sInformer := sharedK8sInformerFactory.Core().V1().ServiceAccounts()
+	k8sInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    serviceAccountCreated,
+		UpdateFunc: serviceAccountUpdated,
+		DeleteFunc: serviceAccountDeleted,
+	})
+}
+
+func serviceAccountCreated(obj interface{}) {
+	logging.Log.Debugf("ServiceAccount Controller detected ServiceAccount '%s' created", obj.(*v1.ServiceAccount).Name)
+	data := broadcaster.SocketData{
+		MessageType: broadcaster.ServiceAccountCreated,
+		Payload:     obj,
+	}
+
+	endpoints.ResourcesChannel <- data
+}
+
+func serviceAccountUpdated(oldObj, newObj interface{}) {
+	oldServiceAccount, newServiceAccount := oldObj.(*v1.ServiceAccount), newObj.(*v1.ServiceAccount)
+	// If resourceVersion differs between old and new, an actual update event was observed
+	if oldServiceAccount.ResourceVersion != newServiceAccount.ResourceVersion {
+		logging.Log.Debugf("ServiceAccount Controller detected ServiceAccount '%s' updated", oldServiceAccount.Name)
+		data := broadcaster.SocketData{
+			MessageType: broadcaster.ServiceAccountUpdated,
+			Payload:     newObj,
+		}
+		endpoints.ResourcesChannel <- data
+	}
+}
+
+func serviceAccountDeleted(obj interface{}) {
+	logging.Log.Debugf("ServiceAccount Controller detected ServiceAccount '%s' deleted", obj.(*v1.ServiceAccount).Name)
+	data := broadcaster.SocketData{
+		MessageType: broadcaster.ServiceAccountDeleted,
+		Payload:     obj,
+	}
+
+	endpoints.ResourcesChannel <- data
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1024

Update our websocket broadcaster to send ServiceAccount
created / updated / deleted events so we can keep the UI
in sync with the state of the cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
