### PR TITLE
Add security context to ensure dashboard runs as non root

### DIFF
--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -48,6 +48,8 @@ spec:
     spec:
       serviceAccountName: tekton-dashboard
       volumes: []
+      securityContext:
+        runAsNonRoot: true
       containers:
         - name: tekton-dashboard
           image: dashboardImage

--- a/overlays/openshift-patches/oauth-proxy-in-deployment.yaml
+++ b/overlays/openshift-patches/oauth-proxy-in-deployment.yaml
@@ -5,6 +5,8 @@
     name: oauth-proxy
     image: openshift/oauth-proxy:latest
     imagePullPolicy: IfNotPresent
+    securityContext:
+      runAsUser: 1000
     ports:
       - name: public
         containerPort: 8443


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds a pod security context to ensure containers are not run as root.

Tested on k8s and openshift (with kind and minishift).

Closes https://github.com/tektoncd/dashboard/issues/865

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
