### PR TITLE
Fix intermittent error loading PipelineResource details page

### DIFF
--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -78,7 +78,7 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
 
   render() {
     const { error, intl, loading, pipelineResource } = this.props;
-    const { params, secrets, type } = pipelineResource.spec;
+    const { params = [], secrets, type } = pipelineResource?.spec || {};
 
     return (
       <ResourceDetails


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Loading the PipelineResource details page directly via URL
would intermittently present an error:
`Cannot read property 'spec' of null`

This happens when the API is slow to respond or if the rendering
of the content happens particularly quickly. The `pipelineResource`
prop may be null when we attempt to process it.

Update the render function to make it null-safe and ensure
the loading state is processed and rendered correctly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
