### PR TITLE
Add CSRF protection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -96,6 +96,22 @@
   version = "v0.4.0"
 
 [[projects]]
+  digest = "1:95f69b444fef3831474cae7338a63f62c58de90bc73e6b1542aa9a911e35de56"
+  name = "github.com/gorilla/csrf"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "79c60d0e4fcf1fbc9653c1cb13d28e82248cf43c"
+  version = "v1.7.0"
+
+[[projects]]
+  digest = "1:e72d1ebb8d395cf9f346fd9cbc652e5ae222dd85e0ac842dc57f175abed6d195"
+  name = "github.com/gorilla/securecookie"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e59506cc896acb7f7bf732d4fdf5e25f7ccd8983"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:6d29f02f0f01c627c2be40fb7347669a9ff2aa215cb97747294c1d13ffa74bdd"
   name = "github.com/gorilla/websocket"
   packages = ["."]
@@ -175,12 +191,12 @@
   revision = "f6563a70e19a12b2f240eaf4e716ef75baf7003e"
 
 [[projects]]
-  digest = "1:9e1d37b58d17113ec3cb5608ac0382313c5b59470b94ed97d0976e69c7022314"
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "614d223910a179a466c1767a985424175c39b465"
-  version = "v0.9.1"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
@@ -746,6 +762,7 @@
   input-imports = [
     "github.com/emicklei/go-restful",
     "github.com/google/go-cmp/cmp",
+    "github.com/gorilla/csrf",
     "github.com/gorilla/websocket",
     "github.com/openshift/client-go/route/clientset/versioned",
     "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,3 +43,6 @@ required = [
 [[prune.project]]
   name = "github.com/tektoncd/plumbing"
   non-go = false
+[[constraint]]
+  name = "github.com/gorilla/csrf"
+  version = "1.7.0"

--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -53,8 +53,8 @@ spec:
               value: "false"
             - name: WEB_RESOURCES_DIR
               value: /var/run/ko/web
-            - name: PIPELINE_RUN_SERVICE_ACCOUNT
-              value: ""
+            - name: CSRF_SECURE_COOKIE
+              value: "true"
             - name: TRIGGERS_NAMESPACE
               value: tekton-pipelines
             - name: PIPELINE_NAMESPACE

--- a/overlays/dev-locked-down/kustomization.yaml
+++ b/overlays/dev-locked-down/kustomization.yaml
@@ -9,3 +9,4 @@ images:
     newTag:
 patches:
   - ../readonly/readonly-deployment-patch.yaml
+  - ../dev/csrf-secure-cookie-patch.yaml

--- a/overlays/dev-openshift-imagestream/kustomization.yaml
+++ b/overlays/dev-openshift-imagestream/kustomization.yaml
@@ -8,6 +8,7 @@ patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
   - ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - ../dev/csrf-secure-cookie-patch.yaml
 images:
   - name: dashboardImage
     newName: tekton-pipelines/tekton-dashboard

--- a/overlays/dev-openshift-locked-down/kustomization.yaml
+++ b/overlays/dev-openshift-locked-down/kustomization.yaml
@@ -8,6 +8,7 @@ patches:
   - ../openshift-patches/serviceaccount.yaml
   - ../openshift-patches/oauth-proxy-in-deployment.yaml
   - ../readonly/readonly-deployment-patch.yaml
+  - ../dev/csrf-secure-cookie-patch.yaml
 images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard

--- a/overlays/dev-openshift/kustomization.yaml
+++ b/overlays/dev-openshift/kustomization.yaml
@@ -7,6 +7,7 @@ patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
   - ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - ../dev/csrf-secure-cookie-patch.yaml
 images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard

--- a/overlays/dev/csrf-secure-cookie-patch.yaml
+++ b/overlays/dev/csrf-secure-cookie-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+        - name: tekton-dashboard
+          env:
+            - name: CSRF_SECURE_COOKIE
+              value: "false"

--- a/overlays/dev/kustomization.yaml
+++ b/overlays/dev/kustomization.yaml
@@ -5,3 +5,5 @@ images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard
     newTag:
+patches:
+  - ./csrf-secure-cookie-patch.yaml

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	restful "github.com/emicklei/go-restful"
+	"github.com/gorilla/csrf"
 	"github.com/tektoncd/dashboard/pkg/logging"
 	"github.com/tektoncd/dashboard/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -216,4 +217,9 @@ func (r Resource) GetProperties(request *restful.Request, response *restful.Resp
 	}
 
 	response.WriteEntity(properties)
