### PR TITLE
Add LoadingShell component to display while loading configuration

### DIFF
--- a/packages/components/src/components/LoadingShell/LoadingShell.js
+++ b/packages/components/src/components/LoadingShell/LoadingShell.js
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import {
+  SkeletonText as CarbonSkeletonText,
+  Content,
+  Loading,
+  SideNav,
+  SideNavItems,
+  SideNavLink,
+  SideNavMenu
+} from 'carbon-components-react';
+import { Header } from '..';
+
+import './LoadingShell.scss';
+
+const SkeletonText = ({ heading, paragraph }) => (
+  <CarbonSkeletonText heading={heading} paragraph={paragraph} width="80%" />
+);
+
+const LoadingShell = ({ intl }) => {
+  const loadingMessage = intl.formatMessage({
+    id: 'dashboard.loading.config',
+    defaultMessage: 'Loading configuration…'
+  });
+
+  return (
+    <div className="tkn--config-loading-shell">
+      <Header />
+      <SideNav
+        isFixedNav
+        expanded
+        isChildOfHeader={false}
+        aria-label="Main navigation"
+        className="tkn--config-loading-nav-skeleton"
+      >
+        <SideNavItems>
+          <SideNavMenu
+            defaultExpanded
+            title={intl.formatMessage({
+              id: 'dashboard.sideNav.tektonResources',
+              defaultMessage: 'Tekton resources'
+            })}
+          >
+            <li>
+              <SkeletonText paragraph />
+            </li>
+          </SideNavMenu>
+
+          <SideNavLink icon={<span />}>Namespace</SideNavLink>
+          <SkeletonText />
+
+          <SkeletonText heading />
+          <SkeletonText paragraph />
+
+          <SideNavLink icon={<span />}>
+            {intl.formatMessage({
+              id: 'dashboard.about.title',
+              defaultMessage: 'About'
+            })}
+          </SideNavLink>
+        </SideNavItems>
+      </SideNav>
+      <Content>
+        <div className="bx--loading-overlay tkn--config-loading-overlay">
+          <Loading description={loadingMessage} withOverlay={false} />
+          <span className="tkn--config-loading-text">{loadingMessage}</span>
+        </div>
+      </Content>
+    </div>
+  );
+};
+
+export default injectIntl(LoadingShell);

--- a/packages/components/src/components/LoadingShell/LoadingShell.scss
+++ b/packages/components/src/components/LoadingShell/LoadingShell.scss
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '~carbon-components/scss/globals/scss/vars';
+
+.tkn--config-loading-shell {
+  .bx--header ~ {
+    .bx--content {
+      background-color: transparent;
+      transform: none;
+      padding-top: $layout-02;
+    }
+  }
+
+  .tkn--config-loading-nav-skeleton {
+    .bx--skeleton__text {
+      margin-left: 1rem;
+    }
+
+    .bx--skeleton__heading {
+      margin-top: 1.5rem;
+    }
+  }
+
+  .bx--loading-overlay.tkn--config-loading-overlay {
+    top: 3rem;
+    flex-direction: column;
+
+    .bx--loading {
+      margin-top: -3rem;
+    }
+
+    .tkn--config-loading-text {
+      color: $text-05;
+      z-index: 10000; // need to put this in front of the overlay
+    }
+  }
+}

--- a/packages/components/src/components/LoadingShell/LoadingShell.stories.js
+++ b/packages/components/src/components/LoadingShell/LoadingShell.stories.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import LoadingShell from './LoadingShell';
+
+storiesOf('Components/LoadingShell', module).add('default', () => (
+  <LoadingShell />
+));

--- a/packages/components/src/components/LoadingShell/index.js
+++ b/packages/components/src/components/LoadingShell/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './LoadingShell';

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -21,6 +21,7 @@ export { default as Graph } from './Graph/Graph';
 export { default as Header } from './Header';
 export { default as KeyValueList } from './KeyValueList';
 export { default as LabelFilter } from './LabelFilter';
+export { default as LoadingShell } from './LoadingShell';
 export { default as Log } from './Log';
 export { default as LogoutButton } from './LogoutButton';
 export { default as Modal } from './Modal';

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,10 +15,6 @@ limitations under the License.
 
 body {
   background-color: #f4f7fb;
-}
-
-main {
-  padding: 2em 5%;
 }
 
 h1 {

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -162,6 +162,7 @@
     "dashboard.labelFilter.searchPlaceholder": "Input a label filter of the format labelKey:labelValue",
     "dashboard.labelFilter.syntaxMessage": "See the Kubernetes Label documentation for valid syntax",
     "dashboard.list.menu.tooltip": "Actions",
+    "dashboard.loading.config": "Loading configuration…",
     "dashboard.logo.alt": "Tekton logo",
     "dashboard.logo.tooltip": "Meow",
     "dashboard.logs.downloadButtonTooltip": "Download logs",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/pull/1425#discussion_r434632900

LoadingShell replicates the major components of the UI shell:
- header
- nav
- content

It provides a loading state mimicking the general look and layout
of the application to maintain the perception of faster loading.

We can improve this further once React.Suspense graduates from
experimental status, and allows for delaying transition / pending
states so we avoid rendering this at all if the config is loaded
quickly.

![image](https://user-images.githubusercontent.com/2829095/83701679-5b4ade00-a602-11ea-9986-9c3855c2515f.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
