### PR TITLE
Disable Secrets and ServiceAccounts routes in read-only mode

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -198,43 +198,50 @@ export /* istanbul ignore next */ class App extends Component {
                   />
 
                   {!this.props.isReadOnly && (
-                    <Route
-                      path={paths.importResources()}
-                      component={ImportResources}
-                    />
-                  )}
+                    <>
+                      <Route
+                        path={paths.importResources()}
+                        component={ImportResources}
+                      />
 
-                  <Route path={paths.secrets.all()} exact component={Secrets} />
-                  <Route
-                    path={paths.secrets.byName()}
-                    exact
-                    component={Secret}
-                  />
-                  <Route
-                    path={paths.secrets.byNamespace()}
-                    exact
-                    component={Secrets}
-                  />
-                  <Route
-                    path={paths.secrets.create()}
-                    exact
-                    component={CreateSecret}
-                  />
-                  <Route
-                    path={paths.serviceAccounts.byName()}
-                    exact
-                    component={ServiceAccount}
-                  />
-                  <Route
-                    path={paths.serviceAccounts.all()}
-                    exact
-                    component={ServiceAccounts}
-                  />
-                  <Route
-                    path={paths.serviceAccounts.byNamespace()}
-                    exact
-                    component={ServiceAccounts}
-                  />
+                      <Route
+                        path={paths.secrets.all()}
+                        exact
+                        component={Secrets}
+                      />
+                      <Route
+                        path={paths.secrets.byName()}
+                        exact
+                        component={Secret}
+                      />
+                      <Route
+                        path={paths.secrets.byNamespace()}
+                        exact
+                        component={Secrets}
+                      />
+                      <Route
+                        path={paths.secrets.create()}
+                        exact
+                        component={CreateSecret}
+                      />
+
+                      <Route
+                        path={paths.serviceAccounts.byName()}
+                        exact
+                        component={ServiceAccount}
+                      />
+                      <Route
+                        path={paths.serviceAccounts.all()}
+                        exact
+                        component={ServiceAccounts}
+                      />
+                      <Route
+                        path={paths.serviceAccounts.byNamespace()}
+                        exact
+                        component={ServiceAccounts}
+                      />
+                    </>
+                  )}
                   <Route
                     path={paths.eventListeners.all()}
                     exact


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1374

The SideNav items for the Secrets and ServiceAccounts pages
were removed in a previous change, but the client routes were
still active. This means that a user could construct a URL (or
follow an old link) to one of these pages and the dashboard
would still attempt to render them.

Of course, since the Dashboard does not have permission to read
Secrets or ServiceAccounts in read-only mode (not included in RBAC)
the pages would have no content, and would display their empty states.

This is a minor cleanup to ensure we don't register the routes
when we know there'll be nothing to display.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
