### PR TITLE
Namespace should not be translated

### DIFF
--- a/packages/components/src/components/PipelineResources/PipelineResources.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.js
@@ -39,10 +39,7 @@ const PipelineResources = ({
     },
     {
       key: 'namespace',
-      header: intl.formatMessage({
-        id: 'dashboard.tableHeader.namespace',
-        defaultMessage: 'Namespace'
-      })
+      header: 'Namespace'
     },
     {
       key: 'type',

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -84,10 +84,7 @@ const PipelineRuns = ({
       id: 'dashboard.tableHeader.pipeline',
       defaultMessage: 'Pipeline'
     }),
-    namespace: intl.formatMessage({
-      id: 'dashboard.tableHeader.namespace',
-      defaultMessage: 'Namespace'
-    }),
+    namespace: 'Namespace',
     createdTime: intl.formatMessage({
       id: 'dashboard.tableHeader.createdTime',
       defaultMessage: 'Created'

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -80,10 +80,7 @@ const TaskRuns = ({
     },
     {
       key: 'namespace',
-      header: intl.formatMessage({
-        id: 'dashboard.tableHeader.namespace',
-        defaultMessage: 'Namespace'
-      })
+      header: 'Namespace'
     },
     {
       key: 'createdTime',

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -85,10 +85,7 @@ export /* istanbul ignore next */ class EventListeners extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'date',

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -83,10 +83,7 @@ export /* istanbul ignore next */ class Pipelines extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'createdTime',

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -120,10 +120,7 @@ export class ResourceListContainer extends Component {
             },
             {
               key: 'namespace',
-              header: intl.formatMessage({
-                id: 'dashboard.tableHeader.namespace',
-                defaultMessage: 'Namespace'
-              })
+              header: 'Namespace'
             },
             {
               key: 'createdTime',

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -182,10 +182,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'serviceAccounts',

--- a/src/containers/ServiceAccounts/ServiceAccounts.js
+++ b/src/containers/ServiceAccounts/ServiceAccounts.js
@@ -85,10 +85,7 @@ export /* istanbul ignore next */ class ServiceAccounts extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'created',

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -83,10 +83,7 @@ export /* istanbul ignore next */ class Tasks extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'createdTime',

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -85,10 +85,7 @@ export /* istanbul ignore next */ class TriggerBindings extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'date',

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -85,10 +85,7 @@ export /* istanbul ignore next */ class TriggerTemplates extends Component {
       },
       {
         key: 'namespace',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.namespace',
-          defaultMessage: 'Namespace'
-        })
+        header: 'Namespace'
       },
       {
         key: 'date',

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -246,7 +246,6 @@
     "dashboard.tableHeader.expression": "Expression",
     "dashboard.tableHeader.key": "Key",
     "dashboard.tableHeader.name": "Name",
-    "dashboard.tableHeader.namespace": "Namespace",
     "dashboard.tableHeader.pipeline": "Pipeline",
     "dashboard.tableHeader.property": "Property",
     "dashboard.tableHeader.serviceAccount": "ServiceAccount",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/453

The word 'Namespace' should not be translated as it's a
Kubernetes kind, and should be treated similar to the others,
e.g. PipelineRun, Task, ServiceAccount

This also resolves a react-intl warning about missing messages
for consumers who are not exposing the namespace column in our
tables, e.g.:

```
[React Intl] Missing message: "dashboard.tableHeader.namespace"
for locale: "fr", using default message as fallback.
```

They shouldn't have to provide a value for a feature they're
not using so this addresses both issues in one. It also gives us
consistency as we were already not translating it in some places.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
