### PR TITLE
Add component for resource details common layout

### DIFF
--- a/packages/components/src/components/ResourceDetails/ResourceDetails.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.js
@@ -1,0 +1,138 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
+import { InlineNotification, Tag } from 'carbon-components-react';
+import { formatLabels, getErrorMessage } from '@tektoncd/dashboard-utils';
+import {
+  FormattedDate,
+  Tab,
+  Tabs,
+  ViewYAML
+} from '@tektoncd/dashboard-components';
+
+const ResourceDetails = ({
+  additionalMetadata,
+  children,
+  error,
+  intl,
+  kind,
+  resource
+}) => {
+  if (error || !resource) {
+    return (
+      <InlineNotification
+        kind="error"
+        hideCloseButton
+        lowContrast
+        title={intl.formatMessage(
+          {
+            id: 'dashboard.resourceDetails.errorloading',
+            defaultMessage: 'Error loading {kind}'
+          },
+          { kind }
+        )}
+        subtitle={getErrorMessage(error)}
+      />
+    );
+  }
+
+  let formattedLabelsToRender = [];
+  if (resource.metadata.labels) {
+    formattedLabelsToRender = formatLabels(resource.metadata.labels);
+  }
+
+  return (
+    <div className="tkn--resourcedetails">
+      <h1>{resource.metadata.name}</h1>
+      <Tabs selected={0}>
+        <Tab
+          label={intl.formatMessage({
+            id: 'dashboard.resource.overviewTab',
+            defaultMessage: 'Overview'
+          })}
+        >
+          <div className="tkn--details">
+            <div className="tkn--resourcedetails-metadata">
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.metadata.dateCreated',
+                    defaultMessage: 'Date Created:'
+                  })}
+                </span>
+                <FormattedDate
+                  date={resource.metadata.creationTimestamp}
+                  relative
+                />
+              </p>
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.metadata.labels',
+                    defaultMessage: 'Labels:'
+                  })}
+                </span>
+                {formattedLabelsToRender.length === 0
+                  ? intl.formatMessage({
+                      id: 'dashboard.metadata.none',
+                      defaultMessage: 'None'
+                    })
+                  : formattedLabelsToRender.map(label => (
+                      <Tag type="blue" key={label}>
+                        {label}
+                      </Tag>
+                    ))}
+              </p>
+              {resource.metadata.namespace && (
+                <p>
+                  <span>
+                    {intl.formatMessage({
+                      id: 'dashboard.metadata.namespace',
+                      defaultMessage: 'Namespace:'
+                    })}
+                  </span>
+                  {resource.metadata.namespace}
+                </p>
+              )}
+              {additionalMetadata}
+            </div>
+            {children}
+          </div>
+        </Tab>
+        <Tab label="YAML">
+          <ViewYAML resource={resource} />
+        </Tab>
+      </Tabs>
+    </div>
+  );
+};
+
+ResourceDetails.defaultProps = {
+  additionalMetadata: null,
+  children: null,
+  error: null,
+  resource: null
+};
+
+ResourceDetails.propTypes = {
+  additionalMetadata: PropTypes.node,
+  children: PropTypes.node,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
+  kind: PropTypes.string.isRequired,
+  resource: PropTypes.shape({})
+};
+
+export default injectIntl(ResourceDetails);

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import ResourceDetails from '.';
+
+const resource = {
+  apiVersion: 'tekton.dev/v1alpha1',
+  kind: 'Condition',
+  metadata: {
+    creationTimestamp: '2020-05-19T16:49:30Z',
+    labels: {
+      'label-key': 'label-value'
+    },
+    name: 'file-exists',
+    namespace: 'tekton-pipelines'
+  },
+  spec: {
+    check: {
+      image: 'alpine',
+      script: 'test -f $(resources.workspace.path)/$(params.path)'
+    },
+    params: [{ name: 'path' }],
+    resources: [{ name: 'workspace', type: 'git' }]
+  }
+};
+
+storiesOf('Components/ResourceDetails', module)
+  .add('error', () => (
+    <ResourceDetails error="A helpful error message" kind="Condition" />
+  ))
+  .add('default', () => (
+    <ResourceDetails kind="Condition" resource={resource} />
+  ))
+  .add('with additional content', () => (
+    <ResourceDetails
+      kind="Condition"
+      resource={resource}
+      additionalMetadata={
+        <p>
+          <span>Custom Field:</span>some additional metadata
+        </p>
+      }
+    >
+      <p>some additional content</p>
+    </ResourceDetails>
+  ));

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.test.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.test.js
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { renderWithIntl } from '../../utils/test';
+import ResourceDetails from './ResourceDetails';
+
+describe('ResourceDetails', () => {
+  it('renders the error state', () => {
+    const errorMessage = 'an error message';
+    const { queryByText } = renderWithIntl(
+      <ResourceDetails error={errorMessage} />
+    );
+    expect(queryByText(/labels/i)).toBeFalsy();
+    expect(queryByText(errorMessage)).toBeTruthy();
+  });
+
+  it('renders the default content', () => {
+    const name = 'fake_name';
+    const namespace = 'fake_namespace';
+    const resource = {
+      metadata: {
+        name,
+        namespace
+      }
+    };
+
+    const { queryByText } = renderWithIntl(
+      <ResourceDetails resource={resource} />
+    );
+    expect(queryByText(/labels/i)).toBeTruthy();
+    expect(queryByText(name)).toBeTruthy();
+    expect(queryByText(namespace)).toBeTruthy();
+  });
+
+  it('renders custom content', () => {
+    const labelKey = 'fake_label-key';
+    const labelValue = 'fake_label-value';
+    const name = 'fake_name';
+    const namespace = 'fake_namespace';
+    const resource = {
+      metadata: {
+        labels: {
+          [labelKey]: labelValue
+        },
+        name,
+        namespace
+      }
+    };
+
+    const additionalMetadata = 'fake_additionalMetadata';
+    const children = 'fake_children';
+
+    const { queryByText } = renderWithIntl(
+      <ResourceDetails
+        resource={resource}
+        additionalMetadata={additionalMetadata}
+      >
+        {children}
+      </ResourceDetails>
+    );
+    expect(queryByText(/labels/i)).toBeTruthy();
+    expect(queryByText(name)).toBeTruthy();
+    expect(queryByText(namespace)).toBeTruthy();
+    expect(queryByText(`${labelKey}: ${labelValue}`)).toBeTruthy();
+    expect(queryByText(additionalMetadata)).toBeTruthy();
+    expect(queryByText(children)).toBeTruthy();
+  });
+});

