### PR TITLE
Add custom DataTableSkeleton component

### DIFF
--- a/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import './DataTableSkeleton.scss';
+
+const DataTableSkeleton = ({
+  className,
+  columnCount,
+  headers,
+  rowCount,
+  ...rest
+}) => {
+  const rowRepeat = rowCount - 1;
+  const columns =
+    headers ||
+    Array.from({ length: columnCount }, (_, index) => ({ key: index }));
+  const rows = Array.from({ length: rowRepeat }, (_, index) => (
+    <tr key={index}>
+      {columns.map(column => (
+        <td key={column} />
+      ))}
+    </tr>
+  ));
+
+  return (
+    <table
+      className={`${className} bx--data-table bx--skeleton tkn--data-table-skeleton`}
+      {...rest}
+    >
+      <thead>
+        <tr>
+          {columns.map(({ key, header }) => (
+            <th key={key}>{header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {columns.map(({ key }) => (
+            <td key={key}>
+              <span />
+            </td>
+          ))}
+        </tr>
+        {rows}
+      </tbody>
+    </table>
+  );
+};
+
+DataTableSkeleton.propTypes = {
+  className: PropTypes.string,
+  columnCount: PropTypes.number,
+  headers: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.shape({
+      key: PropTypes.string,
+      header: PropTypes.node
+    })
+  ]),
+  rowCount: PropTypes.number
+};
+DataTableSkeleton.defaultProps = {
+  className: '',
+  columnCount: 5,
+  headers: [],
+  rowCount: 5
+};
+
+export default DataTableSkeleton;

--- a/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.scss
+++ b/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.scss
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/vars';
+
+.tkn--data-table-skeleton.bx--data-table.bx--skeleton {
+  th {
+    vertical-align: middle;
+
+    &:nth-child(3n + 1) {
+      width: 10%;
+    }
+
+    &:nth-child(3n + 2) {
+      width: 30%;
+    }
+
+    &:nth-child(3n + 3) {
+      width: 15%;
+    }
+  }
+
+  th span,
+  td span {
+    @include skeleton;
+    width: 75%;
+    height: 1rem;
+    display: block;
+  }
+
+  tr:hover {
+    td {
+      border-color: $ui-03;
+      background: transparent;
+      &:first-of-type,
+      &:last-of-type {
+        border-color: $ui-03;
+      }
+    }
+  }
+}

--- a/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
+++ b/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { number, object } from '@storybook/addon-knobs';
+import DataTableSkeleton from './DataTableSkeleton';
+
+const props = () => ({
+  columnCount: number('columnCount', 5),
+  headers: object('headers', [
+    { key: 'status', header: 'Status' },
+    { key: 'name', header: 'Name' },
+    { key: 'pipeline', header: 'Pipeline' },
+    { key: 'namespace', header: 'Namespace' },
+    { key: 'created', header: 'Created' },
+    { key: 'duration', header: 'Duration' }
+  ]),
+  rowCount: number('rowCount', 5)
+});
+
+storiesOf('Components/DataTableSkeleton', module).add('default', () => (
+  <DataTableSkeleton {...props()} />
+));

--- a/packages/components/src/components/DataTableSkeleton/index.js
+++ b/packages/components/src/components/DataTableSkeleton/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+export { default } from './DataTableSkeleton';

--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -17,7 +17,6 @@ import PropTypes from 'prop-types';
 import {
   Button,
   DataTable,
-  DataTableSkeleton,
   TableBatchAction,
   TableBatchActions,
   TableSelectAll,
@@ -27,6 +26,8 @@ import {
 } from 'carbon-components-react';
 
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+
+import { DataTableSkeleton } from '..';
 
 import './Table.scss';
 
@@ -139,6 +140,9 @@ const Table = props => {
   const filterFields = !!dataRows.length && filters;
   const translateWithId = getTranslateWithId(intl);
 
+  const hasToolbar =
+    filterFields || toolbarButtons.length || shouldRenderBatchActions;
+
   return (
     <div
       className={`tableComponent ${filters ? 'tkn--table-with-filters' : ''}`}
@@ -160,9 +164,7 @@ const Table = props => {
           selectedRows
         }) => (
           <TableContainer title={title}>
-            {(filterFields ||
-              toolbarButtons.length ||
-              shouldRenderBatchActions) && (
+            {hasToolbar && (
               <TableToolbar>
                 {filterFields}
                 {shouldRenderBatchActions && (

--- a/packages/components/src/components/Table/Table.stories.js
+++ b/packages/components/src/components/Table/Table.stories.js
@@ -49,14 +49,6 @@ storiesOf('Components/Table', module)
 
     return (
       <Table
-        title={text('title', 'Resource Name')}
-        rows={[]}
-        headers={headers}
-        selectedNamespace={text('selectedNamespace', '*')}
-        loading={boolean('loading', false)}
-        filters={getFilters(
-          boolean('showFilters (for testing purposes only)', false)
-        )}
         emptyTextAllNamespaces={text(
           'emptyTextAllNamespaces',
           'No rows in any namespace'
@@ -65,6 +57,14 @@ storiesOf('Components/Table', module)
           'emptyTextSelectedNamespace',
           'No rows in selected namespace'
         )}
+        filters={getFilters(
+          boolean('showFilters (for testing purposes only)', false)
+        )}
+        headers={headers}
+        loading={boolean('loading', false)}
+        rows={[]}
+        selectedNamespace={text('selectedNamespace', '*')}
+        title={text('title', 'Resource Name')}
       />
     );
   })
@@ -80,23 +80,23 @@ storiesOf('Components/Table', module)
 
     return (
       <Table
-        title={text('title', 'Resource Name')}
-        rows={rows}
+        emptyTextAllNamespaces="No rows in any namespace"
+        emptyTextSelectedNamespace="No rows in selected namespace"
+        filters={getFilters(
+          boolean('showFilters (for testing purposes only)', false)
+        )}
         headers={[
           { key: 'name', header: 'Name' },
           { key: 'namespace', header: 'Namespace' },
           { key: 'date', header: 'Date Created' }
         ]}
-        selectedNamespace="*"
         loading={boolean('loading', false)}
-        filters={getFilters(
-          boolean('showFilters (for testing purposes only)', false)
-        )}
+        rows={rows}
+        selectedNamespace="*"
+        title={text('title', 'Resource Name')}
         toolbarButtons={[
           { onClick: action('handleNew'), text: 'Add', icon: Add }
         ]}
-        emptyTextAllNamespaces="No rows in any namespace"
-        emptyTextSelectedNamespace="No rows in selected namespace"
       />
     );
   })
@@ -112,21 +112,21 @@ storiesOf('Components/Table', module)
 
     return (
       <Table
-        title={text('title', 'Resource Name')}
-        rows={rows}
+        batchActionButtons={[
+          { onClick: action('handleDelete'), text: 'Delete', icon: Delete }
+        ]}
+        filters={getFilters(
+          boolean('showFilters (for testing purposes only)', false)
+        )}
         headers={[
           { key: 'name', header: 'Name' },
           { key: 'namespace', header: 'Namespace' },
           { key: 'date', header: 'Created' }
         ]}
-        selectedNamespace="*"
         loading={boolean('loading', false)}
-        filters={getFilters(
-          boolean('showFilters (for testing purposes only)', false)
-        )}
-        batchActionButtons={[
-          { onClick: action('handleDelete'), text: 'Delete', icon: Delete }
-        ]}
+        rows={rows}
+        selectedNamespace="*"
+        title={text('title', 'Resource Name')}
       />
     );
   })
@@ -156,22 +156,25 @@ storiesOf('Components/Table', module)
 
       return (
         <Table
-          title={text('title', 'Resource Name')}
-          rows={rows}
+          batchActionButtons={[
+            { onClick: action('handleDelete'), text: 'Delete', icon: Delete },
+            { onClick: action('handleRerun'), text: 'Rerun', icon: Rerun }
+          ]}
+          emptyTextAllNamespaces="No rows in any namespace"
+          emptyTextSelectedNamespace="No rows in selected namespace"
+          filters={getFilters(
+            boolean('showFilters (for testing purposes only)', false)
+          )}
           headers={[
             { key: 'name', header: 'Name' },
             { key: 'namespace', header: 'Namespace' },
             { key: 'date', header: 'Date Created' }
           ]}
-          selectedNamespace="*"
           isSortable={boolean('isSortable', true)}
-          filters={getFilters(
-            boolean('showFilters (for testing purposes only)', false)
-          )}
-          batchActionButtons={[
-            { onClick: action('handleDelete'), text: 'Delete', icon: Delete },
-            { onClick: action('handleRerun'), text: 'Rerun', icon: Rerun }
-          ]}
+          loading={boolean('loading', false)}
+          rows={rows}
+          selectedNamespace="*"
+          title={text('title', 'Resource Name')}
           toolbarButtons={[
             { onClick: action('handleNew'), text: 'Add', icon: Add },
             {
@@ -180,9 +183,6 @@ storiesOf('Components/Table', module)
               icon: RerunAll
             }
           ]}
-          loading={false}
-          emptyTextAllNamespaces="No rows in any namespace"
-          emptyTextSelectedNamespace="No rows in selected namespace"
         />
       );
     }

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -13,6 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 export { default as CancelButton } from './CancelButton';
+export { default as DataTableSkeleton } from './DataTableSkeleton';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as FormattedDate } from './FormattedDate';
 export { default as FormattedDuration } from './FormattedDuration';

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -17,13 +17,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   DataTable,
-  DataTableSkeleton,
   InlineNotification,
   Tab,
   Tabs,
   Tag
 } from 'carbon-components-react';
-import { FormattedDate, ViewYAML } from '@tektoncd/dashboard-components';
+import {
+  DataTableSkeleton,
+  FormattedDate,
+  ViewYAML
+} from '@tektoncd/dashboard-components';
 import { formatLabels, getErrorMessage } from '@tektoncd/dashboard-utils';
 
 import {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Carbon 10.11 introduces a new style for the DataTableSkeleton
that is very busy and doesn't work well for our table-heavy UI.
It assumes that all tables have a title and button which is not the
case for many of our pages, and also puts the skeleton loaders
in every cell.

Add our own custom DataTableSkeleton based on the styles that
were present in Carbon 10.10 and earlier. This keeps a cleaner look
without unnecessary elements that would cause jumpiness on
our pages where the button / title aren't used.

For comparison:
- [Carbon skeleton](https://react.carbondesignsystem.com/?path=/story/datatableskeleton--default)
  ![image](https://user-images.githubusercontent.com/2829095/80141044-d3080080-85a0-11ea-857b-cca66368fc3b.png)

- [Custom skeleton from this PR](https://alangreene.github.io/dashboard/?path=/story/components-datatableskeleton--default)
  ![image](https://user-images.githubusercontent.com/2829095/80141090-edda7500-85a0-11ea-9d10-4db13de65d4f.png)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
