### PR TITLE
Update style of metadata card for triggers pages

### DIFF
--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -141,11 +141,12 @@ const Trigger = ({ intl, eventListenerNamespace, trigger }) => {
                     <p>{serviceText}</p>
                     <div className="interceptor--service-details">
                       <p>
-                        {nameText} {interceptor.webhook.objectRef.name}
+                        <span>{nameText}</span>
+                        {interceptor.webhook.objectRef.name}
                       </p>
                       {interceptor.webhook.objectRef.namespace && (
                         <p>
-                          {namespaceText}{' '}
+                          <span>{namespaceText}</span>
                           {interceptor.webhook.objectRef.namespace}
                         </p>
                       )}

--- a/packages/components/src/components/Trigger/Trigger.scss
+++ b/packages/components/src/components/Trigger/Trigger.scss
@@ -52,4 +52,10 @@ limitations under the License.
 
 .interceptor--service-details {
   margin-left: $spacing-04;
+
+  .trigger .details & {
+    p span:first-child {
+      font-weight: normal;
+    }
+  }
 }

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -14,7 +14,6 @@ limitations under the License.
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import '../../scss/Triggers.scss';
 import { injectIntl } from 'react-intl';
 import { InlineNotification, Tag } from 'carbon-components-react';
 import {
@@ -32,6 +31,8 @@ import {
 } from '../../reducers';
 
 import { fetchClusterTriggerBinding } from '../../actions/clusterTriggerBindings';
+
+import '../../scss/Triggers.scss';
 
 export /* istanbul ignore next */ class ClusterTriggerBindingContainer extends Component {
   static notification({ kind, message, intl }) {

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -121,7 +121,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
                 {intl.formatMessage({
                   id: 'dashboard.metadata.dateCreated',
                   defaultMessage: 'Date Created:'
-                })}{' '}
+                })}
               </span>
               <FormattedDate
                 date={eventListener.metadata.creationTimestamp}
@@ -133,7 +133,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
                 {intl.formatMessage({
                   id: 'dashboard.metadata.labels',
                   defaultMessage: 'Labels:'
-                })}{' '}
+                })}
               </span>
               {formattedLabelsToRender.length === 0
                 ? intl.formatMessage({
@@ -151,7 +151,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
                 {intl.formatMessage({
                   id: 'dashboard.metadata.namespace',
                   defaultMessage: 'Namespace:'
-                })}{' '}
+                })}
               </span>
               {eventListener.metadata.namespace}
             </p>
@@ -161,7 +161,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
                   {intl.formatMessage({
                     id: 'dashboard.eventListener.serviceAccount',
                     defaultMessage: 'ServiceAccount:'
-                  })}{' '}
+                  })}
                 </span>
                 {eventListener.spec.serviceAccountName}
               </p>
@@ -172,7 +172,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
                   {intl.formatMessage({
                     id: 'dashboard.eventListener.serviceType',
                     defaultMessage: 'Service Type:'
-                  })}{' '}
+                  })}
                 </span>
                 {eventListener.spec.serviceType}
               </p>

--- a/src/containers/ServiceAccount/ServiceAccount.js
+++ b/src/containers/ServiceAccount/ServiceAccount.js
@@ -146,7 +146,6 @@ export /* istanbul ignore next */ class ServiceAccountContainer extends Componen
               })}
               title={name}
             >
-              {' '}
               {name}
             </Link>
           )

--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -14,7 +14,6 @@ limitations under the License.
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import '../../scss/Triggers.scss';
 import { injectIntl } from 'react-intl';
 import { InlineNotification, Tag } from 'carbon-components-react';
 import {
@@ -33,6 +32,8 @@ import {
 } from '../../reducers';
 
 import { fetchTriggerBinding } from '../../actions/triggerBindings';
+
+import '../../scss/Triggers.scss';
 
 export /* istanbul ignore next */ class TriggerBindingContainer extends Component {
   static notification({ kind, message, intl }) {

--- a/src/containers/TriggerTemplate/TriggerTemplate.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.js
@@ -14,7 +14,6 @@ limitations under the License.
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import '../../scss/Triggers.scss';
 import { injectIntl } from 'react-intl';
 import { DataTable, InlineNotification, Tag } from 'carbon-components-react';
 import {
@@ -33,6 +32,8 @@ import {
 } from '../../reducers';
 
 import { fetchTriggerTemplate } from '../../actions/triggerTemplates';
+
+import '../../scss/Triggers.scss';
 
 const {
   Table,

--- a/src/scss/Triggers.scss
+++ b/src/scss/Triggers.scss
@@ -19,6 +19,7 @@ limitations under the License.
       margin-top: $spacing-03;
       span:first-child {
         font-weight: bold;
+        margin-right: $spacing-02;
       }
     }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Ensure margin between label and value in metadata card of all
triggers pages matches the styles of the EventListener page.

Before:
![image](https://user-images.githubusercontent.com/2829095/78307923-fb22b780-753e-11ea-955e-e77d092b8822.png)

After:
![image](https://user-images.githubusercontent.com/2829095/78307933-ffe76b80-753e-11ea-8660-eb1c3192dab0.png)

It's a minor change but looks a little more polished. There are other design updates remaining to be implemented for the triggers pages but I'm not addressing them here. We can revisit after Triggers 0.4.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
