### PR TITLE
Write frontend build output directly to KO_DATA_PATH

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ You must install these tools:
 
 1. [`go`](https://golang.org/doc/install): The language Tekton Dashboard is built in
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
-1. [`ko`](https://github.com/google/ko): For development. `ko` version v0.1 or higher is required for `dashboard` to work correctly.
+1. [`ko`](https://github.com/google/ko): For development. `ko` version v0.5.1 or higher is required for `dashboard` to work correctly.
 1. [Node.js & npm](https://nodejs.org/): For building and running the frontend locally. See `engines` in [package.json](./package.json) for versions used. _Node.js 10.x is recommended_
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For interacting with your kube cluster.
 1. [`kustomize`](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md): For building the Dashboard kube config. You need a recent version - v3.5.4 is recommended. See [here](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md#try-go) - `GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v3` works correctly. 

--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -65,7 +65,7 @@ spec:
               port: 9097
           args:
             - --port=9097
-            - --web-dir=/var/run/ko/web
+            - --web-dir=/var/run/ko
           env:
             - name: INSTALLED_NAMESPACE
               valueFrom:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bootstrap:ci": "lerna bootstrap && lerna run prepare",
     "build": "webpack --config webpack.prod.js",
     "build:analyze": "webpack --config webpack.prod.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json",
-    "build_ko": "webpack --config webpack.prod.js --output-path='./cmd/dashboard/kodata/web' ",
+    "build_ko": "webpack --config webpack.prod.js --output-path='./cmd/dashboard/kodata' ",
     "clean": "lerna clean --yes && lerna run clean && rimraf node_modules",
     "eslint:check": "eslint --print-config . | eslint-config-prettier-check",
     "i18n:extract": "node scripts/i18n/extractMessages.js",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Write frontend build output (`npm run build_ko`) directly into
`KO_DATA_PATH` (`/var/run/ko` in the container by default,
`cmd/dashboard/kodata` in the project) instead of into a
subfolder `/var/run/ko/web`

This addresses an issue on some platforms (e.g. katacoda) where
the dashboard couldn't read the static files from that location
due to insufficient folder permissions when running as a
nonroot user.

Also update the `ko` version used as it contains a fix for
permissions on the `KO_DATA_PATH` folder itself.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
