### PR TITLE
Ensure consistent behaviour across node versions

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -134,7 +134,7 @@ export function deleteSecret(secrets, cancelMethod) {
       return deleteWithinTimePromise;
     });
 
-    Promise.all(deletePromises)
+    return Promise.all(deletePromises)
       .then(() => {
         dispatch({
           type: 'SECRET_DELETE_SUCCESS'

--- a/src/actions/secrets.test.js
+++ b/src/actions/secrets.test.js
@@ -194,8 +194,10 @@ it('deleteSecret', async () => {
     { type: 'SECRET_DELETE_SUCCESS' }
   ];
 
-  await store.dispatch(deleteSecret(secrets));
+  const cancelMethod = jest.fn();
+  await store.dispatch(deleteSecret(secrets, cancelMethod));
   expect(store.getActions()).toEqual(expectedActions);
+  expect(cancelMethod).toHaveBeenCalled();
 });
 
 it('deleteSecret error', async () => {
@@ -214,11 +216,14 @@ it('deleteSecret error', async () => {
 
   const expectedActions = [
     { type: 'CLEAR_SECRET_ERROR_NOTIFICATION' },
-    { type: 'SECRET_DELETE_REQUEST' }
+    { type: 'SECRET_DELETE_REQUEST' },
+    { type: 'SECRET_DELETE_FAILURE' }
   ];
 
-  await store.dispatch(deleteSecret(secrets));
+  const cancelMethod = jest.fn();
+  await store.dispatch(deleteSecret(secrets, cancelMethod));
   expect(store.getActions()).toEqual(expectedActions);
+  expect(cancelMethod).not.toHaveBeenCalled();
 });
 
 it('createSecret', async () => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,6 +18,9 @@ export function sortRunsByStartTime(runs) {
   runs.sort((a, b) => {
     const aTime = (a.status || {}).startTime;
     const bTime = (b.status || {}).startTime;
+    if (!aTime && !bTime) {
+      return 0;
+    }
     if (!aTime) {
       return -1;
     }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Fix secrets action unit tests by waiting for the promise
to be settled (missing return from the implementation).
We were lucky that this passed on node.js@10, but it was
breaking consistently from node.js@11.0.0 onwards.

Fix utils sortRunsByStartTime to ensure it's stable across
node.js versions. Node.js@11 introduced a major V8 update
to v7.0 which brought a change to the sorting algorithm used:
https://v8.dev/blog/array-sort

Our previous implementation of sortRunsByStartTime was missing
a case where both times were falsy which should result in a stable
sort (i.e. order unchanged). This happened to match the behaviour
of the sorting algorithm in node.js 10 and earlier, but was
unreliable in 11 and later. With this change the bahaviour is
now consistent between browsers and node versions.

Originally reported in https://tektoncd.slack.com/archives/CHTHGRQBC/p1592258102179400
Additional work to test the node.js update will be tracked in https://github.com/tektoncd/dashboard/issues/1523

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
