### PR TITLE
Add v1alpha1 constraint to deleting pipeline resources

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -176,7 +176,11 @@ export function createPipelineResource({ namespace, resource } = {}) {
 }
 
 export function deletePipelineResource({ name, namespace } = {}) {
-  const uri = getTektonAPI('pipelineresources', { name, namespace });
+  const uri = getTektonAPI('pipelineresources', {
+    name,
+    namespace,
+    version: 'v1alpha1'
+  });
   return deleteRequest(uri, name);
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes: https://github.com/tektoncd/dashboard/issues/1269
- Adds a missing `version: v1alpha1` constraint to deleting pipeline resources, as before it was defaulting to `v1beta1` and therefore failing.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
