### PR TITLE
Add frontend support for single namespace visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ These options are documented below:
 | `--read-only` | Enable or disable read only mode | `bool` | `false` |
 | `--web-dir` | Dashboard web resources directory | `string` | `""` |
 | `--logout-url` | If set, enables logout on the frontend and binds the logout button to this url | `string` | `""` |
+| `--namespace` | If set, limits the scope of resources watched to this namespace only | `string` | `""` |
 
 Run `dashboard --help` to show the supported command line arguments and their default value directly from the `dashboard` binary.
+
+**Important note:** using `--namespace` ensures that the dashboard is watching resources in the namespace specified (and drives the frontend).
+It doesn't limit actions that can be performed to this namespace only though. It's important that this flag is used AND that rbac rules are setup accordingly.
 
 ### Optionally set up the Ingress endpoint
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -136,7 +136,7 @@ func main() {
 	logging.Log.Info("Creating controllers")
 	resyncDur := time.Second * 30
 	controllers.StartTektonControllers(resource.PipelineClient, resource.PipelineResourceClient, *tenantNamespace, resyncDur, ctx.Done())
-	controllers.StartKubeControllers(resource.K8sClient, resyncDur, installNamespace, *tenantNamespace, *readOnly, routerHandler, ctx.Done())
+	controllers.StartKubeControllers(resource.K8sClient, resyncDur, *tenantNamespace, *readOnly, routerHandler, ctx.Done())
 
 	logging.Log.Infof("Creating server and entering wait loop")
 	CSRF := csrf.Protect(

--- a/overlays/dev-single-namespace/deployment-patch.yaml
+++ b/overlays/dev-single-namespace/deployment-patch.yaml
@@ -1,0 +1,5 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --namespace=tekton-tenant

--- a/overlays/dev-single-namespace/kustomization.yaml
+++ b/overlays/dev-single-namespace/kustomization.yaml
@@ -1,0 +1,63 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/200-clusterrole-backend.yaml
+  - ../../base/200-clusterrole-extensions.yaml
+  - ../../base/200-clusterrole-pipelines.yaml
+  - ../../base/200-clusterrole-tenant.yaml
+  - ../../base/200-clusterrole-triggers.yaml
+  - ../../base/201-clusterrolebinding-backend.yaml
+  - ../../base/201-rolebinding-extensions.yaml
+  - ../../base/201-rolebinding-pipelines.yaml
+  - ../../base/201-rolebinding-tenant.yaml
+  - ../../base/201-rolebinding-triggers.yaml
+  - ../../base/202-extension-crd.yaml
+  - ../../base/203-serviceaccount.yaml
+  - ../../base/300-deployment.yaml
+  - ../../base/300-service.yaml
+images:
+  - name: dashboardImage
+    newName: github.com/tektoncd/dashboard/cmd/dashboard
+    newTag:
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: tekton-dashboard-backend
+    path: ../full-fat/clusterrole-backend-patch.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: tekton-dashboard-tenant
+    path: ../full-fat/clusterrole-tenant-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../dev/csrf-secure-cookie-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ./deployment-patch.yaml

--- a/packages/components/src/components/LogoutButton/LogoutButton.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.js
@@ -37,7 +37,7 @@ export class LogoutButton extends Component {
       const logoutURL = await this.props.getLogoutURL();
       this.setState({ logoutURL });
     } catch (error) {
-      console.log(error); // eslint-disable-line
+      console.log(error); // eslint-disable-line no-console
     }
   }
 

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -49,14 +49,16 @@ func StartTektonControllers(clientset tektonclientset.Interface, clientresources
 }
 
 // StartKubeControllers creates and starts Kube controllers
-func StartKubeControllers(clientset k8sclientset.Interface, resyncDur time.Duration, installNamespace, tenantNamespace string, readOnly bool, handler *router.Handler, stopCh <-chan struct{}) {
+func StartKubeControllers(clientset k8sclientset.Interface, resyncDur time.Duration, tenantNamespace string, readOnly bool, handler *router.Handler, stopCh <-chan struct{}) {
 	logging.Log.Info("Creating Kube controllers")
 	clusterInformerFactory := k8sinformers.NewSharedInformerFactory(clientset, resyncDur)
 	tenantInformerFactory := k8sinformers.NewSharedInformerFactoryWithOptions(clientset, resyncDur, k8sinformers.WithNamespace(tenantNamespace))
 	// Add all kube controllers
-	kubecontroller.NewExtensionController(clusterInformerFactory, installNamespace, handler)
 	if tenantNamespace == "" {
+		kubecontroller.NewExtensionController(clusterInformerFactory, handler)
 		kubecontroller.NewNamespaceController(clusterInformerFactory)
+	} else {
+		kubecontroller.NewExtensionController(tenantInformerFactory, handler)
 	}
 	if !readOnly {
 		kubecontroller.NewSecretController(tenantInformerFactory)

--- a/pkg/controllers/kubernetes/extension.go
+++ b/pkg/controllers/kubernetes/extension.go
@@ -15,16 +15,14 @@ import (
 // used within informer handler functions
 type extensionHandler struct {
 	*router.Handler
-	installNamespace string
 }
 
 // NewExtensionController registers the K8s shared informer that reacts to
 // extension service updates
-func NewExtensionController(sharedK8sInformerFactory k8sinformer.SharedInformerFactory, dashboardNamespace string, handler *router.Handler) {
+func NewExtensionController(sharedK8sInformerFactory k8sinformer.SharedInformerFactory, handler *router.Handler) {
 	logging.Log.Debug("In NewExtensionController")
 	h := extensionHandler{
-		Handler:          handler,
-		installNamespace: dashboardNamespace,
+		Handler: handler,
 	}
 	extensionServiceInformer := sharedK8sInformerFactory.Core().V1().Services().Informer()
 	// ResourceEventHandler interface functions only pass object interfaces
@@ -38,16 +36,14 @@ func NewExtensionController(sharedK8sInformerFactory k8sinformer.SharedInformerF
 
 func (e extensionHandler) serviceCreated(obj interface{}) {
 	service := obj.(*v1.Service)
-	if service.Namespace == e.installNamespace {
-		if value := service.Labels[router.ExtensionLabelKey]; value == router.ExtensionLabelValue && service.Spec.ClusterIP != "" {
-			logging.Log.Debugf("Extension Controller detected extension '%s' created", service.Name)
-			e.RegisterExtension(service)
-			data := broadcaster.SocketData{
-				MessageType: broadcaster.ExtensionCreated,
-				Payload:     obj,
-			}
-			endpoints.ResourcesChannel <- data
+	if value := service.Labels[router.ExtensionLabelKey]; value == router.ExtensionLabelValue && service.Spec.ClusterIP != "" {
+		logging.Log.Debugf("Extension Controller detected extension '%s' created", service.Name)
+		e.RegisterExtension(service)
+		data := broadcaster.SocketData{
+			MessageType: broadcaster.ExtensionCreated,
+			Payload:     obj,
 		}
+		endpoints.ResourcesChannel <- data
 	}
 }
 
@@ -56,58 +52,54 @@ func (e extensionHandler) serviceUpdated(oldObj, newObj interface{}) {
 	// If resourceVersion differs between old and new, an actual update event was observed
 	versionUpdated := oldService.ResourceVersion != newService.ResourceVersion
 	// Updated services will still be in the same namespace
-	if oldService.Namespace == e.installNamespace {
-		var event string
-		if value := oldService.Labels[router.ExtensionLabelKey]; versionUpdated && value == router.ExtensionLabelValue && oldService.Spec.ClusterIP != "" {
-			logging.Log.Debugf("Extension Controller Update: Removing old extension '%s'", oldService.Name)
-			e.UnregisterExtension(oldService)
-			event = "delete"
+	var event string
+	if value := oldService.Labels[router.ExtensionLabelKey]; versionUpdated && value == router.ExtensionLabelValue && oldService.Spec.ClusterIP != "" {
+		logging.Log.Debugf("Extension Controller Update: Removing old extension '%s'", oldService.Name)
+		e.UnregisterExtension(oldService)
+		event = "delete"
+	}
+	if value := newService.Labels[router.ExtensionLabelKey]; versionUpdated && value == router.ExtensionLabelValue && newService.Spec.ClusterIP != "" {
+		logging.Log.Debugf("Extension Controller Update: Add new extension '%s'", newService.Name)
+		e.RegisterExtension(newService)
+		if len(event) != 0 {
+			event = "update"
+		} else {
+			event = "create"
 		}
-		if value := newService.Labels[router.ExtensionLabelKey]; versionUpdated && value == router.ExtensionLabelValue && newService.Spec.ClusterIP != "" {
-			logging.Log.Debugf("Extension Controller Update: Add new extension '%s'", newService.Name)
-			e.RegisterExtension(newService)
-			if len(event) != 0 {
-				event = "update"
-			} else {
-				event = "create"
-			}
+	}
+	switch event {
+	case "delete": // Service has removed the extension label
+		data := broadcaster.SocketData{
+			MessageType: broadcaster.ExtensionDeleted,
+			Payload:     newObj,
 		}
-		switch event {
-		case "delete": // Service has removed the extension label
-			data := broadcaster.SocketData{
-				MessageType: broadcaster.ExtensionDeleted,
-				Payload:     newObj,
-			}
-			endpoints.ResourcesChannel <- data
-		case "create": // Service has added the extension label
-			data := broadcaster.SocketData{
-				MessageType: broadcaster.ExtensionCreated,
-				Payload:     newObj,
-			}
-			endpoints.ResourcesChannel <- data
-		case "update": // Extension service was modified
-			data := broadcaster.SocketData{
-				MessageType: broadcaster.ExtensionUpdated,
-				Payload:     newObj,
-			}
-			endpoints.ResourcesChannel <- data
+		endpoints.ResourcesChannel <- data
+	case "create": // Service has added the extension label
+		data := broadcaster.SocketData{
+			MessageType: broadcaster.ExtensionCreated,
+			Payload:     newObj,
 		}
+		endpoints.ResourcesChannel <- data
+	case "update": // Extension service was modified
+		data := broadcaster.SocketData{
+			MessageType: broadcaster.ExtensionUpdated,
+			Payload:     newObj,
+		}
+		endpoints.ResourcesChannel <- data
 	}
 }
 
 func (e extensionHandler) serviceDeleted(obj interface{}) {
 	serviceMeta := utils.GetDeletedObjectMeta(obj)
-	if serviceMeta.GetNamespace() == e.installNamespace {
-		if value := serviceMeta.GetLabels()[router.ExtensionLabelKey]; value == router.ExtensionLabelValue {
-			logging.Log.Debugf("Extension Controller detected extension '%s' deleted", serviceMeta.GetName())
-			if serviceMeta.GetUID() != "" {
-				e.UnregisterExtensionByMeta(serviceMeta)
-			}
-			data := broadcaster.SocketData{
-				MessageType: broadcaster.ExtensionDeleted,
-				Payload:     obj,
-			}
-			endpoints.ResourcesChannel <- data
+	if value := serviceMeta.GetLabels()[router.ExtensionLabelKey]; value == router.ExtensionLabelValue {
+		logging.Log.Debugf("Extension Controller detected extension '%s' deleted", serviceMeta.GetName())
+		if serviceMeta.GetUID() != "" {
+			e.UnregisterExtensionByMeta(serviceMeta)
 		}
+		data := broadcaster.SocketData{
+			MessageType: broadcaster.ExtensionDeleted,
+			Payload:     obj,
+		}
+		endpoints.ResourcesChannel <- data
 	}
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -90,7 +90,7 @@ func DummyServer() (*httptest.Server, *endpoints.Resource, string) {
 	stopCh := make(<-chan struct{})
 	resyncDur := time.Second * 30
 	controllers.StartTektonControllers(resource.PipelineClient, resource.PipelineResourceClient, "", resyncDur, stopCh)
-	controllers.StartKubeControllers(resource.K8sClient, resyncDur, dashboardNamespace, "", false, routerHandler, stopCh)
+	controllers.StartKubeControllers(resource.K8sClient, resyncDur, "", false, routerHandler, stopCh)
 	// Wait until namespace is detected by informer and functionally "dropped" since the informer will be eventually consistent
 	timeout := time.After(5 * time.Second)
 	for {

--- a/src/actions/extensions.js
+++ b/src/actions/extensions.js
@@ -12,8 +12,10 @@ limitations under the License.
 */
 
 import { getExtensions } from '../api';
-import { fetchCollection } from './actionCreators';
+import { fetchNamespacedCollection } from './actionCreators';
 
-export function fetchExtensions() {
-  return fetchCollection('Extension', getExtensions);
+export function fetchExtensions({ namespace } = {}) {
+  return fetchNamespacedCollection('Extension', getExtensions, {
+    namespace
+  });
 }

--- a/src/actions/extensions.test.js
+++ b/src/actions/extensions.test.js
@@ -16,10 +16,11 @@ import { fetchExtensions } from './extensions';
 import * as creators from './actionCreators';
 
 it('fetchExtensions', async () => {
-  jest.spyOn(creators, 'fetchCollection');
+  jest.spyOn(creators, 'fetchNamespacedCollection');
   fetchExtensions();
-  expect(creators.fetchCollection).toHaveBeenCalledWith(
+  expect(creators.fetchNamespacedCollection).toHaveBeenCalledWith(
     'Extension',
-    API.getExtensions
+    API.getExtensions,
+    {}
   );
 });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -399,12 +399,13 @@ export function getCustomResource(...args) {
   return get(uri);
 }
 
-export async function getExtensions() {
+export async function getExtensions({ namespace } = {}) {
   const uri = `${apiRoot}/v1/extensions`;
   const resourceExtensionsUri = getResourcesAPI({
     group: 'dashboard.tekton.dev',
     version: 'v1alpha1',
-    type: 'extensions'
+    type: 'extensions',
+    namespace
   });
   let extensions = await get(uri);
   const resourceExtensions = await get(resourceExtensionsUri);

--- a/src/components/CreateSecret/Form/UniversalFields.test.js
+++ b/src/components/CreateSecret/Form/UniversalFields.test.js
@@ -80,7 +80,8 @@ const namespaces = {
 };
 
 const store = mockStore({
-  namespaces
+  namespaces,
+  properties: {}
 });
 
 it('UniversalFields renders with blank inputs', () => {

--- a/src/components/CreateSecret/Form/index.test.js
+++ b/src/components/CreateSecret/Form/index.test.js
@@ -41,7 +41,8 @@ const namespaces = {
 };
 
 const store = mockStore({
-  namespaces
+  namespaces,
+  properties: {}
 });
 
 const props = {

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render } from 'react-testing-library';
+import { render, waitForElement } from 'react-testing-library';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
@@ -25,9 +25,12 @@ beforeEach(() => {
   jest.spyOn(API, 'getPipelines').mockImplementation(() => {});
   jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
   jest.spyOn(selectors, 'isTriggersInstalled').mockImplementation(() => false);
+  jest
+    .spyOn(selectors, 'getTenantNamespace')
+    .mockImplementation(() => undefined);
 });
 
-it('App renders successfully', () => {
+it('App renders successfully in full cluster mode', async () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
@@ -49,6 +52,204 @@ it('App renders successfully', () => {
       />
     </Provider>
   );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+
+  expect(queryByText(/namespaces/i)).toBeTruthy();
   expect(queryByText(/pipelines/i)).toBeTruthy();
   expect(queryByText(/tasks/i)).toBeTruthy();
+});
+
+it('App renders successfully in single namespace mode', async () => {
+  selectors.getTenantNamespace.mockImplementation(() => 'fake');
+
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    secrets: { byNamespace: {} },
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    notifications: {},
+    pipelines: { byNamespace: {} },
+    pipelineRuns: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
+  });
+  const { queryByText } = render(
+    <Provider store={store}>
+      <App
+        extensions={[]}
+        fetchExtensions={() => {}}
+        fetchNamespaces={() => {}}
+        fetchInstallProperties={() => {}}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+
+  expect(queryByText(/namespaces/i)).toBeFalsy();
+  expect(queryByText(/pipelines/i)).toBeTruthy();
+  expect(queryByText(/tasks/i)).toBeTruthy();
+});
+
+it('App selects namespace based on tenant namespace', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    secrets: { byNamespace: {} },
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    notifications: {},
+    pipelines: { byNamespace: {} },
+    pipelineRuns: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
+  });
+  const selectNamespace = jest.fn();
+  const { queryByText } = render(
+    <Provider store={store}>
+      <App
+        extensions={[]}
+        fetchExtensions={() => {}}
+        fetchNamespaces={() => {}}
+        fetchInstallProperties={() => {}}
+        tenantNamespace="fake"
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+  expect(selectNamespace).toHaveBeenCalledWith('fake');
+});
+
+it('App does not call fetchNamespaces in single namespace mode', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    secrets: { byNamespace: {} },
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    notifications: {},
+    pipelines: { byNamespace: {} },
+    pipelineRuns: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
+  });
+  const fetchNamespaces = jest.fn();
+  const selectNamespace = jest.fn();
+  const { queryByText } = render(
+    <Provider store={store}>
+      <App
+        extensions={[]}
+        fetchExtensions={() => {}}
+        fetchNamespaces={fetchNamespaces}
+        fetchInstallProperties={() =>
+          Promise.resolve({
+            TenantNamespace: 'fake'
+          })
+        }
+        tenantNamespace="fake"
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+  expect(selectNamespace).toHaveBeenCalledWith('fake');
+  expect(fetchNamespaces).not.toHaveBeenCalled();
+});
+
+it('App calls fetchNamespaces in full cluster mode', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    secrets: { byNamespace: {} },
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    notifications: {},
+    pipelines: { byNamespace: {} },
+    pipelineRuns: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
+  });
+  const fetchNamespaces = jest.fn();
+  const selectNamespace = jest.fn();
+  const { queryByText } = render(
+    <Provider store={store}>
+      <App
+        extensions={[]}
+        fetchExtensions={() => {}}
+        fetchNamespaces={fetchNamespaces}
+        fetchInstallProperties={() => Promise.resolve({})}
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+  expect(selectNamespace).not.toHaveBeenCalled();
+  expect(fetchNamespaces).toHaveBeenCalled();
+});
+
+it('App calls fetchExtensions for tenant namespace in single namespace mode', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    secrets: { byNamespace: {} },
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    notifications: {},
+    pipelines: { byNamespace: {} },
+    pipelineRuns: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
+  });
+  const fetchExtensions = jest.fn();
+  const selectNamespace = jest.fn();
+  const { queryByText } = render(
+    <Provider store={store}>
+      <App
+        extensions={[]}
+        fetchExtensions={fetchExtensions}
+        fetchInstallProperties={() =>
+          Promise.resolve({
+            TenantNamespace: 'fake'
+          })
+        }
+        tenantNamespace="fake"
+        selectNamespace={selectNamespace}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+  expect(selectNamespace).toHaveBeenCalledWith('fake');
+  expect(fetchExtensions).toHaveBeenCalledWith({ namespace: 'fake' });
+});
+
+it('App calls fetchExtensions without namespace in full cluster mode', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    secrets: { byNamespace: {} },
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    notifications: {},
+    pipelines: { byNamespace: {} },
+    pipelineRuns: { byNamespace: {} },
+    serviceAccounts: { byNamespace: {} }
+  });
+  const fetchExtensions = jest.fn();
+  const fetchNamespaces = jest.fn();
+  const { queryByText } = render(
+    <Provider store={store}>
+      <App
+        extensions={[]}
+        fetchExtensions={fetchExtensions}
+        fetchNamespaces={fetchNamespaces}
+        fetchInstallProperties={() => Promise.resolve({})}
+      />
+    </Provider>
+  );
+
+  await waitForElement(() => queryByText('Tekton resources'));
+  expect(fetchExtensions).toHaveBeenCalledWith({});
+  expect(fetchNamespaces).toHaveBeenCalled();
 });

--- a/src/containers/CreatePipelineResources/CreatePipelineResources.test.js
+++ b/src/containers/CreatePipelineResources/CreatePipelineResources.test.js
@@ -48,6 +48,7 @@ const namespaces = {
 
 const store = mockStore({
   pipelineResources,
+  properties: {},
   namespaces,
   notifications: {}
 });

--- a/src/containers/CreatePipelineResources/CreatePipelineResourcesErrorNotification.test.js
+++ b/src/containers/CreatePipelineResources/CreatePipelineResourcesErrorNotification.test.js
@@ -70,6 +70,7 @@ it('error notification appears', async () => {
       isFetching: false,
       submitError: 'Some error message'
     },
+    properties: {},
     namespaces,
     notifications: {}
   });

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -147,6 +147,7 @@ const testStore = {
   pipelineResources,
   pipelineRuns,
   pipelines,
+  properties: {},
   serviceAccounts
 };
 

--- a/src/containers/CreateSecret/CreateSecret.test.js
+++ b/src/containers/CreateSecret/CreateSecret.test.js
@@ -84,6 +84,7 @@ const store = mockStore({
   secrets,
   namespaces,
   notifications: {},
+  properties: {},
   serviceAccounts: {
     byId: serviceAccountsById,
     byNamespace: serviceAccountsByNamespace,

--- a/src/containers/CreateTaskRun/CreateTaskRun.test.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.js
@@ -172,6 +172,7 @@ const testStore = {
   namespaces,
   notifications: {},
   pipelineResources,
+  properties: {},
   taskRuns,
   tasks,
   clusterTasks,

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -82,7 +82,7 @@ describe('ImportResources component', () => {
     await waitForElement(() => getByText(/Please submit a valid URL/i));
   });
 
-  it('Displays an error when Namepsace is empty', async () => {
+  it('Displays an error when Namespace is empty', async () => {
     const { getByTestId, getByText } = await renderWithIntl(
       <Provider store={store}>
         <ImportResourcesContainer />

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -17,7 +17,11 @@ import { connect } from 'react-redux';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
-import { getNamespaces, isFetchingNamespaces } from '../../reducers';
+import {
+  getNamespaces,
+  getTenantNamespace,
+  isFetchingNamespaces
+} from '../../reducers';
 
 const NamespacesDropdown = ({
   allNamespacesLabel,
@@ -30,6 +34,7 @@ const NamespacesDropdown = ({
   namespaces,
   selectedItem: originalSelectedItem,
   showAllNamespaces,
+  tenantNamespace,
   ...rest
 }) => {
   const labelString =
@@ -57,8 +62,8 @@ const NamespacesDropdown = ({
     selectedItem.text = allNamespacesString;
   }
 
-  const items = [...namespaces];
-  if (showAllNamespaces) {
+  const items = tenantNamespace ? [tenantNamespace] : [...namespaces];
+  if (!tenantNamespace && showAllNamespaces) {
     items.unshift({ id: ALL_NAMESPACES, text: allNamespacesString });
   }
 
@@ -83,7 +88,8 @@ NamespacesDropdown.defaultProps = {
 function mapStateToProps(state) {
   return {
     loading: isFetchingNamespaces(state),
-    namespaces: getNamespaces(state)
+    namespaces: getNamespaces(state),
+    tenantNamespace: getTenantNamespace(state)
   };
 }
 

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
@@ -39,7 +39,8 @@ it('NamespacesDropdown renders items based on Redux state', () => {
     namespaces: {
       byName,
       isFetching: false
-    }
+    },
+    properties: {}
   });
   const { getAllByText, getByPlaceholderText, queryByText } = renderWithIntl(
     <Provider store={store}>
@@ -60,7 +61,8 @@ it('NamespacesDropdown renders controlled selection', () => {
     namespaces: {
       byName,
       isFetching: false
-    }
+    },
+    properties: {}
   });
   // Select item 'namespace-1'
   const { container, queryByPlaceholderText, queryByValue } = renderWithIntl(
@@ -92,7 +94,8 @@ it('NamespacesDropdown renders empty', () => {
     namespaces: {
       byName: {},
       isFetching: false
-    }
+    },
+    properties: {}
   });
 
   const { queryByPlaceholderText } = renderWithIntl(
@@ -108,7 +111,8 @@ it('NamespacesDropdown renders loading skeleton based on Redux state', () => {
     namespaces: {
       byName,
       isFetching: true
-    }
+    },
+    properties: {}
   });
 
   const { queryByPlaceholderText } = renderWithIntl(
@@ -124,7 +128,8 @@ it('NamespacesDropdown handles onChange event', () => {
     namespaces: {
       byName,
       isFetching: false
-    }
+    },
+    properties: {}
   });
   const onChange = jest.fn();
   const { getByPlaceholderText, getByText } = renderWithIntl(
@@ -135,4 +140,21 @@ it('NamespacesDropdown handles onChange event', () => {
   fireEvent.click(getByPlaceholderText(initialTextRegExp));
   fireEvent.click(getByText(/namespace-1/i));
   expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+it('NamespacesDropdown renders tenant namespace in single namespace mode', () => {
+  const store = mockStore({
+    namespaces: {
+      byName: {}
+    },
+    properties: {
+      TenantNamespace: 'fake'
+    }
+  });
+  const { queryByText } = renderWithIntl(
+    <Provider store={store}>
+      <NamespacesDropdown {...props} />
+    </Provider>
+  );
+  expect(queryByText(/fake/i)).toBeTruthy();
 });

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -156,6 +156,7 @@ const testStore = {
   ...pipelineResourcesTestStore,
   ...pipelineRunsTestStore,
   ...pipelinesTestStore,
+  properties: {},
   ...serviceAccountsTestStore
 };
 

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -30,6 +30,7 @@ import { selectNamespace } from '../../actions/namespaces';
 import {
   getExtensions,
   getSelectedNamespace,
+  getTenantNamespace,
   isReadOnly,
   isTriggersInstalled
 } from '../../reducers';
@@ -249,15 +250,21 @@ class SideNav extends Component {
             )}
           </SideNavMenu>
 
-          <SideNavMenuItem
-            element={NamespacesDropdown}
-            id="sidenav-namespace-dropdown"
-            selectedItem={{ id: namespace, text: namespace }}
-            showAllNamespaces
-            onChange={this.selectNamespace}
-          >
-            &nbsp;
-          </SideNavMenuItem>
+          {this.props.tenantNamespace ? (
+            <SideNavMenu defaultExpanded title="Namespace">
+              <SideNavMenuItem>{this.props.tenantNamespace}</SideNavMenuItem>
+            </SideNavMenu>
+          ) : (
+            <SideNavMenuItem
+              element={NamespacesDropdown}
+              id="sidenav-namespace-dropdown"
+              selectedItem={{ id: namespace, text: namespace }}
+              showAllNamespaces={!this.props.tenantNamespace}
+              onChange={this.selectNamespace}
+            >
+              &nbsp;
+            </SideNavMenuItem>
+          )}
 
           {!this.props.isReadOnly && (
             <SideNavMenu
@@ -358,7 +365,8 @@ const mapStateToProps = state => ({
   extensions: getExtensions(state),
   isReadOnly: isReadOnly(state),
   isTriggersInstalled: isTriggersInstalled(state),
-  namespace: getSelectedNamespace(state)
+  namespace: getSelectedNamespace(state),
+  tenantNamespace: getTenantNamespace(state)
 });
 
 const mapDispatchToProps = {

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -20,12 +20,6 @@ import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import SideNavContainer, { SideNavWithIntl as SideNav } from './SideNav';
-import * as selectors from '../../reducers';
-
-beforeEach(() => {
-  jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
-  jest.spyOn(selectors, 'isTriggersInstalled').mockImplementation(() => false);
-});
 
 it('SideNav renders with extensions', () => {
   const middleware = [thunk];
@@ -48,7 +42,8 @@ it('SideNav renders with extensions', () => {
         }
       }
     },
-    namespaces: { byName: {} }
+    namespaces: { byName: {} },
+    properties: {}
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
@@ -62,14 +57,15 @@ it('SideNav renders with extensions', () => {
 });
 
 it('SideNav renders with triggers', async () => {
-  selectors.isReadOnly.mockImplementation(() => false);
-  selectors.isTriggersInstalled.mockImplementation(() => true);
-
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
     extensions: { byName: {} },
-    namespaces: { byName: {} }
+    namespaces: { byName: {} },
+    properties: {
+      TriggersNamespace: 'fake-triggers',
+      TriggersVersion: 'fake-triggers'
+    }
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
@@ -88,7 +84,8 @@ it('SideNav selects namespace based on URL', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
-    namespaces: { byName: {} }
+    namespaces: { byName: {} },
+    properties: {}
   });
   const namespace = 'default';
   const selectNamespace = jest.fn();
@@ -143,7 +140,8 @@ it('SideNav selects namespace when no namespace in URL', async () => {
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const { getByText, getByValue } = renderWithRouter(
@@ -171,7 +169,8 @@ it('SideNav redirects to root when all namespaces selected on namespaced URL', a
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -204,7 +203,8 @@ it('SideNav redirects to PipelineRuns page when all namespaces selected on names
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -237,7 +237,8 @@ it('SideNav redirects to TaskRuns page when all namespaces selected on namespace
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -270,7 +271,8 @@ it('SideNav redirects to PipelineResources page when all namespaces selected on 
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -306,7 +308,8 @@ it('SideNav redirects to Pipelines page when all namespaces selected on namespac
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -342,7 +345,8 @@ it('SideNav redirects to ServiceAccounts page when all namespaces selected on na
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -378,7 +382,8 @@ it('SideNav redirects to EventListeners page when all namespaces selected on nam
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -414,7 +419,8 @@ it('SideNav redirects to TriggerBindings page when all namespaces selected on na
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -450,7 +456,8 @@ it('SideNav redirects to TriggerTemplates page when all namespaces selected on n
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -486,7 +493,8 @@ it('SideNav redirects to Tasks page when all namespaces selected on namespaced U
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -522,7 +530,8 @@ it('SideNav redirects to secrets page when all namespaces selected on namespaced
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -558,7 +567,8 @@ it('SideNav redirects to Conditions page when all namespaces selected on namespa
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -596,7 +606,8 @@ it('SideNav updates namespace in URL', async () => {
       },
       isFetching: false,
       selected: namespace
-    }
+    },
+    properties: {}
   });
   const selectNamespace = jest.fn();
   const push = jest.fn();
@@ -623,13 +634,12 @@ it('SideNav updates namespace in URL', async () => {
 });
 
 it('SideNav renders import in not read-only mode', async () => {
-  selectors.isReadOnly.mockImplementation(() => false);
-
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
     extensions: { byName: {} },
-    namespaces: { byName: {} }
+    namespaces: { byName: {} },
+    properties: {}
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
@@ -644,7 +654,10 @@ it('SideNav does not render import in read-only mode', async () => {
   const mockStore = configureStore(middleware);
   const store = mockStore({
     extensions: { byName: {} },
-    namespaces: { byName: {} }
+    namespaces: { byName: {} },
+    properties: {
+      ReadOnly: true
+    }
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
@@ -653,4 +666,40 @@ it('SideNav does not render import in read-only mode', async () => {
   );
   await waitForElement(() => queryByText(/about/i));
   expect(queryByText(/import/i)).toBeFalsy();
+});
+
+it('Namespace dropdown does not render in single namespace visibility mode', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    properties: {
+      TenantNamespace: 'fake'
+    }
+  });
+  const { queryByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNavContainer isReadOnly />
+    </Provider>
+  );
+  await waitForElement(() => queryByText(/about/i));
+  expect(queryByText(/namespaces/i)).toBeFalsy();
+});
+
+it('Namespace dropdown renders in full cluster visibility mode', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    properties: {}
+  });
+  const { queryByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNavContainer isReadOnly />
+    </Provider>
+  );
+  await waitForElement(() => queryByText(/about/i));
+  expect(queryByText(/namespaces/i)).toBeTruthy();
 });

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -29,6 +29,7 @@
     "dashboard.accessTokenField.showPasswordLabel": "Show access token",
     "dashboard.actions.createButton": "Create",
     "dashboard.actions.deleteButton": "Delete",
+    "dashboard.app.loadingConfigError": "Error loading configuration",
     "dashboard.cancelButton.body": "Are you sure you would like to stop {type} {name}?",
     "dashboard.cancelButton.heading": "Stop {type} {name}",
     "dashboard.cancelButton.primaryText": "Stop {type}",

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -546,3 +546,7 @@ export function getTriggersNamespace(state) {
 export function getTriggersVersion(state) {
   return propertiesSelectors.getTriggersVersion(state.properties);
 }
+
+export function getTenantNamespace(state) {
+  return propertiesSelectors.getTenantNamespace(state.properties);
+}

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -49,6 +49,7 @@ import {
   getTaskRunsErrorMessage,
   getTasks,
   getTasksErrorMessage,
+  getTenantNamespace,
   getTriggersNamespace,
   getTriggersVersion,
   isFetchingClusterTasks,
@@ -651,6 +652,16 @@ it('getTriggersVersion', () => {
     .mockImplementation(() => 'x');
   expect(getTriggersVersion(state)).toBe('x');
   expect(propertiesSelectors.getTriggersVersion).toHaveBeenCalledWith(
+    state.properties
+  );
+});
+
+it('getTenantNamespace', () => {
+  jest
+    .spyOn(propertiesSelectors, 'getTenantNamespace')
+    .mockImplementation(() => 'x');
+  expect(getTenantNamespace(state)).toBe('x');
+  expect(propertiesSelectors.getTenantNamespace).toHaveBeenCalledWith(
     state.properties
   );
 });

--- a/src/reducers/properties.js
+++ b/src/reducers/properties.js
@@ -61,4 +61,8 @@ export function getTriggersVersion(state) {
   return state.TriggersVersion;
 }
 
+export function getTenantNamespace(state) {
+  return state.TenantNamespace;
+}
+
 export default properties;

--- a/src/reducers/properties.test.js
+++ b/src/reducers/properties.test.js
@@ -30,7 +30,8 @@ it('INSTALL_PROPERTIES_SUCCESS', () => {
     PipelineNamespace: 'ns-pipeline',
     PipelineVersion: 'version-pipeline',
     TriggersNamespace: 'ns-triggers',
-    TriggersVersion: 'version-triggers'
+    TriggersVersion: 'version-triggers',
+    TenantNamespace: 'ns-tenant'
   };
 
   const action = {
@@ -49,4 +50,5 @@ it('INSTALL_PROPERTIES_SUCCESS', () => {
   expect(selectors.getPipelineVersion(state)).toBe('version-pipeline');
   expect(selectors.getTriggersNamespace(state)).toBe('ns-triggers');
   expect(selectors.getTriggersVersion(state)).toBe('version-triggers');
+  expect(selectors.getTenantNamespace(state)).toBe('ns-tenant');
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds frontend support for single namespace visibility.

Single namespace or full cluster visibility is driven by the backend returning the `TenantNamespace` property.

When the `TenantNamespace` property is not set, the visibility is considered to be for the whole cluster. The list of namespaces is fetched and the namespace drop down is shown with the `All namespaces` option available.

When the `TenantNamespace` property is not set, the visibility is considered scoped to the tenant namespace itself. The list of namespaces is not fetched and the namespace drop down is not shown at all. The  selected namespace in the store is forced to the tenant namespace. Therefore all API calls are run against the tenant namespace.

This introduces the following change in extensions management (both resource based and service based):
- cluster scope deployment -> all extensions in the cluster are considered
- namespace scope deployment -> only extension in the tenant namespace are considered

I added a simple overlay to test:
```
kubectl create ns tekton-tenant
kustomize build --load_restrictor none overlays/dev-single-namespace | ko apply -f -
```

/cc @AlanGreene @a-roberts 

Extracted from the giant PR https://github.com/tektoncd/dashboard/pull/1371

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
