### PR TITLE
Use getInstallProperties for displaying logout

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -431,11 +431,7 @@ export function getInstallProperties() {
 }
 
 export function shouldDisplayLogout() {
-  const routesUri = getResourcesAPI({
-    group: 'route.openshift.io',
-    version: 'v1'
-  });
-  return get(routesUri, { Accept: 'text/plain' });
+  return getInstallProperties().then(data => data.IsOpenShift);
 }
 
 export async function determineInstallNamespace() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR changes the way `shouldDisplayLogout` is implemented.

Instead of calling an api that will succeed on openshift and fail when running on k8s, it reuses the `getInstallProperties` api and uses the `IsOpenShift` property from the results.

This prevents a call to an api that doesn't exist and moves the logic of determining the condition to the backend rather than doing this on the frontend side.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
