### PR TITLE
Fix links to ClusterTriggerBindings from EventListener page

### DIFF
--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -55,10 +55,16 @@ const Trigger = ({ intl, eventListenerNamespace, trigger }) => {
                 <span key={binding.ref}>
                   <Link
                     className="tkn--trigger-resourcelink"
-                    to={urls.triggerBindings.byName({
-                      namespace: eventListenerNamespace,
-                      triggerBindingName: binding.ref
-                    })}
+                    to={
+                      binding.kind === 'ClusterTriggerBinding'
+                        ? urls.clusterTriggerBindings.byName({
+                            clusterTriggerBindingName: binding.ref
+                          })
+                        : urls.triggerBindings.byName({
+                            namespace: eventListenerNamespace,
+                            triggerBindingName: binding.ref
+                          })
+                    }
                   >
                     <span title={binding.ref}>{binding.ref}</span>
                   </Link>

--- a/packages/components/src/components/Trigger/Trigger.test.js
+++ b/packages/components/src/components/Trigger/Trigger.test.js
@@ -28,6 +28,7 @@ const fakeTrigger = {
     },
     {
       apiversion: 'v1alpha1',
+      kind: 'ClusterTriggerBinding',
       ref: 'triggerbinding-2'
     }
   ],


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When an EventListeners references ClusterTriggerBindings,
we were incorrectly linking to the TriggerBinding URL.

Detect the `kind` of the binding and use the appropriate URL.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
