### PR TITLE
add retries in place for already sorted taskRuns

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -97,7 +97,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       return [];
     }
 
-    const { tasks, taskRuns, intl } = this.props;
+    const { tasks, intl } = this.props;
+    let { taskRuns } = this.props;
 
     if (!tasks || !taskRuns) {
       return [];
@@ -108,19 +109,19 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     } = pipelineRun;
 
     const retryPodIndex = {};
-    const retriedTaskRuns = taskRuns
-      .filter(taskRun => taskRun.status.retriesStatus)
-      .reduce((acc, taskRun) => {
+    taskRuns = taskRuns.reduce((acc, taskRun) => {
+      if (taskRun.status.retriesStatus) {
         taskRun.status.retriesStatus.forEach((retryStatus, index) => {
           const retryRun = { ...taskRun };
           retryRun.status = retryStatus;
           retryPodIndex[retryStatus.podName] = index;
           acc.push(retryRun);
         });
-        return acc;
-      }, []);
+      }
+      acc.push(taskRun);
+      return acc;
+    }, []);
     return taskRuns
-      .concat(retriedTaskRuns)
       .map(taskRun => {
         let taskSpec;
         if (taskRun.spec.taskRef) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For retried taskRuns we need to preserve ordering being passed to the pipelineRun component.

https://github.com/tektoncd/dashboard/issues/936

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
