### PR TITLE
Add a - between git-source and randomly generated letters

### DIFF
--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -135,7 +135,7 @@ export class ImportResources extends Component {
       installNamespace
     } = this.state;
     const pipelineName = 'pipeline0';
-    const gitresourcename = 'git-source';
+    const gitresourcename = 'git-source-';
     const gitcommit = 'master';
 
     // Without the if statement it will not display errors for both the namespace and the url at the same time


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
In import resources add a dash between `git-source` and randomly generated numbers to make it look better 
Originally: `git-sourcev28ph`
Now: `git-source-686vg`
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
