### PR TITLE
Add Content-Security-Policy

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,7 +13,14 @@ limitations under the License.
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = {
+const contentSecurityPolicy = {
+  development:
+    "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-eval'; style-src blob:; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;",
+  production:
+    "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;"
+};
+
+module.exports = ({ mode }) => ({
   entry: ['./src/index.js'],
   output: {
     publicPath: '/'
@@ -48,7 +55,10 @@ module.exports = {
       favicon: path.resolve(__dirname, 'src/images', 'favicon.png'),
       template: path.resolve(__dirname, 'src', 'index.template.html'),
       meta: {
-        viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'
+        'Content-Security-Policy': {
+          'http-equiv': 'Content-Security-Policy',
+          content: contentSecurityPolicy[mode]
+        }
       }
     })
   ],
@@ -57,4 +67,4 @@ module.exports = {
       'react-router-dom': path.resolve('./node_modules/react-router-dom')
     }
   }
-};
+});

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -26,8 +26,10 @@ const extensionConfig = {
   }
 };
 
-module.exports = merge(common, {
-  mode: 'development',
+const mode = 'development';
+
+module.exports = merge(common({ mode }), {
+  mode,
   devtool: 'eval-source-map',
   devServer: {
     historyApiFallback: true,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -18,8 +18,10 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const common = require('./webpack.common.js');
 
-module.exports = merge(common, {
-  mode: 'production',
+const mode = 'production';
+
+module.exports = merge(common({ mode }), {
+  mode,
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1049

I've added the Content-Security-Policy meta tag for both dev
and prod builds to keep us as close as possible to prod restrictions
while developing. There are 2 differences for dev, it allows
'unsafe-eval' scripts, and blob: URIs for styles. Both of these
are to accommodate the webpack dev server and hot reloading.

The policy is quite strict, it blocks everything by default, then
allows for scripts, styles, images, fonts, and connections to the
same origin only, with the exception of fonts which can also
come from Google Fonts. Taking this approach means that object embeds,
media, frames, etc. are all blocked giving us a more locked down
environment.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
