### PR TITLE
Update references to params and resources to use new structure

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -136,8 +136,9 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
         const { pipelineTaskName } = taskRunDetails[taskRunName] || {
           pipelineTaskName: taskRun.metadata.labels['tekton.dev/conditionCheck']
         };
-        const { params, resources: inputResources } = taskRun.spec.inputs;
-        const { resources: outputResources } = taskRun.spec.outputs;
+        const { params, resources } = taskRun.spec;
+        const { inputs: inputResources, outputs: outputResources } =
+          resources || {};
 
         let steps = '';
 

--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.js
@@ -40,8 +40,11 @@ const task = {
 const taskRun = {
   metadata: { name: 'sampleTaskRunName', namespace: 'default' },
   spec: {
-    inputs: {},
-    outputs: {},
+    params: {},
+    resources: {
+      inputs: {},
+      outputs: {}
+    },
     serviceAccountName: 'default',
     taskRef: { kind: 'Task', name: 'task1' },
     timeout: '24h0m0s'

--- a/packages/components/src/components/PipelineRun/PipelineRun.test.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.js
@@ -39,8 +39,11 @@ it('PipelineRunContainer handles init step failures', async () => {
       labels: {}
     },
     spec: {
-      inputs: {},
-      outputs: {},
+      params: {},
+      resources: {
+        inputs: {},
+        outputs: {}
+      },
       taskSpec: {}
     },
     status: {

--- a/packages/components/src/components/StepDefinition/StepDefinition.stories.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.stories.js
@@ -24,10 +24,10 @@ storiesOf('Components/StepDefinition', module)
         args: [
           'build',
           '-f',
-          '${inputs.params.pathToDockerFile}',
+          '${params.pathToDockerFile}',
           '-t',
-          '${outputs.resources.builtImage.url}',
-          '${inputs.params.pathToContext}'
+          '${resources.outputs.builtImage.url}',
+          '${params.pathToContext}'
         ],
         command: ['docker'],
         image: 'docker',

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -124,8 +124,9 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     const taskRunNamespace = taskRun.metadata.namespace;
     const { reason, status: succeeded } = getStatus(taskRun);
     const runSteps = stepsStatus(reorderedSteps, reorderedSteps);
-    const { params, resources: inputResources } = taskRun.spec.inputs;
-    const { resources: outputResources } = taskRun.spec.outputs;
+    const { params, resources } = taskRun.spec;
+    const { inputs: inputResources, outputs: outputResources } =
+      resources || {};
     const { startTime } = taskRun.status;
     taskRun = {
       id: taskRun.metadata.uid,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1198

The fields for params and resources were updated for consistency
across Tekton CRDs and to avoid confusion. We need to adopt the
new structure in Dashboard so we can continue to display TaskRuns
and PipelineRuns correctly.

We go from:

```
spec: {
  inputs: {
    params: ...,
    resources: ...
  },
  outputs: {
    resources: ...
  }
}
```

to

```
spec: {
  params: ...,
  resources: {
    inputs: ...,
    outputs: ...
  }
}
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
