### PR TITLE
Add support for log level and log format flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ These options are documented below:
 | `--web-dir` | Dashboard web resources directory | `string` | `""` |
 | `--logout-url` | If set, enables logout on the frontend and binds the logout button to this url | `string` | `""` |
 | `--namespace` | If set, limits the scope of resources watched to this namespace only | `string` | `""` |
+| `--log-level` | Minimum log level output by the logger | `string` | `"info"` |
+| `--log-format` | Format for log output (json or console) | `string` | `"json"` |
 
 Run `dashboard --help` to show the supported command line arguments and their default value directly from the `dashboard` binary.
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -49,6 +49,8 @@ var (
 	logoutUrl          = flag.String("logout-url", "", "If set, enables logout on the frontend and binds the logout button to this url")
 	csrfSecureCookie   = flag.Bool("csrf-secure-cookie", true, "Enable or disable Secure attribute on the CSRF cookie")
 	tenantNamespace    = flag.String("namespace", "", "If set, limits the scope of resources watched to this namespace only")
+	logLevel           = flag.String("log-level", "info", "Minimum log level output by the logger")
+	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
 )
 
 func getCSRFAuthKey() []byte {
@@ -78,6 +80,8 @@ func main() {
 		flag.PrintDefaults()
 		return
 	}
+
+	logging.InitLogger(*logLevel, *logFormat)
 
 	var cfg *rest.Config
 	var err error


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds support for zap logger presets.

Presets are easy to use, a more flexible solution would be to use a config map with a json zap config.
It would allow more configuration options but would be more complex.

What do you prefer ?

This is related to https://github.com/tektoncd/dashboard/pull/1468

/cc @AlanGreene @a-roberts @CarolynMabbott 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
