### PR TITLE
Define URLs and paths for the 'Create' pages

### DIFF
--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -17,9 +17,32 @@ function byNamespace({ path = '' } = {}) {
 }
 
 export const paths = {
+  about() {
+    return '/about';
+  },
+  byNamespace,
   clusterTasks: {
     all() {
       return '/clustertasks';
+    }
+  },
+  clusterTriggerBindings: {
+    all() {
+      return '/clustertriggerbindings';
+    },
+    byName: function byName() {
+      return '/clustertriggerbindings/:clusterTriggerBindingName';
+    }
+  },
+  eventListeners: {
+    all() {
+      return '/eventlisteners';
+    },
+    byName() {
+      return byNamespace({ path: '/eventlisteners/:eventListenerName' });
+    },
+    byNamespace() {
+      return byNamespace({ path: '/eventlisteners' });
     }
   },
   extensions: {
@@ -30,27 +53,45 @@ export const paths = {
       return `/extensions/${name}`;
     }
   },
-  about() {
-    return '/about';
-  },
   importResources() {
     return '/importresources';
   },
-  byNamespace,
+  kubernetesResources: {
+    all() {
+      return '/:group/:version/:type';
+    },
+    byName() {
+      return byNamespace({ path: '/:group/:version/:type/:name' });
+    },
+    byNamespace() {
+      return byNamespace({ path: '/:group/:version/:type' });
+    },
+    cluster() {
+      return '/:group/:version/:type/:name';
+    }
+  },
   pipelineResources: {
     all() {
       return '/pipelineresources';
     },
+    byName() {
+      return byNamespace({ path: '/pipelineresources/:pipelineResourceName' });
+    },
     byNamespace() {
       return byNamespace({ path: '/pipelineresources' });
     },
-    byName() {
-      return byNamespace({ path: '/pipelineresources/:pipelineResourceName' });
+    create() {
+      return '/pipelineresources/create';
     }
   },
   pipelineRuns: {
     all() {
       return '/pipelineruns';
+    },
+    byName() {
+      return byNamespace({
+        path: '/pipelineruns/:pipelineRunName'
+      });
     },
     byNamespace() {
       return byNamespace({ path: '/pipelineruns' });
@@ -61,10 +102,8 @@ export const paths = {
           '/pipelineruns?labelSelector=tekton.dev%2Fpipeline%3D:pipelineName'
       });
     },
-    byName() {
-      return byNamespace({
-        path: '/pipelineruns/:pipelineRunName'
-      });
+    create() {
+      return '/pipelineruns/create';
     }
   },
   pipelines: {
@@ -76,11 +115,11 @@ export const paths = {
     }
   },
   rawCRD: {
-    cluster() {
-      return '/:type/:name';
-    },
     byNamespace() {
       return byNamespace({ path: '/:type/:name' });
+    },
+    cluster() {
+      return '/:type/:name';
     }
   },
   secrets: {
@@ -92,36 +131,42 @@ export const paths = {
     },
     byNamespace() {
       return byNamespace({ path: '/secrets' });
+    },
+    create() {
+      return '/secrets/create';
     }
   },
   serviceAccounts: {
     all() {
       return '/serviceaccounts';
     },
-    byNamespace() {
-      return byNamespace({ path: '/serviceaccounts' });
-    },
     byName() {
       return byNamespace({ path: '/serviceaccounts/:serviceAccountName' });
+    },
+    byNamespace() {
+      return byNamespace({ path: '/serviceaccounts' });
     }
   },
   taskRuns: {
     all() {
       return '/taskruns';
     },
+    byName() {
+      return byNamespace({ path: '/taskruns/:taskRunName' });
+    },
     byNamespace() {
       return byNamespace({ path: '/taskruns' });
+    },
+    byClusterTask() {
+      return '/taskruns?labelSelector=tekton.dev%2Ftask%3D:taskName';
     },
     byTask() {
       return byNamespace({
         path: '/taskruns?labelSelector=tekton.dev%2Ftask%3D:taskName'
       });
     },
-    byClusterTask() {
-      return '/taskruns?labelSelector=tekton.dev%2Ftask%3D:taskName';
-    },
-    byName() {
-      return byNamespace({ path: '/taskruns/:taskRunName' });
+    create() {
+      return '/taskruns/create';
     }
   },
   tasks: {
@@ -132,59 +177,26 @@ export const paths = {
       return byNamespace({ path: '/tasks' });
     }
   },
-  eventListeners: {
+  triggerBindings: {
     all() {
-      return '/eventlisteners';
-    },
-    byNamespace() {
-      return byNamespace({ path: '/eventlisteners' });
+      return '/triggerbindings';
     },
     byName() {
-      return byNamespace({ path: '/eventlisteners/:eventListenerName' });
+      return byNamespace({ path: '/triggerbindings/:triggerBindingName' });
+    },
+    byNamespace() {
+      return byNamespace({ path: '/triggerbindings' });
     }
   },
   triggerTemplates: {
     all() {
       return '/triggertemplates';
     },
-    byNamespace() {
-      return byNamespace({ path: '/triggertemplates' });
-    },
     byName() {
       return byNamespace({ path: '/triggertemplates/:triggerTemplateName' });
-    }
-  },
-  triggerBindings: {
-    all() {
-      return '/triggerbindings';
     },
     byNamespace() {
-      return byNamespace({ path: '/triggerbindings' });
-    },
-    byName() {
-      return byNamespace({ path: '/triggerbindings/:triggerBindingName' });
-    }
-  },
-  clusterTriggerBindings: {
-    all() {
-      return '/clustertriggerbindings';
-    },
-    byName: function byName() {
-      return '/clustertriggerbindings/:clusterTriggerBindingName';
-    }
-  },
-  kubernetesResources: {
-    all() {
-      return '/:group/:version/:type';
-    },
-    byNamespace() {
-      return byNamespace({ path: '/:group/:version/:type' });
-    },
-    cluster() {
-      return '/:group/:version/:type/:name';
-    },
-    byName() {
-      return byNamespace({ path: '/:group/:version/:type/:name' });
+      return byNamespace({ path: '/triggertemplates' });
     }
   }
 };

--- a/packages/utils/src/utils/router.test.js
+++ b/packages/utils/src/utils/router.test.js
@@ -18,6 +18,7 @@ const namespace = 'fake_namespace';
 const pipelineName = 'fake_pipelineName';
 const pipelineResourceName = 'fake_pipelineResourceName';
 const pipelineRunName = 'fake_pipelineRunName';
+const secretName = 'fake_secretName';
 const serviceAccountName = 'fake_serviceAccountName';
 const taskName = 'fake_taskName';
 const taskRunName = 'fake_taskRunName';
@@ -25,33 +26,8 @@ const triggerBindingName = 'fake_triggerBindingName';
 const clusterTriggerBindingName = 'fake_clusterTriggerBindingName';
 const triggerTemplateName = 'fake_triggerTemplateName';
 
-describe('clusterTasks', () => {
-  it('all', () => {
-    expect(urls.clusterTasks.all()).toEqual(
-      generatePath(paths.clusterTasks.all())
-    );
-  });
-});
-
-describe('extensions', () => {
-  it('all', () => {
-    expect(urls.extensions.all()).toEqual(generatePath(paths.extensions.all()));
-  });
-
-  it('byName', () => {
-    const name = 'name';
-    expect(urls.extensions.byName({ name })).toEqual(
-      generatePath(paths.extensions.byName({ name }), { name })
-    );
-  });
-});
-
 it('about', () => {
   expect(urls.about()).toEqual(generatePath(paths.about()));
-});
-
-it('importResources', () => {
-  expect(urls.importResources()).toEqual(generatePath(paths.importResources()));
 });
 
 describe('byNamespace', () => {
@@ -69,227 +45,10 @@ describe('byNamespace', () => {
   });
 });
 
-describe('pipelineResources', () => {
+describe('clusterTasks', () => {
   it('all', () => {
-    expect(urls.pipelineResources.all()).toEqual(
-      generatePath(paths.pipelineResources.all())
-    );
-  });
-
-  it('byNamespace', () => {
-    expect(urls.pipelineResources.byNamespace({ namespace })).toEqual(
-      generatePath(paths.pipelineResources.byNamespace(), { namespace })
-    );
-  });
-
-  it('byName', () => {
-    expect(
-      urls.pipelineResources.byName({ namespace, pipelineResourceName })
-    ).toEqual(
-      generatePath(paths.pipelineResources.byName(), {
-        namespace,
-        pipelineResourceName
-      })
-    );
-  });
-});
-
-describe('pipelineRuns', () => {
-  it('all', () => {
-    expect(urls.pipelineRuns.all()).toEqual(
-      generatePath(paths.pipelineRuns.all())
-    );
-  });
-
-  it('byNamespace', () => {
-    expect(urls.pipelineRuns.byNamespace({ namespace })).toEqual(
-      generatePath(paths.pipelineRuns.byNamespace(), { namespace })
-    );
-  });
-
-  it('byPipeline', () => {
-    expect(urls.pipelineRuns.byPipeline({ namespace, pipelineName })).toEqual(
-      generatePath(paths.pipelineRuns.byPipeline(), { namespace, pipelineName })
-    );
-  });
-
-  it('byName', () => {
-    expect(urls.pipelineRuns.byName({ namespace, pipelineRunName })).toEqual(
-      generatePath(paths.pipelineRuns.byName(), {
-        namespace,
-        pipelineRunName
-      })
-    );
-  });
-});
-
-describe('pipelines', () => {
-  it('all', () => {
-    expect(urls.pipelines.all()).toEqual(generatePath(paths.pipelines.all()));
-  });
-
-  it('byNamespace', () => {
-    expect(urls.pipelines.byNamespace({ namespace })).toEqual(
-      generatePath(paths.pipelines.byNamespace(), { namespace })
-    );
-  });
-});
-
-describe('rawCRD', () => {
-  it('cluster', () => {
-    const type = 'tasks';
-    const name = taskName;
-    expect(urls.rawCRD.cluster({ type, name })).toEqual(
-      generatePath(paths.rawCRD.cluster(), { type, name })
-    );
-  });
-
-  it('byNamespace', () => {
-    const type = 'tasks';
-    const name = taskName;
-    expect(urls.rawCRD.byNamespace({ namespace, type, name })).toEqual(
-      generatePath(paths.rawCRD.byNamespace(), { namespace, type, name })
-    );
-  });
-});
-
-describe('secrets', () => {
-  it('all', () => {
-    expect(urls.secrets.all()).toEqual(generatePath(paths.secrets.all()));
-  });
-});
-describe('serviceAccounts', () => {
-  it('all', () => {
-    expect(urls.serviceAccounts.all()).toEqual(
-      generatePath(paths.serviceAccounts.all())
-    );
-  });
-  it('byNamespace', () => {
-    expect(urls.serviceAccounts.byNamespace({ namespace })).toEqual(
-      generatePath(paths.serviceAccounts.byNamespace(), { namespace })
-    );
-  });
-  it('byName', () => {
-    expect(
-      urls.serviceAccounts.byName({ namespace, serviceAccountName })
-    ).toEqual(
-      generatePath(paths.serviceAccounts.byName(), {
-        namespace,
-        serviceAccountName
-      })
-    );
-  });
-});
-describe('taskRuns', () => {
-  it('all', () => {
-    expect(urls.taskRuns.all()).toEqual(generatePath(paths.taskRuns.all()));
-  });
-
-  it('byNamespace', () => {
-    expect(urls.taskRuns.byNamespace({ namespace })).toEqual(
-      generatePath(paths.taskRuns.byNamespace(), { namespace })
-    );
-  });
-
-  it('byTask', () => {
-    expect(urls.taskRuns.byTask({ namespace, taskName })).toEqual(
-      generatePath(paths.taskRuns.byTask(), { namespace, taskName })
-    );
-  });
-
-  it('byClusterTask', () => {
-    expect(urls.taskRuns.byClusterTask({ namespace, taskName })).toEqual(
-      generatePath(paths.taskRuns.byClusterTask(), {
-        namespace,
-        taskName
-      })
-    );
-  });
-
-  it('byName', () => {
-    expect(urls.taskRuns.byName({ namespace, taskRunName })).toEqual(
-      generatePath(paths.taskRuns.byName(), { namespace, taskRunName })
-    );
-  });
-});
-
-describe('tasks', () => {
-  it('all', () => {
-    expect(urls.tasks.all()).toEqual(generatePath(paths.tasks.all()));
-  });
-
-  it('byNamespace', () => {
-    expect(urls.tasks.byNamespace({ namespace })).toEqual(
-      generatePath(paths.tasks.byNamespace(), { namespace })
-    );
-  });
-});
-
-describe('eventListeners', () => {
-  it('all', () => {
-    expect(urls.eventListeners.all()).toEqual(
-      generatePath(paths.eventListeners.all())
-    );
-  });
-  it('byNamespace', () => {
-    expect(urls.eventListeners.byNamespace({ namespace })).toEqual(
-      generatePath(paths.eventListeners.byNamespace(), { namespace })
-    );
-  });
-  it('byName', () => {
-    expect(
-      urls.eventListeners.byName({ namespace, eventListenerName })
-    ).toEqual(
-      generatePath(paths.eventListeners.byName(), {
-        namespace,
-        eventListenerName
-      })
-    );
-  });
-});
-
-describe('triggerTemplates', () => {
-  it('all', () => {
-    expect(urls.triggerTemplates.all()).toEqual(
-      generatePath(paths.triggerTemplates.all())
-    );
-  });
-  it('byNamespace', () => {
-    expect(urls.triggerTemplates.byNamespace({ namespace })).toEqual(
-      generatePath(paths.triggerTemplates.byNamespace(), { namespace })
-    );
-  });
-  it('byName', () => {
-    expect(
-      urls.triggerTemplates.byName({ namespace, triggerTemplateName })
-    ).toEqual(
-      generatePath(paths.triggerTemplates.byName(), {
-        namespace,
-        triggerTemplateName
-      })
-    );
-  });
-});
-
-describe('triggerBindings', () => {
-  it('all', () => {
-    expect(urls.triggerBindings.all()).toEqual(
-      generatePath(paths.triggerBindings.all())
-    );
-  });
-  it('byNamespace', () => {
-    expect(urls.triggerBindings.byNamespace({ namespace })).toEqual(
-      generatePath(paths.triggerBindings.byNamespace(), { namespace })
-    );
-  });
-  it('byName', () => {
-    expect(
-      urls.triggerBindings.byName({ namespace, triggerBindingName })
-    ).toEqual(
-      generatePath(paths.triggerBindings.byName(), {
-        namespace,
-        triggerBindingName
-      })
+    expect(urls.clusterTasks.all()).toEqual(
+      generatePath(paths.clusterTasks.all())
     );
   });
 });
@@ -311,6 +70,48 @@ describe('clusterTriggerBindings', () => {
   });
 });
 
+describe('eventListeners', () => {
+  it('all', () => {
+    expect(urls.eventListeners.all()).toEqual(
+      generatePath(paths.eventListeners.all())
+    );
+  });
+
+  it('byName', () => {
+    expect(
+      urls.eventListeners.byName({ namespace, eventListenerName })
+    ).toEqual(
+      generatePath(paths.eventListeners.byName(), {
+        namespace,
+        eventListenerName
+      })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.eventListeners.byNamespace({ namespace })).toEqual(
+      generatePath(paths.eventListeners.byNamespace(), { namespace })
+    );
+  });
+});
+
+describe('extensions', () => {
+  it('all', () => {
+    expect(urls.extensions.all()).toEqual(generatePath(paths.extensions.all()));
+  });
+
+  it('byName', () => {
+    const name = 'name';
+    expect(urls.extensions.byName({ name })).toEqual(
+      generatePath(paths.extensions.byName({ name }), { name })
+    );
+  });
+});
+
+it('importResources', () => {
+  expect(urls.importResources()).toEqual(generatePath(paths.importResources()));
+});
+
 describe('kubernetesResources', () => {
   const group = 'fake_group';
   const name = 'fake_name';
@@ -322,6 +123,21 @@ describe('kubernetesResources', () => {
       generatePath(paths.kubernetesResources.all(), { group, type, version })
     );
   });
+
+  it('byName', () => {
+    expect(
+      urls.kubernetesResources.byName({ group, name, namespace, type, version })
+    ).toEqual(
+      generatePath(paths.kubernetesResources.byName(), {
+        group,
+        name,
+        namespace,
+        type,
+        version
+      })
+    );
+  });
+
   it('byNamespace', () => {
     expect(
       urls.kubernetesResources.byNamespace({ group, namespace, type, version })
@@ -334,6 +150,7 @@ describe('kubernetesResources', () => {
       })
     );
   });
+
   it('cluster', () => {
     expect(
       urls.kubernetesResources.cluster({ group, name, type, version })
@@ -346,17 +163,251 @@ describe('kubernetesResources', () => {
       })
     );
   });
+});
+
+describe('pipelineResources', () => {
+  it('all', () => {
+    expect(urls.pipelineResources.all()).toEqual(
+      generatePath(paths.pipelineResources.all())
+    );
+  });
+
   it('byName', () => {
     expect(
-      urls.kubernetesResources.byName({ group, name, namespace, type, version })
+      urls.pipelineResources.byName({ namespace, pipelineResourceName })
     ).toEqual(
-      generatePath(paths.kubernetesResources.byName(), {
-        group,
-        name,
+      generatePath(paths.pipelineResources.byName(), {
         namespace,
-        type,
-        version
+        pipelineResourceName
       })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.pipelineResources.byNamespace({ namespace })).toEqual(
+      generatePath(paths.pipelineResources.byNamespace(), { namespace })
+    );
+  });
+
+  it('create', () => {
+    expect(urls.pipelineResources.create()).toEqual(
+      generatePath(paths.pipelineResources.create())
+    );
+  });
+});
+
+describe('pipelineRuns', () => {
+  it('all', () => {
+    expect(urls.pipelineRuns.all()).toEqual(
+      generatePath(paths.pipelineRuns.all())
+    );
+  });
+
+  it('byName', () => {
+    expect(urls.pipelineRuns.byName({ namespace, pipelineRunName })).toEqual(
+      generatePath(paths.pipelineRuns.byName(), {
+        namespace,
+        pipelineRunName
+      })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.pipelineRuns.byNamespace({ namespace })).toEqual(
+      generatePath(paths.pipelineRuns.byNamespace(), { namespace })
+    );
+  });
+
+  it('create', () => {
+    expect(urls.pipelineRuns.create()).toEqual(
+      generatePath(paths.pipelineRuns.create())
+    );
+  });
+
+  it('byPipeline', () => {
+    expect(urls.pipelineRuns.byPipeline({ namespace, pipelineName })).toEqual(
+      generatePath(paths.pipelineRuns.byPipeline(), { namespace, pipelineName })
+    );
+  });
+});
+
+describe('pipelines', () => {
+  it('all', () => {
+    expect(urls.pipelines.all()).toEqual(generatePath(paths.pipelines.all()));
+  });
+
+  it('byNamespace', () => {
+    expect(urls.pipelines.byNamespace({ namespace })).toEqual(
+      generatePath(paths.pipelines.byNamespace(), { namespace })
+    );
+  });
+});
+
+describe('rawCRD', () => {
+  it('byNamespace', () => {
+    const type = 'tasks';
+    const name = taskName;
+    expect(urls.rawCRD.byNamespace({ namespace, type, name })).toEqual(
+      generatePath(paths.rawCRD.byNamespace(), { namespace, type, name })
+    );
+  });
+
+  it('cluster', () => {
+    const type = 'tasks';
+    const name = taskName;
+    expect(urls.rawCRD.cluster({ type, name })).toEqual(
+      generatePath(paths.rawCRD.cluster(), { type, name })
+    );
+  });
+});
+
+describe('secrets', () => {
+  it('all', () => {
+    expect(urls.secrets.all()).toEqual(generatePath(paths.secrets.all()));
+  });
+
+  it('byName', () => {
+    expect(urls.secrets.byName({ namespace, secretName })).toEqual(
+      generatePath(paths.secrets.byName(), {
+        namespace,
+        secretName
+      })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.secrets.byNamespace({ namespace })).toEqual(
+      generatePath(paths.secrets.byNamespace(), { namespace })
+    );
+  });
+});
+
+describe('serviceAccounts', () => {
+  it('all', () => {
+    expect(urls.serviceAccounts.all()).toEqual(
+      generatePath(paths.serviceAccounts.all())
+    );
+  });
+
+  it('byName', () => {
+    expect(
+      urls.serviceAccounts.byName({ namespace, serviceAccountName })
+    ).toEqual(
+      generatePath(paths.serviceAccounts.byName(), {
+        namespace,
+        serviceAccountName
+      })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.serviceAccounts.byNamespace({ namespace })).toEqual(
+      generatePath(paths.serviceAccounts.byNamespace(), { namespace })
+    );
+  });
+
+  it('create', () => {
+    expect(urls.secrets.create()).toEqual(generatePath(paths.secrets.create()));
+  });
+});
+
+describe('taskRuns', () => {
+  it('all', () => {
+    expect(urls.taskRuns.all()).toEqual(generatePath(paths.taskRuns.all()));
+  });
+
+  it('byClusterTask', () => {
+    expect(urls.taskRuns.byClusterTask({ namespace, taskName })).toEqual(
+      generatePath(paths.taskRuns.byClusterTask(), {
+        namespace,
+        taskName
+      })
+    );
+  });
+
+  it('byName', () => {
+    expect(urls.taskRuns.byName({ namespace, taskRunName })).toEqual(
+      generatePath(paths.taskRuns.byName(), { namespace, taskRunName })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.taskRuns.byNamespace({ namespace })).toEqual(
+      generatePath(paths.taskRuns.byNamespace(), { namespace })
+    );
+  });
+
+  it('byTask', () => {
+    expect(urls.taskRuns.byTask({ namespace, taskName })).toEqual(
+      generatePath(paths.taskRuns.byTask(), { namespace, taskName })
+    );
+  });
+
+  it('create', () => {
+    expect(urls.taskRuns.create()).toEqual(
+      generatePath(paths.taskRuns.create())
+    );
+  });
+});
+
+describe('tasks', () => {
+  it('all', () => {
+    expect(urls.tasks.all()).toEqual(generatePath(paths.tasks.all()));
+  });
+
+  it('byNamespace', () => {
+    expect(urls.tasks.byNamespace({ namespace })).toEqual(
+      generatePath(paths.tasks.byNamespace(), { namespace })
+    );
+  });
+});
+
+describe('triggerBindings', () => {
+  it('all', () => {
+    expect(urls.triggerBindings.all()).toEqual(
+      generatePath(paths.triggerBindings.all())
+    );
+  });
+
+  it('byName', () => {
+    expect(
+      urls.triggerBindings.byName({ namespace, triggerBindingName })
+    ).toEqual(
+      generatePath(paths.triggerBindings.byName(), {
+        namespace,
+        triggerBindingName
+      })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.triggerBindings.byNamespace({ namespace })).toEqual(
+      generatePath(paths.triggerBindings.byNamespace(), { namespace })
+    );
+  });
+});
+
+describe('triggerTemplates', () => {
+  it('all', () => {
+    expect(urls.triggerTemplates.all()).toEqual(
+      generatePath(paths.triggerTemplates.all())
+    );
+  });
+
+  it('byName', () => {
+    expect(
+      urls.triggerTemplates.byName({ namespace, triggerTemplateName })
+    ).toEqual(
+      generatePath(paths.triggerTemplates.byName(), {
+        namespace,
+        triggerTemplateName
+      })
+    );
+  });
+
+  it('byNamespace', () => {
+    expect(urls.triggerTemplates.byNamespace({ namespace })).toEqual(
+      generatePath(paths.triggerTemplates.byNamespace(), { namespace })
     );
   });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/966

As we start to move from our current use of modal dialogs for
the create pages (PipelineResource, PipelineRun, Secret, and soon TaskRun)
to a full-page experience, we need to ensure we have a consistent
URL strategy for these pages.

Define a set of `/<kind>/create` URLs and paths to use for this purpose,
e.g. the Create PipelineResource UI would be at `/pipelineresources/create`

Also reorder the definitions and tests alphabetically to make
it easier to work with them. I found myself jumping around (to
the wrong part of the file) far too often.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
