### PR TITLE
Fix pipelines and triggers rbac issue

### DIFF
--- a/base/201-clusterrolebinding-pipelines.yaml
+++ b/base/201-clusterrolebinding-pipelines.yaml
@@ -14,10 +14,9 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: tekton-dashboard-triggers
-  namespace: tekton-pipelines
+  name: tekton-dashboard-pipelines
   labels:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
@@ -29,4 +28,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-dashboard-triggers
+  name: tekton-dashboard-pipelines

--- a/base/201-clusterrolebinding-triggers.yaml
+++ b/base/201-clusterrolebinding-triggers.yaml
@@ -14,10 +14,9 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: tekton-dashboard-pipelines
-  namespace: tekton-pipelines
+  name: tekton-dashboard-triggers
   labels:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
@@ -29,4 +28,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-dashboard-pipelines
+  name: tekton-dashboard-triggers

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -23,15 +23,15 @@ resources:
   - 200-clusterrole-triggers.yaml
   - 201-clusterrolebinding-backend.yaml
   - 201-clusterrolebinding-extensions.yaml
+  - 201-clusterrolebinding-pipelines.yaml
   - 201-clusterrolebinding-tenant.yaml
+  - 201-clusterrolebinding-triggers.yaml
   # this one should be used instead of 201-clusterrolebinding-extensions.yaml
   # to enable single namespace visibility
   # - 201-rolebinding-extensions.yaml
-  - 201-rolebinding-pipelines.yaml
   # this one should be used instead of 201-clusterrolebinding-tenant.yaml
   # to enable single namespace visibility
   # - 201-rolebinding-tenant.yaml
-  - 201-rolebinding-triggers.yaml
   - 202-extension-crd.yaml
   - 203-serviceaccount.yaml
   - 300-deployment.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR changes RBAC back to `ClusterRoleBinding` instead of `RoleBinding` for getting pipelines and triggers infos.

When using `--pipelines-namespace` and  `--triggers-namespace`, getting infos have a good chance to fail because RBAC is not in sync with the values passed in the flags.

Closes https://github.com/tektoncd/dashboard/issues/1491

/cc @Megan-Wright 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
