### PR TITLE
Minor style tweaks to be more consistent with Carbon guidelines

### DIFF
--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -24,8 +24,7 @@ pre.tkn--log {
 
   line-height: 0.95rem; // Update the react-window List itemSize if changing this
   overflow: hidden;
-  text-shadow: 0.1px 0.1px 0 #272d3340;
-  background-color: #f1f2f4;
+  background-color: $ui-01;
 
   word-break: normal;
   word-wrap: normal;

--- a/packages/components/src/components/Step/Step.scss
+++ b/packages/components/src/components/Step/Step.scss
@@ -40,7 +40,7 @@ limitations under the License.
     align-items: baseline;
     position: relative;
     padding: 0 2.25rem;
-    margin: 1px;
+    margin: 1px 0;
     line-height: 2.2rem;
     font-size: 0.78rem;
     letter-spacing: 0.02rem;

--- a/packages/components/src/components/Task/Task.scss
+++ b/packages/components/src/components/Task/Task.scss
@@ -98,15 +98,17 @@ limitations under the License.
     padding: 0 1.25rem;
     text-decoration: none;
     color: inherit;
-    margin: 1px;
+    margin: 1px 0;
     line-height: 2.2rem;
     white-space: nowrap;
     font-size: 0.76rem;
     letter-spacing: 0.06rem;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
 
-
+  &:first-child > a.tkn--task-link {
+    margin-top: 0;
   }
 
   .tkn--task-icon {

--- a/packages/components/src/scss/Run.scss
+++ b/packages/components/src/scss/Run.scss
@@ -14,8 +14,6 @@ limitations under the License.
 .tkn--tasks {
   display: flex;
   flex-wrap: nowrap;
-  border: 1px solid #dfe3e6;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.07);
   min-height: calc(100vh - 16rem);
   align-items: stretch;
   background-color: white;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- update background colour of log container to be consistent
  with step details + status tabs
- remove border + box-shadow around tasks container
- remove unecessary margins on task and step links in TaskTree

These changes are subtle but provide a cleaner look, are more
inline with Carbon guidelines, and will make it easier to
apply future planned design changes for the TaskTree component.

Before:
![image](https://user-images.githubusercontent.com/2829095/85171820-a7835880-b267-11ea-9e48-2f208738b2ae.png)

After:
![image](https://user-images.githubusercontent.com/2829095/85171835-ae11d000-b267-11ea-8e61-638f6aeced90.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
