### PR TITLE
Separate RBAC used to lookup triggers and pipelines versions

### DIFF
--- a/base/200-clusterrole-backend.yaml
+++ b/base/200-clusterrole-backend.yaml
@@ -43,9 +43,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log", "namespaces"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions", "apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["tasks", "clustertasks", "taskruns", "pipelines",
                 "pipelineruns", "pipelineresources", "conditions"]

--- a/base/200-clusterrole-pipelines.yaml
+++ b/base/200-clusterrole-pipelines.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tekton Authors
+# Copyright 2020 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 ---
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - 200-clusterrole-backend.yaml
-  - 200-clusterrole-pipelines.yaml
-  - 200-clusterrole-triggers.yaml
-  - 201-clusterrolebinding.yaml
-  - 201-rolebinding-pipelines.yaml
-  - 201-rolebinding-triggers.yaml
-  - 202-extension-crd.yaml
-  - 203-serviceaccount.yaml
-  - 300-deployment.yaml
-  - 300-service.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-pipelines
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+rules:
+  # this is needed to lookup pipelines version
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list

--- a/base/200-clusterrole-triggers.yaml
+++ b/base/200-clusterrole-triggers.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tekton Authors
+# Copyright 2020 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 ---
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - 200-clusterrole-backend.yaml
-  - 200-clusterrole-pipelines.yaml
-  - 200-clusterrole-triggers.yaml
-  - 201-clusterrolebinding.yaml
-  - 201-rolebinding-pipelines.yaml
-  - 201-rolebinding-triggers.yaml
-  - 202-extension-crd.yaml
-  - 203-serviceaccount.yaml
-  - 300-deployment.yaml
-  - 300-service.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-triggers
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+rules:
+  # this is needed to lookup triggers version
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list

--- a/base/201-rolebinding-pipelines.yaml
+++ b/base/201-rolebinding-pipelines.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tekton Authors
+# Copyright 2020 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 ---
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - 200-clusterrole-backend.yaml
-  - 200-clusterrole-pipelines.yaml
-  - 200-clusterrole-triggers.yaml
-  - 201-clusterrolebinding.yaml
-  - 201-rolebinding-pipelines.yaml
-  - 201-rolebinding-triggers.yaml
-  - 202-extension-crd.yaml
-  - 203-serviceaccount.yaml
-  - 300-deployment.yaml
-  - 300-service.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-pipelines
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-pipelines

--- a/base/201-rolebinding-triggers.yaml
+++ b/base/201-rolebinding-triggers.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tekton Authors
+# Copyright 2020 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 ---
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - 200-clusterrole-backend.yaml
-  - 200-clusterrole-pipelines.yaml
-  - 200-clusterrole-triggers.yaml
-  - 201-clusterrolebinding.yaml
-  - 201-rolebinding-pipelines.yaml
-  - 201-rolebinding-triggers.yaml
-  - 202-extension-crd.yaml
-  - 203-serviceaccount.yaml
-  - 300-deployment.yaml
-  - 300-service.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-triggers
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-triggers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR separates `ClusterRole`s used to look up pipelines and triggers version from the main `ClusterRole`.

These two new `ClusterRole`s are added to the dashboard service account using `RoleBinding`s and therefore target a single namespace (not the whole cluster).

/cc @AlanGreene @a-roberts 

Extracted from the giant PR https://github.com/tektoncd/dashboard/pull/1371

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
