### PR TITLE
Switch from Delete16 icon (deprecated) to TrashCan32

### DIFF
--- a/packages/components/src/components/PipelineResources/PipelineResources.test.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.test.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
-import { Delete16 } from '@carbon/icons-react';
+import { TrashCan32 as Delete } from '@carbon/icons-react';
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import PipelineResources from './PipelineResources';
 
@@ -74,7 +74,7 @@ it('PipelineResources renders correct data', async () => {
         {
           onClick: batchDeleteSpy,
           text: 'Delete',
-          icon: Delete16
+          icon: Delete
         }
       ]}
     />

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
@@ -17,7 +17,7 @@ import StoryRouter from 'storybook-react-router';
 import { getStatus } from '@tektoncd/dashboard-utils';
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import { Delete16 as Delete } from '@carbon/icons-react';
+import { TrashCan32 as Delete } from '@carbon/icons-react';
 import { Dropdown } from 'carbon-components-react';
 
 import { StatusIcon } from '..';

--- a/packages/components/src/components/Table/Table.stories.js
+++ b/packages/components/src/components/Table/Table.stories.js
@@ -18,7 +18,7 @@ import { boolean, text } from '@storybook/addon-knobs';
 import { Dropdown } from 'carbon-components-react';
 import {
   Add16 as Add,
-  Delete16 as Delete,
+  TrashCan32 as Delete,
   Restart16 as Rerun,
   Renew16 as RerunAll
 } from '@carbon/icons-react';

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -32,7 +32,7 @@ import {
   ListItem,
   UnorderedList
 } from 'carbon-components-react';
-import { Add16 as Add, Delete16 as Delete } from '@carbon/icons-react';
+import { Add16 as Add, TrashCan32 as Delete } from '@carbon/icons-react';
 
 import { LabelFilter } from '..';
 import { fetchPipelineResources } from '../../actions/pipelineResources';

--- a/src/containers/Secrets/Secrets.js
+++ b/src/containers/Secrets/Secrets.js
@@ -30,7 +30,7 @@ import {
   getTitle,
   urls
 } from '@tektoncd/dashboard-utils';
-import { Add16 as Add, Delete16 as Delete } from '@carbon/icons-react';
+import { Add16 as Add, TrashCan32 as Delete } from '@carbon/icons-react';
 import { LabelFilter } from '..';
 import DeleteModal from '../../components/SecretsDeleteModal';
 import {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The `Delete16` icon from `@carbon/icons-react` is deprecated.
`TrashCan32` can be used as a direct drop-in replacement and will be correctly resized in use.
`https://github.com/carbon-design-system/carbon/issues/3494#issuecomment-514352314`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