--- a/packages/components/src/components/ResourceDetails/index.js
+++ b/packages/components/src/components/ResourceDetails/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,30 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '~carbon-components/scss/globals/scss/vars';
-
-.tkn--resourcedetails {
-  .tkn--details {
-    p {
-      margin-top: $spacing-03;
-      span:first-child {
-        font-weight: bold;
-        margin-right: $spacing-02;
-      }
-    }
-
-    .bx--data-table-container {
-      width: 50%;
-    }
-  }
-
-  .bx--snippet--multi {
-    margin-top: $spacing-03
-  }
-}
-
-.tkn--resourcedetails-metadata {
-  margin-bottom: $layout-01;
-  padding: $layout-01;
-  background-color: $ui-02;
-}
+export { default } from './ResourceDetails';

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -30,6 +30,7 @@ export { default as PipelineResources } from './PipelineResources';
 export { default as PipelineRun } from './PipelineRun';
 export { default as PipelineRuns } from './PipelineRuns';
 export { default as Rerun } from './Rerun';
+export { default as ResourceDetails } from './ResourceDetails';
 export { default as ResourceTable } from './ResourceTable';
 export { default as RunDropdown } from './RunDropdown';
 export { default as RunHeader } from './RunHeader';

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -155,7 +155,7 @@ export /* istanbul ignore next */ class ClusterTriggerBindingContainer extends C
     });
 
     return (
-      <div className="tkn--trigger">
+      <div className="tkn--resourcedetails">
         <h1>{clusterTriggerBindingName}</h1>
         <Tabs selected={0} aria-label="ClusterTriggerBinding details">
           <Tab
@@ -166,7 +166,7 @@ export /* istanbul ignore next */ class ClusterTriggerBindingContainer extends C
             })}
           >
             <div className="tkn--details">
-              <div className="tkn--resource--detail-block">
+              <div className="tkn--resourcedetails-metadata">
                 <p>
                   <span>
                     {intl.formatMessage({

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -124,7 +124,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
     }
 
     return (
-      <div className="tkn--trigger">
+      <div className="tkn--resourcedetails">
         <h1>{eventListenerName}</h1>
         <Tabs selected={0}>
           <Tab
@@ -134,7 +134,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
             })}
           >
             <div className="tkn--details">
