### PR TITLE
Support running e2e tests locally with kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ stats.json
 Thumbs.db
 
 dashboard
+csrf_headers.txt

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -31,12 +31,14 @@ function print_diagnostic_info() {
 }
 
 function install_kustomize() {
-  echo ">> Installing kustomize"
-  tar=kustomize_v3.6.1_linux_amd64.tar.gz
-  curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.6.1/$tar
-  tar xzf ./$tar
+  if ! type "kustomize" > /dev/null; then
+    echo ">> Installing kustomize"
+    tar=kustomize_v3.6.1_linux_amd64.tar.gz
+    curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.6.1/$tar
+    tar xzf ./$tar
 
-  cp ./kustomize /usr/local/bin
+    cp ./kustomize /usr/local/bin
+  fi
 }
 
 function install_pipeline_crd() {

--- a/test/local-e2e-tests.sh
+++ b/test/local-e2e-tests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Tekton Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+CLUSTERNAME="dashboard-tests"
+
+verifySupported() {
+  local OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+  local SED="sed"
+
+  if [ "$OS" == "darwin" ]; then
+    SED="gsed"
+  fi
+
+  if ! type "kubectl" > /dev/null; then
+    echo "kubectl is required"
+    exit 1
+  fi
+
+  if ! type "kind" > /dev/null; then
+    echo "kind is required"
+    exit 1
+  fi
+
+  if ! type "helm" > /dev/null; then
+    echo "helm is required"
+    exit 1
+  fi
+
+  if ! type "ko" > /dev/null; then
+    echo "ko is required"
+    exit 1
+  fi
+
+  if ! type "kustomize" > /dev/null; then
+    echo "kustomize is required"
+    exit 1
+  fi
+
+  if ! type "$SED" > /dev/null; then
+    echo "$SED is required"
+    exit 1
+  fi
+}
+
+fail_trap() {
+  result=$?
+  teardown
+  exit $result
+}
+
+setup() {
+  kind create cluster --name $CLUSTERNAME
+  helm install --wait registry stable/docker-registry --set fullnameOverride=registry
+}
+
+run() {
+  $(git rev-parse --show-toplevel)/test/e2e-tests.sh;
+}
+
+teardown() {
+  kind delete cluster --name $CLUSTERNAME
+}
+
+trap "fail_trap" EXIT
+
+export LOCAL_RUN="true"
+
+verifySupported
+setup
+run
+teardown


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR makes it possible to run e2e tests locally with kind

Run `test/local-e2e-tests.sh`, it will:
- create a kind cluster
- deploy a docker registry in the cluster (we need one to run the tests)
- execute `test/e2e-tests.sh`
- shutdown kind cluster

Closes https://github.com/tektoncd/dashboard/issues/949

/cc @a-roberts 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
