### PR TITLE
Fixed controller crash when receiving tombstone events in delete functions.

### DIFF
--- a/pkg/controllers/kubernetes/namespaces.go
+++ b/pkg/controllers/kubernetes/namespaces.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1 "k8s.io/api/core/v1"
@@ -31,7 +32,7 @@ func namespaceCreated(obj interface{}) {
 }
 
 func namespaceDeleted(obj interface{}) {
-	logging.Log.Debugf("Namespace Controller detected namespace '%s' deleted", obj.(*v1.Namespace).Name)
+	logging.Log.Debugf("Namespace Controller detected namespace '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.NamespaceDeleted,
 		Payload:     obj,

--- a/pkg/controllers/kubernetes/secret.go
+++ b/pkg/controllers/kubernetes/secret.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1 "k8s.io/api/core/v1"
@@ -45,7 +46,7 @@ func secretUpdated(oldObj, newObj interface{}) {
 }
 
 func secretDeleted(obj interface{}) {
-	logging.Log.Debugf("Secret Controller detected secret '%s' deleted", obj.(*v1.Secret).Name)
+	logging.Log.Debugf("Secret Controller detected secret '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.SecretDeleted,
 		Payload:     obj,

--- a/pkg/controllers/kubernetes/serviceAccount.go
+++ b/pkg/controllers/kubernetes/serviceAccount.go
@@ -15,6 +15,7 @@ package kubernetes
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1 "k8s.io/api/core/v1"
@@ -58,7 +59,7 @@ func serviceAccountUpdated(oldObj, newObj interface{}) {
 }
 
 func serviceAccountDeleted(obj interface{}) {
-	logging.Log.Debugf("ServiceAccount Controller detected ServiceAccount '%s' deleted", obj.(*v1.ServiceAccount).Name)
+	logging.Log.Debugf("ServiceAccount Controller detected ServiceAccount '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.ServiceAccountDeleted,
 		Payload:     obj,

--- a/pkg/controllers/tekton/clustertask.go
+++ b/pkg/controllers/tekton/clustertask.go
@@ -15,6 +15,7 @@ package tekton
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -55,7 +56,7 @@ func clusterTaskUpdated(oldObj, newObj interface{}) {
 }
 
 func clusterTaskDeleted(obj interface{}) {
-	logging.Log.Debugf("Cluster Task Controller detected clusterTask '%s' deleted", obj.(*v1alpha1.ClusterTask).Name)
+	logging.Log.Debugf("Cluster Task Controller detected clusterTask '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.ClusterTaskDeleted,
 		Payload:     obj,

--- a/pkg/controllers/tekton/pipeline.go
+++ b/pkg/controllers/tekton/pipeline.go
@@ -2,6 +2,7 @@ package tekton
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -43,7 +44,7 @@ func pipelineUpdated(oldObj, newObj interface{}) {
 }
 
 func pipelineDeleted(obj interface{}) {
-	logging.Log.Debugf("Pipeline Controller detected pipeline '%s' deleted", obj.(*v1alpha1.Pipeline).Name)
+	logging.Log.Debugf("Pipeline Controller detected pipeline '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.PipelineDeleted,
 		Payload:     obj,

--- a/pkg/controllers/tekton/pipelineresource.go
+++ b/pkg/controllers/tekton/pipelineresource.go
@@ -2,6 +2,7 @@ package tekton
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -43,7 +44,7 @@ func pipelineResourceUpdated(oldObj, newObj interface{}) {
 }
 
 func pipelineResourceDeleted(obj interface{}) {
-	logging.Log.Debugf("PipelineResource Controller detected pipelineResource '%s' deleted", obj.(*v1alpha1.PipelineResource).Name)
+	logging.Log.Debugf("PipelineResource Controller detected pipelineResource '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.PipelineResourceDeleted,
 		Payload:     obj,

--- a/pkg/controllers/tekton/pipelinerun.go
+++ b/pkg/controllers/tekton/pipelinerun.go
@@ -2,6 +2,7 @@ package tekton
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -43,7 +44,7 @@ func pipelineRunUpdated(oldObj, newObj interface{}) {
 }
 
 func pipelineRunDeleted(obj interface{}) {
-	logging.Log.Debugf("PipelineRun Controller detected pipelineRun '%s' deleted", obj.(*v1alpha1.PipelineRun).Name)
+	logging.Log.Debugf("PipelineRun Controller detected pipelineRun '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.PipelineRunDeleted,
 		Payload:     obj,

--- a/pkg/controllers/tekton/task.go
+++ b/pkg/controllers/tekton/task.go
@@ -2,6 +2,7 @@ package tekton
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -42,7 +43,7 @@ func taskUpdated(oldObj, newObj interface{}) {
 }
 
 func taskDeleted(obj interface{}) {
-	logging.Log.Debugf("Task Controller detected task '%s' deleted", obj.(*v1alpha1.Task).Name)
+	logging.Log.Debugf("Task Controller detected task '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.TaskDeleted,
 		Payload:     obj,

--- a/pkg/controllers/tekton/taskrun.go
+++ b/pkg/controllers/tekton/taskrun.go
@@ -2,6 +2,7 @@ package tekton
 
 import (
 	"github.com/tektoncd/dashboard/pkg/broadcaster"
+	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/endpoints"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -42,7 +43,7 @@ func taskRunUpdated(oldObj, newObj interface{}) {
 }
 
 func taskRunDeleted(obj interface{}) {
-	logging.Log.Debugf("TaskRun Controller detected taskRun '%s' deleted", obj.(*v1alpha1.TaskRun).Name)
+	logging.Log.Debugf("TaskRun Controller detected taskRun '%s' deleted", utils.GetDeletedObjectMeta(obj).GetName())
 	data := broadcaster.SocketData{
 		MessageType: broadcaster.TaskRunDeleted,
 		Payload:     obj,

--- a/pkg/controllers/utils/utils.go
+++ b/pkg/controllers/utils/utils.go
@@ -25,8 +25,7 @@ func GetDeletedObjectMeta(obj interface{}) metav1.Object {
 	// Deal with tombstone events by pulling the object out.  Tombstone events wrap the object in a
 	// DeleteFinalStateUnknown struct, so the object needs to be pulled out.
 	// Copied from sample-controller
-	// This should never happen if we aren't missing events, which we have concluded that we are not
-	// and made decisions off of this belief.  Maybe this shouldn't be here?
+	// This should only happen when we're missing events.
 	if _, ok := obj.(metav1.Object); !ok {
 		// If the object doesn't have Metadata, assume it is a tombstone object of type DeletedFinalStateUnknown
 		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); !ok {

--- a/pkg/controllers/utils/utils.go
+++ b/pkg/controllers/utils/utils.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	logging "github.com/tektoncd/dashboard/pkg/logging"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Adapted from https://github.com/kubernetes-sigs/controller-runtime/blob/v0.5.2/pkg/source/internal/eventsource.go#L131-L149
+func GetDeletedObjectMeta(obj interface{}) metav1.Object {
+	// Deal with tombstone events by pulling the object out.  Tombstone events wrap the object in a
+	// DeleteFinalStateUnknown struct, so the object needs to be pulled out.
+	// Copied from sample-controller
+	// This should never happen if we aren't missing events, which we have concluded that we are not
+	// and made decisions off of this belief.  Maybe this shouldn't be here?
+	if _, ok := obj.(metav1.Object); !ok {
+		// If the object doesn't have Metadata, assume it is a tombstone object of type DeletedFinalStateUnknown
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); !ok {
+			logging.Log.Errorf("Error decoding object: Expected cache.DeletedFinalStateUnknown, got %T", obj)
+			return &metav1.ObjectMeta{}
+		} else {
+			// Set obj to the tombstone obj
+			obj = tombstone.Obj
+		}
+	}
+
+	// Pull metav1.Object out of the object
+	if o, err := meta.Accessor(obj); err != nil {
+		logging.Log.Errorf("Missing meta for object %T: %v", obj, err)
+		return &metav1.ObjectMeta{}
+	} else {
+		return o
+	}
+}


### PR DESCRIPTION
# Changes

The type assertions in controller's delete functions are unsafe, because if events are missing the objects passed to the delete functions will be tombstone events. See:
https://github.com/kubernetes/client-go/blob/v12.0.0/tools/cache/delta_fifo.go#L648-L655
https://github.com/kubernetes-sigs/controller-runtime/blob/v0.5.2/pkg/source/internal/eventsource.go#L131-L149

This PR introduces the `GetDeletedObjectMeta()` utility function to safely retrieve metadata for deleted objects. To simplify error handling, it logs the error and returns `&metav1.ObjectMeta{}` when an error occurs.

Fixes #1226 

Special thanks to @jbarrick-mesosphere for helping triaging this! 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
