### PR TITLE
Add guard against missing namespace in SecretDeleted handler

### DIFF
--- a/src/reducers/secrets.js
+++ b/src/reducers/secrets.js
@@ -52,7 +52,9 @@ function byNamespace(state = {}, action) {
     case 'SecretDeleted':
       const newState = { ...state };
       const { name, namespace } = action.payload.metadata;
-      delete newState[namespace][name];
+      if (newState[namespace]) {
+        delete newState[namespace][name];
+      }
       return newState;
     default:
       return state;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
1. `kubectl create namespace foo`
2. open ServiceAccounts page on All Namespaces
3. `kubectl delete namespace foo`
4. See console error

Adding this guard prevents the console error and any related side effects of this unhandled state.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
