### PR TITLE
Do not watch secrets and service accounts when read-only

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -146,7 +146,7 @@ func main() {
 	logging.Log.Info("Creating controllers")
 	resyncDur := time.Second * 30
 	controllers.StartTektonControllers(resource.PipelineClient, resource.PipelineResourceClient, resyncDur, ctx.Done())
-	controllers.StartKubeControllers(resource.K8sClient, resyncDur, dashboardConfig.installNamespace, routerHandler, ctx.Done())
+	controllers.StartKubeControllers(resource.K8sClient, resyncDur, dashboardConfig.installNamespace, *readOnly, routerHandler, ctx.Done())
 
 	logging.Log.Infof("Creating server and entering wait loop")
 	CSRF := csrf.Protect(

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -90,7 +90,7 @@ func DummyServer() (*httptest.Server, *endpoints.Resource, string) {
 	stopCh := make(<-chan struct{})
 	resyncDur := time.Second * 30
 	controllers.StartTektonControllers(resource.PipelineClient, resource.PipelineResourceClient, resyncDur, stopCh)
-	controllers.StartKubeControllers(resource.K8sClient, resyncDur, dashboardNamespace, routerHandler, stopCh)
+	controllers.StartKubeControllers(resource.K8sClient, resyncDur, dashboardNamespace, false, routerHandler, stopCh)
 	// Wait until namespace is detected by informer and functionally "dropped" since the informer will be eventually consistent
 	timeout := time.After(5 * time.Second)
 	for {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR does not start controllers for `secrets` and `service accounts` when the dashboard backend runs in read-only mode.

As RBAC doesn't allow access to these resources, the logs are full of:
```
E0520 12:02:01.741412       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:02.745356       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:03.749885       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:04.755146       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:05.758109       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:06.761589       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:07.729306       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
E0520 12:02:08.732198       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:tekton-pipelines:tekton-dashboard" cannot list resource "secrets" in API group "" at the cluster scope
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
