### PR TITLE
Fix character encoding of displayed Secrets username column

### DIFF
--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -59,6 +59,25 @@ const initialState = {
   toBeDeleted: []
 };
 
+function base64Decode(input) {
+  return decodeURIComponent(
+    atob(input)
+      .split('')
+      .map(
+        character =>
+          '%' + // eslint-disable-line prefer-template
+          (
+            '00' + // eslint-disable-line prefer-template
+            character
+              .charCodeAt(0) // returns UTF-16 code unit for this character
+              .toString(16)
+          ) // set radix 16 to ensure we get a UTF-16 encoded string
+            .slice(-2) // account for the '00' padding
+      )
+      .join('')
+  );
+}
+
 export /* istanbul ignore next */ class Secrets extends Component {
   constructor(props) {
     super(props);
@@ -288,7 +307,7 @@ export /* istanbul ignore next */ class Secrets extends Component {
       let secretTypeToDisplay = translatedReload;
 
       if (secret.data.username) {
-        secretUsernameToDisplay = atob(secret.data.username);
+        secretUsernameToDisplay = base64Decode(secret.data.username);
       }
 
       if (secret.type) {

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -68,7 +68,7 @@ const byNamespace = {
       },
       type: 'kubernetes.io/basic-auth',
       data: {
-        username: 'bXl1c2VybmFtZQ==' // This is "myusername"
+        username: '5rWL6K+V' // This is "测试"
       }
     }
   ]
@@ -283,7 +283,8 @@ it('SecretsTable renders username in regular form (not encoded)', () => {
     { route: urls.secrets.all() }
   );
   expect(queryByText(/github-repo-access-secret/i)).toBeTruthy();
-  expect(getByText(/myusername/i)).toBeTruthy();
+  expect(getByText('myusername')).toBeTruthy();
+  expect(getByText('测试')).toBeTruthy();
 });
 
 it('Secrets can be filtered on a single label filter', async () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
`window.atob` only supports ASCII, which means that usernames
with non-ASCII characters get garbled when displayed in the table.

Add a `base64Decode` implementation that handles an expanded
character set to ensure these are displayed correctly.

Before:
username with value '测试' displayed as:
![image](https://user-images.githubusercontent.com/2829095/83623966-ee93fd00-a589-11ea-9176-183fa3dd678c.png)

After:
![image](https://user-images.githubusercontent.com/2829095/83623928-e50a9500-a589-11ea-87d6-8a1f7e4205ea.png)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
