### PR TITLE
Add VAR GOARCH in Dockerfile

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -167,6 +167,23 @@ To look at the dashboard logs, run:
 kubectl logs -l app=tekton-dashboard
 ```
 
+## Changing the target ARCH
+
+You can build for another ARCH by overriding GOARCH (`amd64` by default).
+
+With `Dockerfile`:
+
+```shell
+docker build --build-arg GOARCH=ppc64le .
+```
+
+With `ko`:
+
+```shell
+export GOARCH=ppc64le
+kustomize build overlays/dev | ko apply -f -
+```
+
 ## Frontend
 
 ### Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,17 @@ RUN npm run bootstrap:ci
 RUN npm run build
 
 FROM golang:1.12-alpine as goBuilder
+
+# Pass --build-arg GOARCH=ppc64le when building with docker build to build for another arch
+ARG GOARCH=amd64
+
 USER root
 RUN apk add curl git
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x /usr/local/bin/dep
 WORKDIR /go/src/github.com/tektoncd/dashboard
 COPY . .
 RUN dep ensure -vendor-only
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tekton_dashboard_backend ./cmd/dashboard
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH go build -a -installsuffix cgo -o tekton_dashboard_backend ./cmd/dashboard
 
 FROM alpine@sha256:7df6db5aa61ae9480f52f0b3a06a140ab98d427f86d8d5de0bedab9b8df6b1c0
 RUN addgroup -g 1000 kgroup && \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds `VAR GOARCH=amd64` in Dockerfile.

This allows building for another GOARCH than `amd64` (eg `ppc64le`).

`docker build --no-cache --build-arg GOARCH=ppc64le .`

Closes https://github.com/tektoncd/dashboard/issues/542

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
