### PR TITLE
Update Table to add tooltips to all string values passed as cell content

### DIFF
--- a/packages/components/src/components/PipelineResources/PipelineResources.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.js
@@ -77,14 +77,10 @@ const PipelineResources = ({
           {pipelineResourceName}
         </Link>
       ) : (
-        <span title={pipelineResourceName}>{pipelineResourceName}</span>
+        pipelineResourceName
       ),
-      namespace: <span title={namespace}>{namespace}</span>,
-      type: (
-        <span title={pipelineResource.spec.type}>
-          {pipelineResource.spec.type}
-        </span>
-      ),
+      namespace,
+      type: pipelineResource.spec.type,
       createdTime: (
         <FormattedDate
           date={pipelineResource.metadata.creationTimestamp}

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -160,7 +160,7 @@ const PipelineRuns = ({
           {pipelineRunName}
         </Link>
       ) : (
-        <span title={pipelineRunName}>{pipelineRunName}</span>
+        pipelineRunName
       ),
       pipeline:
         pipelineRefName &&
@@ -169,9 +169,9 @@ const PipelineRuns = ({
             {pipelineRefName}
           </Link>
         ) : (
-          <span title={pipelineRefName}>{pipelineRefName}</span>
+          pipelineRefName
         )),
-      namespace: <span title={namespace}>{namespace}</span>,
+      namespace,
       status: (
         <div className="definition">
           <div

--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -244,6 +244,9 @@ const Table = props => {
                             key={cell.id}
                             id={cell.id}
                             className={`cell-${cell.info.header}`}
+                            {...typeof cell.value === 'string' && {
+                              title: cell.value
+                            }}
                           >
                             {cell.value}
                           </TableCell>

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -131,7 +131,7 @@ const TaskRuns = ({
           {taskRunName}
         </Link>
       ) : (
-        <span title={taskRunName}>{taskRunName}</span>
+        taskRunName
       ),
       task: taskRefName ? (
         <Link
@@ -146,11 +146,7 @@ const TaskRuns = ({
       ) : (
         ''
       ),
-      namespace: (
-        <span title={taskRun.metadata.namespace}>
-          {taskRun.metadata.namespace}
-        </span>
-      ),
+      namespace: taskRun.metadata.namespace,
       status: (
         <div className="definition">
           <div

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -106,11 +106,7 @@ export /* istanbul ignore next */ class EventListeners extends Component {
           {listener.metadata.name}
         </Link>
       ),
-      namespace: (
-        <span title={listener.metadata.namespace}>
-          {listener.metadata.namespace}
-        </span>
-      ),
+      namespace: listener.metadata.namespace,
       date: (
         <FormattedDate date={listener.metadata.creationTimestamp} relative />
       )

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -87,6 +87,7 @@ export const Extensions = /* istanbul ignore next */ ({
                         })
                       : urls.extensions.byName({ name })
                   }
+                  title={displayName}
                 >
                   {displayName}
                 </Link>

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -108,11 +108,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
           {pipeline.metadata.name}
         </Link>
       ),
-      namespace: (
-        <span title={pipeline.metadata.namespace}>
-          {pipeline.metadata.namespace}
-        </span>
-      ),
+      namespace: pipeline.metadata.namespace,
       createdTime: (
         <FormattedDate date={pipeline.metadata.creationTimestamp} relative />
       ),

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -156,7 +156,7 @@ export class ResourceListContainer extends Component {
                 {name}
               </Link>
             ),
-            namespace: <span title={namespace}>{namespace}</span>,
+            namespace,
             createdTime: <FormattedDate date={creationTimestamp} relative />
           };
         })}

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -307,7 +307,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
       }
 
       const formattedSecret = {
-        annotations: <span title={annotations}>{annotations}</span>,
+        annotations,
         id: `${secret.metadata.namespace}:${secret.metadata.name}`,
         name: (
           <Link
@@ -320,21 +320,13 @@ export /* istanbul ignore next */ class Secrets extends Component {
             {secret.metadata.name}
           </Link>
         ),
-        namespace: (
-          <span title={secret.metadata.namespace}>
-            {secret.metadata.namespace}
-          </span>
-        ),
+        namespace: secret.metadata.namespace,
         created: (
           <FormattedDate date={secret.metadata.creationTimestamp} relative />
         ),
-        serviceAccounts: (
-          <span title={serviceAccountsString}>{serviceAccountsString}</span>
-        ),
-        type: <span title={secretTypeToDisplay}>{secretTypeToDisplay}</span>,
-        username: (
-          <span title={secretUsernameToDisplay}>{secretUsernameToDisplay}</span>
-        )
+        serviceAccounts: serviceAccountsString,
+        type: secretTypeToDisplay,
+        username: secretUsernameToDisplay
       };
       return formattedSecret;
     });

--- a/src/containers/ServiceAccounts/ServiceAccounts.js
+++ b/src/containers/ServiceAccounts/ServiceAccounts.js
@@ -114,11 +114,7 @@ export /* istanbul ignore next */ class ServiceAccounts extends Component {
           {serviceAccount.metadata.name}
         </Link>
       ),
-      namespace: (
-        <span title={serviceAccount.metadata.namespace}>
-          {serviceAccount.metadata.namespace}
-        </span>
-      )
+      namespace: serviceAccount.metadata.namespace
     }));
 
     return (

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -108,9 +108,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
           {task.metadata.name}
         </Link>
       ),
-      namespace: (
-        <span title={task.metadata.namespace}>{task.metadata.namespace}</span>
-      ),
+      namespace: task.metadata.namespace,
       createdTime: (
         <FormattedDate date={task.metadata.creationTimestamp} relative />
       ),

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -106,11 +106,7 @@ export /* istanbul ignore next */ class TriggerBindings extends Component {
           {binding.metadata.name}
         </Link>
       ),
-      namespace: (
-        <span title={binding.metadata.namespace}>
-          {binding.metadata.namespace}
-        </span>
-      ),
+      namespace: binding.metadata.namespace,
       date: <FormattedDate date={binding.metadata.creationTimestamp} relative />
     }));
 

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -106,11 +106,7 @@ export /* istanbul ignore next */ class TriggerTemplates extends Component {
           {template.metadata.name}
         </Link>
       ),
-      namespace: (
-        <span title={template.metadata.namespace}>
-          {template.metadata.namespace}
-        </span>
-      ),
+      namespace: template.metadata.namespace,
       date: (
         <FormattedDate date={template.metadata.creationTimestamp} relative />
       )


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1232

We display tooltips on Table cell contents which is important
when the content may be truncated. This was not applied consistently
across all pages.

Update the Table component to automatically apply a tooltip to
any cell data of type `string` so this no longer has to be handled
by the consumer. This also makes it easier for us to update the tooltip
handling in future, for example adopting one of the Carbon tooltip components
as it's now controlled more centrally.

In the case of non-string cell data, the consumer is modifying / wrapping
the content in a custom manner, adding the tooltip remains the responsibility
of the consumer, e.g. we display full date in tooltip instead of
the relative time format displayed in the table.

This will likely change in a future PR related to sorting / filtering,
which would adopt a more flexible approach to specifying the contents,
allowing the consumer to provide tooltip values and sortable values
related to the display value.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
