### PR TITLE
Replace env variables with flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ stats.json
 # System Files
 .DS_Store
 Thumbs.db
+
+dashboard

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN addgroup -g 1000 kgroup && \
 USER 1000
 
 WORKDIR /go/src/github.com/tektoncd/dashboard
-ENV WEB_RESOURCES_DIR=./web
+
 COPY --from=nodeBuilder /go/src/github.com/tektoncd/dashboard/dist ./web
 COPY --from=goBuilder /go/src/github.com/tektoncd/dashboard/tekton_dashboard_backend .
 

--- a/Dockerfile_race_test
+++ b/Dockerfile_race_test
@@ -19,7 +19,6 @@ RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/down
 WORKDIR /go/src/github.com/tektoncd/dashboard
 COPY . .
 RUN dep ensure -vendor-only
-ENV WEB_RESOURCES_DIR=/go/src/github.com/tektoncd/dashboard/testdata/web/
 
 # CGO_ENABLED=1 is needed for -race on go test
 RUN CGO_ENABLED=1 NAMESPACE=default GOOS=linux go test -race -v ./...

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -19,6 +19,5 @@ WORKDIR /go/src/github.com/tektoncd/dashboard/
 COPY . .
 RUN dep ensure -vendor-only
 WORKDIR /go/src/github.com/tektoncd/dashboard
-ENV WEB_RESOURCES_DIR=/go/src/github.com/tektoncd/dashboard/testdata/web/
 
 RUN CGO_ENABLED=0 NAMESPACE=default GOOS=linux go test -v ./...

--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         app: tekton-dashboard
     spec:
       serviceAccountName: tekton-dashboard
+      volumes: []
       containers:
         - name: tekton-dashboard
           image: dashboardImage
@@ -46,15 +47,10 @@ spec:
             httpGet:
               path: /readiness
               port: 9097
+          args:
+            - --port=9097
+            - --web-dir=/var/run/ko/web
           env:
-            - name: PORT
-              value: "9097"
-            - name: READ_ONLY
-              value: "false"
-            - name: WEB_RESOURCES_DIR
-              value: /var/run/ko/web
-            - name: CSRF_SECURE_COOKIE
-              value: "true"
             - name: INSTALLED_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/overlays/dev-locked-down/kustomization.yaml
+++ b/overlays/dev-locked-down/kustomization.yaml
@@ -7,6 +7,18 @@ images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard
     newTag:
-patches:
-  - ../readonly/readonly-deployment-patch.yaml
-  - ../dev/csrf-secure-cookie-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../readonly/readonly-deployment-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../dev/csrf-secure-cookie-patch.yaml

--- a/overlays/dev-openshift-imagestream/kustomization.yaml
+++ b/overlays/dev-openshift-imagestream/kustomization.yaml
@@ -7,8 +7,21 @@ resources:
 patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
-  - ../openshift-patches/oauth-proxy-in-deployment.yaml
-  - ../dev/csrf-secure-cookie-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../dev/csrf-secure-cookie-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../openshift-patches/oauth-proxy-in-deployment.yaml
 images:
   - name: dashboardImage
     newName: tekton-pipelines/tekton-dashboard

--- a/overlays/dev-openshift-locked-down/kustomization.yaml
+++ b/overlays/dev-openshift-locked-down/kustomization.yaml
@@ -6,9 +6,28 @@ resources:
 patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
-  - ../openshift-patches/oauth-proxy-in-deployment.yaml
-  - ../readonly/readonly-deployment-patch.yaml
-  - ../dev/csrf-secure-cookie-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../readonly/readonly-deployment-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../dev/csrf-secure-cookie-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../openshift-patches/oauth-proxy-in-deployment.yaml
 images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard

--- a/overlays/dev-openshift/kustomization.yaml
+++ b/overlays/dev-openshift/kustomization.yaml
@@ -6,8 +6,21 @@ resources:
 patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
-  - ../openshift-patches/oauth-proxy-in-deployment.yaml
-  - ../dev/csrf-secure-cookie-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../dev/csrf-secure-cookie-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../openshift-patches/oauth-proxy-in-deployment.yaml
 images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard

--- a/overlays/dev/csrf-secure-cookie-patch.yaml
+++ b/overlays/dev/csrf-secure-cookie-patch.yaml
@@ -1,14 +1,5 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: tekton-dashboard
-  namespace: tekton-pipelines
-spec:
-  template:
-    spec:
-      containers:
-        - name: tekton-dashboard
-          env:
-            - name: CSRF_SECURE_COOKIE
-              value: "false"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --csrf-secure-cookie=false

--- a/overlays/dev/kustomization.yaml
+++ b/overlays/dev/kustomization.yaml
@@ -5,5 +5,11 @@ images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard
     newTag:
