### PR TITLE
Adapt test script to easily test with another pipelines version

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,8 +18,6 @@
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 
-pipeline_release=https://github.com/tektoncd/pipeline/releases/download/v0.11.0/release.yaml
-
 function print_diagnostic_info() {
   echo "Diagnostics:"
   resources=("pv" "pvc" "pods")
@@ -42,8 +40,10 @@ function install_kustomize() {
 }
 
 function install_pipeline_crd() {
-  echo ">> Deploying Tekton Pipelines"
-  kubectl apply --filename $pipeline_release  || fail_test "Tekton pipeline installation failed"
+  local version=$1
+
+  echo ">> Deploying Tekton Pipelines ($version)"
+  kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/$version/release.yaml" || fail_test "Tekton pipeline installation failed"
 
   # Make sure thateveything is cleaned up in the current namespace.
   for res in pipelineresources tasks pipelines taskruns pipelineruns; do
@@ -55,8 +55,10 @@ function install_pipeline_crd() {
 }
 
 function delete_pipeline_crd() {
-  echo ">> Deleting Tekton Pipelines"
-  kubectl delete --filename $pipeline_release || fail_test "Tekton pipeline deletion failed"
+  local version=$1
+  
+  echo ">> Deleting Tekton Pipelines ($version)"
+  kubectl delete --filename "https://github.com/tektoncd/pipeline/releases/download/$version/release.yaml" || fail_test "Tekton pipeline deletion failed"
 }
 
 # Called by `fail_test` (provided by `e2e-tests.sh`) to dump info on test failure


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adapts the test script to ease testing with another pipelines version.

It does so by allowing passing a version to the pipelines installer.
An end user can override the pipelines version deployed by defining the `PIPELINES_VERSION` environment variable:
```base
export PIPELINES_VERSION=v0.12.1
```

The default pipelines version used in our integration tests bumps from `v0.11.0` to `v0.13.2`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
