### PR TITLE
Add installer script for local dev

### DIFF
--- a/overlays/installer/base/flags.yaml
+++ b/overlays/installer/base/flags.yaml
@@ -1,0 +1,29 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --logout-url=--logout-url
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --pipelines-namespace=--pipelines-namespace
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --triggers-namespace=--triggers-namespace
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --read-only=--read-only
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --csrf-secure-cookie=--csrf-secure-cookie
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --log-level=--log-level
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --log-format=--log-format

--- a/overlays/installer/base/kustomization.yaml
+++ b/overlays/installer/base/kustomization.yaml
@@ -1,0 +1,28 @@
+---
+resources:
+  - ../../../base/200-clusterrole-backend.yaml
+  - ../../../base/200-clusterrole-extensions.yaml
+  - ../../../base/200-clusterrole-pipelines.yaml
+  - ../../../base/200-clusterrole-tenant.yaml
+  - ../../../base/200-clusterrole-triggers.yaml
+  - ../../../base/201-clusterrolebinding-backend.yaml
+  - ../../../base/201-clusterrolebinding-extensions.yaml
+  # - ../../../base/201-clusterrolebinding-pipelines.yaml
+  - ../../../base/201-clusterrolebinding-tenant.yaml
+  # - ../../../base/201-clusterrolebinding-triggers.yaml
+  - ../../../base/202-extension-crd.yaml
+  - ../../../base/203-serviceaccount.yaml
+  - ../../../base/300-deployment.yaml
+  - ../../../base/300-service.yaml
+images:
+  - name: dashboardImage
+    newName: github.com/tektoncd/dashboard/cmd/dashboard
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: flags.yaml
+namespace: tekton-dashboard

--- a/overlays/installer/k8s/base/kustomization.yaml
+++ b/overlays/installer/k8s/base/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - ../../base

--- a/overlays/installer/k8s/read-only/kustomization.yaml
+++ b/overlays/installer/k8s/read-only/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - ../base

--- a/overlays/installer/k8s/read-write/kustomization.yaml
+++ b/overlays/installer/k8s/read-write/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+resources:
+  - ../base
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: tekton-dashboard-backend
+    path: ../../../full-fat/clusterrole-backend-patch.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: tekton-dashboard-tenant
+    path: ../../../full-fat/clusterrole-tenant-patch.yaml

--- a/overlays/installer/openshift/base/kustomization.yaml
+++ b/overlays/installer/openshift/base/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+resources:
+  - ../../base
+  - ../../../openshift-patches/route.yaml
+  - ../../../openshift-patches/internal-dashboard-service.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tekton-dashboard
+      namespace: tekton-pipelines
+    path: ../../../openshift-patches/oauth-proxy-in-deployment.yaml

--- a/overlays/installer/openshift/read-only/kustomization.yaml
+++ b/overlays/installer/openshift/read-only/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - ../base

--- a/overlays/installer/openshift/read-write/kustomization.yaml
+++ b/overlays/installer/openshift/read-write/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+resources:
+  - ../base
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: tekton-dashboard-backend
+    path: ../../../full-fat/clusterrole-backend-patch.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: tekton-dashboard-tenant
+    path: ../../../full-fat/clusterrole-tenant-patch.yaml

