### PR TITLE
Display filters on empty table

### DIFF
--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -137,11 +137,10 @@ const Table = props => {
   const shouldRenderBatchActions = !!(
     dataRows.length && batchActionButtons.length
   );
-  const filterFields = !!dataRows.length && filters;
   const translateWithId = getTranslateWithId(intl);
 
   const hasToolbar =
-    filterFields || toolbarButtons.length || shouldRenderBatchActions;
+    filters || toolbarButtons.length || shouldRenderBatchActions;
 
   return (
     <div className={`tkn--table ${filters ? 'tkn--table-with-filters' : ''}`}>
@@ -164,7 +163,7 @@ const Table = props => {
           <TableContainer title={title}>
             {hasToolbar && (
               <TableToolbar>
-                {filterFields}
+                {filters}
                 {shouldRenderBatchActions && (
                   <TableBatchActions
                     {...getBatchActionProps()}

--- a/packages/components/src/components/Table/Table.test.js
+++ b/packages/components/src/components/Table/Table.test.js
@@ -108,7 +108,7 @@ describe('Table', () => {
     expect(queryByText(/Add/i)).toBeTruthy();
     expect(queryByLabelText('Select all rows')).toBeFalsy();
     expect(queryByLabelText('Select row')).toBeFalsy();
-    expect(queryByText(filters)).toBeFalsy();
+    expect(queryByText(filters)).toBeTruthy();
     expect(queryByText(emptyTextSelectedNamespace)).toBeTruthy();
     expect(queryByText(emptyTextAllNamespaces)).toBeFalsy();
   });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Ensure any provided filters are rendered on an empty table,
otherwise there's no easy way for the user to change the
filter value. The original intent of hiding the filters when
the table was empty was only meant to impact the case where
no resources were found in any namespace but unintentionally
affects all cases. For the sake of consistency we should just
always display the filters if provided.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
