### PR TITLE
Restore display of CEL interceptor details

### DIFF
--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -245,11 +245,9 @@ const Trigger = ({ intl, eventListenerNamespace, trigger }) => {
                   expression: overlay.expression
                 }));
 
-                const displayContentCEL = false;
-
                 content = (
                   <>
-                    {displayContentCEL && (
+                    {interceptor.cel.filter && (
                       <>
                         <p>
                           {intl.formatMessage({
@@ -260,30 +258,29 @@ const Trigger = ({ intl, eventListenerNamespace, trigger }) => {
                         <code className="bx--snippet--multi interceptor--cel-filter">
                           {interceptor.cel.filter}
                         </code>
-                        <p>
-                          {intl.formatMessage({
-                            id:
-                              'dashboard.triggerDetails.celInterceptorOverlays',
-                            defaultMessage: 'Overlays:'
-                          })}
-                        </p>
-                        <Table
-                          headers={headers}
-                          rows={rows}
-                          isSortable={false}
-                          emptyTextAllNamespaces={intl.formatMessage({
-                            id: 'dashboard.trigger.noOverlays',
-                            defaultMessage:
-                              'No overlays found for this interceptor.'
-                          })}
-                          emptyTextSelectedNamespace={intl.formatMessage({
-                            id: 'dashboard.trigger.noOverlays',
-                            defaultMessage:
-                              'No overlays found for this interceptor.'
-                          })}
-                        />
                       </>
                     )}
+                    <p>
+                      {intl.formatMessage({
+                        id: 'dashboard.triggerDetails.celInterceptorOverlays',
+                        defaultMessage: 'Overlays:'
+                      })}
+                    </p>
+                    <Table
+                      headers={headers}
+                      rows={rows}
+                      isSortable={false}
+                      emptyTextAllNamespaces={intl.formatMessage({
+                        id: 'dashboard.trigger.noOverlays',
+                        defaultMessage:
+                          'No overlays found for this interceptor.'
+                      })}
+                      emptyTextSelectedNamespace={intl.formatMessage({
+                        id: 'dashboard.trigger.noOverlays',
+                        defaultMessage:
+                          'No overlays found for this interceptor.'
+                      })}
+                    />
                   </>
                 );
               } else {

--- a/packages/components/src/components/Trigger/Trigger.test.js
+++ b/packages/components/src/components/Trigger/Trigger.test.js
@@ -151,7 +151,9 @@ describe('Trigger', () => {
     expect(queryByText(/gitlab-event-2/i)).toBeTruthy();
     // Check CEL Interceptor
     expect(queryByText(/(cel)/i)).toBeTruthy();
+    expect(queryByText(/cel-filter/i)).toBeTruthy();
     expect(queryByText(/key/i)).toBeTruthy();
+    expect(queryByText(/expression/i)).toBeTruthy();
   });
 
   it('handles no objectRef in webhook Interceptor', () => {

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -17,7 +17,13 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { InlineNotification, Tag } from 'carbon-components-react';
 import { formatLabels } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Trigger } from '@tektoncd/dashboard-components';
+import {
+  FormattedDate,
+  Tab,
+  Tabs,
+  Trigger,
+  ViewYAML
+} from '@tektoncd/dashboard-components';
 import {
   getEventListener,
   getEventListenersErrorMessage,
@@ -114,84 +120,96 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
     return (
       <div className="trigger">
         <h1>{eventListenerName}</h1>
-        <div className="details">
-          <div className="resource--detail-block">
-            <p>
-              <span>
-                {intl.formatMessage({
-                  id: 'dashboard.metadata.dateCreated',
-                  defaultMessage: 'Date Created:'
-                })}
-              </span>
-              <FormattedDate
-                date={eventListener.metadata.creationTimestamp}
-                relative
-              />
-            </p>
-            <p>
-              <span>
-                {intl.formatMessage({
-                  id: 'dashboard.metadata.labels',
-                  defaultMessage: 'Labels:'
-                })}
-              </span>
-              {formattedLabelsToRender.length === 0
-                ? intl.formatMessage({
-                    id: 'dashboard.metadata.none',
-                    defaultMessage: 'None'
-                  })
-                : formattedLabelsToRender.map(label => (
-                    <Tag type="blue" key={label}>
-                      {label}
-                    </Tag>
-                  ))}
-            </p>
-            <p>
-              <span>
-                {intl.formatMessage({
-                  id: 'dashboard.metadata.namespace',
-                  defaultMessage: 'Namespace:'
-                })}
-              </span>
-              {eventListener.metadata.namespace}
-            </p>
-            {eventListener.spec.serviceAccountName && (
-              <p>
-                <span>
-                  {intl.formatMessage({
-                    id: 'dashboard.eventListener.serviceAccount',
-                    defaultMessage: 'ServiceAccount:'
-                  })}
-                </span>
-                {eventListener.spec.serviceAccountName}
-              </p>
-            )}
-            {eventListener.spec.serviceType && (
-              <p>
-                <span>
-                  {intl.formatMessage({
-                    id: 'dashboard.eventListener.serviceType',
-                    defaultMessage: 'Service Type:'
-                  })}
-                </span>
-                {eventListener.spec.serviceType}
-              </p>
-            )}
-          </div>
-          <div className="eventlistener--triggers">
-            {triggers.map((trigger, idx) => (
-              <div
-                className="resource--detail-block"
-                key={trigger.name ? trigger.name : idx}
-              >
-                <Trigger
-                  eventListenerNamespace={eventListenerNamespace}
-                  trigger={trigger}
-                />
+        <Tabs selected={0}>
+          <Tab
+            label={intl.formatMessage({
+              id: 'dashboard.resource.detailsTab',
+              defaultMessage: 'Details'
+            })}
+          >
+            <div className="details">
+              <div className="resource--detail-block">
+                <p>
+                  <span>
+                    {intl.formatMessage({
+                      id: 'dashboard.metadata.dateCreated',
+                      defaultMessage: 'Date Created:'
+                    })}
+                  </span>
+                  <FormattedDate
+                    date={eventListener.metadata.creationTimestamp}
+                    relative
+                  />
+                </p>
+                <p>
+                  <span>
+                    {intl.formatMessage({
+                      id: 'dashboard.metadata.labels',
+                      defaultMessage: 'Labels:'
+                    })}
+                  </span>
+                  {formattedLabelsToRender.length === 0
+                    ? intl.formatMessage({
+                        id: 'dashboard.metadata.none',
+                        defaultMessage: 'None'
+                      })
+                    : formattedLabelsToRender.map(label => (
+                        <Tag type="blue" key={label}>
+                          {label}
+                        </Tag>
+                      ))}
+                </p>
+                <p>
+                  <span>
+                    {intl.formatMessage({
+                      id: 'dashboard.metadata.namespace',
+                      defaultMessage: 'Namespace:'
+                    })}
+                  </span>
+                  {eventListener.metadata.namespace}
+                </p>
+                {eventListener.spec.serviceAccountName && (
+                  <p>
+                    <span>
+                      {intl.formatMessage({
+                        id: 'dashboard.eventListener.serviceAccount',
+                        defaultMessage: 'ServiceAccount:'
+                      })}
+                    </span>
+                    {eventListener.spec.serviceAccountName}
+                  </p>
+                )}
+                {eventListener.spec.serviceType && (
+                  <p>
+                    <span>
+                      {intl.formatMessage({
+                        id: 'dashboard.eventListener.serviceType',
+                        defaultMessage: 'Service Type:'
+                      })}
+                    </span>
+                    {eventListener.spec.serviceType}
+                  </p>
+                )}
               </div>
-            ))}
-          </div>
-        </div>
+              <div className="eventlistener--triggers">
+                {triggers.map((trigger, idx) => (
+                  <div
+                    className="resource--detail-block"
+                    key={trigger.name ? trigger.name : idx}
+                  >
+                    <Trigger
+                      eventListenerNamespace={eventListenerNamespace}
+                      trigger={trigger}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Tab>
+          <Tab label="YAML">
+            <ViewYAML resource={eventListener} />
+          </Tab>
+        </Tabs>
       </div>
     );
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1129

Now that Triggers 0.4 supports [Secret access in CEL interceptors](https://github.com/tektoncd/triggers/issues/486)
it should be safe for us to restore the previous functionality
and display details of the CEL interceptor's filter and overlays.

~~Needs to be rebased after https://github.com/tektoncd/dashboard/pull/1234~~

Ignoring whitespace will help with reviewing this one
https://github.com/tektoncd/dashboard/pull/1236/files?w=1

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
