### PR TITLE
Move CreateSecret to URL addressable page

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -209,49 +209,48 @@ export function updateUnexecutedSteps(steps) {
 
 export function getFilters({ search }) {
   const queryParams = new URLSearchParams(search);
-  let filters = [];
-  queryParams.forEach(function filterValueSplit(value) {
-    filters = value.split(',');
-  });
+  const filters = queryParams
+    .getAll('labelSelector')
+    .toString()
+    .split(',')
+    .filter(Boolean);
   return filters;
 }
 
-export function getAddFilterHandler({ history, match }) {
+export function getAddFilterHandler({ history, location, match }) {
   return function handleAddFilter(labelFilters) {
-    const queryParams = `?${new URLSearchParams({
-      labelSelector: labelFilters
-    }).toString()}`;
-
-    const browserURL = match.url.concat(queryParams);
+    const queryParams = new URLSearchParams(location.search);
+    queryParams.set('labelSelector', labelFilters);
+    const browserURL = match.url.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   };
 }
 
 export function getDeleteFilterHandler({ history, location, match }) {
   return function handleDeleteFilter(filter) {
-    const currentQueryParams = new URLSearchParams(location.search);
-    const labelFilters = currentQueryParams.getAll('labelSelector');
+    const queryParams = new URLSearchParams(location.search);
+    const labelFilters = queryParams.getAll('labelSelector');
     const labelFiltersArray = labelFilters.toString().split(',');
     const index = labelFiltersArray.indexOf(filter);
     labelFiltersArray.splice(index, 1);
 
-    const currentURL = match.url;
     if (labelFiltersArray.length === 0) {
-      history.push(currentURL);
+      queryParams.delete('labelSelector');
     } else {
-      const newQueryParams = `?${new URLSearchParams({
-        labelSelector: labelFiltersArray
-      }).toString()}`;
-      const browserURL = currentURL.concat(newQueryParams);
-      history.push(browserURL);
+      queryParams.set('labelSelector', labelFiltersArray);
     }
+    const queryString = queryParams.toString();
+    const browserURL = match.url.concat(queryString ? `?${queryString}` : '');
+    history.push(browserURL);
   };
 }
 
-export function getClearFiltersHandler({ history, match }) {
+export function getClearFiltersHandler({ history, location, match }) {
   return function handleClearFilters() {
-    const currentURL = match.url;
-    history.push(currentURL);
+    const queryParams = new URLSearchParams(location.search);
+    queryParams.delete('labelSelector');
+    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    history.push(browserURL);
   };
 }
 

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -452,12 +452,15 @@ it('getFilters', () => {
 it('getAddFilterHandler', () => {
   const url = 'someURL';
   const history = { push: jest.fn() };
+  const location = { search: '?nonFilterQueryParam=someValue' };
   const match = { url };
-  const handleAddFilter = getAddFilterHandler({ history, match });
+  const handleAddFilter = getAddFilterHandler({ history, location, match });
   const labelFilters = ['foo1=bar1', 'foo2=bar2'];
   handleAddFilter(labelFilters);
   expect(history.push).toHaveBeenCalledWith(
-    `${url}?labelSelector=${encodeURIComponent('foo1=bar1,foo2=bar2')}`
+    `${url}?nonFilterQueryParam=someValue&labelSelector=${encodeURIComponent(
+      'foo1=bar1,foo2=bar2'
+    )}`
   );
 });
 

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -36,6 +36,7 @@ import {
   ClusterTasks,
   ClusterTriggerBinding,
   ClusterTriggerBindings,
+  CreateSecret,
   CustomResourceDefinition,
   EventListener,
   EventListeners,
@@ -215,6 +216,11 @@ export /* istanbul ignore next */ class App extends Component {
                     path={paths.secrets.byNamespace()}
                     exact
                     component={Secrets}
+                  />
+                  <Route
+                    path={paths.secrets.create()}
+                    exact
+                    component={CreateSecret}
                   />
                   <Route
                     path={paths.serviceAccounts.byName()}

--- a/src/containers/CreateSecret/CreateSecret.test.js
+++ b/src/containers/CreateSecret/CreateSecret.test.js
@@ -91,17 +91,20 @@ const store = mockStore({
   }
 });
 
-it('SecretsCreate renders blank', () => {
-  const props = {
-    open: true
-  };
+const nameValidationErrorMsgRegExp = /Must not start or end with - and be less than 253 characters, contain only lowercase alphanumeric characters or -/i;
+const namespaceValidationErrorRegExp = /Namespace required./i;
+const usernameValidationErrorRegExp = /Username required./i;
+const passwordValidationErrorRegExp = /Password required./i;
+const accessTokenValidationErrorRegExp = /Access Token required./i;
+const serverurlValidationErrorRegExp = /Server URL required./i;
 
+it('SecretsCreate renders blank', () => {
   jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
 
   const { queryByText } = renderWithIntl(
     <Provider store={store}>
-      <CreateSecret {...props} />
+      <CreateSecret location={{ search: '' }} />
     </Provider>
   );
   expect(queryByText('Create new Secret')).toBeTruthy();
@@ -110,13 +113,14 @@ it('SecretsCreate renders blank', () => {
 });
 
 it('Test CreateSecret click events', () => {
-  const handleClose = jest.fn();
-  const handleSubmit = jest.fn();
-  const props = {
-    secrets,
-    handleClose
+  const history = {
+    push: jest.fn()
   };
-
+  const props = {
+    history,
+    location: { search: '' },
+    secrets
+  };
   jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
 
@@ -126,28 +130,21 @@ it('Test CreateSecret click events', () => {
     </Provider>
   );
   fireEvent.click(queryByText('Cancel'));
-  expect(handleClose).toHaveBeenCalledTimes(1);
+  expect(history.push).toHaveBeenCalled();
 
   rerenderWithIntl(
     rerender,
     <Provider store={store}>
-      <CreateSecret open={false} />
+      <CreateSecret {...props} />
     </Provider>
   );
+  expect(queryByText(nameValidationErrorMsgRegExp)).toBeFalsy();
   fireEvent.click(queryByText('Create'));
-  expect(handleSubmit).toHaveBeenCalledTimes(0);
+  expect(queryByText(nameValidationErrorMsgRegExp)).toBeTruthy();
 });
 
-const nameValidationErrorMsgRegExp = /Must not start or end with - and be less than 253 characters, contain only lowercase alphanumeric characters or -/i;
-const namespaceValidationErrorRegExp = /Namespace required./i;
-const usernameValidationErrorRegExp = /Username required./i;
-const passwordValidationErrorRegExp = /Password required./i;
-const accessTokenValidationErrorRegExp = /Access Token required./i;
-const serverurlValidationErrorRegExp = /Server URL required./i;
-
 const props = {
-  secrets: [],
-  handleClose: () => {}
+  location: { search: '' }
 };
 
 it('Create Secret validates universal inputs', () => {
@@ -164,7 +161,7 @@ it('Create Secret validates universal inputs', () => {
 it('Create Secret validates access token inputs', () => {
   const { queryByText, queryByLabelText } = renderWithIntl(
     <Provider store={store}>
-      <CreateSecret {...props} />
+      <CreateSecret location={{ search: '?secretType=accessToken' }} />
     </Provider>
   );
   fireEvent.click(queryByLabelText('Access Token'));

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -147,8 +147,13 @@ const store = mockStore({
   }
 });
 
-it('click add new secret & modal appears', () => {
+it('click add new secret and create secret UI appears', () => {
   const currentProps = {
+    error: null,
+    history: {
+      push: jest.fn()
+    },
+    loading: false,
     secrets: [
       {
         metadata: {
@@ -158,18 +163,14 @@ it('click add new secret & modal appears', () => {
           }
         }
       }
-    ],
-    loading: false,
-    error: null
+    ]
   };
 
   jest.spyOn(API, 'getCredentials').mockImplementation(() => []);
-
   jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
-
   jest.spyOn(API, 'getServiceAccounts').mockImplementation(() => []);
 
-  const { queryByTestId, getByText } = renderWithRouter(
+  const { getByText } = renderWithRouter(
     <Provider store={store}>
       <Route
         path={urls.secrets.all()}
@@ -179,11 +180,10 @@ it('click add new secret & modal appears', () => {
     { route: urls.secrets.all() }
   );
 
-  expect(queryByTestId('createSecret')).toBeFalsy();
-
   fireEvent.click(getByText('Create'));
-
-  expect(queryByTestId('createSecret')).toBeTruthy();
+  expect(currentProps.history.push).toHaveBeenCalledWith(
+    `${urls.secrets.create()}?secretType=password`
+  );
 });
 
 it('click delete secret & modal appears', () => {

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -66,6 +66,11 @@ class SideNav extends Component {
     }
   }
 
+  setPath(path) {
+    const { history, location } = this.props;
+    history.push(path + location.search);
+  }
+
   getPath(path) {
     const { match } = this.props;
     if (match && match.params.namespace) {
@@ -86,55 +91,63 @@ class SideNav extends Component {
       return;
     }
 
-    if (namespace === ALL_NAMESPACES) {
-      this.props.selectNamespace(namespace);
-      const currentURL = this.props.match.url;
-      if (currentURL.includes(urls.taskRuns.all())) {
-        history.push(urls.taskRuns.all());
-        return;
-      }
-      if (currentURL.includes(urls.pipelineResources.all())) {
-        history.push(urls.pipelineResources.all());
-        return;
-      }
-      if (currentURL.includes(urls.pipelines.all())) {
-        history.push(urls.pipelines.all());
-        return;
-      }
-      if (currentURL.includes(urls.serviceAccounts.all())) {
-        history.push(urls.serviceAccounts.all());
-        return;
-      }
-      if (currentURL.includes(urls.eventListeners.all())) {
-        history.push(urls.eventListeners.all());
-        return;
-      }
-      if (currentURL.includes(urls.triggerBindings.all())) {
-        history.push(urls.triggerBindings.all());
-        return;
-      }
-      if (currentURL.includes(urls.clusterTriggerBindings.all())) {
-        history.push(urls.clusterTriggerBindings.all());
-        return;
-      }
-      if (currentURL.includes(urls.triggerTemplates.all())) {
-        history.push(urls.triggerTemplates.all());
-        return;
-      }
-      if (currentURL.includes(urls.secrets.all())) {
-        history.push(urls.secrets.all());
-        return;
-      }
-      if (currentURL.includes(urls.tasks.all())) {
-        history.push(urls.tasks.all());
-        return;
-      }
-      history.push('/');
+    if (namespace !== ALL_NAMESPACES) {
+      const newURL = generatePath(match.path, {
+        namespace,
+        0: match.params[0]
+      });
+      this.setPath(newURL);
       return;
     }
 
-    const newURL = generatePath(match.path, { namespace, 0: match.params[0] });
-    history.push(newURL);
+    this.props.selectNamespace(namespace);
+    const currentURL = this.props.match.url;
+    if (currentURL.includes(urls.taskRuns.all())) {
+      this.setPath(urls.taskRuns.all());
+      return;
+    }
+    if (currentURL.includes(urls.pipelineResources.all())) {
+      this.setPath(urls.pipelineResources.all());
+      return;
+    }
+    if (currentURL.includes(urls.pipelines.all())) {
+      this.setPath(urls.pipelines.all());
+      return;
+    }
+    if (currentURL.includes(urls.pipelineRuns.all())) {
+      this.setPath(urls.pipelineRuns.all());
+      return;
+    }
+    if (currentURL.includes(urls.serviceAccounts.all())) {
+      this.setPath(urls.serviceAccounts.all());
+      return;
+    }
+    if (currentURL.includes(urls.eventListeners.all())) {
+      this.setPath(urls.eventListeners.all());
+      return;
+    }
+    if (currentURL.includes(urls.triggerBindings.all())) {
+      this.setPath(urls.triggerBindings.all());
+      return;
+    }
+    if (currentURL.includes(urls.clusterTriggerBindings.all())) {
+      this.setPath(urls.clusterTriggerBindings.all());
+      return;
+    }
+    if (currentURL.includes(urls.triggerTemplates.all())) {
+      this.setPath(urls.triggerTemplates.all());
+      return;
+    }
+    if (currentURL.includes(urls.secrets.all())) {
+      this.setPath(urls.secrets.all());
+      return;
+    }
+    if (currentURL.includes(urls.tasks.all())) {
+      this.setPath(urls.tasks.all());
+      return;
+    }
+
+    history.push('/');
   };
 
   checkTriggersInstalled() {

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -182,7 +182,8 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
       <SideNav
         extensions={[]}
         history={{ push }}
-        match={{ params: { namespace }, url: urls.pipelineRuns.all() }}
+        location={{ search: '' }}
+        match={{ params: { namespace }, url: '/someResource' }}
         namespace={namespace}
         selectNamespace={selectNamespace}
       />
@@ -192,6 +193,39 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
   fireEvent.click(getByText(/all namespaces/i));
   expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
   expect(push).toHaveBeenCalledWith('/');
+});
+
+it('SideNav redirects to PipelineRuns page when all namespaces selected on namespaced URL on PipelineRuns', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const namespace = 'default';
+  const store = mockStore({
+    namespaces: {
+      byName: {
+        [namespace]: true
+      },
+      isFetching: false,
+      selected: namespace
+    }
+  });
+  const selectNamespace = jest.fn();
+  const push = jest.fn();
+  const { getByText, getByValue } = renderWithRouter(
+    <Provider store={store}>
+      <SideNav
+        extensions={[]}
+        history={{ push }}
+        location={{ search: '' }}
+        match={{ params: { namespace }, url: urls.pipelineRuns.all() }}
+        namespace={namespace}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+  fireEvent.click(getByValue(namespace));
+  fireEvent.click(getByText(/all namespaces/i));
+  expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
+  expect(push).toHaveBeenCalledWith(urls.pipelineRuns.all());
 });
 
 it('SideNav redirects to TaskRuns page when all namespaces selected on namespaced URL on TaskRuns', async () => {
@@ -214,6 +248,7 @@ it('SideNav redirects to TaskRuns page when all namespaces selected on namespace
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{ params: { namespace }, url: urls.taskRuns.all() }}
         namespace={namespace}
         selectNamespace={selectNamespace}
@@ -246,6 +281,7 @@ it('SideNav redirects to PipelineResources page when all namespaces selected on 
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.pipelineResources.all()
@@ -281,6 +317,7 @@ it('SideNav redirects to Pipelines page when all namespaces selected on namespac
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.pipelines.all()
@@ -316,6 +353,7 @@ it('SideNav redirects to ServiceAccounts page when all namespaces selected on na
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.serviceAccounts.all()
@@ -351,6 +389,7 @@ it('SideNav redirects to EventListeners page when all namespaces selected on nam
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.eventListeners.all()
@@ -386,6 +425,7 @@ it('SideNav redirects to TriggerBindings page when all namespaces selected on na
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.triggerBindings.all()
@@ -421,6 +461,7 @@ it('SideNav redirects to TriggerTemplates page when all namespaces selected on n
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.triggerTemplates.all()
@@ -456,6 +497,7 @@ it('SideNav redirects to Tasks page when all namespaces selected on namespaced U
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.tasks.all()
@@ -491,6 +533,7 @@ it('SideNav redirects to secrets page when all namespaces selected on namespaced
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           url: urls.secrets.all()
@@ -528,6 +571,7 @@ it('SideNav updates namespace in URL', async () => {
       <SideNav
         extensions={[]}
         history={{ push }}
+        location={{ search: '' }}
         match={{
           params: { namespace },
           path: paths.pipelines.byNamespace()

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -18,6 +18,7 @@ export {
   default as CustomResourceDefinition
 } from './CustomResourceDefinition';
 export { default as CreatePipelineRun } from './CreatePipelineRun';
+export { default as CreateSecret } from './CreateSecret';
 export { default as ClusterTriggerBinding } from './ClusterTriggerBinding';
 export { default as ClusterTriggerBindings } from './ClusterTriggerBindings';
 export { default as EventListener } from './EventListener';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This addresses quite a few issues:
- Link to access tokens list: Fixes https://github.com/tektoncd/dashboard/issues/1121
- Respect user's chosen secret type when navigating to Create Secret page: Fixes https://github.com/tektoncd/dashboard/issues/1239
- Ensure correct namespace + secret type displayed after creation: Fixes https://github.com/tektoncd/dashboard/issues/1271
- Keep selected secret type when switching namespaces: Fixes https://github.com/tektoncd/dashboard/issues/1299
- https://github.com/tektoncd/dashboard/issues/1304
  - Switching namespaces no longer hides the Create Namespace UI Fixes https://github.com/tektoncd/dashboard/issues/1300

Move CreateSecret UI to full page at `/secrets/create`
Also add `secretType` query param on Secrets page so it can
be used to ensure users see the created secret once the Create
Secret UI is dismissed, regardless of secret type.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
