### PR TITLE
Add support for external filters on Table component

### DIFF
--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -40,6 +40,7 @@ const {
   TableHeader
 } = DataTable;
 
+/* istanbul ignore next */
 function getTranslateWithId(intl) {
   return function translateWithId(id, state) {
     switch (id) {
@@ -120,6 +121,7 @@ const Table = props => {
     batchActionButtons,
     emptyTextAllNamespaces,
     emptyTextSelectedNamespace,
+    filters,
     headers: dataHeaders,
     intl,
     isSortable,
@@ -134,10 +136,13 @@ const Table = props => {
   const shouldRenderBatchActions = !!(
     dataRows.length && batchActionButtons.length
   );
+  const filterFields = !!dataRows.length && filters;
   const translateWithId = getTranslateWithId(intl);
 
   return (
-    <div className="tableComponent">
+    <div
+      className={`tableComponent ${filters ? 'tkn--table-with-filters' : ''}`}
+    >
       <DataTable
         key={selectedNamespace}
         rows={dataRows}
@@ -155,8 +160,11 @@ const Table = props => {
           selectedRows
         }) => (
           <TableContainer title={title}>
-            {(toolbarButtons.length || shouldRenderBatchActions) && (
+            {(filterFields ||
+              toolbarButtons.length ||
+              shouldRenderBatchActions) && (
               <TableToolbar>
+                {filterFields}
                 {shouldRenderBatchActions && (
                   <TableBatchActions
                     {...getBatchActionProps()}
@@ -222,11 +230,7 @@ const Table = props => {
                 <TableBody>
                   {!loading && dataRows.length === 0 && (
                     <TableRow>
-                      <TableCell
-                        colSpan={
-                          headers.length + (shouldRenderBatchActions ? 1 : 0)
-                        }
-                      >
+                      <TableCell colSpan={headers.length}>
                         <div className="noRows">
                           {selectedNamespace === ALL_NAMESPACES
                             ? emptyTextAllNamespaces

--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+@import '~carbon-components/scss/globals/scss/vars';
+
 .tableComponent {
   .bx--table-toolbar {
     background: transparent;
@@ -68,6 +70,84 @@ limitations under the License.
 
     .bx--batch-summary {
       margin-left: 1rem;
+    }
+  }
+
+  &.tkn--table-with-filters {
+    .bx--data-table-container {
+      overflow: visible;
+    }
+
+    .bx--table-toolbar {
+      overflow: visible;
+      flex-direction: row;
+      background-color: $ui-01;
+      border-bottom: 1px solid $ui-03;
+
+      .bx--multi-select__wrapper {
+        .bx--combo-box {
+          border: none;
+        }
+
+        .bx--text-input {
+          background-color: $ui-01;
+          border: none;
+        }
+      }
+
+      .bx--multi-select__wrapper,
+      .bx--dropdown__wrapper {
+        display: flex;
+        align-items: center;
+        border-right: 1px solid $ui-03;
+        margin-right: 0;
+        padding-right: $spacing-03;
+        white-space: nowrap;
+
+        .bx--label {
+          padding-left: $spacing-05;
+        }
+
+        .bx--text-input {
+          padding: 0 $spacing-07 0 $spacing-03;
+        }
+
+        .bx--list-box__menu-icon {
+          right: $spacing-03;
+        }
+
+        .bx--dropdown,
+        .bx--multi-select {
+          width: 10rem;
+        }
+
+        .bx--multi-select--inline,
+        .bx--list-box--inline {
+          background-color: $ui-01;
+          height: 100%;
+          max-height: 3rem;
+        }
+
+        .bx--list-box__field {
+          height: 100%;
+
+          input.bx--text-input {
+            &:placeholder-shown {
+              text-overflow: ellipsis;
+            }
+          }
+        }
+
+        &.bx--dropdown__wrapper--inline .bx--label {
+          padding-left: 1rem;
+        }
+
+        @media (max-width: 672px) {
+          &.bx--list-box__wrapper--inline .bx--label {
+            display: none;
+          }
+        }
+      }
     }
   }
 }

--- a/packages/components/src/components/Table/Table.stories.js
+++ b/packages/components/src/components/Table/Table.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,6 +15,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
+import { Dropdown } from 'carbon-components-react';
 import {
   Add16 as Add,
   Delete16 as Delete,
@@ -23,6 +24,20 @@ import {
 } from '@carbon/icons-react';
 
 import Table from './Table';
+
+function getFilters(showFilters) {
+  return showFilters ? (
+    <Dropdown
+      id="status-filter"
+      initialSelectedItem="All"
+      items={['All', 'Succeeded', 'Failed']}
+      light
+      label="Status"
+      titleText="Status:"
+      type="inline"
+    />
+  ) : null;
+}
 
 storiesOf('Components/Table', module)
   .add('simple table with title no rows, no buttons, no checkboxes', () => {
@@ -39,6 +54,7 @@ storiesOf('Components/Table', module)
         headers={headers}
         selectedNamespace={text('selectedNamespace', '*')}
         loading={boolean('loading', false)}
+        filters={getFilters(boolean('showFilters', false))}
         emptyTextAllNamespaces={text(
           'emptyTextAllNamespaces',
           'No rows in any namespace'
@@ -71,6 +87,7 @@ storiesOf('Components/Table', module)
         ]}
         selectedNamespace="*"
         loading={boolean('loading', false)}
+        filters={getFilters(boolean('showFilters', false))}
         toolbarButtons={[
           { onClick: action('handleNew'), text: 'Add', icon: Add }
         ]}
@@ -100,6 +117,7 @@ storiesOf('Components/Table', module)
         ]}
         selectedNamespace="*"
         loading={boolean('loading', false)}
+        filters={getFilters(boolean('showFilters', false))}
         batchActionButtons={[
           { onClick: action('handleDelete'), text: 'Delete', icon: Delete }
         ]}
@@ -141,6 +159,7 @@ storiesOf('Components/Table', module)
           ]}
           selectedNamespace="*"
           isSortable={boolean('isSortable', true)}
+          filters={getFilters(boolean('showFilters', false))}
           batchActionButtons={[
             { onClick: action('handleDelete'), text: 'Delete', icon: Delete },
             { onClick: action('handleRerun'), text: 'Rerun', icon: Rerun }
@@ -160,90 +179,3 @@ storiesOf('Components/Table', module)
       );
     }
   );
-
-/*
-  HOW TO USE:
-  - Required Props:
-      - headers: Array containing each column (in form of object)
-        appearing in data table.
-        Example:
-          [
-            { key: 'name', header: 'Name' },
-            { key: 'namespace', header: 'Namespace' },
-            { key: 'date', header: 'Date Modified' }
-          ]
-
-      - rows: Array containing each row (in form of object)
-        appearing in data table.
-        *all keys in dataHeaders must be specified in each row object*
-          Example:
-            [
-              {
-                **id: 'namespace1:resource-one',
-                name: 'resource-one',
-                namespace: 'namespace1',
-                date: '16 minutes ago'
-              }
-            ]
-          ** Must be specified for React to know which rows have changed,
-            are added, or are removed. **
-
-      - selectedNamespace: String Retrieved from Redux store and passed as prop.
-        Used when no rows are available and allows us to tell the user in which
-        namespace.
-
-     - emptyTextAllNamespaces: String used to denote user that there are no rows
-     in any namespace.
-
-     - emptyTextAllNamespaces: String used to denote user that there are no rows
-      in selected namespace.
-
-    Optional Props:
-
-      - loading: Boolean Retrieved from Redux store and passed as prop from the container.
-
-      - sortable: Boolean enables sorted by a specific column.
-
-      - title: if String is supplied, a Title element will render with table.
-
-      - batchActionButtons: Array containing buttons with the purpose of manipulating one,
-          a few or all rows in table. If no elements are prersent in the array, the
-          checkboxes will not appear.
-        Example:
-          [
-            {
-              **onClick: ()=>{},
-              text: Delete,
-              *icon: CarbonDesingIcon
-            },
-            {
-              **onClick: ()=>{},
-              text: Rerun,
-              *icon: null
-            }
-          ]
-        ** Must take 2 arguments, selectedRows (Array) and cancel batch action (function) to unselect rows once deletion is
-        finished. It is recommended to save batchAction as state for future use. When called the table will revert to its default view**
-
-      - toolbarButtons: Array containing buttonss with the purpose of adding to the table or manipulating all rows.
-        Example:
-          [
-            {
-              **onClick: ()=>{},
-              text: Add,
-              *icon: CarbonDesingIcon
-            },
-            {
-              **onClick: ()=>{},
-              text: DeleteAll,
-              *icon: null
-            },
-            {
-              **onClick: ()=>{},
-              text: Rerun All,
-              *icon: CarbonDesingIcon
-            }
-          ]
-        ** Does not take arguments since all rows are either affected or not at all. **
-
-  */

--- a/packages/components/src/components/Table/Table.test.js
+++ b/packages/components/src/components/Table/Table.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,6 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from 'react-testing-library';
+import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { renderWithIntl } from '../../utils/test';
 import Table from './Table';
@@ -52,346 +53,365 @@ const emptyTextAllNamespaces = 'No rows in any namespace';
 const emptyTextSelectedNamespace = 'No rows in selected namespace';
 const title = 'Resource';
 
-it('Table renders plain with ALL_NAMESPACES no rows', () => {
-  const props = {
-    loading: false,
-    rows: [],
-    headers,
-    selectedNamespace: '*',
-    emptyTextAllNamespaces,
-    emptyTextSelectedNamespace
-  };
-  const { queryByLabelText, queryByText } = renderWithIntl(
-    <Table {...props} />
-  );
+describe('Table', () => {
+  it('renders plain with ALL_NAMESPACES no rows', () => {
+    const props = {
+      loading: false,
+      rows: [],
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      emptyTextAllNamespaces,
+      emptyTextSelectedNamespace
+    };
+    const { queryByLabelText, queryByText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(queryByText(title)).toBeFalsy();
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/Name/i)).toBeTruthy();
-  expect(queryByText(/Namespace/i)).toBeTruthy();
-  expect(queryByText(/Date Created/i)).toBeTruthy();
-  expect(queryByText(/Delete/i)).toBeFalsy();
-  expect(queryByText(/Add/i)).toBeFalsy();
-  expect(queryByText(emptyTextAllNamespaces)).toBeTruthy();
-  expect(queryByText(emptyTextSelectedNamespace)).toBeNull();
-  expect(queryByLabelText('Select all rows')).toBeFalsy();
-  expect(queryByLabelText('Select row')).toBeFalsy();
-});
+    expect(queryByText(title)).toBeFalsy();
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/Name/i)).toBeTruthy();
+    expect(queryByText(/Namespace/i)).toBeTruthy();
+    expect(queryByText(/Date Created/i)).toBeTruthy();
+    expect(queryByText(/Delete/i)).toBeFalsy();
+    expect(queryByText(/Add/i)).toBeFalsy();
+    expect(queryByText(emptyTextAllNamespaces)).toBeTruthy();
+    expect(queryByText(emptyTextSelectedNamespace)).toBeNull();
+    expect(queryByLabelText('Select all rows')).toBeFalsy();
+    expect(queryByLabelText('Select row')).toBeFalsy();
+  });
 
-it('Table renders title with no rows, selected namespace, 1 batch and 1 toolbar button, checkboxes and non-sortable', () => {
-  const props = {
-    batchActionButtons: batchActionButtons.slice(0, 1),
-    loading: false,
-    rows: [],
-    headers,
-    selectedNamespace: 'default',
-    title,
-    toolbarButtons: toolbarButtons.slice(0, 1),
-    emptyTextAllNamespaces,
-    emptyTextSelectedNamespace
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders title with no rows, selected namespace, 1 filter, 1 batch, and 1 toolbar button, checkboxes and non-sortable', () => {
+    const filters = 'FAKE_FILTERS';
+    const props = {
+      batchActionButtons: batchActionButtons.slice(0, 1),
+      emptyTextAllNamespaces,
+      emptyTextSelectedNamespace,
+      filters,
+      headers,
+      loading: false,
+      rows: [],
+      selectedNamespace: 'default',
+      title,
+      toolbarButtons: toolbarButtons.slice(0, 1)
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(queryByText('Resource')).toBeTruthy();
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/Delete/i)).toBeFalsy();
-  expect(queryByText(/Add/i)).toBeTruthy();
-  expect(queryByLabelText('Select all rows')).toBeFalsy();
-  expect(queryByLabelText('Select row')).toBeFalsy();
-  expect(queryByText(emptyTextSelectedNamespace)).toBeTruthy();
-  expect(queryByText(emptyTextAllNamespaces)).toBeFalsy();
-});
+    expect(queryByText('Resource')).toBeTruthy();
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/Delete/i)).toBeFalsy();
+    expect(queryByText(/Add/i)).toBeTruthy();
+    expect(queryByLabelText('Select all rows')).toBeFalsy();
+    expect(queryByLabelText('Select row')).toBeFalsy();
+    expect(queryByText(filters)).toBeFalsy();
+    expect(queryByText(emptyTextSelectedNamespace)).toBeTruthy();
+    expect(queryByText(emptyTextAllNamespaces)).toBeFalsy();
+  });
 
-it('Table renders plain with one row, ALL_NAMESPACES', () => {
-  const props = {
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*'
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders plain with one row, ALL_NAMESPACES', () => {
+    const props = {
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(queryByText(title)).toBeNull();
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/resource-one/i)).toBeTruthy();
-  expect(queryByText(/namespace1/i)).toBeTruthy();
-  expect(queryByText(/16 minutes ago/i)).toBeTruthy();
-  expect(queryByText(/Delete/i)).toBeNull();
-  expect(queryByText(/Add/i)).toBeNull();
-  expect(queryByLabelText('Select all rows')).toBeNull();
-  expect(queryByLabelText('Select row')).toBeNull();
-  expect(queryByText(emptyTextSelectedNamespace)).toBeNull();
-  expect(queryByText(emptyTextSelectedNamespace)).toBeNull();
-});
+    expect(queryByText(title)).toBeNull();
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/resource-one/i)).toBeTruthy();
+    expect(queryByText(/namespace1/i)).toBeTruthy();
+    expect(queryByText(/16 minutes ago/i)).toBeTruthy();
+    expect(queryByText(/Delete/i)).toBeNull();
+    expect(queryByText(/Add/i)).toBeNull();
+    expect(queryByLabelText('Select all rows')).toBeNull();
+    expect(queryByLabelText('Select row')).toBeNull();
+    expect(queryByText(emptyTextSelectedNamespace)).toBeNull();
+    expect(queryByText(emptyTextSelectedNamespace)).toBeNull();
+  });
 
-it('Table renders plain with one row, ALL_NAMESPACES and sortable', () => {
-  const props = {
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*',
-    isSortable: true
-  };
-  const { queryByText } = renderWithIntl(<Table {...props} />);
+  it('renders plain with one row, ALL_NAMESPACES and sortable', () => {
+    const props = {
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      isSortable: true
+    };
+    const { queryByText } = renderWithIntl(<Table {...props} />);
 
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeTruthy();
-});
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeTruthy();
+  });
 
-it('Table renders with one row, ALL_NAMESPACES, 1 toolbar button only, no checkboxes and non-sortable', () => {
-  const props = {
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*',
-    toolbarButtons: toolbarButtons.slice(0, 1)
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders filters', () => {
+    const filters = 'FAKE_FILTERS';
+    const props = {
+      filters,
+      loading: false,
+      headers,
+      rows: rows.slice(0, 1),
+      selectedNamespace: ALL_NAMESPACES
+    };
+    const { queryByText } = renderWithIntl(<Table {...props} />);
 
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/Delete/i)).toBeNull();
-  expect(queryByText(/Rerun All/i)).toBeNull();
-  expect(queryByText(/Add/i)).toBeTruthy();
-  expect(queryByLabelText('Select all rows')).toBeNull();
-  expect(queryByLabelText('Select row')).toBeNull();
-});
+    expect(queryByText(filters)).toBeTruthy();
+  });
 
-it('Table renders with one row, ALL_NAMESPACES, 2 toolbar buttons only, no checkboxes and non-sortable', () => {
-  const props = {
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*',
-    toolbarButtons
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders with one row, ALL_NAMESPACES, 1 toolbar button only, no checkboxes and non-sortable', () => {
+    const props = {
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      toolbarButtons: toolbarButtons.slice(0, 1)
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/Delete/i)).toBeNull();
-  expect(queryByText(/Add/i)).toBeTruthy();
-  expect(queryByText(/Rerun All/i)).toBeTruthy();
-  expect(queryByLabelText('Select all rows')).toBeNull();
-  expect(queryByLabelText('Select row')).toBeNull();
-});
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/Delete/i)).toBeNull();
+    expect(queryByText(/Rerun All/i)).toBeNull();
+    expect(queryByText(/Add/i)).toBeTruthy();
+    expect(queryByLabelText('Select all rows')).toBeNull();
+    expect(queryByLabelText('Select row')).toBeNull();
+  });
 
