### PR TITLE
Fix styles on Import Resources page

### DIFF
--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -21,8 +21,7 @@ import {
   FormGroup,
   InlineNotification,
   TextInput,
-  ToastNotification,
-  Tooltip
+  ToastNotification
 } from 'carbon-components-react';
 
 import { connect } from 'react-redux';
@@ -318,34 +317,11 @@ export class ImportResources extends Component {
                 id: 'dashboard.importResources.expandCollapse',
                 defaultMessage: 'Expand/Collapse'
               })}
-              title={
-                <Tooltip
-                  direction="right"
-                  triggerText={intl.formatMessage({
-                    id: 'dashboard.importResources.advanced.accordionText',
-                    defaultMessage:
-                      'Advanced configuration for the Import PipelineRun'
-                  })}
-                >
-                  <div>
-                    {intl.formatMessage(
-                      {
-                        id: 'dashboard.importResources.advanced.tooltip',
-                        defaultMessage:
-                          'Change these parameters if you want the PipelineRun that will do the importing to run in a different namespace from the Dashboard.{break}You can optionally provide a different ServiceAccount too.'
-                      },
-                      {
-                        break: (
-                          <>
-                            <br />
-                            <br />
-                          </>
-                        )
-                      }
-                    )}
-                  </div>
-                </Tooltip>
-              }
+              title={intl.formatMessage({
+                id: 'dashboard.importResources.advanced.accordionText',
+                defaultMessage:
+                  'Advanced configuration for the Import PipelineRun'
+              })}
             >
               <NamespacesDropdown
                 id="import-install-namespaces-dropdown"

--- a/src/containers/ImportResources/ImportResources.scss
+++ b/src/containers/ImportResources/ImportResources.scss
@@ -20,15 +20,15 @@ limitations under the License.
 }
 
 .tkn--importresources-outer {
-  
+
   .bx--form__helper-text {
     color: $text-05; // Since by default the contrast/colour choice is barely readable.
-  } 
+  }
 
   .bx--label--disabled {
     color: $text-05;
   }
-  
+
   background-color: white;
   min-height: 30rem;
 
@@ -47,8 +47,13 @@ limitations under the License.
     font-size: 1rem;
   }
 
+  .bx--combo-box.bx--list-box,
+  .bx--text-input__field-wrapper {
+    width: 50%;
+  }
+
   .bx--combo-box.bx--list-box {
-    width: 30%;
+    max-width: 350px;
   }
 
   .bx--toast-notification {
@@ -75,19 +80,20 @@ limitations under the License.
     margin-bottom: 2rem;
   }
 
-  .bx--text-input__field-wrapper {
-    width: 50%;
-  }
-
   .bx--accordion {
     margin-bottom: 1rem;
-  }
 
-  .bx--accordion__title {
-    padding-left: 1.5rem;
-  }
+    .bx--accordion__heading {
+      align-items: center;
 
-  .bx--accordion__content, .bx--accordion__item--active .bx--accordion__content {
-    padding: .5rem 0;
+      .bx--accordion__title {
+        padding-left: 1.5rem;
+      }
+    }
+
+    .bx--accordion__content,
+    .bx--accordion__item--active .bx--accordion__content {
+      padding: .5rem 0;
+    }
   }
 }

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -119,7 +119,6 @@
     "dashboard.graph.zoomOut": "Zoom Out",
     "dashboard.header.logOut": "Log out",
     "dashboard.importResources.advanced.accordionText": "Advanced configuration for the Import PipelineRun",
-    "dashboard.importResources.advanced.tooltip": "Change these parameters if you want the PipelineRun that will do the importing to run in a different namespace from the Dashboard.{break}You can optionally provide a different ServiceAccount too.",
     "dashboard.importResources.directory.helperText": "The location of the Tekton resources to import from the repository. Leave blank if the resources are at the top-level directory.",
     "dashboard.importResources.directory.labelText": "Repository directory (optional)",
     "dashboard.importResources.directory.placeholder": "Enter repository directory",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The last Carbon update brought some changes to the Accordion
components:
- only accepts a string for the `title` prop on AccordionItem
  This means it's currently displaying '[object Object]' in a
  browser native tooltip on hover
- change in vertical alignment for the heading

Address these by:
- removing the Carbon tooltip on the heading. We already have
  explanatory text on the fields in the accordion content
- override the heading styles to center the content vertically

Also give the combo boxes a little more breathing room so
they match the width of the text inputs until they hit a max
size (chosen arbitrarily, looks reasonable).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
