### PR TITLE
Use the redux store to get the logout url and dashboard namespace

### DIFF
--- a/packages/components/src/components/LogoutButton/LogoutButton.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.js
@@ -35,7 +35,9 @@ export class LogoutButton extends Component {
     try {
       const logoutURL = await this.props.getLogoutURL();
       this.setState({ logoutURL });
-    } catch (error) {} // eslint-disable-line
+    } catch (error) {
+      console.log(error);
+    }
   }
 
   render() {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -422,21 +422,6 @@ export function getInstallProperties() {
   return get(uri);
 }
 
-export function getLogoutURL() {
-  return getInstallProperties().then(data => data.LogoutURL);
-}
-
-export async function determineDashboardNamespace() {
-  const response = getInstallProperties()
-    .then(installProps => {
-      return installProps.DashboardNamespace;
-    })
-    .catch(error => {
-      throw error;
-    });
-  return response;
-}
-
 export function getTriggerTemplates({ filters = [], namespace } = {}) {
   const uri = getTektonAPI(
     'triggertemplates',

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -64,7 +64,6 @@ import {
   TriggerTemplates
 } from '..';
 
-import { getLogoutURL } from '../../api';
 import { fetchExtensions } from '../../actions/extensions';
 import { fetchNamespaces, selectNamespace } from '../../actions/namespaces';
 import { fetchInstallProperties } from '../../actions/properties';
@@ -72,6 +71,7 @@ import { fetchInstallProperties } from '../../actions/properties';
 import {
   getExtensions,
   getLocale,
+  getLogoutURL,
   getSelectedNamespace,
   isReadOnly,
   isWebSocketConnected
@@ -120,7 +120,9 @@ export /* istanbul ignore next */ class App extends Component {
     const { extensions } = this.props;
 
     const lang = messages[this.props.lang] ? this.props.lang : 'en';
-    const logoutButton = <LogoutButton getLogoutURL={getLogoutURL} />;
+    const logoutButton = (
+      <LogoutButton getLogoutURL={() => this.props.logoutURL} />
+    );
 
     return (
       <IntlProvider locale={lang} defaultLocale="en" messages={messages[lang]}>
@@ -384,6 +386,7 @@ const mapStateToProps = state => ({
   extensions: getExtensions(state),
   namespace: getSelectedNamespace(state),
   lang: getLocale(state),
+  logoutURL: getLogoutURL(state),
   isReadOnly: isReadOnly(state),
   webSocketConnected: isWebSocketConnected(state)
 });

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -35,15 +35,11 @@ import {
 } from '@tektoncd/dashboard-utils';
 import { getGitValues } from '../../utils';
 
-import { determineDashboardNamespace, importResources } from '../../api';
-import { getSelectedNamespace } from '../../reducers';
+import { importResources } from '../../api';
+import { getDashboardNamespace, getSelectedNamespace } from '../../reducers';
 import { NamespacesDropdown, ServiceAccountsDropdown } from '..';
 
 import './ImportResources.scss';
-
-async function getDashboardNamespace() {
-  return determineDashboardNamespace();
-}
 
 function validateURL(url) {
   if (!url.trim().startsWith('http://') && !url.trim().startsWith('https://')) {
@@ -73,7 +69,6 @@ export class ImportResources extends Component {
       invalidNamespace: false,
       invalidImporterNamespace: false,
       importerNamespace: '',
-      importerNamespaceError: false,
       logsURL: '',
       namespace: props.navNamespace !== ALL_NAMESPACES && props.navNamespace,
       repositoryURL: '',
@@ -84,24 +79,16 @@ export class ImportResources extends Component {
   }
 
   componentDidMount() {
-    const { intl } = this.props;
+    const { intl, dashboardNamespace } = this.props;
     document.title = getTitle({
       page: intl.formatMessage({
         id: 'dashboard.importResources.title',
         defaultMessage: 'Import resources'
       })
     });
-    getDashboardNamespace()
-      .then(foundImporterNamespace => {
-        this.setState({
-          importerNamespace: foundImporterNamespace
-        });
-      })
-      .catch(() => {
-        this.setState({
-          importerNamespaceError: true
-        });
-      });
+    this.setState({
+      importerNamespace: dashboardNamespace
+    });
   }
 
   resetError = () => {
@@ -193,15 +180,10 @@ export class ImportResources extends Component {
           pipelineRunName
         });
 
-        this.setState(prevState => {
-          return {
-            logsURL:
-              prevState.importerNamespaceError === false
-                ? finalURL
-                : urls.pipelineRuns.all(),
-            submitSuccess: true,
-            invalidInput: false
-          };
+        this.setState({
+          logsURL: finalURL,
+          submitSuccess: true,
+          invalidInput: false
         });
       })
       .catch(error => {
@@ -423,7 +405,8 @@ export class ImportResources extends Component {
 /* istanbul ignore next */
 function mapStateToProps(state) {
   return {
-    navNamespace: getSelectedNamespace(state)
+    navNamespace: getSelectedNamespace(state),
+    dashboardNamespace: getDashboardNamespace(state)
   };
 }
 

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -33,6 +33,9 @@ describe('ImportResources component', () => {
       selected: ALL_NAMESPACES
     },
     notifications: {},
+    properties: {
+      DashboardNamespace: 'namespace1'
+    },
     serviceAccounts: {
       byNamespace: {
         namespace1: {
@@ -180,12 +183,6 @@ describe('ImportResources component', () => {
         }
       );
 
-    const installNamespace = 'namespace1';
-
-    jest
-      .spyOn(API, 'determineDashboardNamespace')
-      .mockImplementation(() => installNamespace);
-
     const namespace = 'default';
 
     const {
@@ -216,7 +213,7 @@ describe('ImportResources component', () => {
         .innerHTML
     ).toContain(
       urls.pipelineRuns.byName({
-        namespace: installNamespace,
+        namespace: 'namespace1',
         pipelineRunName
       })
     );
@@ -228,10 +225,6 @@ describe('ImportResources component', () => {
     jest
       .spyOn(API, 'importResources')
       .mockImplementation(() => Promise.reject(importResourcesResponseMock));
-
-    jest
-      .spyOn(API, 'determineDashboardNamespace')
-      .mockImplementation(() => 'namespace1');
 
     const {
       getByPlaceholderText,
@@ -254,10 +247,6 @@ describe('ImportResources component', () => {
   });
 
   it('Failure to populate required field displays error', async () => {
-    jest
-      .spyOn(API, 'determineDashboardNamespace')
-      .mockImplementation(() => 'namespace1');
-
     const { getByText } = await renderWithIntl(
       <Provider store={store}>
         <ImportResourcesContainer />
@@ -269,10 +258,6 @@ describe('ImportResources component', () => {
   });
 
   it('URL TextInput handles onChange event', async () => {
-    jest
-      .spyOn(API, 'determineDashboardNamespace')
-      .mockImplementation(() => 'namespace1');
-
     const { getByTestId, queryByDisplayValue } = await renderWithIntl(
       <Provider store={store}>
         <ImportResourcesContainer />

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -486,3 +486,11 @@ export function isReadOnly(state) {
 export function isTriggersInstalled(state) {
   return propertiesSelectors.isTriggersInstalled(state.properties);
 }
+
+export function getLogoutURL(state) {
+  return propertiesSelectors.getLogoutURL(state.properties);
+}
+
+export function getDashboardNamespace(state) {
+  return propertiesSelectors.getDashboardNamespace(state.properties);
+}

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -15,10 +15,12 @@ import {
   getClusterTask,
   getClusterTasks,
   getClusterTasksErrorMessage,
+  getDashboardNamespace,
   getDeleteSecretsErrorMessage,
   getExtensions,
   getExtensionsErrorMessage,
   getLocale,
+  getLogoutURL,
   getNamespaces,
   getPatchSecretsErrorMessage,
   getPipelineResource,
@@ -512,6 +514,26 @@ it('isTriggersInstalled', () => {
     .mockImplementation(() => true);
   expect(isTriggersInstalled(state)).toBe(true);
   expect(propertiesSelectors.isTriggersInstalled).toHaveBeenCalledWith(
+    state.properties
+  );
+});
+
+it('getLogoutURL', () => {
+  jest
+    .spyOn(propertiesSelectors, 'getLogoutURL')
+    .mockImplementation(() => '/logout');
+  expect(getLogoutURL(state)).toBe('/logout');
+  expect(propertiesSelectors.getLogoutURL).toHaveBeenCalledWith(
+    state.properties
+  );
+});
+
+it('getDashboardNamespace', () => {
+  jest
+    .spyOn(propertiesSelectors, 'getDashboardNamespace')
+    .mockImplementation(() => 'ns');
+  expect(getDashboardNamespace(state)).toBe('ns');
+  expect(propertiesSelectors.getDashboardNamespace).toHaveBeenCalledWith(
     state.properties
   );
 });

--- a/src/reducers/properties.js
+++ b/src/reducers/properties.js
@@ -26,7 +26,15 @@ export function isReadOnly(state) {
 }
 
 export function isTriggersInstalled(state) {
-  return (state.TriggersNamespace && state.TriggersVersion) || false;
+  return !!(state.TriggersNamespace && state.TriggersVersion);
+}
+
+export function getLogoutURL(state) {
+  return state.LogoutURL;
+}
+
+export function getDashboardNamespace(state) {
+  return state.DashboardNamespace;
 }
 
 export default properties;

--- a/src/reducers/properties.test.js
+++ b/src/reducers/properties.test.js
@@ -20,7 +20,15 @@ it('handles init or unknown actions', () => {
 });
 
 it('INSTALL_PROPERTIES_SUCCESS', () => {
-  const installProperties = { fake: 'installProperties', ReadOnly: false };
+  const installProperties = {
+    fake: 'installProperties',
+    ReadOnly: false,
+    LogoutURL: '/logout',
+    DashboardNamespace: 'ns',
+    TriggersNamespace: 'ns',
+    TriggersVersion: 'x'
+  };
+
   const action = {
     type: 'INSTALL_PROPERTIES_SUCCESS',
     data: installProperties
@@ -28,5 +36,7 @@ it('INSTALL_PROPERTIES_SUCCESS', () => {
 
   const state = propertiesReducer({}, action);
   expect(selectors.isReadOnly(state)).toBe(false);
-  expect(selectors.isTriggersInstalled(state)).toBe(false);
+  expect(selectors.isTriggersInstalled(state)).toBe(true);
+  expect(selectors.getLogoutURL(state)).toBe('/logout');
+  expect(selectors.getDashboardNamespace(state)).toBe('ns');
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR uses the redux store to get the logout url and dashboard namespace instead of calling the api.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
