### PR TITLE
Add unsafe inline and blob to CSP

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -17,7 +17,7 @@ const contentSecurityPolicy = {
   development:
     "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-eval'; style-src blob:; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;",
   production:
-    "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;"
+    "default-src 'none'; img-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;"
 };
 
 module.exports = ({ mode }) => ({


### PR DESCRIPTION
For https://github.com/tektoncd/dashboard/issues/1311

# Changes

Adds unsafe inline and blob - blob allows the extension to try and load, unsafe inline remedies the css problems. Unsure if unsafe inline is good to have in a prod CSP though so want your take on this please @AlanGreene (have read it's best not to use it where possible, preferring dedicated files)

Also, should I be augmenting the dev config too?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
