### PR TITLE
Update react-intl and polyfills for recent Safari versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5705,7 +5705,7 @@
       "requires": {
         "@babel/cli": "^7.5.5",
         "@formatjs/intl-pluralrules": "^1.2.1",
-        "@formatjs/intl-relativetimeformat": "^4.1.1",
+        "@formatjs/intl-relativetimeformat": "^4.5.12",
         "@tektoncd/dashboard-utils": "file:packages/utils",
         "@vx/event": "0.0.192",
         "@vx/network": "0.0.192",
@@ -5719,17 +5719,17 @@
       },
       "dependencies": {
         "@formatjs/intl-relativetimeformat": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.1.1.tgz",
-          "integrity": "sha512-k+WADErd1ORTcJ/4LyrVzJcXkcXL3l9wKCsMT2d7Kq4dbap2OKv2GLBGdKR3H7SBKCooyDRV5W79et9egGzsyQ==",
+          "version": "4.5.12",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.12.tgz",
+          "integrity": "sha512-Fh57ZnwOgAIA61i3BQhTb8C8OrCP1zDLQ35xzJ7yv/UiDDExAS8rQPf80+7Hu/8+kydL1DDgVY1PXvE63fxF+Q==",
           "requires": {
-            "@formatjs/intl-utils": "^1.3.0"
+            "@formatjs/intl-utils": "^2.2.2"
           }
         },
         "@formatjs/intl-utils": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz",
-          "integrity": "sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw=="
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.2.tgz",
+          "integrity": "sha512-rKINaMRYH3FeNwYjEQwPtsA0kP2/hLLMB9mLi/QYfszz/huTqkInFmYilFRCX4oLlhFXDK5UQQMGNfEavN02Sg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-hot-loader": "^4.8.0",
-    "react-intl": "^3.1.1",
+    "react-intl": "^3.12.1",
     "react-redux": "^7.0.1",
     "react-router-dom": "^5.0.0",
     "reconnecting-websocket": "^4.2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/cli": "^7.5.5",
     "@formatjs/intl-pluralrules": "^1.2.1",
-    "@formatjs/intl-relativetimeformat": "^4.1.1",
+    "@formatjs/intl-relativetimeformat": "^4.5.12",
     "@tektoncd/dashboard-utils": "file:../utils",
     "@vx/event": "0.0.192",
     "@vx/network": "0.0.192",
@@ -29,7 +29,7 @@
     "carbon-components-react": "^7.10.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-intl": "^3.1.1",
+    "react-intl": "^3.12.1",
     "react-router-dom": "^5.0.0"
   },
   "engines": {

--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -19,3 +19,4 @@ import 'es6-promise/auto';
 import './object-is';
 import '@formatjs/intl-pluralrules/polyfill';
 import '@formatjs/intl-relativetimeformat/polyfill';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/en';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update intl dependencies to account for changes in recent
versions of Safari that break feature detection, causing
the polyfills to be applied partially.

This partial application of the polyfills applies in one of
two ways:
- Some builds of Safari 12 with non-English locale settings:
  error loading the page as the polyfill was loaded but
  missing locale data
- Recent builds of Safari 13: negative numbers displayed
  instead of relative time format

Load the 'en' data for Intl.RelativeTimeFormat since we only
support English for display in the Dashboard at this time. A
future change will need to handle this dynamically based on
user locale detection once we have our content translated.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
