### PR TITLE
Remove unused styles for code blocks

### DIFF
--- a/packages/components/src/components/StepDefinition/StepDefinition.scss
+++ b/packages/components/src/components/StepDefinition/StepDefinition.scss
@@ -17,17 +17,4 @@ limitations under the License.
     font-size: 0.75rem;
     margin-bottom: 1rem;
   }
-
-  > pre {
-    font-family: ibm-plex-mono, monospace;
-    font-size: 0.75rem;
-    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
-      font-size: 0.6875rem;
-    }
-    line-height: 0.95rem;
-    white-space: pre-wrap;
-    word-break: break-all;
-    overflow: hidden;
-    text-shadow: 0.1px 0.1px 0 #272d3340;
-  }
 }

--- a/packages/components/src/components/StepStatus/StepStatus.scss
+++ b/packages/components/src/components/StepStatus/StepStatus.scss
@@ -17,17 +17,4 @@ limitations under the License.
     font-size: 0.75rem;
     margin-bottom: 1rem;
   }
-
-  > pre {
-    font-family: ibm-plex-mono, monospace;
-    font-size: 0.75rem;
-    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
-      font-size: 0.6875rem;
-    }
-    line-height: 0.95rem;
-    white-space: pre-wrap;
-    word-break: break-all;
-    overflow: hidden;
-    text-shadow: 0.1px 0.1px 0 #272d3340;
-  }
 }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
@@ -17,19 +17,6 @@ limitations under the License.
     font-size: 0.75rem;
     margin-bottom: 1rem;
   }
-
-  > pre {
-    font-family: ibm-plex-mono, monospace;
-    font-size: 0.75rem;
-    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
-      font-size: 0.6875rem;
-    }
-    line-height: 0.95rem;
-    white-space: pre-wrap;
-    word-break: break-all;
-    overflow: hidden;
-    text-shadow: 0.1px 0.1px 0 #272d3340;
-  }
 }
 
 .tkn--step-details {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
We use the default Carbon styles for the multiline snippet.
Remove the unused styles to avoid confusion and reduce
redundant code that could cause problems in future.

The selector doesn't match (`pre` isn't an immediate child
of the container), so these styles weren't being applied anyway.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
