### PR TITLE
Ensure param and resource handling is still compatible with v1alpha1

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -19,6 +19,8 @@ import {
 import { FormattedMessage, injectIntl } from 'react-intl';
 import {
   getErrorMessage,
+  getParams,
+  getResources,
   getStatus,
   reorderSteps,
   selectedTask,
@@ -136,9 +138,9 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
         const { pipelineTaskName } = taskRunDetails[taskRunName] || {
           pipelineTaskName: taskRun.metadata.labels['tekton.dev/conditionCheck']
         };
-        const { params, resources } = taskRun.spec;
-        const { inputs: inputResources, outputs: outputResources } =
-          resources || {};
+
+        const params = getParams(taskRun.spec);
+        const { inputResources, outputResources } = getResources(taskRun.spec);
 
         let steps = '';
 

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -251,3 +251,45 @@ export function getClearFiltersHandler({ history, match }) {
     history.push(currentURL);
   };
 }
+
+/*
+    getParams and getResources below required to support 3rd-party consumers
+    of certain dashboard components (e.g. PipelineRun) while they migrate to
+    the Tekton beta.
+
+    Support both the Pipelines beta (0.11+) structure
+      {
+        params: ...,
+        resources: {
+          inputs: ...,
+          outputs: ...
+        }
+      }
+    and the older alpha (<0.11) structure
+      {
+        inputs: {
+          params: ...,
+          resources: ...
+        },
+        outputs: {
+          resources: ...
+        }
+      }
+ */
+export function getParams({ params, inputs }) {
+  return params || (inputs && inputs.params);
+}
+
+export function getResources({ resources, inputs, outputs }) {
+  if (resources) {
+    return {
+      inputResources: resources.inputs,
+      outputResources: resources.outputs
+    };
+  }
+
+  return {
+    inputResources: inputs && inputs.resources,
+    outputResources: outputs && outputs.resources
+  };
+}

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -18,6 +18,8 @@ import {
   getDeleteFilterHandler,
   getErrorMessage,
   getFilters,
+  getParams,
+  getResources,
   getStatus,
   isRunning,
   reorderSteps,
@@ -482,5 +484,42 @@ describe('getDeleteFilterHandler', () => {
     expect(history.push).toHaveBeenCalledWith(
       `${url}?labelSelector=${encodeURIComponent('foo2=bar2')}`
     );
+  });
+});
+
+describe('getParams', () => {
+  it('supports v1alpha1 structure', () => {
+    const fakeParams = { fake: 'params' };
+    const params = getParams({ inputs: { params: fakeParams } });
+    expect(params).toEqual(fakeParams);
+  });
+
+  it('supports v1beta1 structure', () => {
+    const fakeParams = { fake: 'params' };
+    const params = getParams({ params: fakeParams });
+    expect(params).toEqual(fakeParams);
+  });
+});
+
+describe('getResources', () => {
+  it('supports v1alpha1 structure', () => {
+    const fakeInputResources = { fake: 'inputResources' };
+    const fakeOutputResources = { fake: 'outputResources' };
+    const { inputResources, outputResources } = getResources({
+      inputs: { resources: fakeInputResources },
+      outputs: { resources: fakeOutputResources }
+    });
+    expect(inputResources).toEqual(fakeInputResources);
+    expect(outputResources).toEqual(fakeOutputResources);
+  });
+
+  it('supports v1beta1 structure', () => {
+    const fakeInputResources = { fake: 'inputResources' };
+    const fakeOutputResources = { fake: 'outputResources' };
+    const { inputResources, outputResources } = getResources({
+      resources: { inputs: fakeInputResources, outputs: fakeOutputResources }
+    });
+    expect(inputResources).toEqual(fakeInputResources);
+    expect(outputResources).toEqual(fakeOutputResources);
   });
 });

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -26,6 +26,8 @@ import {
   TaskTree
 } from '@tektoncd/dashboard-components';
 import {
+  getParams,
+  getResources,
   getStatus,
   reorderSteps,
   stepsStatus,
@@ -124,9 +126,8 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     const taskRunNamespace = taskRun.metadata.namespace;
     const { reason, status: succeeded } = getStatus(taskRun);
     const runSteps = stepsStatus(reorderedSteps, reorderedSteps);
-    const { params, resources } = taskRun.spec;
-    const { inputs: inputResources, outputs: outputResources } =
-      resources || {};
+    const params = getParams(taskRun.spec);
+    const { inputResources, outputResources } = getResources(taskRun.spec);
     const { startTime } = taskRun.status;
     taskRun = {
       id: taskRun.metadata.uid,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Follow up to https://github.com/tektoncd/dashboard/pull/1201

Some consumers of certain dashboard components (e.g. PipelineRun)
have not yet upgraded to the Tekton Pipelines beta, or where they
have, still need to display data captured from the v1alpha1 APIs.

Add utils to handle retrieving the param and resource data in
a backwards compatible manner so they can continue consuming
updates to the dashboard components while managing the upgrade process.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
