### PR TITLE
Remove references to extensions/deployments

### DIFF
--- a/base/200-clusterrole-pipelines.yaml
+++ b/base/200-clusterrole-pipelines.yaml
@@ -24,7 +24,6 @@ metadata:
 rules:
   # this is needed to lookup pipelines version
   - apiGroups:
-      - extensions
       - apps
     resources:
       - deployments

--- a/base/200-clusterrole-triggers.yaml
+++ b/base/200-clusterrole-triggers.yaml
@@ -24,7 +24,6 @@ metadata:
 rules:
   # this is needed to lookup triggers version
   - apiGroups:
-      - extensions
       - apps
     resources:
       - deployments

--- a/docs/samples/extension/config/tekton-kubernetes-resource-extension-sample.yaml
+++ b/docs/samples/extension/config/tekton-kubernetes-resource-extension-sample.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"
 rules:
-  - apiGroups: ["extensions"]
+  - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]
 ---
@@ -16,6 +16,6 @@ metadata:
   name: sample-deployment-extension
   namespace: tekton-pipelines
 spec:
-  apiVersion: extensions/v1beta1
+  apiVersion: apps/v1
   name: deployments
   displayname: k8s deployments

--- a/test/resources/static/service-account.yaml
+++ b/test/resources/static/service-account.yaml
@@ -13,7 +13,6 @@ metadata:
 rules:
   - apiGroups:
       - ''
-      - extensions
       - apps
     resources:
       - pods


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Kubernetes deployments are available in the apps API group
since Kubernetes 1.9, and removed (previously deprecated) from the
extensions API group in 1.16.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Remove references to extensions/deployments or replace with
apps/deployments as appropriate. In particular this ensures
the sample kube resource extension we provide works on
Kubernetes 1.16 or newer.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