-it('Table renders with one row, ALL_NAMESPACES, 1 batch button only with checkboxes and non-sortable', () => {
-  const props = {
-    batchActionButtons: batchActionButtons.slice(0, 1),
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*'
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders with one row, ALL_NAMESPACES, 2 toolbar buttons only, no checkboxes and non-sortable', () => {
+    const props = {
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      toolbarButtons
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/Delete/i)).toBeTruthy();
-  expect(queryByText(/Add/i)).toBeNull();
-  expect(queryByText(/Rerun/i)).toBeNull();
-  expect(queryByLabelText('Select all rows')).toBeTruthy();
-  expect(queryByLabelText('Select row')).toBeTruthy();
-});
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/Delete/i)).toBeNull();
+    expect(queryByText(/Add/i)).toBeTruthy();
+    expect(queryByText(/Rerun All/i)).toBeTruthy();
+    expect(queryByLabelText('Select all rows')).toBeNull();
+    expect(queryByLabelText('Select row')).toBeNull();
+  });
 
-it('Table renders with one row, ALL_NAMESPACES, 2 batch buttons only with checkboxes and non-sortable', () => {
-  const props = {
-    batchActionButtons,
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*'
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders with one row, ALL_NAMESPACES, 1 batch button only with checkboxes and non-sortable', () => {
+    const props = {
+      batchActionButtons: batchActionButtons.slice(0, 1),
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeFalsy();
-  expect(queryByText(/Delete/i)).toBeTruthy();
-  expect(queryByText(/Rerun/i)).toBeTruthy();
-  expect(queryByText(/Rerun All/i)).toBeNull();
-  expect(queryByText(/Add/i)).toBeNull();
-  expect(queryByLabelText('Select all rows')).toBeTruthy();
-  expect(queryByLabelText('Select row')).toBeTruthy();
-});
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/Delete/i)).toBeTruthy();
+    expect(queryByText(/Add/i)).toBeNull();
+    expect(queryByText(/Rerun/i)).toBeNull();
+    expect(queryByLabelText('Select all rows')).toBeTruthy();
+    expect(queryByLabelText('Select row')).toBeTruthy();
+  });
 
