### PR TITLE
pkg/endpoints: forward Impersonate headers in ProxyRequest

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -48,6 +48,7 @@ var (
 	webDir             = flag.String("web-dir", "", "Dashboard web resources dir")
 	logoutUrl          = flag.String("logout-url", "", "If set, enables logout on the frontend and binds the logout button to this url")
 	csrfSecureCookie   = flag.Bool("csrf-secure-cookie", true, "Enable or disable Secure attribute on the CSRF cookie")
+	impersonate        = flag.Bool("imporsonate", false, "Enable user impersonation")
 )
 
 func getCSRFAuthKey() []byte {
@@ -117,6 +118,7 @@ func main() {
 		ReadOnly:           *readOnly,
 		WebDir:             *webDir,
 		LogoutURL:          *logoutUrl,
+		Impersonate:        *impersonate,
 	}
 
 	resource := endpoints.Resource{

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -15,6 +15,10 @@ type Options struct {
 	ReadOnly           bool
 	WebDir             string
 	LogoutURL          string
+	// Expect and forward Impersonate-* and Authorization headers
+	// so requests are performed using the client's privileges instead
+	// of the dashboard's privileges.
+	Impersonate        bool
 }
 
 // GetPipelinesNamespace returns the PipelinesNamespace property if set


### PR DESCRIPTION
# Changes

Forward the `Impersonate-User`, `Impersonate-Group` and `Authorization` headers when proxying requests to the apiserver. See https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation

This partially addresses the privilege escalation where users with limited privileges, who can view the Tekton dashboard, essentially have the same privileges as the dashboard itself via the `/proxy` endpoint. 

There remain endpoints that still amount to privilege escalation: a user with read-only permissions to a given namespace can still re-trigger pipelines, as just one example.

This PR assumes that the Tekton dashboard will be fronted by an authenticating reverse proxy that forwards end-users' OIDC `email` and `group` claims in the `Impersonate-User` and `Impersonate-Group` headers, respectively.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
