### PR TITLE
Disable caching of all `/v1/*` and `/proxy/*` responses

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -192,6 +192,7 @@ func (h *Handler) getAllExtensions(request *restful.Request, response *restful.R
 
 func registerKubeAPIProxy(r endpoints.Resource, container *restful.Container) {
 	proxy := new(restful.WebService)
+	proxy.Filter(restful.NoBrowserCacheFilter)
 	proxy.Consumes(restful.MIME_JSON, "text/plain", "application/json-patch+json").
 		Produces(restful.MIME_JSON, "text/plain", "application/json-patch+json").
 		Path("/proxy")
@@ -223,6 +224,7 @@ func registerWeb(container *restful.Container) {
 // registerEndpoints registers the APIs to interface with core Tekton/K8s pieces
 func registerEndpoints(r endpoints.Resource, container *restful.Container) {
 	wsv1 := new(restful.WebService)
+	wsv1.Filter(restful.NoBrowserCacheFilter)
 	wsv1.
 		Path("/v1/namespaces").
 		Consumes(restful.MIME_JSON, "text/plain").
@@ -283,6 +285,7 @@ func registerReadinessProbe(r endpoints.Resource, container *restful.Container) 
 func registerPropertiesEndpoint(r endpoints.Resource, container *restful.Container) {
 	logging.Log.Info("Adding API for properties")
 	wsDefaults := new(restful.WebService)
+	wsDefaults.Filter(restful.NoBrowserCacheFilter)
 	wsDefaults.
 		Path("/v1/properties").
 		Consumes(restful.MIME_JSON, "text/plain").


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1050

Disable caching of all responses from the Dashboard `/v1/*` APIs
(including properties), as well as the Kube APIs at `/proxy/*`.

Technically the only header required to achieve this would be:
  `Cache-Control: no-store`

go-restful has a handy built-in filter we can use though that
also adds some legacy headers that ensure even older HTTP 1.0
clients or proxies will not cache the responses.

`restful.NoBrowserCacheFilter` adds the following response headers:

```
Cache-Control: "no-cache, no-store, must-revalidate"  // HTTP 1.1.
Pragma: "no-cache"                                    // HTTP 1.0.
Expires: "0"
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