-              <div className="tkn--resource--detail-block">
+              <div className="tkn--resourcedetails-metadata">
                 <p>
                   <span>
                     {intl.formatMessage({
@@ -200,7 +200,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
               <div className="tkn--eventlistener--triggers">
                 {triggers.map((trigger, idx) => (
                   <div
-                    className="tkn--resource--detail-block"
+                    className="tkn--resourcedetails-metadata"
                     key={trigger.name ? trigger.name : idx}
                   >
                     <Trigger

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -142,7 +142,7 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
     }
 
     return (
-      <div className="tkn--trigger">
+      <div className="tkn--resourcedetails">
         <h1>{pipelineResourceName}</h1>
 
         <Tabs selected={0} aria-label="PipelineResource details">
@@ -154,7 +154,7 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
             })}
           >
             <div className="tkn--details">
-              <div className="tkn--resource--detail-block">
+              <div className="tkn--resourcedetails-metadata">
                 <p>
                   <span>
                     {intl.formatMessage({

--- a/src/containers/Secret/Secret.js
+++ b/src/containers/Secret/Secret.js
@@ -170,9 +170,9 @@ export /* istanbul ignore next */ class SecretContainer extends Component {
     return (
       <>
         <h1>{secretName}</h1>
-        <div className="tkn--trigger">
+        <div className="tkn--resourcedetails">
           <div className="tkn--details">
-            <div className="tkn--resource--detail-block">
+            <div className="tkn--resourcedetails-metadata">
               <p>
                 <span>
                   {intl.formatMessage({

--- a/src/containers/ServiceAccount/ServiceAccount.js
+++ b/src/containers/ServiceAccount/ServiceAccount.js
@@ -190,7 +190,7 @@ export /* istanbul ignore next */ class ServiceAccountContainer extends Componen
     });
 
     return (
-      <div className="tkn--trigger">
+      <div className="tkn--resourcedetails">
         <h1>{serviceAccountName}</h1>
         <Tabs selected={0} aria-label="ServiceAccount details">
           <Tab
@@ -201,7 +201,7 @@ export /* istanbul ignore next */ class ServiceAccountContainer extends Componen
             })}
           >
             <div className="tkn--details">
-              <div className="tkn--resource--detail-block">
+              <div className="tkn--resourcedetails-metadata">
                 <p>
                   <span>
                     {intl.formatMessage({

--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -154,7 +154,7 @@ export /* istanbul ignore next */ class TriggerBindingContainer extends Componen
     });
 
     return (
-      <div className="tkn--trigger">
+      <div className="tkn--resourcedetails">
         <h1>{triggerBindingName}</h1>
         <Tabs selected={0} aria-label="TriggerBinding details">
           <Tab
@@ -165,7 +165,7 @@ export /* istanbul ignore next */ class TriggerBindingContainer extends Componen
             })}
           >
             <div className="tkn--details">
-              <div className="tkn--resource--detail-block">
+              <div className="tkn--resourcedetails-metadata">
                 <p>
                   <span>
                     {intl.formatMessage({

--- a/src/containers/TriggerTemplate/TriggerTemplate.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.js
@@ -184,7 +184,7 @@ export /* istanbul ignore next */ class TriggerTemplateContainer extends Compone
     });
 
     return (
-      <div className="tkn--trigger">
+      <div className="tkn--resourcedetails">
         <h1>{triggerTemplateName}</h1>
         <Tabs selected={0} aria-label="TriggerTemplate details">
           <Tab
@@ -195,7 +195,7 @@ export /* istanbul ignore next */ class TriggerTemplateContainer extends Compone
             })}
           >
             <div className="tkn--details">
-              <div className="tkn--resource--detail-block">
+              <div className="tkn--resourcedetails-metadata">
                 <p>
                   <span>
                     {intl.formatMessage({

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -225,6 +225,7 @@
     "dashboard.rerunPipelineRun.actionText": "Rerun",
     "dashboard.resource.detailsTab": "Details",
     "dashboard.resource.overviewTab": "Overview",
+    "dashboard.resourceDetails.errorloading": "Error loading {kind}",
     "dashboard.resourceList.emptyState": "No resources for type {type}.",
     "dashboard.resourceList.errorLoading": "Error loading {type}",
     "dashboard.secret.errorLoading": "Error loading Secret",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1221

Add a ResourceDetails component which will be used to give a
consistent layout and style for our resource detail pages, i.e.
the view when following a link to view a single resource (excluding
PipelineRun / TaskRun).

This view follows the existing pattern for these pages, with
Overview and YAML tabs.

A follow-up PR will migrate the existing pages to use this new component.

![image](https://user-images.githubusercontent.com/2829095/83639855-383d1180-a5a3-11ea-9f14-9da086722967.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