-it('Table renders with two rows, ALL_NAMESPACES, 2 batch and 2 toolbar buttons, checkboxes and sortable', () => {
-  const props = {
-    batchActionButtons,
-    loading: false,
-    rows,
-    headers,
-    selectedNamespace: '*',
-    toolbarButtons,
-    isSortable: true
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('renders with one row, ALL_NAMESPACES, 2 batch buttons only with checkboxes and non-sortable', () => {
+    const props = {
+      batchActionButtons,
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(
-    queryByText(/Name/i).parentNode.className.includes('sort')
-  ).toBeTruthy();
-  expect(queryByText(/Add/i)).toBeTruthy();
-  expect(queryByText(/Delete/i)).toBeTruthy();
-  expect(queryByText('Rerun')).toBeTruthy();
-  expect(queryByText('Rerun All')).toBeTruthy();
-  expect(queryByLabelText('Select all rows')).toBeTruthy();
-  expect(queryByLabelText('Select row')).toBeTruthy();
-});
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeFalsy();
+    expect(queryByText(/Delete/i)).toBeTruthy();
+    expect(queryByText(/Rerun/i)).toBeTruthy();
+    expect(queryByText(/Rerun All/i)).toBeNull();
+    expect(queryByText(/Add/i)).toBeNull();
+    expect(queryByLabelText('Select all rows')).toBeTruthy();
+    expect(queryByLabelText('Select row')).toBeTruthy();
+  });
 
-it('Table loading with no rows, ALL_NAMESPACES, 1 toolbar button, no checkboxes and non-sortable', () => {
-  const props = {
-    loading: true,
-    rows: [],
-    headers,
-    selectedNamespace: '*',
-    toolbarButtons: toolbarButtons.slice(0, 1)
-  };
-  const { queryByText } = renderWithIntl(<Table {...props} />);
+  it('renders with two rows, ALL_NAMESPACES, 2 batch and 2 toolbar buttons, checkboxes and sortable', () => {
+    const props = {
+      batchActionButtons,
+      loading: false,
+      rows,
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      toolbarButtons,
+      isSortable: true
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(queryByText(/Add/i).disabled).toBeTruthy();
-});
+    expect(
+      queryByText(/Name/i).parentNode.className.includes('sort')
+    ).toBeTruthy();
+    expect(queryByText(/Add/i)).toBeTruthy();
+    expect(queryByText(/Delete/i)).toBeTruthy();
+    expect(queryByText('Rerun')).toBeTruthy();
+    expect(queryByText('Rerun All')).toBeTruthy();
+    expect(queryByLabelText('Select all rows')).toBeTruthy();
+    expect(queryByLabelText('Select row')).toBeTruthy();
+  });
 
-it('Table loading plain with one row and ALL_NAMESPACES', () => {
-  const props = {
-    loading: true,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*'
-  };
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+  it('loading with no rows, ALL_NAMESPACES, 1 toolbar button, no checkboxes and non-sortable', () => {
+    const props = {
+      loading: true,
+      rows: [],
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      toolbarButtons: toolbarButtons.slice(0, 1)
+    };
+    const { queryByText } = renderWithIntl(<Table {...props} />);
 
-  expect(queryByText(/Resources/i)).toBeNull();
-  expect(queryByText(/Name/i)).toBeTruthy();
-  expect(queryByText(/Namespace/i)).toBeTruthy();
-  expect(queryByText(/Date Created/i)).toBeTruthy();
-  expect(queryByText(/Delete/i)).toBeNull();
-  expect(queryByText(/Add/i)).toBeNull();
-  expect(queryByLabelText('Select all rows')).toBeNull();
-  expect(queryByLabelText('Select row')).toBeNull();
-  expect(
-    queryByText("No Resources created in namespace 'default'.")
-  ).toBeNull();
-  expect(queryByText('No Resources created in any namespace.')).toBeNull();
-});
+    expect(queryByText(/Add/i).disabled).toBeTruthy();
+  });
 
-it("Table's batch action button specifies correct arguments for callback with one row selected", () => {
-  const handleDelete = jest.fn();
+  it('loading plain with one row and ALL_NAMESPACES', () => {
+    const props = {
+      loading: true,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES
+    };
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  const props = {
-    batchActionButtons: batchActionButtons.slice(0, 1),
-    loading: false,
-    rows: rows.slice(0, 1),
-    headers,
-    selectedNamespace: '*'
-  };
-  props.batchActionButtons[0].onClick = handleDelete;
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+    expect(queryByText(/Resources/i)).toBeNull();
+    expect(queryByText(/Name/i)).toBeTruthy();
+    expect(queryByText(/Namespace/i)).toBeTruthy();
+    expect(queryByText(/Date Created/i)).toBeTruthy();
+    expect(queryByText(/Delete/i)).toBeNull();
+    expect(queryByText(/Add/i)).toBeNull();
+    expect(queryByLabelText('Select all rows')).toBeNull();
+    expect(queryByLabelText('Select row')).toBeNull();
+    expect(
+      queryByText("No Resources created in namespace 'default'.")
+    ).toBeNull();
+    expect(queryByText('No Resources created in any namespace.')).toBeNull();
+  });
 
-  expect(queryByText(/Delete/i)).toBeTruthy();
-  expect(queryByText(/Add/i)).toBeNull();
+  it('batch action button specifies correct arguments for callback with one row selected', () => {
+    const handleDelete = jest.fn();
 
-  fireEvent.click(queryByLabelText('Select row'));
-  fireEvent.click(queryByText(/Delete/i));
+    const props = {
+      batchActionButtons: batchActionButtons.slice(0, 1),
+      loading: false,
+      rows: rows.slice(0, 1),
+      headers,
+      selectedNamespace: ALL_NAMESPACES
+    };
+    props.batchActionButtons[0].onClick = handleDelete;
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(handleDelete).toHaveBeenCalledTimes(1);
+    expect(queryByText(/Delete/i)).toBeTruthy();
+    expect(queryByText(/Add/i)).toBeNull();
 
-  expect(
-    handleDelete.mock.calls[0][0].map(row => {
-      return row.id;
-    })
-  ).toEqual(
-    props.rows.map(row => {
-      return row.id;
-    })
-  );
+    fireEvent.click(queryByLabelText('Select row'));
+    fireEvent.click(queryByText(/Delete/i));
 
-  expect(typeof handleDelete.mock.calls[0][1]).toEqual('function');
-});
+    expect(handleDelete).toHaveBeenCalledTimes(1);
 
-it("Table's batch action button specifies correct arguments for callback with two rows selected", () => {
-  const handleDelete = jest.fn();
+    expect(
+      handleDelete.mock.calls[0][0].map(row => {
+        return row.id;
+      })
+    ).toEqual(
+      props.rows.map(row => {
+        return row.id;
+      })
+    );
 
-  const props = {
-    batchActionButtons: batchActionButtons.slice(0, 1),
-    loading: false,
-    rows,
-    headers,
-    selectedNamespace: '*'
-  };
-  props.batchActionButtons[0].onClick = handleDelete;
-  const { queryByText, queryByLabelText } = renderWithIntl(
-    <Table {...props} />
-  );
+    expect(typeof handleDelete.mock.calls[0][1]).toEqual('function');
+  });
 
-  expect(queryByText(/Delete/i)).toBeTruthy();
-  expect(queryByText(/Add/i)).toBeNull();
+  it('batch action button specifies correct arguments for callback with two rows selected', () => {
+    const handleDelete = jest.fn();
 
-  fireEvent.click(queryByLabelText('Select all rows'));
-  fireEvent.click(queryByText(/Delete/i));
+    const props = {
+      batchActionButtons: batchActionButtons.slice(0, 1),
+      loading: false,
+      rows,
+      headers,
+      selectedNamespace: ALL_NAMESPACES
+    };
+    props.batchActionButtons[0].onClick = handleDelete;
+    const { queryByText, queryByLabelText } = renderWithIntl(
+      <Table {...props} />
+    );
 
-  expect(handleDelete).toHaveBeenCalledTimes(1);
+    expect(queryByText(/Delete/i)).toBeTruthy();
+    expect(queryByText(/Add/i)).toBeNull();
 
-  expect(
-    handleDelete.mock.calls[0][0].map(row => {
-      return row.id;
-    })
-  ).toEqual(
-    props.rows.map(row => {
-      return row.id;
-    })
-  );
+    fireEvent.click(queryByLabelText('Select all rows'));
+    fireEvent.click(queryByText(/Delete/i));
 
-  expect(typeof handleDelete.mock.calls[0][1]).toEqual('function');
-});
+    expect(handleDelete).toHaveBeenCalledTimes(1);
 
-it("Table's toolbar button responds correctly", () => {
-  const handleAdd = jest.fn();
+    expect(
+      handleDelete.mock.calls[0][0].map(row => {
+        return row.id;
+      })
+    ).toEqual(
+      props.rows.map(row => {
+        return row.id;
+      })
+    );
 
-  const props = {
-    loading: false,
-    rows,
-    headers,
-    selectedNamespace: '*',
-    toolbarButtons: toolbarButtons.slice(0, 1)
-  };
-  props.toolbarButtons[0].onClick = handleAdd;
-  const { queryByText } = renderWithIntl(<Table {...props} />);
+    expect(typeof handleDelete.mock.calls[0][1]).toEqual('function');
+  });
 
-  expect(queryByText(/Delete/i)).toBeNull();
-  expect(queryByText(/Add/i)).toBeTruthy();
+  it('toolbar button responds correctly', () => {
+    const handleAdd = jest.fn();
 
-  fireEvent.click(queryByText(/Add/i));
-  fireEvent.click(queryByText(/Add/i));
-  fireEvent.click(queryByText(/Add/i));
+    const props = {
+      loading: false,
+      rows,
+      headers,
+      selectedNamespace: ALL_NAMESPACES,
+      toolbarButtons: toolbarButtons.slice(0, 1)
+    };
+    props.toolbarButtons[0].onClick = handleAdd;
+    const { queryByText } = renderWithIntl(<Table {...props} />);
 
-  expect(handleAdd).toHaveBeenCalledTimes(3);
+    expect(queryByText(/Delete/i)).toBeNull();
+    expect(queryByText(/Add/i)).toBeTruthy();
+
+    fireEvent.click(queryByText(/Add/i));
+    fireEvent.click(queryByText(/Add/i));
+    fireEvent.click(queryByText(/Add/i));
+
+    expect(handleAdd).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
'External filters' generally take the form of dropdowns or
comboboxes in the table toolbar.

See for example: https://www.carbondesignsystem.com/patterns/filtering#single-selection

These may be used by 3rd party consumers of the dashboard components,
either using the Table component directly, or more likely via
PipelineRuns or similar.

Example from the storybook:
![image](https://user-images.githubusercontent.com/2829095/79384193-56e93980-7f5e-11ea-9a45-363072fedcc1.png)

Fit and finish styling is left as an exercise for the consumer but the base styles provided should give a reasonable start for most common uses.

**Note:** for easier review, ignore whitespace, real change in the tests is very small.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
