### PR TITLE
Decouple logout button and openshift

### DIFF
--- a/packages/components/src/components/Header/Header.stories.js
+++ b/packages/components/src/components/Header/Header.stories.js
@@ -24,7 +24,7 @@ storiesOf('Components/Header', module)
   .add('with logout', () => (
     <Header
       logoutButton={
-        <LogoutButton shouldDisplayLogout={() => Promise.resolve(true)} />
+        <LogoutButton getLogoutURL={() => Promise.resolve('/something')} />
       }
     />
   ));

--- a/packages/components/src/components/LogoutButton/LogoutButton.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.js
@@ -17,36 +17,37 @@ import { injectIntl } from 'react-intl';
 import React, { Component } from 'react';
 import './LogoutButton.scss';
 
-/* istanbul ignore next */
-function handleLogout() {
-  window.location.href = '/oauth/sign_out';
-}
-
 export class LogoutButton extends Component {
   state = {
-    showLogout: false
+    logoutURL: null
   };
 
   componentDidMount() {
-    this.determineOpenShift();
+    this.determineLogoutURL();
   }
 
-  async determineOpenShift() {
+  handleLogout = () => {
+    const { logoutURL } = this.state;
+    window.location.href = logoutURL;
+  };
+
+  async determineLogoutURL() {
     try {
-      const showLogout = await this.props.shouldDisplayLogout();
-      this.setState({ showLogout });
+      const logoutURL = await this.props.getLogoutURL();
+      this.setState({ logoutURL });
     } catch (error) {} // eslint-disable-line
   }
 
   render() {
-    if (!this.state.showLogout) {
+    const { logoutURL } = this.state;
+    if (!logoutURL) {
       return null;
     }
     return (
       <HeaderGlobalAction
         data-testid="logout-btn"
         className="tkn--logout-btn"
-        onClick={handleLogout}
+        onClick={this.handleLogout}
         title={this.props.intl.formatMessage({
           id: 'dashboard.header.logOut',
           defaultMessage: 'Log out'

--- a/packages/components/src/components/LogoutButton/LogoutButton.test.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.test.js
@@ -16,29 +16,29 @@ import { waitForElement } from 'react-testing-library';
 import { renderWithRouter } from '../../utils/test';
 import Logout from './LogoutButton';
 
-it('Header renders logout button if on OpenShift', async () => {
-  const mockedResponse = {
-    headers: { get: () => 'text/plain' },
-    ok: true,
-    status: 200,
-    text: () => Promise.resolve('')
-  };
-  const shouldDisplayLogoutTrueMock = jest
-    .fn()
-    .mockImplementation(() => mockedResponse);
-  const logoutButton = (
-    <Logout shouldDisplayLogout={shouldDisplayLogoutTrueMock} />
-  );
+it('Header renders logout button when logout url is set', async () => {
+  const mockedResponse = Promise.resolve('/blabla');
+
+  const getLogoutURLMock = jest.fn().mockImplementation(() => mockedResponse);
+  const logoutButton = <Logout getLogoutURL={getLogoutURLMock} />;
   const { queryByTitle } = renderWithRouter(logoutButton);
   await waitForElement(() => queryByTitle(/log out/i));
 });
 
-it('Header does not render logout button if not on OpenShift', async () => {
-  const shouldDisplayLogoutFalseMock = jest
-    .fn()
-    .mockImplementation(() => Promise.reject());
+it('Header renders logout button when logout url is not set', async () => {
+  const mockedResponse = Promise.resolve(null);
+
+  const getLogoutURLMock = jest.fn().mockImplementation(() => mockedResponse);
   const { queryByText } = renderWithRouter(
-    <Logout shouldDisplayLogout={shouldDisplayLogoutFalseMock} />
+    <Logout getLogoutURL={getLogoutURLMock} />
+  );
+  expect(queryByText(/log out/i)).toBeFalsy();
+});
+
+it('Header does not render logout button when promise for getting properties is rejected', async () => {
+  const getLogoutURLMock = jest.fn().mockImplementation(() => Promise.reject());
+  const { queryByText } = renderWithRouter(
+    <Logout getLogoutURL={getLogoutURLMock} />
   );
   expect(queryByText(/log out/i)).toBeFalsy();
 });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -430,8 +430,8 @@ export function getInstallProperties() {
   return get(uri);
 }
 
-export function shouldDisplayLogout() {
-  return getInstallProperties().then(data => data.IsOpenShift);
+export function getLogoutURL() {
+  return getInstallProperties().then(data => data.LogoutURL);
 }
 
 export async function determineInstallNamespace() {

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -63,7 +63,7 @@ import {
   TriggerTemplates
 } from '..';
 
-import { shouldDisplayLogout } from '../../api';
+import { getLogoutURL } from '../../api';
 import { fetchExtensions } from '../../actions/extensions';
 import { fetchNamespaces, selectNamespace } from '../../actions/namespaces';
 import { fetchInstallProperties } from '../../actions/properties';
@@ -107,9 +107,7 @@ export /* istanbul ignore next */ class App extends Component {
 
     const lang = messages[this.props.lang] ? this.props.lang : 'en';
 
-    const logoutButton = (
-      <LogoutButton shouldDisplayLogout={shouldDisplayLogout} />
-    );
+    const logoutButton = <LogoutButton getLogoutURL={getLogoutURL} />;
 
     return (
       <IntlProvider locale={lang} defaultLocale="en" messages={messages[lang]}>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR changes the logic behind the logout button.
This a follow up for this PR https://github.com/tektoncd/dashboard/pull/1343

Instead of hardcoding the logout url and using the `IsOpenshift` property to show/hide the button, the backend returns a `LogoutUrl` property.

The `LogoutUrl` property is then used to show/hide the logout button (the button is not rendered when the value is not set).

/cc @a-roberts 