-patches:
-  - ./csrf-secure-cookie-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: csrf-secure-cookie-patch.yaml

--- a/overlays/latest-locked-down/kustomization.yaml
+++ b/overlays/latest-locked-down/kustomization.yaml
@@ -5,5 +5,11 @@ images:
   - name: dashboardImage
     newName: gcr.io/tekton-nightly/dashboard
     newTag: latest
-patches:
-  - ../readonly/readonly-deployment-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../readonly/readonly-deployment-patch.yaml

--- a/overlays/latest-openshift-locked-down/kustomization.yaml
+++ b/overlays/latest-openshift-locked-down/kustomization.yaml
@@ -6,8 +6,21 @@ resources:
 patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
-  - ../openshift-patches/oauth-proxy-in-deployment.yaml
-  - ../readonly/readonly-deployment-patch.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../readonly/readonly-deployment-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../openshift-patches/oauth-proxy-in-deployment.yaml
 images:
   - name: dashboardImage
     newName: gcr.io/tekton-nightly/dashboard

--- a/overlays/latest-openshift/kustomization.yaml
+++ b/overlays/latest-openshift/kustomization.yaml
@@ -6,7 +6,14 @@ resources:
 patches:
   - ../openshift-patches/dashboard-service.yaml
   - ../openshift-patches/serviceaccount.yaml
-  - ../openshift-patches/oauth-proxy-in-deployment.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../openshift-patches/oauth-proxy-in-deployment.yaml
 images:
   - name: dashboardImage
     newName: gcr.io/tekton-nightly/dashboard

--- a/overlays/openshift-patches/oauth-proxy-in-deployment.yaml
+++ b/overlays/openshift-patches/oauth-proxy-in-deployment.yaml
@@ -1,44 +1,29 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: tekton-dashboard
-  namespace: tekton-pipelines
-  labels:
-    app: tekton-dashboard
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: tekton-dashboard
-  template:
-    metadata:
-      name: tekton-dashboard
-      labels:
-        app: tekton-dashboard
-    spec:
-      containers:
-        - name: oauth-proxy
-          image: openshift/oauth-proxy:latest
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: public
-              containerPort: 8443
-          args:
-            - --https-address=:8443
-            - --provider=openshift
-            - --skip-provider-button=true
-            - --openshift-service-account=tekton-dashboard
-            - --upstream=http://localhost:9097
-            - --tls-cert=/etc/tls/private/tls.crt
-            - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
-            - --skip-auth-regex=^/v1/extensions/.*\.js
-          volumeMounts:
-            - name: proxy-tls
-              mountPath: /etc/tls/private
-      serviceAccountName: tekton-dashboard
-      volumes:
-        - name: proxy-tls
-          secret:
-            secretName: proxy-tls
+- op: add
+  path: /spec/template/spec/containers/-
+  value:
+    name: oauth-proxy
+    image: openshift/oauth-proxy:latest
+    imagePullPolicy: IfNotPresent
+    ports:
+      - name: public
+        containerPort: 8443
+    args:
+      - --https-address=:8443
+      - --provider=openshift
+      - --skip-provider-button=true
+      - --openshift-service-account=tekton-dashboard
+      - --upstream=http://localhost:9097
+      - --tls-cert=/etc/tls/private/tls.crt
+      - --tls-key=/etc/tls/private/tls.key
+      - --cookie-secret=SECRET
+      - --skip-auth-regex=^/v1/extensions/.*\.js
+    volumeMounts:
+      - name: proxy-tls
+        mountPath: /etc/tls/private
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: proxy-tls
+    secret:
+      secretName: proxy-tls

