### PR TITLE
Use install properties to check if triggers is installed

### DIFF
--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -24,6 +24,7 @@ import * as selectors from '../../reducers';
 beforeEach(() => {
   jest.spyOn(API, 'getPipelines').mockImplementation(() => {});
   jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isTriggersInstalled').mockImplementation(() => false);
 });
 
 it('App renders successfully', () => {

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -30,25 +30,19 @@ import { selectNamespace } from '../../actions/namespaces';
 import {
   getExtensions,
   getSelectedNamespace,
-  isReadOnly
+  isReadOnly,
+  isTriggersInstalled
 } from '../../reducers';
-import { getCustomResource } from '../../api';
 
 import './SideNav.scss';
 
 class SideNav extends Component {
-  state = {
-    isTriggersInstalled: false
-  };
-
   componentDidMount() {
     const { match } = this.props;
 
     if (match && match.params.namespace) {
       this.props.selectNamespace(match.params.namespace);
     }
-
-    this.checkTriggersInstalled();
   }
 
   componentDidUpdate(prevProps) {
@@ -150,22 +144,8 @@ class SideNav extends Component {
     history.push('/');
   };
 
-  checkTriggersInstalled() {
-    getCustomResource({
-      group: 'apiextensions.k8s.io',
-      version: 'v1beta1',
-      type: 'customresourcedefinitions',
-      name: 'eventlisteners.triggers.tekton.dev'
-    })
-      .then(() => {
-        this.setState({ isTriggersInstalled: true });
-      })
-      .catch(() => {});
-  }
-
   render() {
     const { extensions, intl, namespace } = this.props;
-    const { isTriggersInstalled } = this.state;
 
     return (
       <CarbonSideNav
@@ -224,7 +204,7 @@ class SideNav extends Component {
             >
               TaskRuns
             </SideNavMenuItem>
-            {isTriggersInstalled && (
+            {this.props.isTriggersInstalled && (
               <>
                 <SideNavMenuItem
                   element={NavLink}
@@ -358,10 +338,15 @@ class SideNav extends Component {
   }
 }
 
+SideNav.defaultProps = {
+  isTriggersInstalled: false
+};
+
 /* istanbul ignore next */
 const mapStateToProps = state => ({
   extensions: getExtensions(state),
   isReadOnly: isReadOnly(state),
+  isTriggersInstalled: isTriggersInstalled(state),
   namespace: getSelectedNamespace(state)
 });
 

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -20,11 +20,11 @@ import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import SideNavContainer, { SideNavWithIntl as SideNav } from './SideNav';
-import * as API from '../../api';
 import * as selectors from '../../reducers';
 
 beforeEach(() => {
   jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
+  jest.spyOn(selectors, 'isTriggersInstalled').mockImplementation(() => false);
 });
 
 it('SideNav renders with extensions', () => {
@@ -62,7 +62,8 @@ it('SideNav renders with extensions', () => {
 });
 
 it('SideNav renders with triggers', async () => {
-  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
+  selectors.isReadOnly.mockImplementation(() => false);
+  selectors.isTriggersInstalled.mockImplementation(() => true);
 
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
@@ -70,9 +71,6 @@ it('SideNav renders with triggers', async () => {
     extensions: { byName: {} },
     namespaces: { byName: {} }
   });
-  jest
-    .spyOn(API, 'getCustomResource')
-    .mockImplementation(() => Promise.resolve());
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
       <SideNavContainer />
@@ -589,7 +587,7 @@ it('SideNav updates namespace in URL', async () => {
 });
 
 it('SideNav renders import in not read-only mode', async () => {
-  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
+  selectors.isReadOnly.mockImplementation(() => false);
 
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
@@ -597,9 +595,6 @@ it('SideNav renders import in not read-only mode', async () => {
     extensions: { byName: {} },
     namespaces: { byName: {} }
   });
-  jest
-    .spyOn(API, 'getCustomResource')
-    .mockImplementation(() => Promise.resolve());
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
       <SideNavContainer />
@@ -615,9 +610,6 @@ it('SideNav does not render import in read-only mode', async () => {
     extensions: { byName: {} },
     namespaces: { byName: {} }
   });
-  jest
-    .spyOn(API, 'getCustomResource')
-    .mockImplementation(() => Promise.resolve());
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
       <SideNavContainer isReadOnly />

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -482,3 +482,7 @@ export function isFetchingEventListeners(state) {
 export function isReadOnly(state) {
   return propertiesSelectors.isReadOnly(state.properties);
 }
+
+export function isTriggersInstalled(state) {
+  return propertiesSelectors.isTriggersInstalled(state.properties);
+}

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -49,7 +49,8 @@ import {
   isFetchingSecrets,
   isFetchingTaskRuns,
   isFetchingTasks,
-  isReadOnly
+  isReadOnly,
+  isTriggersInstalled
 } from '.';
 import * as clusterTaskSelectors from './clusterTasks';
 import * as extensionSelectors from './extensions';
@@ -503,4 +504,14 @@ it('isReadOnly', () => {
   jest.spyOn(propertiesSelectors, 'isReadOnly').mockImplementation(() => true);
   expect(isReadOnly(state)).toBe(true);
   expect(propertiesSelectors.isReadOnly).toHaveBeenCalledWith(state.properties);
+});
+
+it('isTriggersInstalled', () => {
+  jest
+    .spyOn(propertiesSelectors, 'isTriggersInstalled')
+    .mockImplementation(() => true);
+  expect(isTriggersInstalled(state)).toBe(true);
+  expect(propertiesSelectors.isTriggersInstalled).toHaveBeenCalledWith(
+    state.properties
+  );
 });

--- a/src/reducers/properties.js
+++ b/src/reducers/properties.js
@@ -25,4 +25,8 @@ export function isReadOnly(state) {
   return state.ReadOnly;
 }
 
+export function isTriggersInstalled(state) {
+  return (state.TriggersNamespace && state.TriggersVersion) || false;
+}
+
 export default properties;

--- a/src/reducers/properties.test.js
+++ b/src/reducers/properties.test.js
@@ -28,4 +28,5 @@ it('INSTALL_PROPERTIES_SUCCESS', () => {
 
   const state = propertiesReducer({}, action);
   expect(selectors.isReadOnly(state)).toBe(false);
+  expect(selectors.isTriggersInstalled(state)).toBe(false);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR changes the way we detect if triggers is installed.
It uses the `getInstallProperties` api instead of trying to access the CRD.

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
