### PR TITLE
Add `tkn` prefix to CSS class names - part 1

### DIFF
--- a/packages/components/src/components/CancelButton/CancelButton.js
+++ b/packages/components/src/components/CancelButton/CancelButton.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -53,7 +53,7 @@ class CancelButton extends Component {
             },
             { type }
           )}
-          className="cancel-button"
+          className="tkn--cancel-button"
           onClick={this.handleShow}
         >
           {closeIcon}

--- a/packages/components/src/components/CancelButton/CancelButton.scss
+++ b/packages/components/src/components/CancelButton/CancelButton.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 
-.cancel-button {
+.tkn--cancel-button {
   background: none;
   color: inherit;
   border: none;

--- a/packages/components/src/components/Header/Header.js
+++ b/packages/components/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -26,8 +26,8 @@ import tektonLogo from '../../images/tekton-logo-20x20.svg';
 
 function Header({ intl, logoutButton }) {
   return (
-    <CarbonHeader aria-label="Tekton Dashboard" className="header">
-      <span className="logo">
+    <CarbonHeader aria-label="Tekton Dashboard" className="tkn--header">
+      <span className="tkn--logo">
         <img
           alt={intl.formatMessage({
             id: 'dashboard.logo.alt',

--- a/packages/components/src/components/Header/Header.scss
+++ b/packages/components/src/components/Header/Header.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-header.bx--header {
-  .logo {
+header.bx--header.tkn--header {
+  .tkn--logo {
     display: flex;
     align-items: center;
     width: 3rem;
@@ -24,7 +24,7 @@ header.bx--header {
     }
   }
 
-  .logout-btn {
+  .tkn--logout-btn {
     padding-right: 2px;
   }
 }

--- a/packages/components/src/components/LabelFilter/LabelFilter.js
+++ b/packages/components/src/components/LabelFilter/LabelFilter.js
@@ -138,7 +138,7 @@ class LabelFilter extends Component {
     });
 
     return (
-      <div className="dashboard-label-filter">
+      <div className="tkn--label-filter">
         {!isValid && (
           <InlineNotification
             lowContrast
@@ -154,7 +154,6 @@ class LabelFilter extends Component {
         <Form onSubmit={this.handleAddFilter} autoComplete="on">
           <Search
             placeHolderText={searchDescription}
-            className="search"
             labelText={searchDescription}
             onChange={this.handleChange}
             value={currentFilterValue}
@@ -168,7 +167,7 @@ class LabelFilter extends Component {
             })}
           </Button>
         </Form>
-        <div className="filters">
+        <div className="tkn--filters">
           {filters.map(filter => (
             <Tag
               type="blue"

--- a/packages/components/src/components/LabelFilter/LabelFilter.scss
+++ b/packages/components/src/components/LabelFilter/LabelFilter.scss
@@ -13,12 +13,12 @@ limitations under the License.
 
 @import '~carbon-components/scss/globals/scss/vars';
 
-.dashboard-label-filter {
+.tkn--label-filter {
   form {
     display: flex;
   }
 
-  .filters {
+  .tkn--filters {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;

--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -135,7 +135,7 @@ export class LogContainer extends Component {
     }
 
     return (
-      <div className="log-trailer" data-status={reason}>
+      <div className="tkn--log-trailer" data-status={reason}>
         {trailer}
       </div>
     );
@@ -145,13 +145,13 @@ export class LogContainer extends Component {
     const { downloadButton } = this.props;
     const { loading } = this.state;
     return (
-      <pre className="tkn-log">
+      <pre className="tkn--log">
         {loading ? (
           <SkeletonText paragraph width="60%" />
         ) : (
           <>
             {downloadButton}
-            <div className="log-container">{this.getLogList()}</div>
+            <div className="tkn--log-container">{this.getLogList()}</div>
             {this.logTrailer()}
           </>
         )}

--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -13,7 +13,7 @@ limitations under the License.
 
 @import '~@tektoncd/dashboard-components/dist/scss/vars';
 
-pre.tkn-log {
+pre.tkn--log {
   position: relative;
   padding: 2rem 1.6rem 1.3rem 1.6rem;
   font-family: ibm-plex-mono, monospace;
@@ -41,7 +41,7 @@ pre.tkn-log {
     right: 0;
   }
 
-  .log-trailer {
+  .tkn--log-trailer {
     font-family: ibm-plex-sans, sans-serif;
     font-weight: bold;
 
@@ -53,11 +53,11 @@ pre.tkn-log {
     }
   }
 
-  .log-container {
+  .tkn--log-container {
     overflow-x: auto;
   }
 
-  .log-container:not(:empty) + .log-trailer {
+  .tkn--log-container:not(:empty) + .tkn--log-trailer {
     margin-top: 1rem;
   }
 }

--- a/packages/components/src/components/LogoutButton/LogoutButton.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -45,7 +45,7 @@ export class LogoutButton extends Component {
     return (
       <HeaderGlobalAction
         data-testid="logout-btn"
-        className="logout-btn"
+        className="tkn--logout-btn"
         onClick={handleLogout}
         title={this.props.intl.formatMessage({
           id: 'dashboard.header.logOut',

--- a/packages/components/src/components/LogoutButton/LogoutButton.scss
+++ b/packages/components/src/components/LogoutButton/LogoutButton.scss
@@ -1,4 +1,17 @@
-.bx--btn.logout-btn.bx--btn--ghost {
+/*
+Copyright 2019-2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.bx--btn.tkn--logout-btn.bx--btn--ghost {
   position: absolute;
   right: 32px;
   border-width: 1px;

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -347,7 +347,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           {rerun}
         </RunHeader>
         {customNotification}
-        <div className="tasks">
+        <div className="tkn--tasks">
           <TaskTree
             onSelect={this.handleTaskSelected}
             selectedTaskId={selectedTaskId}

--- a/packages/components/src/components/Rerun/Rerun.js
+++ b/packages/components/src/components/Rerun/Rerun.js
@@ -83,7 +83,7 @@ export class Rerun extends Component {
       <Button
         data-testid="rerun-btn"
         kind="ghost"
-        className="rerun-btn"
+        className="tkn--rerun-btn"
         renderIcon={Restart}
         onClick={this.handleRerun}
       >

--- a/packages/components/src/components/Rerun/Rerun.scss
+++ b/packages/components/src/components/Rerun/Rerun.scss
@@ -1,3 +1,16 @@
-.bx--btn.rerun-btn.bx--btn--ghost {
+/*
+Copyright 2019-2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.bx--btn.tkn--rerun-btn.bx--btn--ghost {
   border-width: 1px;
 }

--- a/packages/components/src/components/Rerun/Rerun.test.js
+++ b/packages/components/src/components/Rerun/Rerun.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -65,7 +65,7 @@ it('rerun button is ghost styled', async () => {
   );
   const rerunButton = getByTestId('rerun-btn');
   const rerunButtonIsGhost = rerunButton.getElementsByClassName(
-    'rerun-btn bx--btn bx--btn--ghost'
+    'tkn--rerun-btn bx--btn bx--btn--ghost'
   );
   await waitForElement(() => rerunButtonIsGhost);
 });

--- a/packages/components/src/components/RunHeader/RunHeader.scss
+++ b/packages/components/src/components/RunHeader/RunHeader.scss
@@ -46,7 +46,7 @@ limitations under the License.
       white-space: nowrap;
     }
 
-    .rerun-btn {
+    .tkn--rerun-btn {
       margin-left: auto;
     }
   }

--- a/packages/components/src/components/Spinner/Spinner.js
+++ b/packages/components/src/components/Spinner/Spinner.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,7 +19,7 @@ export default function Spinner({ className }) {
   return (
     <svg
       aria-label="running"
-      className={`spinner ${className}`}
+      className={`tkn--spinner ${className}`}
       viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/packages/components/src/components/Spinner/Spinner.scss
+++ b/packages/components/src/components/Spinner/Spinner.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.spinner {
+.tkn--spinner {
   width: 20px;
   height: 20px;
   animation-name: rotateThis;

--- a/packages/components/src/components/Step/Step.scss
+++ b/packages/components/src/components/Step/Step.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -52,7 +52,7 @@ limitations under the License.
     align-self: center;
     margin-right: 0.55rem;
 
-    &.spinner {
+    &.tkn--spinner {
       position: relative;
       top: -0.1rem;
       left: -0.1rem;

--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -145,7 +145,7 @@ class StepDefinition extends Component {
 
     const paramsResources = this.getIOTables();
     return (
-      <div className="step-definition">
+      <div className="tkn--step-definition">
         <div className="title">
           <FormattedMessage
             id="dashboard.step.stepDefinition"

--- a/packages/components/src/components/StepDefinition/StepDefinition.scss
+++ b/packages/components/src/components/StepDefinition/StepDefinition.scss
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.step-definition {
+.tkn--step-definition {
   > .title {
     font-weight: bold;
     font-size: 0.75rem;

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -34,7 +34,7 @@ const StepDetails = props => {
       ? 'cancelled'
       : status;
   return (
-    <div className="step-details">
+    <div className="tkn--step-details">
       <StepDetailsHeader
         reason={reason}
         status={status}

--- a/packages/components/src/components/StepDetails/StepDetails.scss
+++ b/packages/components/src/components/StepDetails/StepDetails.scss
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.step-details {
+.tkn--step-details {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;

--- a/packages/components/src/components/StepDetailsHeader/StepDetailsHeader.js
+++ b/packages/components/src/components/StepDetailsHeader/StepDetailsHeader.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -98,7 +98,7 @@ class StepDetailsHeader extends Component {
     const statusLabel = this.statusLabel();
     return (
       <header
-        className="step-details-header"
+        className="tkn--step-details-header"
         data-status={status}
         data-reason={reason}
       >

--- a/packages/components/src/components/StepDetailsHeader/StepDetailsHeader.scss
+++ b/packages/components/src/components/StepDetailsHeader/StepDetailsHeader.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 @import '~@tektoncd/dashboard-components/dist/scss/vars';
 
-.step-details-header {
+.tkn--step-details-header {
   padding: 1.3rem 1.6rem 0;
 
   > h2 {
@@ -32,7 +32,7 @@ limitations under the License.
       width: 24px;
       height: 24px;
 
-      &.spinner {
+      &.tkn--spinner {
         position: relative;
         top: -0.1rem;
         left: -0.1rem;

--- a/packages/components/src/components/StepStatus/StepStatus.js
+++ b/packages/components/src/components/StepStatus/StepStatus.js
@@ -36,7 +36,7 @@ const StepStatus = ({ intl, status }) => {
       });
 
   return (
-    <div className="step-status">
+    <div className="tkn--step-status">
       <div className="title">
         {intl.formatMessage({
           id: 'dashboard.step.containerStatus',

--- a/packages/components/src/components/StepStatus/StepStatus.scss
+++ b/packages/components/src/components/StepStatus/StepStatus.scss
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.step-status {
+.tkn--step-status {
   > .title {
     font-weight: bold;
     font-size: 0.75rem;

--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -140,9 +140,7 @@ const Table = props => {
   const translateWithId = getTranslateWithId(intl);
 
   return (
-    <div
-      className={`tableComponent ${filters ? 'tkn--table-with-filters' : ''}`}
-    >
+    <div className={`tkn--table ${filters ? 'tkn--table-with-filters' : ''}`}>
       <DataTable
         key={selectedNamespace}
         rows={dataRows}

--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -13,7 +13,7 @@ limitations under the License.
 
 @import '~carbon-components/scss/globals/scss/vars';
 
-.tableComponent {
+.tkn--table {
   .bx--table-toolbar {
     background: transparent;
   }

--- a/packages/components/src/components/Task/Task.scss
+++ b/packages/components/src/components/Task/Task.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -106,7 +106,7 @@ limitations under the License.
     vertical-align: text-top;
     margin-right: 0.7rem;
 
-    &.spinner {
+    &.tkn--spinner {
       position: relative;
       top: -0.1rem;
       left: -0.1rem;

--- a/packages/components/src/components/TaskRunStatus/TaskRunStatus.js
+++ b/packages/components/src/components/TaskRunStatus/TaskRunStatus.js
@@ -24,8 +24,8 @@ const TaskRunStatus = props => {
   const displayName = taskRun.pipelineTaskName || taskRun.taskRunName;
 
   return (
-    <div className="step-details">
-      <header className="step-details-header">
+    <div className="tkn--step-details">
+      <header className="tkn--step-details-header">
         <h2>
           <ChevronRight className="status-icon" />
           {displayName}
@@ -45,7 +45,7 @@ const TaskRunStatus = props => {
             defaultMessage: 'Status'
           })}
         >
-          <div className="step-status">
+          <div className="tkn--step-status">
             <ViewYAML resource={taskRun.status} />
           </div>
         </Tab>

--- a/packages/components/src/components/TaskRunStatus/TaskRunStatus.scss
+++ b/packages/components/src/components/TaskRunStatus/TaskRunStatus.scss
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.step-status {
+.tkn--step-status {
   > .title {
     font-weight: bold;
     font-size: 0.75rem;
@@ -32,7 +32,7 @@ limitations under the License.
   }
 }
 
-.step-details {
+.tkn--step-details {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;

--- a/packages/components/src/components/TaskSkeleton/TaskSkeleton.js
+++ b/packages/components/src/components/TaskSkeleton/TaskSkeleton.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,8 +18,8 @@ import './TaskSkeleton.scss';
 
 export default function TaskSkeleton() {
   return (
-    <li className="task-skeleton">
-      <SkeletonPlaceholder className="task-placeholder" />
+    <li className="tkn--task-skeleton">
+      <SkeletonPlaceholder className="tkn--task-placeholder" />
     </li>
   );
 }

--- a/packages/components/src/components/TaskSkeleton/TaskSkeleton.scss
+++ b/packages/components/src/components/TaskSkeleton/TaskSkeleton.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.task-skeleton {
+.tkn--task-skeleton {
   height: 2.1rem;
   padding: 8px 8px 0;
 
-  .task-placeholder {
+  .tkn--task-placeholder {
     width: 80%;
     height: 100%;
   }

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -29,7 +29,7 @@ class TaskTree extends Component {
     }
 
     return (
-      <ol className="task-tree">
+      <ol className="tkn--task-tree">
         {taskRuns.map((taskRun, index) => {
           if (!taskRun) {
             return null;

--- a/packages/components/src/components/TaskTree/TaskTree.scss
+++ b/packages/components/src/components/TaskTree/TaskTree.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.task-tree {
+.tkn--task-tree {
   border-right: 1px solid #dfe3e6;
   width: 21%;
   min-width: 15rem;

--- a/packages/components/src/scss/Run.scss
+++ b/packages/components/src/scss/Run.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.tasks {
+.tkn--tasks {
   display: flex;
   flex-wrap: nowrap;
   border: 1px solid #dfe3e6;
@@ -21,11 +21,11 @@ limitations under the License.
   background-color: white;
 }
 
-.task-tree {
+.tkn--task-tree {
   flex-shrink: 0;
 }
 
-.step-details {
+.tkn--step-details {
   flex-grow: 1;
 }
 

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -234,7 +234,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
           runName={taskRun.taskRunName}
           status={taskRun.succeeded}
         />
-        <div className="tasks">
+        <div className="tkn--tasks">
           <TaskTree
             onSelect={this.handleTaskSelected}
             selectedTaskId={taskRun.id}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/596

Add `tkn` prefix to our CSS class names to prevent styles
leaking to 3rd party host pages, and also to avoid generically
named class selectors from the host page's style inadvertently
impacting the dashboard components.

`tkn` was chosen as it's short and recognisable (same name as
the Tekton CLI).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
