### PR TITLE
Remove Sanitizing Secret debug message

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -130,7 +130,6 @@ func SanitizeSecret(obj interface{}, skipDeletedCheck bool) interface{} {
 		Annotations:       annotations,
 	}
 
-	logging.Log.Debug("Sanitizing Secret")
 	data := make(map[string][]byte)
 	if secret.Data["username"] != nil {
 		data["username"] = secret.Data["username"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Remove the debug message  `logging.Log.Debug("Sanitizing Secret")` as it clogs up my dashboard logs and cant see anything else 


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
