### PR TITLE
Remove unnecessary margin on table noRows element

### DIFF
--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -64,13 +64,8 @@ limitations under the License.
   .noRows {
     width: 100%;
     text-align: center;
-    margin-top: 5px;
     font-style: italic;
     font-size: 1rem;
-  }
-
-  .bx--data-table--short .noRows {
-    margin-top: 0;
   }
 
   .bx--batch-actions--active {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In a previous commit I removed the margin-top for the noRows
element on 'short' tables, however this is not necessary on
standard height table rows either.

Remove the margin-top from `.noRows` entirely.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
