### PR TITLE
Fix step order issues

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -132,16 +132,19 @@ export function reorderSteps(unorderedSteps, orderedSteps) {
   if (!unorderedSteps || !orderedSteps) {
     return [];
   }
-  return orderedSteps.map(({ name, ...rest }, idx) => {
-    let findName = name;
-    if (name === '') {
-      findName = `unnamed-${idx}`;
-    }
-    const orderedStep = unorderedSteps.find(step => step.name === findName);
+
+  const unnamedSteps = unorderedSteps
+    .filter(({ name }) => name.startsWith('unnamed-'))
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+
+  return orderedSteps.map(({ name, ...rest }) => {
+    const stepStatus = name
+      ? unorderedSteps.find(step => step.name === name)
+      : unnamedSteps.shift();
     return {
       name,
       ...rest,
-      ...orderedStep
+      ...stepStatus
     };
   });
 }

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -261,81 +261,91 @@ it('stepsStatus step is terminated with error', () => {
   expect(returnedStep.reason).toEqual(reason);
 });
 
-it('reorderSteps returns empty array for undefined unorderedSteps', () => {
-  const unorderedSteps = undefined;
-  const orderedSteps = [{ name: 'a' }];
-  const want = [];
-  const got = reorderSteps(unorderedSteps, orderedSteps);
-  expect(got).toEqual(want);
-});
+describe('reorderSteps', () => {
+  it('returns empty array for undefined unorderedSteps', () => {
+    const unorderedSteps = undefined;
+    const orderedSteps = [{ name: 'a' }];
+    const want = [];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
 
-it('reorderSteps returns empty array for undefined ordered', () => {
-  const unorderedSteps = [{ name: 'a' }];
-  const orderedSteps = undefined;
-  const want = [];
-  const got = reorderSteps(unorderedSteps, orderedSteps);
-  expect(got).toEqual(want);
-});
+  it('returns empty array for undefined ordered', () => {
+    const unorderedSteps = [{ name: 'a' }];
+    const orderedSteps = undefined;
+    const want = [];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
 
-it('reorderSteps works on empty steps', () => {
-  const unorderedSteps = [];
-  const orderedSteps = [];
-  const want = [];
-  const got = reorderSteps(unorderedSteps, orderedSteps);
-  expect(got).toEqual(want);
-});
+  it('works on empty steps', () => {
+    const unorderedSteps = [];
+    const orderedSteps = [];
+    const want = [];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
 
-it('reorderSteps works on ordered steps', () => {
-  const unorderedSteps = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
-  const orderedSteps = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
-  const want = [...unorderedSteps];
-  const got = reorderSteps(unorderedSteps, orderedSteps);
-  expect(got).toEqual(want);
-});
+  it('works on ordered steps', () => {
+    const unorderedSteps = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+    const orderedSteps = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+    const want = [...unorderedSteps];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
 
-it('reorderSteps properly reorders unnamed steps', () => {
-  const unorderedSteps = [
-    { name: 'unnamed-1' },
-    { name: 'unnamed-2' },
-    { name: 'unnamed-0' }
-  ];
-  const orderedSteps = [{ name: '' }, { name: '' }, { name: '' }];
-  const want = [
-    { name: 'unnamed-0' },
-    { name: 'unnamed-1' },
-    { name: 'unnamed-2' }
-  ];
-  const got = reorderSteps(unorderedSteps, orderedSteps);
-  expect(got).toEqual(want);
-});
+  it('properly reorders unnamed steps', () => {
+    const unorderedSteps = [
+      { name: 'unnamed-1' },
+      { name: 'unnamed-2' },
+      { name: 'unnamed-0' }
+    ];
+    const orderedSteps = [{ name: '' }, { name: '' }, { name: '' }];
+    const want = [
+      { name: 'unnamed-0' },
+      { name: 'unnamed-1' },
+      { name: 'unnamed-2' }
+    ];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
 
-it('reorderSteps properly reorders unnamed and named steps', () => {
-  const unorderedSteps = [
-    { name: 'c' },
-    { name: 'unnamed-4' },
-    { name: 'a' },
-    { name: 'unnamed-0' },
-    { name: 'b' },
-    { name: 'unnamed-5' }
-  ];
-  const orderedSteps = [
-    { name: '' },
-    { name: 'a' },
-    { name: 'b' },
-    { name: 'c' },
-    { name: '' },
-    { name: '' }
-  ];
-  const want = [
-    { name: 'unnamed-0' },
-    { name: 'a' },
-    { name: 'b' },
-    { name: 'c' },
-    { name: 'unnamed-4' },
-    { name: 'unnamed-5' }
-  ];
-  const got = reorderSteps(unorderedSteps, orderedSteps);
-  expect(got).toEqual(want);
+  it('properly reorders unnamed and named steps', () => {
+    const unorderedSteps = [
+      { name: 'c' },
+      { name: 'unnamed-4' },
+      { name: 'a' },
+      { name: 'unnamed-0' },
+      { name: 'b' },
+      { name: 'unnamed-5' }
+    ];
+    const orderedSteps = [
+      { name: '' },
+      { name: 'a' },
+      { name: 'b' },
+      { name: 'c' },
+      { name: '' },
+      { name: '' }
+    ];
+    const want = [
+      { name: 'unnamed-0' },
+      { name: 'a' },
+      { name: 'b' },
+      { name: 'c' },
+      { name: 'unnamed-4' },
+      { name: 'unnamed-5' }
+    ];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
+
+  it('handles pipeline resource init steps and unnamed steps', () => {
+    const unorderedSteps = [{ name: 'some-init-step' }, { name: 'unnamed-1' }];
+    const orderedSteps = [{ name: '' }];
+    const want = [{ name: 'unnamed-1' }];
+    const got = reorderSteps(unorderedSteps, orderedSteps);
+    expect(got).toEqual(want);
+  });
 });
 
 it('generateId', () => {

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -125,7 +125,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     const taskRunName = taskRun.metadata.name;
     const taskRunNamespace = taskRun.metadata.namespace;
     const { reason, status: succeeded } = getStatus(taskRun);
-    const runSteps = stepsStatus(reorderedSteps, reorderedSteps);
+    const runSteps = stepsStatus(reorderedSteps, taskRun.status.steps);
     const params = getParams(taskRun.spec);
     const { inputResources, outputResources } = getResources(taskRun.spec);
     const { startTime } = taskRun.status;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1285

Dealing with unnamed steps has caused a number of problems in
the past. We've put in various fixes for specific cases but
every so often find another case where our assumptions don't
hold up.

This PR is an attempt to address that in a simpler and hopefully
more resilient way.

Unnamed steps are named based on the order they appear in the
Task spec. So given a Task with 2 unnamed steps these are
`unnamed-0` and `unnamed-1`. However, if the Task uses PipelineResources
there may be init steps included in the TaskRun status, and these
are also affect the order for naming unnamed steps.

e.g. given a Task using an input resource and having 1 unnamed
step, the steps listed in the status would be:
1. `some-resource-init-step`
1. `unnamed-1`

Instead of trying to match the status + spec by index across
the two lists:
1. extract the unnamed steps from the status (let's
call these `unnamedStepsStatus`)
1. sort the `unnamedStepsStatus` in natural order, i.e.
  `unnamed-2` < `unnamed-10`
1. iterate over the steps from the Task spec
1. if step name is falsy, shift the next item off the front of
  `unnamedStepsStatus` and use that as our step status
1. otherwise find a match by name as usual

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
