### PR TITLE
Change publish.yaml to use overlays/latest instead of overlays/dev

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -87,10 +87,10 @@ spec:
           ko version
           kustomize version # Tested with 3.5.4
 
-          kustomize build overlays/dev | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml
-          kustomize build overlays/dev-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml
-          kustomize build overlays/dev-openshift --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml
-          kustomize build overlays/dev-openshift-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml
+          kustomize build overlays/latest | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml
+          kustomize build overlays/latest-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml
+          kustomize build overlays/latest-openshift --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml
+          kustomize build overlays/latest-openshift-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml
       volumeMounts:
         - name: gcp-secret
           mountPath: /secret


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Changes publish.yaml to use overlays/latest instead of overlays/dev 

This will make the nightlys the same as the overlays/latest which it what we tell people in the README 
The nightlys currently use overlays/dev so this PR will make both ways we tell users to install the nightly give the same result 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._

/cc @a-roberts @AlanGreene 
