### PR TITLE
Use ClusterRole aggregation for standalone extensions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -306,7 +306,8 @@ Selecting an item from the list provides a more detailed view of the selected re
 
 There are 2 steps to exposing a resource type.
 
-1. The `tekton-dashboard` service account must have a cluster role and binding giving it access to the target resources.
+1. The `tekton-dashboard` service account must have access to the target resources. To allow such access you can extend the `tekton-dashboard` `ClusterRole` by creating a `ClusterRole` containing the necessary permissions and attach the `rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"` label to it.
+
 Replace `rules.apiGroups` and `rules.resources` with the target values for the resource.
 
 ```
@@ -314,24 +315,12 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-dashboard-extensions
-  namespace: tekton-pipelines
+  labels:
+    rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"
 rules:
   - apiGroups: ["targetGroup"]
     resources: ["targetResource"]
     verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tekton-dashboard-extensions
-subjects:
-  - kind: ServiceAccount
-    name: tekton-dashboard
-    namespace: tekton-pipelines
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-dashboard-extensions
 ```
 
 2. Add an extension resource specifying the target resource to be listed. Replace `metadata.name`, 

--- a/base/200-clusterrole.yaml
+++ b/base/200-clusterrole.yaml
@@ -3,11 +3,24 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-dashboard-minimal
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-core
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/docs/samples/extension/README.md
+++ b/docs/samples/extension/README.md
@@ -66,7 +66,4 @@ The sample [here](https://github.com/tektoncd/dashboard/tree/master/docs/samples
 
 Once applied the Tekton Dashboard will include `k8s deployments` as an option on the left nav.
 
-Note: This sample does not include RBAC and Service Service Account bindings. 
-
-This example reuses access to deployment 
-resources which the Tekton Dashboard service account already has - for different resource types a role binding may need to be applied. 
+**RBAC**: Tekton Dashboard cluster role is extended using [ClusterRole aggregation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles). The extension adds the necessary permissions by creating its own `ClusterRole` and setting the `rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"` label.

--- a/docs/samples/extension/config/tekton-kubernetes-resource-extension-sample.yaml
+++ b/docs/samples/extension/config/tekton-kubernetes-resource-extension-sample.yaml
@@ -1,3 +1,15 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-deployment-extension
+  labels:
+    rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+---
 apiVersion: dashboard.tekton.dev/v1alpha1
 kind: Extension
 metadata:

--- a/overlays/full-fat/kustomization.yaml
+++ b/overlays/full-fat/kustomization.yaml
@@ -6,6 +6,5 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: ClusterRole
-      name: tekton-dashboard-minimal
-      namespace: tekton-pipelines
+      name: tekton-dashboard-core
     path: cluster-role-patch-json.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR changes the way the `tekton-dashboard` `ClusterRole` is constructed by allowing [ClusterRole aggregation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).

This way, extensions can create the `ClusterRole` they need to work, the additional permissions will automatically be aggregated on the `tekton-dashboard` `ClusterRole`.

This makes extensions more standalone.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
