### PR TITLE
Show loading spinner only at startup

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -128,7 +128,8 @@ const ConfigError = injectIntl(ConfigErrorComponent);
 
 const initialState = {
   loadingConfigError: null,
-  loadingConfig: true
+  loadingConfig: true,
+  showLoadingState: true
 };
 
 export /* istanbul ignore next */ class App extends Component {
@@ -172,16 +173,20 @@ export /* istanbul ignore next */ class App extends Component {
     this.setState({ loadingConfig: true });
     try {
       await this.props.fetchInstallProperties();
-      this.setState({ loadingConfig: false });
+      this.setState({ loadingConfig: false, showLoadingState: false });
     } catch (error) {
       console.error(error); // eslint-disable-line no-console
-      this.setState({ loadingConfigError: error, loadingConfig: false });
+      this.setState({
+        loadingConfigError: error,
+        loadingConfig: false,
+        showLoadingState: false
+      });
     }
   }
 
   render() {
     const { extensions } = this.props;
-    const { loadingConfigError, loadingConfig } = this.state;
+    const { loadingConfigError, showLoadingState } = this.state;
 
     const lang = messages[this.props.lang] ? this.props.lang : 'en';
     const logoutButton = (
@@ -192,8 +197,8 @@ export /* istanbul ignore next */ class App extends Component {
       <IntlProvider locale={lang} defaultLocale="en" messages={messages[lang]}>
         <ConfigError loadingConfigError={loadingConfigError} />
 
-        {loadingConfig && <LoadingShell />}
-        {!loadingConfig && (
+        {showLoadingState && <LoadingShell />}
+        {!showLoadingState && (
           <Router>
             <>
               <Header logoutButton={logoutButton} />


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR ensures we show loading spinner only at startup.

This should fix an issue when web socket disconnects frequently (though the websocket issue should be properly fixed too)

/cc @CarolynMabbott @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
