### PR TITLE
Add recommended k8s labels

### DIFF
--- a/base/200-clusterrole.yaml
+++ b/base/200-clusterrole.yaml
@@ -4,6 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-dashboard-minimal
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/base/201-clusterrolebinding.yaml
+++ b/base/201-clusterrolebinding.yaml
@@ -3,6 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-dashboard-minimal
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
 subjects:
   - kind: ServiceAccount
     name: tekton-dashboard

--- a/base/202-extension-crd.yaml
+++ b/base/202-extension-crd.yaml
@@ -3,6 +3,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: extensions.dashboard.tekton.dev
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
 spec:
   group: dashboard.tekton.dev
   names:

--- a/base/203-serviceaccount.yaml
+++ b/base/203-serviceaccount.yaml
@@ -2,7 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    app: tekton-dashboard
   name: tekton-dashboard
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard

--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -5,18 +5,31 @@ metadata:
   name: tekton-dashboard
   namespace: tekton-pipelines
   labels:
+    app.kubernetes.io/name: dashboard
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-dashboard
+    dashboard.tekton.dev/release: "devel"
     app: tekton-dashboard
     version: "devel"
-    dashboard.tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-dashboard
+      app.kubernetes.io/name: dashboard
+      app.kubernetes.io/component: dashboard
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-dashboard
   template:
     metadata:
       name: tekton-dashboard
       labels:
+        app.kubernetes.io/name: dashboard
+        app.kubernetes.io/component: dashboard
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: tekton-dashboard
         app: tekton-dashboard
     spec:
       serviceAccountName: tekton-dashboard

--- a/base/300-service.yaml
+++ b/base/300-service.yaml
@@ -5,9 +5,14 @@ metadata:
   name: tekton-dashboard
   namespace: tekton-pipelines
   labels:
+    app.kubernetes.io/name: dashboard
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-dashboard
+    dashboard.tekton.dev/release: "devel"
     app: tekton-dashboard
     version: "devel"
-    dashboard.tekton.dev/release: "devel"
 spec:
   ports:
     - name: http
@@ -15,4 +20,7 @@ spec:
       port: 9097
       targetPort: 9097
   selector:
-    app: tekton-dashboard
+    app.kubernetes.io/name: dashboard
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard


### PR DESCRIPTION
This PR adds recommended k8s labels on resources.
Implementation for proposal https://github.com/tektoncd/pipeline/issues/2497

Related PR in pipelines: https://github.com/tektoncd/pipeline/pull/2501

Base: added labels and updated selectors for all resources in `/base`
Go: changed go code in `/pkg/endpoints/dashboard.go`

**NOTES**:
- I removed some old code that implemented various strategies to find dependent applications version. I don't think it's an issue because these versions are old and should not work with the current dashboard (pre v1beta1).
- I didn't touch the code in `/pkg/endpoints/cluster.go`. The code there is bound to ingresses which is not part of this repository. I will address this code in another PR.
- This will introduce a breaking change when trying to update deployments as label selectors have changed.