### PR TITLE
ImportResources : Add dropdown for install namespace

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -595,7 +595,7 @@ export function importResources({
   namespace,
   labels,
   serviceAccount,
-  installNamespace
+  importerNamespace
 }) {
   const taskSpec = {
     resources: {
@@ -753,6 +753,6 @@ export function importResources({
     payload.spec.serviceAccountName = serviceAccount;
   }
 
-  const uri = getTektonAPI('pipelineruns', { namespace: installNamespace });
+  const uri = getTektonAPI('pipelineruns', { namespace: importerNamespace });
   return post(uri, payload);
 }

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -869,14 +869,14 @@ it('importResources', () => {
   const applyDirectory = 'fake-directory';
   const namespace = 'fake-namespace';
   const serviceAccount = 'fake-serviceAccount';
-  const installNamespace = 'fake-install-namespace';
+  const importerNamespace = 'fake-importer-namespace';
 
   const payload = {
     repositoryURL,
     applyDirectory,
     namespace,
     serviceAccount,
-    installNamespace
+    importerNamespace
   };
   const data = {
     apiVersion: 'tekton.dev/v1beta1',

--- a/src/containers/ImportResources/ImportResources.scss
+++ b/src/containers/ImportResources/ImportResources.scss
@@ -21,8 +21,23 @@ limitations under the License.
 
 .outer {
   background-color: white;
-  min-height: 46rem;
+  min-height: 30rem;
 
+  legend.bx--label {
+    margin-left: 2.5rem;
+    margin-bottom: 1rem;
+    font-size: 1rem;
+  }
+
+  .bx--tooltip__label {
+    font-size: 1rem;
+  }
+  
+  legend.bx--label.bx--tooltip__label {
+    margin-left: 0;
+    font-size: 1rem;
+  }
+  
   .bx--combo-box.bx--list-box {
     width: 30%;
   }
@@ -32,19 +47,38 @@ limitations under the License.
   }
 
   .bx--list-box__wrapper {
-    margin-left: 2.8rem;
+    margin-left: 2.5rem;
+    margin-bottom: 2rem;
   }
 
   .bx--btn {
-    margin-left: 2.8rem;
-    margin-top: 2.8rem;
+    margin-left: 2.5rem;
+    margin-top: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .bx--fieldset {
+    margin-bottom: 0;
   }
 
   .bx--form-item {
-    margin: 2.8rem;
+    margin-left: 2.5rem;
+    margin-bottom: 2rem;
   }
 
   .bx--text-input__field-wrapper {
     width: 50%;
+  }
+
+  .bx--accordion {
+    margin-bottom: 1rem;
+  }
+
+  .bx--accordion__title {
+    padding-left: 1.5rem;
+  }
+
+  .bx--accordion__content, .bx--accordion__item--active .bx--accordion__content {
+    padding: .5rem 0;
   }
 }

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -161,7 +161,7 @@ describe('ImportResources component', () => {
           namespace,
           labels,
           serviceAccount,
-          installNamespace
+          importerNamespace
         }) => {
           const labelsShouldEqual = {
             gitOrg: 'test',
@@ -174,7 +174,7 @@ describe('ImportResources component', () => {
           expect(namespace).toEqual('default');
           expect(labels).toEqual(labelsShouldEqual);
           expect(serviceAccount).toEqual('');
-          expect(installNamespace).toEqual('namespace1');
+          expect(importerNamespace).toEqual('namespace1');
 
           return Promise.resolve(headers);
         }


### PR DESCRIPTION
This PR adds a drop down for install namespace selection in the ImportResources container.

Now that the import resources pipeline run is not dependent of a pipeline/task installed in the same namespace as the dashboard, this is not a requirement anymore that the pipeline run executes in the namespace where the dashboard was installed.

This allows to select the namespace where the pipeline run executes and therefore a service account in the selected install namespace.

**NOTE**: install namespace is somewhat unclear as it is not related to dashboard install but i couldn't find a better name. Feel free to suggest a better name.