--- a/scripts/installer
+++ b/scripts/installer
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Tekton Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dashboard flavour
+OPENSHIFT="false"
+READONLY="false"
+
+# configuration default values
+DEBUG="false"
+INSTALL_NAMESPACE="tekton-pipelines"
+PIPELINES_NAMESPACE="tekton-pipelines"
+TRIGGERS_NAMESPACE="tekton-pipelines"
+LOGOUT_URL=""
+CSRF_SECURE_COOKIE="false"
+LOG_LEVEL="info"
+LOG_FORMAT="json"
+
+initOS() {
+  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+
+  case "$OS" in
+    # Minimalist GNU for Windows
+    mingw*) OS='windows';;
+  esac
+
+  debug "Detected OS: $OS"
+}
+
+verifySupported() {
+  if ! type "kubectl" > /dev/null; then
+    echo "kubectl is required"
+    exit 1
+  fi
+
+  if ! type "kustomize" > /dev/null; then
+    echo "kustomize is required"
+    exit 1
+  fi
+
+  if ! type "ko" > /dev/null; then
+    echo "ko is required"
+    exit 1
+  fi
+
+  if ! type "sed" > /dev/null; then
+    echo "sed is required"
+    exit 1
+  fi
+}
+
+debug() {
+  local messsage=$1
+
+  if [ "$DEBUG" == "true" ]; then
+    echo "$message"
+  fi
+}
+
+build() {
+  local overlay="overlays/installer"
+
+  if [ "$OPENSHIFT" == "true" ]; then
+    overlay="$overlay/openshift"
+  else
+    overlay="$overlay/k8s"
+  fi
+
+  if [ "$READONLY" == "true" ]; then
+    overlay="$overlay/read-only"
+  else
+    overlay="$overlay/read-write"
+  fi
+
+  debug "Building overlay $overlay ..."
+
+  kustomize build --load_restrictor none "$overlay" | ko resolve -f - > "$TMP_FILE"
+}
+
+setup() {
+  if [ ! -z "$OVERRIDE_NAMESPACE" ]; then
+    INSTALL_NAMESPACE="$OVERRIDE_NAMESPACE"
+  elif [ "$OPENSHIFT" == "true" ]; then
+    INSTALL_NAMESPACE="openshift-pipelines"
+  fi
+
+  if [ ! -z "$OVERRIDE_PIPELINES_NAMESPACE" ]; then
+    PIPELINES_NAMESPACE="$OVERRIDE_PIPELINES_NAMESPACE"
+  elif [ "$OPENSHIFT" == "true" ]; then
+    PIPELINES_NAMESPACE="openshift-pipelines"
+  fi
+
+  if [ ! -z "$OVERRIDE_TRIGGERS_NAMESPACE" ]; then
+    TRIGGERS_NAMESPACE="$OVERRIDE_TRIGGERS_NAMESPACE"
+  elif [ "$OPENSHIFT" == "true" ]; then
+    TRIGGERS_NAMESPACE="openshift-pipelines"
+  fi
+
+  if [ -z "$LOGOUT_URL" ] && [ "$OPENSHIFT" == "true" ]; then
+    LOGOUT_URL="/oauth/sign_out"
+  fi
+}
+
+replace() {
+  local src=$1
+  local dest=$2
+  
+  debug "REPLACE $src -> $dest"
+
+  if [ "$OS" == "darwin" ]; then
+    sed -i "" "s~$src~$dest~g" $TMP_FILE
+  else
+    sed -i "s~$src~$dest~g" $TMP_FILE
+  fi
+}
+
+patch() {
+  replace "--pipelines-namespace=--pipelines-namespace" "--pipelines-namespace=$PIPELINES_NAMESPACE"
+  replace "--triggers-namespace=--triggers-namespace" "--triggers-namespace=$TRIGGERS_NAMESPACE"
+  replace "--csrf-secure-cookie=--csrf-secure-cookie" "--csrf-secure-cookie=$CSRF_SECURE_COOKIE"
+  replace "--log-level=--log-level" "--log-level=$LOG_LEVEL"
+  replace "--log-format=--log-format" "--log-format=$LOG_FORMAT"
+  replace "--logout-url=--logout-url" "--logout-url=$LOGOUT_URL"
+  replace "--read-only=--read-only" "--read-only=$READONLY"
+  replace "namespace: tekton-dashboard" "namespace: $INSTALL_NAMESPACE"
+}
+
+ingress() {
+if [ ! -z "$INGRESS_URL" ] && [ ! -z "$INGRESS_SECRET" ]; then
+cat <<EOF >> $TMP_FILE
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: $INSTALL_NAMESPACE
+spec:
+  tls:
+  - hosts:
+    - $INGRESS_URL
+    secretName: $INGRESS_SECRET
+  rules:
+  - host: $INGRESS_URL
+    http:
+      paths:
+      - backend:
+          serviceName: tekton-dashboard
+          servicePort: 9097
+EOF
+elif [ ! -z "$INGRESS_URL" ]; then
+cat <<EOF >> $TMP_FILE
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: $INSTALL_NAMESPACE
+spec:
+  rules:
+  - host: $INGRESS_URL
+    http:
+      paths:
+      - backend:
+          serviceName: tekton-dashboard
+          servicePort: 9097
+EOF
+fi
+}
+
+rbac() {
+cat <<EOF >> $TMP_FILE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-pipelines
+  namespace: $PIPELINES_NAMESPACE
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: $INSTALL_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-pipelines
+EOF
+
+cat <<EOF >> $TMP_FILE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-triggers
+  namespace: $TRIGGERS_NAMESPACE
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: $INSTALL_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-triggers
+EOF
+}
+
+# install invokes kubectl apply with the downloaded manifest.
+install() {
+  kubectl create ns $INSTALL_NAMESPACE || true
+  kubectl apply -f $TMP_FILE
+}
+
+# uninstall invokes kubectl delete with the downloaded manifest.
+uninstall() {
+  kubectl delete -f $TMP_FILE
+}
+
+# uninstall invokes kubectl delete with the downloaded manifest.
+resolve() {
+  cat $TMP_FILE
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+  result=$?
+  cleanup
+  exit $result
+}
+
+# help provides possible cli installation arguments
+help () {
+  echo -e "Global command syntax:"
+  echo -e "\tinstaller COMMAND [OPTIONS]"
+  echo -e ""
+  echo -e "Accepted commands:"
+  echo -e "\thelp|h\t\t\t\t\tPrints this help"
+  echo -e "\tinstall|i\t\t\t\tInstalls the dashboard"
+  echo -e "\tuninstall|u\t\t\t\tUninstalls the dashboard"
+  echo -e "\tbuild|b\t\t\t\t\tBuilds the manifests and docker image and outputs manfiests in the console"
+  echo -e ""
+  echo -e "Accepted options:"
+  echo -e "\t[--debug]\t\t\t\tPrints additional messages in the console"
+  echo -e "\t[--csrf-secure-cookie]\t\t\tEnable secure CSRF cookie"
+  echo -e "\t[--openshift]\t\t\t\tWill build manifests for openshift"
+  echo -e "\t[--read-only]\t\t\t\tWill build manifests for a readonly deployment"
+  echo -e "\t[--namespace <namespace>]\t\tWill override install namespace"
+  echo -e "\t[--pipelines-namespace <namespace>]\tOverride the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)"
+  echo -e "\t[--triggers-namespace <namespace>]\tOverride the namespace where Tekton Triggers is installed (defaults to tekton-pipelines)"
+  echo -e "\t[--ingress-url <url>]\t\t\tWill create an additional ingress with the specified url"
+  echo -e "\t[--ingress-secret <secret>]\t\tWill add ssl support to the ingress"
+}
+
+# cleanup temporary files
+cleanup() {
+  if [[ -d "${TMP_ROOT:-}" ]]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+
+set -e
+
+# Parsing command
+case $1 in
+  'help'|h)
+    help
+    exit 0
+    ;;
+  'install'|i)
+    ACTION="install"
+    shift
+    ;;
+  'uninstall'|u)
+    ACTION="uninstall"
+    shift
+    ;;
+  'build'|b)
+    ACTION="build"
+    shift
+    ;;
+  *)
+    ACTION="build"
+    ;;
+esac
+
+set -u
+
+# Parsing options (if any)
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    '--openshift')
+      OPENSHIFT="true"
+      ;;
+    '--read-only')
+      READONLY="true"
+      ;;
+    '--csrf-secure-cookie')
+      CSRF_SECURE_COOKIE="true"
+      ;;
+    '--namespace')
+      shift
+      export OVERRIDE_NAMESPACE="${1}"
+      ;;
+    '--pipelines-namespace')
+      shift
+      export OVERRIDE_PIPELINES_NAMESPACE="${1}"
+      ;;
+    '--triggers-namespace')
+      shift
+      export OVERRIDE_TRIGGERS_NAMESPACE="${1}"
+      ;;
+    '--ingress-url')
+      shift
+      export INGRESS_URL="${1}"
+      ;;
+    '--ingress-secret')
+      shift
+      export INGRESS_SECRET="${1}"
+      ;;
+    '--debug')
+      DEBUG="true"
+      ;;
+    *)
+      echo "ERROR: Unknown option $1"
+      help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+set +u
+
+TMP_ROOT="$(mktemp -dt tekton-dashboard-installer.XXXXXX)"
+TMP_FILE="$TMP_ROOT/manifest.yaml"
+
+initOS
+verifySupported
+build
+setup
+patch
+rbac
+ingress
+
+case $ACTION in
+  'install')
+    install
+    ;;
+  'uninstall')
+    uninstall
+    ;;
+  'build')
+    resolve
+    ;;
+esac
+
+cleanup

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -84,7 +84,11 @@ function dump_extra_cluster_state() {
 function install_dashboard_backend() {
   overlay=$1
   echo ">> Deploying the Dashboard backend ($overlay)"
-  kustomize build --load_restrictor none overlays/$overlay | ko apply -f - || fail_test "Dashboard backend installation failed"	
+  kustomize build --load_restrictor none overlays/$overlay | ko apply -f - || fail_test "Dashboard backend installation failed"
+  wait_dashboard_backend
+}
+
+function wait_dashboard_backend() {
   # Wait until deployment is running before checking pods, stops timing error
   for i in {1..30}
   do


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds an installer script for local dev only.

It supports the following arguments:
```
Global command syntax:
        installer COMMAND [OPTIONS]

Accepted commands:
        help|h                                  Prints this help
        install|i                               Installs the dashboard
        uninstall|u                             Uninstalls the dashboard
        build|b                                 Builds the manifests and docker image and outputs manfiests in the console

Accepted options:
        [--debug]                               Prints additional messages in the console
        [--csrf-secure-cookie]                  Enable secure CSRF cookie
        [--openshift]                           Will build manifests for openshift
        [--read-only]                           Will build manifests for a readonly deployment
        [--namespace <namespace>]               Will override install namespace
        [--pipelines-namespace <namespace>]     Override the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)
        [--triggers-namespace <namespace>]      Override the namespace where Tekton Triggers is installed (defaults to tekton-pipelines)
        [--ingress-url <url>]                   Will create an additional ingress with the specified url
        [--ingress-secret <secret>]             Will add ssl support to the ingress
```

The script will use `kustomize` with new overlays dedicated to the installer to build the manifests, then it will invoke `ko` to build the docker image.
Some resources will be added to get a complete set of manifests (role bindings and ingress).
At the end, it will execute `sed` commands to patch the manifest with the arguments provided and will apply the results to the cluster using `kubectl`.

Installing for kubernetes should be as simple as:
- read-write: `./scripts/installer install`
- read-only: `./scripts/installer install --read-only`

Installing for openshift (pipelines and triggers installed with operator pipelines operator):
- read-write: `./scripts/installer install --openshift`
- read-only: `./scripts/installer install --openshift --read-only`

Installing for openshift (pipelines and triggers installed without operator pipelines operator):
- read-write: `./scripts/installer install --openshift --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines`
- read-only: `./scripts/installer install --openshift --read-only --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines`

Next step will be to get the installer script to work with our releases.

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
