### PR TITLE
Remove query string from page location when constructing API root

### DIFF
--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -20,8 +20,8 @@ const defaultOptions = {
 };
 
 export function getAPIRoot() {
-  const { href, hash } = window.location;
-  let baseURL = href.replace(hash, '');
+  const { host, pathname, protocol } = window.location;
+  let baseURL = `${protocol}//${host}${pathname}`;
   if (baseURL.endsWith('/')) {
     baseURL = baseURL.slice(0, -1);
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/1405

Google Cloud's Cloud Shell adds a `?authuser=0` query string
to web preview URLs when opening the web preview for a selected
port. Since the dashboard client code wasn't expecting a query
string to be present in the URL it ended up being included in
the wrong position when constructing API URLs.

e.g. we'd end up with `/?authuser=0/proxy/api/v1/namespaces`
instead of `/proxy/api/v1/namespaces`

Change how we construct the API root to ensure we omit both
the hash and query string.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
