### PR TITLE
Remove `iconDescription` prop from `AccordionItem` on Import Resources page

### DIFF
--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -313,10 +313,6 @@ export class ImportResources extends Component {
           </FormGroup>
           <Accordion>
             <AccordionItem
-              iconDescription={intl.formatMessage({
-                id: 'dashboard.importResources.expandCollapse',
-                defaultMessage: 'Expand/Collapse'
-              })}
               title={intl.formatMessage({
                 id: 'dashboard.importResources.advanced.accordionText',
                 defaultMessage:

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -118,7 +118,6 @@
     "dashboard.importResources.directory.helperText": "The location of the Tekton resources to import from the repository. Leave blank if the resources are at the top-level directory.",
     "dashboard.importResources.directory.labelText": "Repository directory (optional)",
     "dashboard.importResources.directory.placeholder": "Enter repository directory",
-    "dashboard.importResources.expandCollapse": "Expand/Collapse",
     "dashboard.importResources.heading": "Import resources from repository",
     "dashboard.importResources.importApplyButton": "Import and Apply",
     "dashboard.importResources.importerNamespace.helperText": "The namespace in which the PipelineRun fetching the repository and creating the resources will run",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Carbon have deprecated the `iconDescription` prop on the
`AccordionItem` component. In fact, it's no longer used at
all in the component.

Remove the prop and clean up the unused string.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