--- a/overlays/readonly/readonly-deployment-patch.yaml
+++ b/overlays/readonly/readonly-deployment-patch.yaml
@@ -1,14 +1,5 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: tekton-dashboard
-  namespace: tekton-pipelines
-spec:
-  template:
-    spec:
-      containers:
-        - name: tekton-dashboard
-          env:
-            - name: READ_ONLY
-              value: "true"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --read-only=true

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -158,19 +157,17 @@ func (r Resource) GetEndpoints(request *restful.Request, response *restful.Respo
 // the version of the Tekton Dashboard, the version of Tekton Pipelines, whether or not one's
 // running on OpenShift, when one's in read-only mode and Tekton Triggers version (if Installed)
 func (r Resource) GetProperties(request *restful.Request, response *restful.Response) {
-	installedNamespace := os.Getenv("INSTALLED_NAMESPACE")
-	dashboardVersion := GetDashboardVersion(r, installedNamespace)
-	isOpenShift := IsOpenShift(r, installedNamespace)
-	isReadOnly := IsReadOnly()
+	dashboardVersion := GetDashboardVersion(r, r.Options.InstallNamespace)
+	isOpenShift := IsOpenShift(r, r.Options.InstallNamespace)
 	pipelineNamespace, pipelineVersion := GetPipelineNamespaceAndVersion(r, isOpenShift)
 
 	properties := Properties{
-		DashboardNamespace: installedNamespace,
+		DashboardNamespace: r.Options.InstallNamespace,
 		DashboardVersion:   dashboardVersion,
 		PipelineNamespace:  pipelineNamespace,
 		PipelineVersion:    pipelineVersion,
 		IsOpenShift:        isOpenShift,
-		ReadOnly:           isReadOnly,
+		ReadOnly:           r.Options.ReadOnly,
 	}
 
 	// If running on OpenShift, set the logout url
@@ -181,7 +178,7 @@ func (r Resource) GetProperties(request *restful.Request, response *restful.Resp
 	isTriggersInstalled := IsTriggersInstalled(r, isOpenShift)
 
 	if isTriggersInstalled {
-		triggersNamespace, triggersVersion := GetTriggersVersion(r, isOpenShift)
+		triggersNamespace, triggersVersion := GetTriggersNamespaceAndVersion(r, isOpenShift)
 		properties.TriggersNamespace = triggersNamespace
 		properties.TriggersVersion = triggersVersion
 	}

--- a/pkg/endpoints/dashboard.go
+++ b/pkg/endpoints/dashboard.go
@@ -14,8 +14,6 @@ limitations under the License.
 package endpoints
 
 import (
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/tektoncd/dashboard/pkg/logging"
@@ -53,17 +51,6 @@ func GetDashboardVersion(r Resource, installedNamespace string) string {
 		return ""
 	}
 	return version
-}
-
-// IsReadOnly determines whether the Dashboard is running in read-only mode or not
-func IsReadOnly() bool {
-	asBool, err := strconv.ParseBool(os.Getenv("READ_ONLY"))
-	if err == nil {
-		logging.Log.Infof("Dashboard is in read-only mode: %t", asBool)
-		return asBool
-	}
-	logging.Log.Warnf("Couldn't determine if the Dashboard is in read-only mode or not, assuming not")
-	return false
 }
 
 // IsOpenShift determines whether the Dashboard is running on OpenShift or not
@@ -203,7 +190,7 @@ func getDeployments(r Resource, thingSearchingFor string) (string, string) {
 }
 
 // Get triggers version
-func GetTriggersVersion(r Resource, isOpenShift bool) (string, string) {
+func GetTriggersNamespaceAndVersion(r Resource, isOpenShift bool) (string, string) {
 	namespace, version := getDeployments(r, "triggers")
 
 	if version == "" {

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -7,6 +7,13 @@ import (
 	k8sclientset "k8s.io/client-go/kubernetes"
 )
 
+// Options for enpoints
+type Options struct {
+	InstallNamespace string
+	ReadOnly         bool
+	WebDir           string
+}
+
 // Store all types here that are reused throughout files
 // Wrapper around all necessary clients used for endpoints
 type Resource struct {
@@ -14,4 +21,5 @@ type Resource struct {
 	PipelineResourceClient resourceversioned.Interface
 	K8sClient              k8sclientset.Interface
 	RouteClient            routeclient.Interface
+	Options                Options
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -60,7 +59,6 @@ const ExtensionDisplayNameKey = "tekton-dashboard-display-name"
 // ExtensionRoot is the URL root when accessing extensions
 const ExtensionRoot = "/v1/extensions"
 
-var webResourcesDir = os.Getenv("WEB_RESOURCES_DIR")
 var webResourcesStaticPattern = regexp.MustCompile("^/([[:alnum:]]+\\.)?[[:alnum:]]+\\.(js)|(css)|(png)$")
 var webResourcesStaticExcludePattern = regexp.MustCompile("^/favicon.png$")
 
@@ -72,7 +70,7 @@ func Register(resource endpoints.Resource) *Handler {
 		uidExtensionMap: make(map[string]*Extension),
 	}
 
-	registerWeb(h.Container)
+	registerWeb(h.Container, resource.Options.WebDir)
 	registerEndpoints(resource, h.Container)
 	registerPropertiesEndpoint(resource, h.Container)
 	registerWebsocket(resource, h.Container)
@@ -215,7 +213,7 @@ func registerKubeAPIProxy(r endpoints.Resource, container *restful.Container) {
 	container.Add(proxy)
 }
 
-func registerWeb(container *restful.Container) {
+func registerWeb(container *restful.Container, webResourcesDir string) {
 	logging.Log.Info("Adding Web API")
 
 	fs := http.FileServer(http.Dir(webResourcesDir))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR replaces the use of environment variables to configure option by standard command line flags.
It also adds support for `--help` argument to print the available options and their default value.

Environment variables spread over the code are difficult to follow, error prone, and hard to document.
This should help users interacting with supported options and will let us add validation when necessary.

Also, it should be useful for writing unit tests.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
