### PR TITLE
Fix intermittent error loading rerun PipelineRun

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -184,6 +184,9 @@ export function formatLabels(labelsRaw) {
 
 // Sorts the steps by finishedAt and startedAt timestamps
 export function sortStepsByTimestamp(steps) {
+  if (!steps) {
+    return [];
+  }
   return steps.sort((i, j) => {
     const iFinishAt = new Date(i.stepStatus?.terminated?.finishedAt).getTime();
     const jFinishAt = new Date(j.stepStatus?.terminated?.finishedAt).getTime();

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -376,6 +376,10 @@ it('formatLabels', () => {
   ]);
 });
 
+it('sortStepsByTimestamp handles falsy steps', () => {
+  expect(sortStepsByTimestamp(null)).toEqual([]);
+});
+
 it('sortStepsByTimestamp preserves order if no timestamps present', () => {
   const steps = ['t', 'e', 's', 't'];
   const want = ['t', 'e', 's', 't'];


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When re-running a PipelineRun and **very quickly** clicking on the link to view the details, it's possible to get there between the first TaskRun appearing and the first steps being resolved. This leads to an error when we attempt to sort the steps for display.

Handle this by explicitly returning an empty array when `steps` is falsy.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
