### PR TITLE
Update loading states to be less disruptive

### DIFF
--- a/packages/components/src/components/TooltipDropdown/TooltipDropdown.js
+++ b/packages/components/src/components/TooltipDropdown/TooltipDropdown.js
@@ -42,7 +42,16 @@ const TooltipDropdown = ({
   ...rest
 }) => {
   if (loading) {
-    return <DropdownSkeleton className={className} id={id} inline={inline} />;
+    return (
+      <div className="bx--list-box__wrapper">
+        {titleText && <span className="bx--label">{titleText}</span>}
+        <DropdownSkeleton
+          className={`bx--combo-box ${className || ''}`}
+          id={id}
+          inline={inline}
+        />
+      </div>
+    );
   }
 
   const options = items.map(itemToObject);

--- a/packages/components/src/components/TooltipDropdown/TooltipDropdown.stories.js
+++ b/packages/components/src/components/TooltipDropdown/TooltipDropdown.stories.js
@@ -13,6 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { text } from '@storybook/addon-knobs';
 
 import TooltipDropdown from './TooltipDropdown';
 
@@ -24,12 +25,21 @@ const props = {
 };
 
 storiesOf('Components/TooltipDropdown', module)
+  .addDecorator(storyFn => <div style={{ width: '200px' }}>{storyFn()}</div>)
   .add('default', () => {
-    return <TooltipDropdown {...props} />;
+    return <TooltipDropdown {...props} titleText={text('titleText', '')} />;
   })
   .add('loading', () => {
-    return <TooltipDropdown {...props} loading />;
+    return (
+      <TooltipDropdown {...props} loading titleText={text('titleText', '')} />
+    );
   })
   .add('empty', () => {
-    return <TooltipDropdown {...props} items={[]} />;
+    return (
+      <TooltipDropdown
+        {...props}
+        items={[]}
+        titleText={text('titleText', '')}
+      />
+    );
   });

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -112,7 +112,7 @@ export /* istanbul ignore next */ class ClusterTasksContainer extends Component 
         <Table
           headers={initialHeaders}
           rows={clusterTasksFormatted}
-          loading={loading}
+          loading={loading && !clusterTasksFormatted.length}
           emptyTextAllNamespaces={intl.formatMessage(
             {
               id: 'dashboard.emptyState.clusterTasks',

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
@@ -117,7 +117,7 @@ export /* istanbul ignore next */ class ClusterTriggerBindings extends Component
         <Table
           headers={initialHeaders}
           rows={clusterTriggerBindingsFormatted}
-          loading={loading}
+          loading={loading && !clusterTriggerBindingsFormatted.length}
           emptyTextAllNamespaces={intl.formatMessage(
             {
               id: 'dashboard.emptyState.clusterTriggerBindings',

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -135,7 +135,7 @@ export /* istanbul ignore next */ class EventListeners extends Component {
         <Table
           headers={initialHeaders}
           rows={eventListenersFormatted}
-          loading={loading}
+          loading={loading && !eventListenersFormatted.length}
           selectedNamespace={selectedNamespace}
           emptyTextAllNamespaces={intl.formatMessage(
             {

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -81,27 +81,8 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
     const { error, intl, loading, match, pipelineResource } = this.props;
     const { pipelineResourceName } = match.params;
 
-    if (loading) {
-      return (
-        <DataTableSkeleton
-          headers={[
-            {
-              key: 'name',
-              header: intl.formatMessage({
-                id: 'dashboard.tableHeader.paramName',
-                defaultMessage: 'Param Name'
-              })
-            },
-            {
-              key: 'value',
-              header: intl.formatMessage({
-                id: 'dashboard.tableHeader.value',
-                defaultMessage: 'Value'
-              })
-            }
-          ]}
-        />
-      );
+    if (loading && !pipelineResource) {
+      return <DataTableSkeleton />;
     }
 
     if (error) {

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -301,7 +301,7 @@ export /* istanbul ignore next */ class PipelineResources extends Component {
         )}
         <PipelineResourcesList
           batchActionButtons={batchActionButtons}
-          loading={loading}
+          loading={loading && !pipelineResources.length}
           pipelineResources={pipelineResources}
           selectedNamespace={selectedNamespace}
           toolbarButtons={toolbarButtons}

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -66,12 +66,14 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       pipelineRunName: prevPipelineRunName
     } = prevMatch.params;
 
+    const websocketReconnected =
+      webSocketConnected && prevWebSocketConnected === false;
     if (
       namespace !== prevNamespace ||
       pipelineRunName !== prevPipelineRunName ||
-      (webSocketConnected && prevWebSocketConnected === false)
+      websocketReconnected
     ) {
-      this.fetchData();
+      this.fetchData({ skipLoading: websocketReconnected });
     }
   }
 
@@ -79,10 +81,10 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     this.setState({ showRerunNotification: value });
   }
 
-  fetchData() {
+  fetchData({ skipLoading } = {}) {
     const { match } = this.props;
     const { namespace, pipelineRunName } = match.params;
-    this.setState({ loading: true }, async () => {
+    this.setState({ loading: !skipLoading }, async () => {
       await Promise.all([
         this.props.fetchPipelineRun({ name: pipelineRunName, namespace }),
         this.props.fetchTasks(),

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -311,7 +311,7 @@ export /* istanbul ignore next */ class PipelineRuns extends Component {
           />
         )}
         <PipelineRunsList
-          loading={loading}
+          loading={loading && !pipelineRuns.length}
           pipelineRuns={pipelineRuns}
           pipelineRunActions={pipelineRunActions}
           selectedNamespace={selectedNamespace}

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -147,7 +147,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
         <Table
           headers={initialHeaders}
           rows={pipelinesFormatted}
-          loading={loading}
+          loading={loading && !pipelinesFormatted.length}
           selectedNamespace={selectedNamespace}
           emptyTextAllNamespaces={intl.formatMessage(
             {

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -448,7 +448,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
               rows={secretsFormatted}
               handleDisplayModal={this.handleDisplayModalClick}
               handleDelete={this.handleDeleteSecretClick}
-              loading={loading}
+              loading={loading && !secretsFormatted.length}
               selectedNamespace={selectedNamespace}
               emptyTextAllNamespaces={intl.formatMessage(
                 {

--- a/src/containers/ServiceAccounts/ServiceAccounts.js
+++ b/src/containers/ServiceAccounts/ServiceAccounts.js
@@ -140,7 +140,7 @@ export /* istanbul ignore next */ class ServiceAccounts extends Component {
         <Table
           headers={initialHeaders}
           rows={serviceAccountsFormatted}
-          loading={loading}
+          loading={loading && !serviceAccountsFormatted.length}
           selectedNamespace={selectedNamespace}
           emptyTextAllNamespaces={intl.formatMessage(
             {

--- a/src/containers/ServiceAccounts/ServiceAccounts.test.js
+++ b/src/containers/ServiceAccounts/ServiceAccounts.test.js
@@ -149,8 +149,8 @@ it('ServiceAccounts renders in loading state', () => {
 
   const store = mockStore({
     serviceAccounts: {
-      byId,
-      byNamespace,
+      byId: {},
+      byNamespace: {},
       isFetching: true,
       errorMessage: null
     },
@@ -170,5 +170,4 @@ it('ServiceAccounts renders in loading state', () => {
 
   expect(queryByText(/ServiceAccounts/i)).toBeTruthy();
   expect(queryByText('No ServiceAccounts in any namespace.')).toBeFalsy();
-  expect(queryByText('foo-service-account')).toBeFalsy();
 });

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -96,12 +96,15 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     } = prevProps;
     const { taskRunName: prevTaskRunName } = prevMatch.params;
 
+    const websocketReconnected =
+      webSocketConnected && prevWebSocketConnected === false;
+
     if (
       taskRunName !== prevTaskRunName ||
       namespace !== prevNamespace ||
-      (webSocketConnected && prevWebSocketConnected === false)
+      websocketReconnected
     ) {
-      this.setState({ loading: true }); // eslint-disable-line
+      this.setState({ loading: !websocketReconnected }); // eslint-disable-line
       this.fetchTaskAndRuns(taskRunName, namespace);
     }
   }

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -225,7 +225,7 @@ export /* istanbul ignore next */ class TaskRuns extends Component {
         <h1>TaskRuns</h1>
         <LabelFilter {...this.props} />
         <TaskRunsList
-          loading={loading}
+          loading={loading && !taskRuns.length}
           selectedNamespace={selectedNamespace}
           taskRuns={taskRuns}
           taskRunActions={taskRunActions}

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -147,7 +147,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
         <Table
           headers={initialHeaders}
           rows={tasksFormatted}
-          loading={loading}
+          loading={loading && !tasksFormatted.length}
           selectedNamespace={selectedNamespace}
           emptyTextAllNamespaces={intl.formatMessage(
             {

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -133,7 +133,7 @@ export /* istanbul ignore next */ class TriggerBindings extends Component {
         <Table
           headers={initialHeaders}
           rows={triggerBindingsFormatted}
-          loading={loading}
+          loading={loading && !triggerBindingsFormatted.length}
           selectedNamespace={selectedNamespace}
           emptyTextAllNamespaces={intl.formatMessage(
             {

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -135,7 +135,7 @@ export /* istanbul ignore next */ class TriggerTemplates extends Component {
         <Table
           headers={initialHeaders}
           rows={triggerTemplatesFormatted}
-          loading={loading}
+          loading={loading && !triggerTemplatesFormatted.length}
           selectedNamespace={selectedNamespace}
           emptyTextAllNamespaces={intl.formatMessage(
             {

--- a/src/containers/TriggerTemplates/TriggerTemplates.test.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.test.js
@@ -151,8 +151,8 @@ it('TriggerTemplates renders in loading state', () => {
 
   const store = mockStore({
     triggerTemplates: {
-      byId,
-      byNamespace,
+      byId: {},
+      byNamespace: {},
       isFetching: true,
       errorMessage: null
     },
@@ -172,5 +172,4 @@ it('TriggerTemplates renders in loading state', () => {
 
   expect(queryByText(/TriggerTemplates/i)).toBeTruthy();
   expect(queryByText('No TriggerTemplates in any namespace.')).toBeFalsy();
-  expect(queryByText('trigger-template')).toBeFalsy();
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1021

Some of our loading states can be quite disruptive to the
user experience, replacing the main content with a skeleton
until the new data is retrieved and processed.

This is particularly disruptive when looking at the PipelineRun
or TaskRun views and the websocket connection drops and reconnects,
especially if this happens frequently.

In the case of the PipelineRun and TaskRun views, the user would
in many cases be switched from their currently selected step or
tab.

Update our loading states to be as transparent to the user as
possible. Silently fetch new data in the background and only
show a skeleton if there's no existing data available for display.

Also tighten up the styles for the TooltipDropdown loading state
to prevent jumping in the side nav.

Before:
Notice the bottom half of the side nav jumps, and the selected tab on the PipelineRun details is lost (was originally viewing Status tab).
![before](https://user-images.githubusercontent.com/2829095/78941753-2ada3e00-7ab0-11ea-8e88-de376e79c667.gif)

After:
Only the content of the namespaces dropdown in the side nav enters a visible loading state.
This may be improved further in a separate PR.
![after](https://user-images.githubusercontent.com/2829095/78941802-46dddf80-7ab0-11ea-8bd3-65106bb82a94.gif)

Similar reduction in jumpiness on the list pages.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
