### PR TITLE
Update Logs component to display full logs up to 20,000 lines

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -25,6 +25,9 @@ const LogLine = ({ data, index, style }) => (
   </div>
 );
 
+const itemSize = 15; // This should be kept in sync with the line-height in SCSS
+const defaultHeight = itemSize * 100 + itemSize / 2;
+
 export class LogContainer extends Component {
   state = { loading: true };
 
@@ -49,8 +52,10 @@ export class LogContainer extends Component {
       ]
     } = this.state;
 
-    const itemSize = 15; // This should be kept in sync with the line-height in SCSS
-    const defaultHeight = 800;
+    if (logs.length < 20000) {
+      return <Ansi>{logs.join('\n')}</Ansi>;
+    }
+
     const height = reason
       ? Math.min(defaultHeight, itemSize * logs.length)
       : defaultHeight;
@@ -87,6 +92,7 @@ export class LogContainer extends Component {
     }
   };
 
+  /* istanbul ignore next */
   initPolling = () => {
     const { stepStatus, pollingInterval } = this.props;
     if (!this.timer && stepStatus && !stepStatus.terminated) {

--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -51,6 +51,10 @@ pre.tkn-log {
     &[data-status='Error'] {
       color: $failed;
     }
+  }
+
+  .log-container {
+    overflow-x: auto;
   }
 
   .log-container:not(:empty) + .log-trailer {

--- a/packages/components/src/components/Log/Log.stories.js
+++ b/packages/components/src/components/Log/Log.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,7 +18,14 @@ import Log from './Log';
 const ansiLog =
   '\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-git-source-skaffold-git-ml8j4 ===\n{"level":"info","ts":1553865693.943092,"logger":"fallback-logger","caller":"git-init/main.go:100","msg":"Successfully cloned https://github.com/GoogleContainerTools/skaffold @ \\"master\\" in path \\"/workspace\\""}\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-build-and-push ===\n\u001b[36mINFO\u001b[0m[0000] Downloading base image golang:1.10.1-alpine3.7\n2019/03/29 13:21:34 No matching credentials were found, falling back on anonymous\n\u001b[36mINFO\u001b[0m[0001] Executing 0 build triggers\n\u001b[36mINFO\u001b[0m[0001] Unpacking rootfs as cmd RUN go build -o /app . requires it.\n\u001b[36mINFO\u001b[0m[0010] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0015] Using files from context: [/workspace/examples/microservices/leeroy-app/app.go]\n\u001b[36mINFO\u001b[0m[0015] COPY app.go .\n\u001b[36mINFO\u001b[0m[0015] Taking snapshot of files...\n\u001b[36mINFO\u001b[0m[0015] RUN go build -o /app .\n\u001b[36mINFO\u001b[0m[0015] cmd: /bin/sh\n\u001b[36mINFO\u001b[0m[0015] args: [-c go build -o /app .]\n\u001b[36mINFO\u001b[0m[0016] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0036] CMD ["./app"]\n\u001b[36mINFO\u001b[0m[0036] COPY --from=builder /app .\n\u001b[36mINFO\u001b[0m[0036] Taking snapshot of files...\nerror pushing image: failed to push to destination gcr.io/christiewilson-catfactory/leeroy-app:latest: Get https://gcr.io/v2/token?scope=repository%3Achristiewilson-catfactory%2Fleeroy-app%3Apush%2Cpull\u0026scope=repository%3Alibrary%2Falpine%3Apull\u0026service=gcr.io exit status 1\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: nop ===\nBuild successful\n';
 
-const long = Array.from({ length: 2000 }, (v, i) => `Line ${i + 1}\n`).join('');
+const long = Array.from({ length: 60000 }, (v, i) => `Line ${i + 1}\n`).join(
+  ''
+);
+
+const performanceTest = Array.from(
+  { length: 700 },
+  (v, i) => `Batch ${i + 1}\n${ansiLog}\n`
+).join('');
 
 storiesOf('Components/Log', module)
   .addDecorator(story => <div style={{ width: '500px' }}>{story()}</div>)
@@ -49,6 +56,13 @@ storiesOf('Components/Log', module)
     <Log
       stepStatus={{ terminated: { reason: 'Completed' } }}
       fetchLogs={() => long}
+      status="Completed"
+    />
+  ))
+  .add('performance test (<20,000 lines with ANSI)', () => (
+    <Log
+      stepStatus={{ terminated: { reason: 'Completed' } }}
+      fetchLogs={() => performanceTest}
       status="Completed"
     />
   ));

--- a/packages/components/src/components/Log/Log.test.js
+++ b/packages/components/src/components/Log/Log.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,43 +16,54 @@ import { waitForElement } from 'react-testing-library';
 import Log from './Log';
 import { renderWithIntl } from '../../utils/test';
 
-it('Log renders default content', () => {
-  const { getByText } = renderWithIntl(<Log fetchLogs={() => undefined} />);
-  waitForElement(() => getByText(/No log available/i));
-});
+describe('Log', () => {
+  it('renders default content', async () => {
+    const { getByText } = renderWithIntl(<Log fetchLogs={() => undefined} />);
+    await waitForElement(() => getByText(/No log available/i));
+  });
 
-it('Log renders the provided content', () => {
-  const { getByText } = renderWithIntl(
-    <Log
-      stepStatus={{ terminated: { reason: 'Completed' } }}
-      fetchLogs={() => 'testing'}
-    />
-  );
-  waitForElement(() => getByText(/testing/i));
-});
+  it('renders the provided content', async () => {
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Completed' } }}
+        fetchLogs={() => 'testing'}
+      />
+    );
+    await waitForElement(() => getByText(/testing/i));
+  });
 
-it('Log renders trailer', () => {
-  const { getByText } = renderWithIntl(
-    <Log stepStatus={{ terminated: { reason: 'Completed' } }} />
-  );
-  waitForElement(() => getByText(/step completed/i));
-});
+  it('renders trailer', async () => {
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Completed' } }}
+        fetchLogs={() => 'testing'}
+      />
+    );
+    await waitForElement(() => getByText(/step completed/i));
+  });
 
-it('Log renders error trailer', () => {
-  const { getByText } = renderWithIntl(
-    <Log stepStatus={{ terminated: { reason: 'Error' } }} />
-  );
-  waitForElement(() => getByText(/step failed/i));
-});
+  it('renders error trailer', async () => {
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Error' } }}
+        fetchLogs={() => 'testing'}
+      />
+    );
+    await waitForElement(() => getByText(/step failed/i));
+  });
 
