### PR TITLE
Update eventlistener bindings to use 'ref' instead of 'name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It is **strongly recommended** to use the **v0.6.1.4** release or newer for Tekt
 
 | Version | Docs | Pipelines | Triggers |
 | ------- | ---- | --------- | -------- |
-| [HEAD](./DEVELOPMENT.md) | [Docs @ HEAD](./docs/README.md) | v0.11.x - v0.13.x | v0.5.x |
+| [HEAD](./DEVELOPMENT.md) | [Docs @ HEAD](./docs/README.md) | v0.11.x - v0.13.x | v0.5.x - 0.6.x |
 | [v0.7.0](https://github.com/tektoncd/dashboard/releases/tag/v0.7.0) | [Docs @ v0.7.0](https://github.com/tektoncd/dashboard/tree/v0.7.0/docs) | v0.11.x - v0.13.x | v0.4.x - 0.5.x |
 | [v0.6.1.5](https://github.com/tektoncd/dashboard/releases/tag/v0.6.1.5) | [Docs @ v0.6.1.5](https://github.com/tektoncd/dashboard/tree/v0.6.1.5/docs) | v0.11.x - v0.12.x | v0.4.x |
 | [v0.6.1.4](https://github.com/tektoncd/dashboard/releases/tag/v0.6.1.4) | [Docs @ v0.6.1.4](https://github.com/tektoncd/dashboard/tree/v0.6.1.4/docs) | v0.11.x | v0.4.x |

--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -52,15 +52,15 @@ const Trigger = ({ intl, eventListenerNamespace, trigger }) => {
             </span>
             <div>
               {trigger.bindings.map((binding, index) => (
-                <span key={binding.name}>
+                <span key={binding.ref}>
                   <Link
                     className="tkn--trigger-resourcelink"
                     to={urls.triggerBindings.byName({
                       namespace: eventListenerNamespace,
-                      triggerBindingName: binding.name
+                      triggerBindingName: binding.ref
                     })}
                   >
-                    <span title={binding.name}>{binding.name}</span>
+                    <span title={binding.ref}>{binding.ref}</span>
                   </Link>
                   {index !== trigger.bindings.length - 1 && <span>, </span>}
                 </span>

--- a/packages/components/src/components/Trigger/Trigger.test.js
+++ b/packages/components/src/components/Trigger/Trigger.test.js
@@ -20,15 +20,15 @@ const fakeTrigger = {
   bindings: [
     {
       apiversion: 'v1alpha1',
-      name: 'triggerbinding-0'
+      ref: 'triggerbinding-0'
     },
     {
       apiversion: 'v1alpha1',
-      name: 'triggerbinding-1'
+      ref: 'triggerbinding-1'
     },
     {
       apiversion: 'v1alpha1',
-      name: 'triggerbinding-2'
+      ref: 'triggerbinding-2'
     }
   ],
   template: {

--- a/src/containers/EventListener/EventListener.test.js
+++ b/src/containers/EventListener/EventListener.test.js
@@ -45,7 +45,7 @@ const fakeEventListenerWithLabels = {
         bindings: [
           {
             apiversion: 'v1alpha1',
-            name: 'my-triggerbinding-0'
+            ref: 'my-triggerbinding-0'
           }
         ],
         template: {
@@ -71,7 +71,7 @@ const fakeEventListenerWithLabels = {
         bindings: [
           {
             apiversion: 'v1alpha1',
-            name: 'my-triggerbinding-1'
+            ref: 'my-triggerbinding-1'
           }
         ],
         template: {
@@ -97,7 +97,7 @@ const fakeEventListenerWithLabels = {
         bindings: [
           {
             apiversion: 'v1alpha1',
-            name: 'my-triggerbinding-2'
+            ref: 'my-triggerbinding-2'
           }
         ],
         template: {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
For: https://github.com/tektoncd/dashboard/issues/1526
- Updates TriggerBindings within an EventListener to use `ref` instead of `name` as per https://github.com/tektoncd/triggers/pull/603
- This will mean the dashboard will work with the upcoming triggers 0.6.0 release, as well as triggers 0.5.0, however, it will not work with any triggers releases prior to this.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
