### PR TITLE
Change finish button for patching secrets to a toolbar button

### DIFF
--- a/src/components/CreateSecret/ServiceAccountSelector.js
+++ b/src/components/CreateSecret/ServiceAccountSelector.js
@@ -16,7 +16,7 @@ import { injectIntl } from 'react-intl';
 
 import { Table } from '@tektoncd/dashboard-components';
 import { getErrorMessage } from '@tektoncd/dashboard-utils';
-import { Button, InlineNotification } from 'carbon-components-react';
+import { InlineNotification } from 'carbon-components-react';
 import { DataConnected24 as Patch } from '@carbon/icons-react';
 
 const ServiceAccountSelector = props => {
@@ -80,15 +80,6 @@ const ServiceAccountSelector = props => {
             { name }
           )}
         </h1>
-        <Button
-          iconDescription={intl.formatMessage({
-            id: 'dashboard.createSecret.finishButton',
-            defaultMessage: 'Finish'
-          })}
-          onClick={handleClose}
-        >
-          Finish
-        </Button>
       </div>
       <div>
         <p>
@@ -118,6 +109,15 @@ const ServiceAccountSelector = props => {
           },
           { kind: 'Secrets', selectedNamespace: namespace }
         )}
+        toolbarButtons={[
+          {
+            onClick: handleClose,
+            text: intl.formatMessage({
+              id: 'dashboard.createSecret.finishButton',
+              defaultMessage: 'Finish'
+            })
+          }
+        ]}
         batchActionButtons={[
           {
             onClick: serviceAccountsSelected => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1105

- Moves the  finish button on the secret patching page to a toolbar button, meaning you will never be able to see both the finish and the patch button

<img width="1134" alt="Screenshot 2020-04-21 at 16 55 15" src="https://user-images.githubusercontent.com/52741262/79961803-22eea680-847f-11ea-8c80-52414dbfd3cc.png">
<img width="1128" alt="Screenshot 2020-04-21 at 16 55 22" src="https://user-images.githubusercontent.com/52741262/79961808-24b86a00-847f-11ea-809e-d6cc950ea186.png">


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