-it('Log renders loading state', () => {
-  const { queryByText } = renderWithIntl(
-    <Log
-      stepStatus={{ terminated: { reason: 'Completed' } }}
-      fetchLogs={() => {
-        return 'testing';
-      }}
-    />
-  );
-  expect(queryByText(/testing/i)).toBeFalsy();
+  it('renders virtualized list', async () => {
+    const long = Array.from(
+      { length: 60000 },
+      (v, i) => `Line ${i + 1}\n`
+    ).join('');
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Completed' } }}
+        fetchLogs={() => long}
+      />
+    );
+
+    await waitForElement(() => getByText(/Line 1/i));
+  });
 });

--- a/packages/components/src/components/Tab/index.js
+++ b/packages/components/src/components/Tab/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 import { Tab } from 'carbon-components-react';
 
 export default Tab;

--- a/packages/components/src/components/Tabs/index.js
+++ b/packages/components/src/components/Tabs/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,5 +10,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 export { default } from './Tabs';

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 export { default as Breadcrumbs } from './Breadcrumbs';
 export { default as CancelButton } from './CancelButton';

--- a/src/containers/LogDownloadButton/index.js
+++ b/src/containers/LogDownloadButton/index.js
@@ -10,5 +10,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 export { default } from './LogDownloadButton';

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { InlineNotification } from 'carbon-components-react';
@@ -22,7 +22,7 @@ import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 import { getCustomResources } from '../../api';
 import { getSelectedNamespace, isWebSocketConnected } from '../../reducers';
 
-export /* istanbul ignore next */ class ResourceListContainer extends Component {
+export class ResourceListContainer extends Component {
   state = {
     loading: true,
     resources: []
@@ -168,7 +168,6 @@ export /* istanbul ignore next */ class ResourceListContainer extends Component 
   }
 }
 
-/* istanbul ignore next */
 function mapStateToProps(state, props) {
   const { namespace: namespaceParam } = props.match.params;
   const namespace = namespaceParam || getSelectedNamespace(state);

--- a/src/containers/ResourceList/index.js
+++ b/src/containers/ResourceList/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,5 +10,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 export { default } from './ResourceList';

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 export { default as About } from './About';
 export { default as ClusterTasks } from './ClusterTasks';
 export {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1075

We introduced react-window due to performance issues with very
large logs (tens of thousands of lines, multiple megabytes), but
this had the unfortunate side effect of breaking browser native
'find in page' functionality since only a subset of the log
content is actually present in the DOM.

Update the Log component to display the full log for up to 20,000
lines, and fall back to the virtualized list for larger logs only.

Performance of the UI holds up fine (even in a dev build) with
logs of this size, including processing for ANSI colour codes.

Including a storybook entry to cover this and make it easier to
monitor for performance issues in future.

Also update Log unit tests to add missing `await` and esure the tests
actually fail when expected.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
