### PR TITLE
Add flag for logout url

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ These options are documented below:
 | `--port` | Dashboard port number | `int` | `8080` |
 | `--read-only` | Enable or disable read only mode | `bool` | `false` |
 | `--web-dir` | Dashboard web resources directory | `string` | `""` |
-        
+| `--logout-url` | If set, enables logout on the frontend and binds the logout button to this url | `string` | `""` |
+
 Run `dashboard --help` to show the supported command line arguments and their default value directly from the `dashboard` binary.
 
 ### Optionally set up the Ingress endpoint

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -46,6 +46,7 @@ var (
 	portNumber         = flag.Int("port", 8080, "Dashboard port number")
 	readOnly           = flag.Bool("read-only", false, "Enable or disable read only mode")
 	webDir             = flag.String("web-dir", "", "Dashboard web resources dir")
+	logoutUrl          = flag.String("logout-url", "", "If set, enables logout on the frontend and binds the logout button to this url")
 	csrfSecureCookie   = flag.Bool("csrf-secure-cookie", true, "Enable or disable Secure attribute on the CSRF cookie")
 )
 
@@ -115,6 +116,7 @@ func main() {
 		TriggersNamespace:  *triggersNamespace,
 		ReadOnly:           *readOnly,
 		WebDir:             *webDir,
+		LogoutURL:          *logoutUrl,
 	}
 
 	resource := endpoints.Resource{

--- a/overlays/dev-openshift-imagestream/kustomization.yaml
+++ b/overlays/dev-openshift-imagestream/kustomization.yaml
@@ -22,6 +22,13 @@ patchesJson6902:
       name: tekton-dashboard
       namespace: tekton-pipelines
     path: ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../logout/deployment-patch.yaml
 images:
   - name: dashboardImage
     newName: tekton-pipelines/tekton-dashboard

--- a/overlays/dev-openshift-locked-down/kustomization.yaml
+++ b/overlays/dev-openshift-locked-down/kustomization.yaml
@@ -28,6 +28,13 @@ patchesJson6902:
       name: tekton-dashboard
       namespace: tekton-pipelines
     path: ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../logout/deployment-patch.yaml
 images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard

--- a/overlays/dev-openshift/kustomization.yaml
+++ b/overlays/dev-openshift/kustomization.yaml
@@ -21,6 +21,13 @@ patchesJson6902:
       name: tekton-dashboard
       namespace: tekton-pipelines
     path: ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../logout/deployment-patch.yaml
 images:
   - name: dashboardImage
     newName: github.com/tektoncd/dashboard/cmd/dashboard

--- a/overlays/latest-openshift-locked-down/kustomization.yaml
+++ b/overlays/latest-openshift-locked-down/kustomization.yaml
@@ -21,6 +21,13 @@ patchesJson6902:
       name: tekton-dashboard
       namespace: tekton-pipelines
     path: ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../logout/deployment-patch.yaml
 images:
   - name: dashboardImage
     newName: gcr.io/tekton-nightly/dashboard

--- a/overlays/latest-openshift/kustomization.yaml
+++ b/overlays/latest-openshift/kustomization.yaml
@@ -14,6 +14,13 @@ patchesJson6902:
       name: tekton-dashboard
       namespace: tekton-pipelines
     path: ../openshift-patches/oauth-proxy-in-deployment.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../logout/deployment-patch.yaml
 images:
   - name: dashboardImage
     newName: gcr.io/tekton-nightly/dashboard

--- a/overlays/logout/deployment-patch.yaml
+++ b/overlays/logout/deployment-patch.yaml
@@ -1,0 +1,5 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --logout-url=/oauth/sign_out

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -170,11 +170,7 @@ func (r Resource) GetProperties(request *restful.Request, response *restful.Resp
 		PipelineVersion:    pipelineVersion,
 		IsOpenShift:        isOpenShift,
 		ReadOnly:           r.Options.ReadOnly,
-	}
-
-	// If running on OpenShift, set the logout url
-	if isOpenShift {
-		properties.LogoutURL = "/oauth/sign_out"
+		LogoutURL:          r.Options.LogoutURL,
 	}
 
 	isTriggersInstalled := isTriggersInstalled(r, triggersNamespace)

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -14,6 +14,7 @@ type Options struct {
 	TriggersNamespace  string
 	ReadOnly           bool
 	WebDir             string
+	LogoutURL          string
 }
 
 // GetPipelinesNamespace returns the PipelinesNamespace property if set


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds a command line flags to set a logout url.

The `LougoutURL` was added in the backend properties a while ago but the url itself was hardcoded and the logic behind enabling logout was driven by the backend running on Openshift or not.

This PR makes it an end user decision and makes the url configurable.
Overlays have been updated.
The flag has been documented.

/cc @AlanGreene @a-roberts 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
