### PR TITLE
Add pipelines and triggers namespace flags

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -39,12 +39,14 @@ import (
 const csrfTokenLength = 32
 
 var (
-	help             = flag.Bool("help", false, "Prints defaults")
-	kubeConfigPath   = flag.String("kube-config", "", "Path to kube config file")
-	portNumber       = flag.Int("port", 8080, "Dashboard port number")
-	readOnly         = flag.Bool("read-only", false, "Enable or disable read only mode")
-	webDir           = flag.String("web-dir", "", "Dashboard web resources dir")
-	csrfSecureCookie = flag.Bool("csrf-secure-cookie", true, "Enable or disable Secure attribute on the CSRF cookie")
+	help               = flag.Bool("help", false, "Prints defaults")
+	pipelinesNamespace = flag.String("pipelines-namespace", "", "Namespace where Tekton pipelines is installed (assumes same namespace as dashboard if not specified)")
+	triggersNamespace  = flag.String("triggers-namespace", "", "Namespace where Tekton triggers is installed (assumes same namespace as dashboard if not specified)")
+	kubeConfigPath     = flag.String("kube-config", "", "Path to kube config file")
+	portNumber         = flag.Int("port", 8080, "Dashboard port number")
+	readOnly           = flag.Bool("read-only", false, "Enable or disable read only mode")
+	webDir             = flag.String("web-dir", "", "Dashboard web resources dir")
+	csrfSecureCookie   = flag.Bool("csrf-secure-cookie", true, "Enable or disable Secure attribute on the CSRF cookie")
 )
 
 // Stores config env
@@ -117,9 +119,11 @@ func main() {
 	}
 
 	options := endpoints.Options{
-		InstallNamespace: installNamespace,
-		ReadOnly:         *readOnly,
-		WebDir:           *webDir,
+		InstallNamespace:   installNamespace,
+		PipelinesNamespace: *pipelinesNamespace,
+		TriggersNamespace:  *triggersNamespace,
+		ReadOnly:           *readOnly,
+		WebDir:             *webDir,
 	}
 
 	resource := endpoints.Resource{

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -157,9 +157,11 @@ func (r Resource) GetEndpoints(request *restful.Request, response *restful.Respo
 // the version of the Tekton Dashboard, the version of Tekton Pipelines, whether or not one's
 // running on OpenShift, when one's in read-only mode and Tekton Triggers version (if Installed)
 func (r Resource) GetProperties(request *restful.Request, response *restful.Response) {
-	dashboardVersion := GetDashboardVersion(r, r.Options.InstallNamespace)
-	isOpenShift := IsOpenShift(r, r.Options.InstallNamespace)
-	pipelineNamespace, pipelineVersion := GetPipelineNamespaceAndVersion(r, isOpenShift)
+	pipelineNamespace := r.Options.GetPipelinesNamespace()
+	triggersNamespace := r.Options.GetTriggersNamespace()
+	dashboardVersion := getDashboardVersion(r, r.Options.InstallNamespace)
+	isOpenShift := isOpenShift(r, r.Options.InstallNamespace)
+	pipelineVersion := getPipelineVersion(r, pipelineNamespace)
 
 	properties := Properties{
 		DashboardNamespace: r.Options.InstallNamespace,
@@ -175,10 +177,10 @@ func (r Resource) GetProperties(request *restful.Request, response *restful.Resp
 		properties.LogoutURL = "/oauth/sign_out"
 	}
 
-	isTriggersInstalled := IsTriggersInstalled(r, isOpenShift)
+	isTriggersInstalled := isTriggersInstalled(r, triggersNamespace)
 
 	if isTriggersInstalled {
-		triggersNamespace, triggersVersion := GetTriggersNamespaceAndVersion(r, isOpenShift)
+		triggersVersion := getTriggersVersion(r, triggersNamespace)
 		properties.TriggersNamespace = triggersNamespace
 		properties.TriggersVersion = triggersVersion
 	}

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -9,9 +9,31 @@ import (
 
 // Options for enpoints
 type Options struct {
-	InstallNamespace string
-	ReadOnly         bool
-	WebDir           string
+	InstallNamespace   string
+	PipelinesNamespace string
+	TriggersNamespace  string
+	ReadOnly           bool
+	WebDir             string
+}
+
+// GetPipelinesNamespace returns the PipelinesNamespace property if set
+// or the InstallNamespace property otherwise (this assumes Tekton pipelines
+// is installed in the same namespace as the dashboard if the property is not set)
+func (o Options) GetPipelinesNamespace() string {
+	if o.PipelinesNamespace != "" {
+		return o.PipelinesNamespace
+	}
+	return o.InstallNamespace
+}
+
+// GetTriggersNamespace returns the TriggersNamespace property if set
+// or the InstallNamespace property otherwise (this assumes Tekton triggers
+// is installed in the same namespace as the dashboard if the property is not set)
+func (o Options) GetTriggersNamespace() string {
+	if o.TriggersNamespace != "" {
+		return o.TriggersNamespace
+	}
+	return o.InstallNamespace
 }
 
 // Store all types here that are reused throughout files


### PR DESCRIPTION
# Changes

This PR adds flags to specify the namespaces where pipelines and triggers are installed.
This should allow for restricting the permissions in those namespaces only instead of looking in all namespaces.

If the flags are not set, we assume pipelines and triggers are in the same namespace as the dashboard.

/cc @AlanGreene @a-roberts 

Extracted from the giant PR https://github.com/tektoncd/dashboard/pull/1371

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
