### PR TITLE
Add OpenShift support for release pipeline

### DIFF
--- a/tekton/openshift/publish.yaml
+++ b/tekton/openshift/publish.yaml
@@ -1,0 +1,136 @@
+---
+# yamllint disable rule:line-length
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: publish-tekton-dashboard
+spec:
+  params:
+    - name: versionTag
+      description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
+    - name: imageRegistry
+      description: TODO(#569) This is a hack to make it easy for folks to switch the registry being used by the many many image outputs
+    - name: pathToProject
+      description: The path to the folder in the go/src dir that contains the project, which is used by `ko` to name the resulting images
+    - name: bucketName
+      description: Use latest if it's a real release, otherwise the name of a test bucket you've made on GCS
+  resources:
+    inputs:
+      - name: dashboard-source-repo
+        type: git
+        targetPath: go/src/github.com/tektoncd/dashboard
+      - name: bucket-for-dashboard
+        type: storage
+    outputs:
+      - name: bucket-for-dashboard
+        type: storage
+      - name: builtDashboardImage
+        type: image
+  steps:
+    - name: link-input-bucket-to-output
+      image: busybox
+      command: ["cp"]
+      args:
+        - -r
+        - "/workspace/bucket-for-dashboard"
+        - "/workspace/output/"
+    - name: ensure-release-dirs-exist
+      image: busybox
+      command: ["mkdir"]
+      args:
+        - "-p"
+        - "/workspace/output/bucket-for-dashboard/$(params.bucketName)/"
+    - name: dashboard-run-ko
+      # TODO(#639) we should be able to use the image built by an upstream Task here instead of hardcoding
+      # Want to use your own plumbing image? Change this
+      image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+      imagePullPolicy: Always
+      env:
+        - name: KO_DOCKER_REPO
+          value: $(params.imageRegistry)
+        - name: GOPATH
+          value: /workspace/go
+        - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+          value: /secret/release.json
+        - name: GO111MODULE
+          value:
+      command:
+        - /bin/sh
+      args:
+        - -ce
+        - |
+          set -e
+          set -x
+
+          # Auth with CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+          gcloud auth configure-docker
+
+          # ko requires this variable to be set in order to set image creation timestamps correctly https://github.com/google/go-containerregistry/pull/146
+          export SOURCE_DATE_EPOCH=`date +%s`
+
+          # Change to directory with our .ko.yaml
+          cd /workspace/go/src/github.com/tektoncd/dashboard
+
+          # Rewrite "devel" to params.versionTag
+          sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/300-deployment.yaml
+          sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/300-service.yaml
+          sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/overlays/openshift-patches/dashboard-service.yaml
+          sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/overlays/openshift-patches/internal-dashboard-service.yaml
+
+          # Publish images and create release.yamls
+          which ko # Tested with 0.2.0
+          ko version
+          kustomize version # Tested with 3.5.4
+
+          kustomize build overlays/dev | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml
+          kustomize build overlays/dev-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml
+          kustomize build overlays/dev-openshift --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml
+          kustomize build overlays/dev-openshift-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml
+      volumeMounts:
+        - name: gcp-secret
+          mountPath: /secret
+    # Todo reintroduce lockdown.py step for OpenShift
+    - name: tag-images
+      image: google/cloud-sdk
+      command:
+        - /bin/bash
+      volumeMounts:
+        - name: gcp-secret
+          mountPath: /secret
+      args:
+        - -ce
+        - |
+          set -e
+          set -x
+
+          curl https://raw.githubusercontent.com/tektoncd/pipeline/master/tekton/koparse/koparse.py --output /usr/bin/koparse.py
+          chmod +x /usr/bin/koparse.py
+
+          REGIONS=(us eu asia)
+          IMAGES=(
+            $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtDashboardImage.url)
+          )
+          # Parse the built images from the release.yaml generated by ko
+          BUILT_IMAGES=( $(/usr/bin/koparse.py --path /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml --base $(params.imageRegistry)/$(params.pathToProject) --images ${IMAGES[@]}) )
+
+          # Auth with account credentials
+          gcloud auth activate-service-account --key-file=/secret/release.json
+
+          # Tag the images and put them in all the regions
+          for IMAGE in "${BUILT_IMAGES[@]}"
+          do
+            IMAGE_WITHOUT_SHA=${IMAGE%%@*}
+            gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:$(params.bucketName)
+            gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:$(params.versionTag)
+            for REGION in "${REGIONS[@]}"
+            do
+              for TAG in "$(params.bucketName)" $(params.versionTag)
+              do
+                gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:$TAG
+              done
+            done
+          done
+  volumes:
+    - name: gcp-secret
+      secret:
+        secretName: release-secret

--- a/tekton/resources.yaml
+++ b/tekton/resources.yaml
@@ -9,7 +9,7 @@ spec:
     - name: url
       value: https://github.com/tektoncd/dashboard
     - name: revision
-      value: v0.5.2
+      value: v0.6.1
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR includes the changes I had to make to get the release pipeline working on OpenShift instead of Docker Desktop.

Noticably:
- `scc` commands for permissions then documenting a configured namespace and SA
- Omitting the lockdown step as this uses Docker (relying on a Docker socket)
- Docs

Outstanding:
- [x] Check no RBAC needs to be added
- [ ] See if we can reintroduce the lockdown step by perhaps using a buildah client if that exists, or some other way (like, bud pulling, getting that tag with sed, using that). Update: doesn't exist, podman looks to be using a Docker socket too, and you can't even docker pull on OCP 4.3 (mentions the socket too)
- [ ] See if we can reduce Tekton Task duplication/effort (testing now with removed use of /previous as that was where the pinned images ended up for us to stage)
- [x] Ensure resources.yaml doesn't reference a given bucket location 😄 
- [x] Check both oc permissions are required - I'm convinced they are, it'll run as root

We'll want to do the same for the webhooks extension then. I'd like to do this so we have another route to do releases on - I'd often like to use Docker Desktop for other things and it's handy to have the extra platform support incase someone wants to do a release and doesn't have Docker Desktop.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