+}
+
+func (r Resource) GetToken(request *restful.Request, response *restful.Response) {
+	response.Header().Add("X-CSRF-Token", csrf.Token(request.Request))
+	response.Write([]byte("OK"))
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -79,6 +79,7 @@ func Register(resource endpoints.Resource) *Handler {
 	registerHealthProbe(resource, h.Container)
 	registerReadinessProbe(resource, h.Container)
 	registerKubeAPIProxy(resource, h.Container)
+	registerCSRFTokenEndpoint(resource, h.Container)
 	h.registerExtensions()
 	return h
 }
@@ -300,6 +301,14 @@ func registerPropertiesEndpoint(r endpoints.Resource, container *restful.Contain
 
 	wsDefaults.Route(wsDefaults.GET("/").To(r.GetProperties))
 	container.Add(wsDefaults)
+}
+
+func registerCSRFTokenEndpoint(r endpoints.Resource, container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.Filter(restful.NoBrowserCacheFilter)
+	ws.Path("/v1/token").Produces("text/plain")
+	ws.Route(ws.GET("/").To(r.GetToken))
+	container.Add(ws)
 }
 
 // Extension is the back-end representation of an extension. A service is an

--- a/src/api/comms.test.js
+++ b/src/api/comms.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,6 +23,7 @@ import {
   post,
   request
 } from './comms';
+import { mockCSRFToken } from '../utils/test';
 
 const uri = 'http://example.com';
 
@@ -138,6 +139,7 @@ describe('post', () => {
     const data = {
       fake: 'data'
     };
+    mockCSRFToken();
     fetchMock.post(uri, data);
     return post(uri, data).then(() => {
       const options = fetchMock.lastOptions();
@@ -170,6 +172,7 @@ describe('patchAddSecret', () => {
     const data = {
       fake: 'data'
     };
+    mockCSRFToken();
     fetchMock.mock(uri, data);
     return patchAddSecret(uri, data).then(response => {
       expect(response).toEqual(data);

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -14,6 +14,7 @@ limitations under the License.
 import fetchMock from 'fetch-mock';
 import * as comms from './comms';
 import * as index from '.';
+import { mockCSRFToken } from '../utils/test';
 
 describe('getAPIRoot', () => {
   it('handles base URL with trailing slash', () => {
@@ -199,6 +200,7 @@ it('getPipelineRun', () => {
 it('deletePipelineRun', () => {
   const name = 'foo';
   const data = { fake: 'pipelineRun' };
+  mockCSRFToken();
   fetchMock.delete(`end:${name}`, data);
   return index.deletePipelineRun({ name }).then(pipelineRun => {
     expect(pipelineRun).toEqual(data);
@@ -210,6 +212,7 @@ it('cancelPipelineRun', () => {
   const name = 'foo';
   const namespace = 'foospace';
   const data = { fake: 'pipelineRun', spec: { status: 'running' } };
+  mockCSRFToken();
   fetchMock.get(/pipelineruns/, Promise.resolve(data));
   const payload = {
     fake: 'pipelineRun',
@@ -228,6 +231,7 @@ it('cancelTaskRun', () => {
   const name = 'foo';
   const namespace = 'foospace';
   const data = { fake: 'taskRun', spec: { status: 'running' } };
+  mockCSRFToken();
   fetchMock.get(/taskruns/, Promise.resolve(data));
   const payload = {
     fake: 'taskRun',
@@ -399,6 +403,7 @@ it('createPipelineResource', () => {
     }
   };
   const data = { fake: 'data' };
+  mockCSRFToken();
   fetchMock.post('*', data);
   return index.createPipelineResource({ namespace, payload }).then(response => {
     expect(response).toEqual(data);
@@ -448,6 +453,7 @@ it('createPipelineRun', () => {
       timeout
     }
   };
+  mockCSRFToken();
   fetchMock.post('*', data);
   return index.createPipelineRun(payload).then(response => {
     expect(response).toEqual(data);
@@ -499,6 +505,7 @@ it('createCredential', () => {
   const type = 'type';
   const payload = { id, username, password, type };
   const data = { fake: 'data' };
+  mockCSRFToken();
   fetchMock.post('*', data);
   return index.createCredential(payload).then(response => {
     expect(response).toEqual(data);
@@ -516,6 +523,7 @@ it('updateCredential', () => {
   const type = 'type';
   const payload = { id, username, password, type };
   const data = { fake: 'data' };
+  mockCSRFToken();
   fetchMock.put('*', data);
   return index.updateCredential(payload).then(response => {
     expect(response).toEqual(data);
@@ -529,6 +537,7 @@ it('updateCredential', () => {
 it('deleteCredential', () => {
   const credentialId = 'fake credential id';
   const data = { fake: 'data' };
+  mockCSRFToken();
   fetchMock.delete('*', data);
   return index.deleteCredential(credentialId).then(response => {
     expect(response).toEqual(data);
@@ -590,6 +599,7 @@ it('getServiceAccounts returns the correct data', () => {
 it('patchServiceAccount', () => {
   const data = 'data';
   jest.spyOn(comms, 'patchAddSecret').mockImplementation(() => data);
+  mockCSRFToken();
   fetchMock.get(/serviceaccounts/, data);
   return index
     .patchServiceAccount('default', 'default', 'secret-name')
@@ -719,6 +729,7 @@ it('getEventListeners', () => {
 it('deletePipelineResource', () => {
   const name = 'foo';
   const data = { fake: 'pipelineResource' };
+  mockCSRFToken();
   fetchMock.delete(`end:${name}`, data);
   return index.deletePipelineResource({ name }).then(pipelineResource => {
     expect(pipelineResource).toEqual(data);
@@ -729,6 +740,7 @@ it('deletePipelineResource', () => {
 it('deleteTaskRun', () => {
   const name = 'foo';
   const data = { fake: 'taskRun' };
+  mockCSRFToken();
   fetchMock.delete(`end:${name}`, data);
   return index.deleteTaskRun({ name }).then(taskRun => {
     expect(taskRun).toEqual(data);
@@ -739,6 +751,7 @@ it('deleteTaskRun', () => {
 it('rerunPipelineRun', () => {
   const namespace = 'namespace';
   const data = { fake: 'pipelineRun' };
+  mockCSRFToken();
   fetchMock.post(`end:/rerun/`, data);
   return index
     .rerunPipelineRun(namespace, { fake: 'existingPipelineRun' })
@@ -750,6 +763,7 @@ it('rerunPipelineRun', () => {
 
 it('createTaskRun uses correct kubernetes information', () => {
   const data = { fake: 'createtaskrun' };
+  mockCSRFToken();
   fetchMock.post(/taskruns/, data);
   return index.createTaskRun({}).then(response => {
     expect(response).toEqual(data);
@@ -769,6 +783,7 @@ it('createTaskRun has correct metadata', () => {
   const namespace = 'fake-namespace';
   const taskName = 'fake-task';
   const labels = { app: 'fake-app' };
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ namespace, taskName, labels }).then(() => {
     const sentMetadata = JSON.parse(fetchMock.lastOptions().body).metadata;
@@ -784,6 +799,7 @@ it('createTaskRun has correct metadata', () => {
 
 it('createTaskRun handles taskRef', () => {
   const taskName = 'fake-task';
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ taskName }).then(() => {
     const sentSpec = JSON.parse(fetchMock.lastOptions().body).spec;
@@ -795,6 +811,7 @@ it('createTaskRun handles taskRef', () => {
 
 it('createTaskRun handles ClusterTask in taskRef', () => {
   const taskName = 'fake-task';
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ taskName, kind: 'ClusterTask' }).then(() => {
     const sentSpec = JSON.parse(fetchMock.lastOptions().body).spec;
@@ -806,6 +823,7 @@ it('createTaskRun handles ClusterTask in taskRef', () => {
 it('createTaskRun handles parameters', () => {
   const taskName = 'fake-task';
   const params = { 'fake-param-name': 'fake-param-value' };
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ taskName, params }).then(() => {
     const sentSpec = JSON.parse(fetchMock.lastOptions().body).spec;
@@ -823,6 +841,7 @@ it('createTaskRun handles resources', () => {
     inputs: { 'fake-task-input': 'fake-input-resource' },
     outputs: { 'fake-task-output': 'fake-output-resource' }
   };
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ taskName, resources }).then(() => {
     const sentResources = JSON.parse(fetchMock.lastOptions().body).spec
@@ -842,6 +861,7 @@ it('createTaskRun handles resources', () => {
 it('createTaskRun handles serviceAccount', () => {
   const taskName = 'fake-task';
   const serviceAccount = 'fake-service-account';
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ taskName, serviceAccount }).then(() => {
     const sentSpec = JSON.parse(fetchMock.lastOptions().body).spec;
@@ -853,6 +873,7 @@ it('createTaskRun handles serviceAccount', () => {
 it('createTaskRun handles timeout', () => {
   const taskName = 'fake-task';
   const timeout = 'fake-timeout';
+  mockCSRFToken();
   fetchMock.post(/taskruns/, {});
   return index.createTaskRun({ taskName, timeout }).then(() => {
     const sentSpec = JSON.parse(fetchMock.lastOptions().body).spec;
@@ -1022,6 +1043,7 @@ it('importResources', () => {
     }
   };
 
+  mockCSRFToken();
   fetchMock.post('*', data);
   return index.importResources(payload).then(response => {
     expect(response).toEqual(data);

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,6 +12,7 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import React from 'react';
+import fetchMock from 'fetch-mock';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import { render } from 'react-testing-library';
@@ -61,4 +62,12 @@ export function rerenderWithIntl(rerender, ui) {
   return {
     ...rerender(wrapWithIntl(ui))
   };
+}
+
+export function mockCSRFToken() {
+  fetchMock.get('/v1/token', () => ({
+    headers: {
+      'X-CSRF-Token': 'fake_token'
+    }
+  }));
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 The Tekton Authors
+# Copyright 2018-2020 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ function json_curl_envsubst_resource() {
   fi
   yq --version
   set -x
-  cat "$1" | envsubst | yq r -j - | curl -sS -X "$2" --data-binary @- -H "Content-Type: application/json" "$3"
+  cat "$1" | envsubst | yq r -j - | curl -sS -X "$2" --data-binary @- -H "Content-Type: application/json" "$3" -H "Cookie: $CSRF_COOKIE" -H "X-CSRF-Token: $CSRF_TOKEN"
   set +x
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 The Tekton Authors
+# Copyright 2018-2020 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ for i in {1..20};do
   if [ "$respF" != "" ]; then
     dashboardExists=true
     break
-	else
+  else
     sleep 5
   fi
 done
@@ -62,9 +62,14 @@ export REPO_URL="https://github.com/ncskier/go-hello-world"
 export EXPECTED_RETURN_VALUE="Hello World!"
 export REGISTRY="gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img"
 export TEKTON_PROXY_URL="http://localhost:9097/proxy/apis/tekton.dev/v1alpha1/namespaces/tekton-pipelines"
+export CSRF_HEADERS_STORE="csrf_headers.txt"
 
 # Kubectl static resources
 kubectl apply -f ${tekton_repo_dir}/test/resources/static
+
+curl -D $CSRF_HEADERS_STORE http://localhost:9097/v1/token
+export CSRF_TOKEN=`grep -i 'X-CSRF-Token' $CSRF_HEADERS_STORE | sed -e 's/^X-CSRF-Token: //i;s/\r//'`
+export CSRF_COOKIE=`grep -i 'Set-Cookie' $CSRF_HEADERS_STORE | sed -e 's/Set-Cookie: //i;s/; .*//;s/\r//'`
 
 # Create envsubst resources through dashboard proxy
 pipelineResourceFiles=($(find ${tekton_repo_dir}/test/resources/envsubst -iname "pipelineresource*.y?ml"))
@@ -102,7 +107,7 @@ do
     echo "TaskRun info"
     kubectl -n tekton-pipelines get TaskRun -o json
     echo "PipelineRun info"
-    kubectl -n tekton-pipelines get PipelineRun -o json    
+    kubectl -n tekton-pipelines get PipelineRun -o json
     echo "PipelineRun container info"
     kubectl -n tekton-pipelines logs -l app=e2e-pipelinerun --all-containers
     sleep 5


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1255

Wrap the routerHandler with gorilla/csrf to enable CSRF protection
on our APIs. This uses the 'double submit' method requiring both
a cookie and custom header on mutating requests.

A CSRF_SECURE_COOKIE environment variable is added to allow for
dev access over insecure connections. Default is "true" which sets
the Secure attribute on the anti-CSRF token cookie, meaning browsers
will not send this cookie over an insecure connection. We override
this in the dev overlays to set it to "false".

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
