### PR TITLE
Change how we disable the Secrets and ServiceAccounts UI routes

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -48,6 +48,7 @@ import {
   PipelineRun,
   PipelineRuns,
   Pipelines,
+  ReadWriteRoute,
   ResourceList,
   Secret,
   Secrets,
@@ -192,56 +193,57 @@ export /* istanbul ignore next */ class App extends Component {
                     component={ClusterTasks}
                   />
                   <Route path={paths.about()} component={About} />
-                  <Route
+
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
                     path={paths.importResources()}
                     component={ImportResources}
                   />
 
-                  {!this.props.isReadOnly && (
-                    <>
-                      <Route
-                        path={paths.importResources()}
-                        component={ImportResources}
-                      />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.secrets.all()}
+                    exact
+                    component={Secrets}
+                  />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.secrets.byName()}
+                    exact
+                    component={Secret}
+                  />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.secrets.byNamespace()}
+                    exact
+                    component={Secrets}
+                  />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.secrets.create()}
+                    exact
+                    component={CreateSecret}
+                  />
 
-                      <Route
-                        path={paths.secrets.all()}
-                        exact
-                        component={Secrets}
-                      />
-                      <Route
-                        path={paths.secrets.byName()}
-                        exact
-                        component={Secret}
-                      />
-                      <Route
-                        path={paths.secrets.byNamespace()}
-                        exact
-                        component={Secrets}
-                      />
-                      <Route
-                        path={paths.secrets.create()}
-                        exact
-                        component={CreateSecret}
-                      />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.serviceAccounts.byName()}
+                    exact
+                    component={ServiceAccount}
+                  />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.serviceAccounts.all()}
+                    exact
+                    component={ServiceAccounts}
+                  />
+                  <ReadWriteRoute
+                    isReadOnly={this.props.isReadOnly}
+                    path={paths.serviceAccounts.byNamespace()}
+                    exact
+                    component={ServiceAccounts}
+                  />
 
-                      <Route
-                        path={paths.serviceAccounts.byName()}
-                        exact
-                        component={ServiceAccount}
-                      />
-                      <Route
-                        path={paths.serviceAccounts.all()}
-                        exact
-                        component={ServiceAccounts}
-                      />
-                      <Route
-                        path={paths.serviceAccounts.byNamespace()}
-                        exact
-                        component={ServiceAccounts}
-                      />
-                    </>
-                  )}
                   <Route
                     path={paths.eventListeners.all()}
                     exact

--- a/src/containers/ReadWriteRoute/ReadWriteRoute.js
+++ b/src/containers/ReadWriteRoute/ReadWriteRoute.js
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+
+const ReadWriteRoute = ({
+  component: Component,
+  exact,
+  isReadOnly,
+  path,
+  ...rest
+}) => {
+  return (
+    <Route
+      {...rest}
+      exact={exact}
+      path={path}
+      render={props =>
+        isReadOnly ? <Redirect to="/" /> : <Component {...props} />
+      }
+    />
+  );
+};
+
+export default ReadWriteRoute;

--- a/src/containers/ReadWriteRoute/index.js
+++ b/src/containers/ReadWriteRoute/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+export { default } from './ReadWriteRoute';

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -39,6 +39,7 @@ export { default as PipelineRun } from './PipelineRun';
 export { default as PipelineRuns } from './PipelineRuns';
 export { default as Pipelines } from './Pipelines';
 export { default as PipelinesDropdown } from './PipelinesDropdown';
+export { default as ReadWriteRoute } from './ReadWriteRoute';
 export { default as ResourceList } from './ResourceList';
 export { default as Secrets } from './Secrets';
 export { default as Secret } from './Secret';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1392

Update the route logic in App.js to avoid bulk adding/removing
routes as this was messing with react-router and causing some
pages to disappear after being rendered initially.

Introduce a new ReadWriteRoute container that will redirect to
the landing page if matched in read-only mode. Use this container
instead of the default react-router Route for any paths that
should be disabled in read-only mode.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
