### PR TITLE
Add rendering for retried taskRuns

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.test.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.js
@@ -70,3 +70,60 @@ it('PipelineRunContainer handles init step failures', async () => {
   );
   await waitForElement(() => getByText(initStepName));
 });
+
+it('PipelineRunContainer handles init step failures for retry', async () => {
+  const initStepName = 'my-failed-init-step';
+  const pipelineRunName = 'fake_pipelineRunName';
+  const taskRunName = 'fake_taskRunName';
+  const retryText = '(retry 1)';
+
+  const taskRun = {
+    metadata: {
+      name: taskRunName,
+      labels: {}
+    },
+    spec: {
+      params: {},
+      resources: {
+        inputs: {},
+        outputs: {}
+      },
+      taskSpec: {}
+    },
+    status: {
+      steps: [
+        {
+          terminated: {},
+          name: initStepName
+        }
+      ],
+      retriesStatus: [
+        {
+          status: {
+            steps: [
+              {
+                terminated: {},
+                name: initStepName
+              }
+            ]
+          }
+        }
+      ]
+    }
+  };
+
+  const pipelineRun = {
+    metadata: {
+      name: pipelineRunName
+    },
+    status: {
+      taskRuns: []
+    }
+  };
+
+  const { getByText } = renderWithIntl(
+    <PipelineRun pipelineRun={pipelineRun} taskRuns={[taskRun]} tasks={[]} />
+  );
+  await waitForElement(() => getByText(initStepName));
+  await waitForElement(() => getByText(retryText));
+});

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -192,6 +192,7 @@
     "dashboard.pipelineRun.logEmpty": "No log available",
     "dashboard.pipelineRun.logFailed": "Unable to fetch log",
     "dashboard.pipelineRun.notFound": "PipelineRun not found",
+    "dashboard.pipelineRun.pipelineTaskName.retry": "{pipelineTaskName} (retry {retryNumber, number})",
     "dashboard.pipelineRun.rerunStatusMessage": "View status",
     "dashboard.pipelineRun.stepCompleted": "Step completed",
     "dashboard.pipelineRun.stepFailed": "Step failed",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

https://github.com/tektoncd/dashboard/issues/936

Adds a rendering for taskRun retries.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._


One thing to follow up on. Why do we sort by step started time on the taskRun tree. https://github.com/tektoncd/dashboard/blob/master/packages/components/src/components/PipelineRun/PipelineRun.js#L67 

The values can be blank - below is a sample
```
conditions:
  - type: Succeeded
    status: Unknown
    lastTransitionTime: '2020-05-26T16:14:42Z'
    reason: Pending
    message: >-
      pod status "Ready":"False"; message: "containers with unready status:
      [step-task-one-step-one step-task-one-step-two]"
podName: sample-piperun-on-tenbase7-task2-hjrw2-pod-xh4n6
startTime: '2020-05-26T16:14:39Z'
steps:
  - waiting:
      reason: PodInitializing
    name: task-one-step-one
    container: step-task-one-step-one
  - waiting:
      reason: PodInitializing
    name: task-one-step-two
    container: step-task-one-step-two
```