### PR TITLE
Remove unnecessary use of `createIntl` in tests

### DIFF
--- a/packages/components/src/components/PipelineResources/PipelineResources.test.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,15 +13,9 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent, waitForElement } from 'react-testing-library';
-import { createIntl } from 'react-intl';
 import { TrashCan32 as Delete } from '@carbon/icons-react';
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import PipelineResources from './PipelineResources';
-
-const intl = createIntl({
-  locale: 'en',
-  defaultLocale: 'en'
-});
 
 it('PipelineResources renders empty state', () => {
   const { queryByText } = renderWithIntl(
@@ -46,7 +40,6 @@ it('PipelineResources renders correct data', async () => {
   const batchDeleteSpy = jest.fn();
   const { queryByText, getByLabelText, getByText } = renderWithRouter(
     <PipelineResources
-      intl={intl}
       pipelineResources={[
         {
           metadata: {

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
@@ -13,14 +13,8 @@ limitations under the License.
 
 import React from 'react';
 
-import { createIntl } from 'react-intl';
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import PipelineRuns from './PipelineRuns';
-
-const intl = createIntl({
-  locale: 'en',
-  defaultLocale: 'en'
-});
 
 describe('PipelineRuns', () => {
   it('renders empty state', () => {
@@ -127,7 +121,6 @@ describe('PipelineRuns', () => {
     const pipelineRunName = 'pipeline-run-20190816124708';
     const { queryByText, queryByTitle } = renderWithRouter(
       <PipelineRuns
-        intl={intl}
         pipelineRuns={[
           {
             metadata: {
@@ -170,7 +163,6 @@ describe('PipelineRuns', () => {
     const pipelineRunName = 'pipeline-run-20190816124708';
     const { queryByText } = renderWithRouter(
       <PipelineRuns
-        intl={intl}
         pipelineRuns={[
           {
             metadata: {

--- a/packages/components/src/components/TaskRuns/TaskRuns.test.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.test.js
@@ -12,14 +12,9 @@ limitations under the License.
 */
 
 import React from 'react';
-import { createIntl } from 'react-intl';
+
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import TaskRuns from './TaskRuns';
-
-const intl = createIntl({
-  locale: 'en',
-  defaultLocale: 'en'
-});
 
 it('TaskRuns renders empty state', () => {
   const { queryByText } = renderWithIntl(<TaskRuns taskRuns={[]} />);
@@ -37,11 +32,10 @@ it('TaskRuns renders headers state', () => {
   expect(document.getElementsByClassName('bx--overflow-menu')).toBeTruthy();
 });
 
-it('TaskRun renders correct data', async () => {
+it('TaskRuns renders correct data', async () => {
   const taskRunName = 'pipeline0-run-123';
   const { queryByText, queryByTitle } = renderWithRouter(
     <TaskRuns
-      intl={intl}
       taskRuns={[
         {
           kind: 'TaskRun',
@@ -105,11 +99,10 @@ it('TaskRun renders correct data', async () => {
   expect(queryByText(/cluster-taskrun/i)).toBeTruthy();
 });
 
-it('TaskRun renders pending', async () => {
+it('TaskRuns renders pending', async () => {
   const taskRunName = 'task-run-of-doom';
   const { queryByText, queryByTitle } = renderWithRouter(
     <TaskRuns
-      intl={intl}
       taskRuns={[
         {
           kind: 'TaskRun',
@@ -150,20 +143,7 @@ it('TaskRun renders pending', async () => {
           }
         }
       ]}
-      taskRunActions={[
-        {
-          actionText: intl.formatMessage({
-            id: 'test.actionText',
-            defaultMessage: 'Delete'
-          })
-        },
-        {
-          actionText: intl.formatMessage({
-            id: 'test.actionText',
-            defaultMessage: 'Stop'
-          })
-        }
-      ]}
+      taskRunActions={[{ actionText: 'Delete' }, { actionText: 'Stop' }]}
     />
   );
   expect(queryByText(taskRunName)).toBeTruthy();

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import React from 'react';
-import { createIntl } from 'react-intl';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import { Route } from 'react-router-dom';
@@ -26,11 +25,6 @@ import * as selectors from '../../reducers';
 
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
-
-const intl = createIntl({
-  locale: 'en',
-  defaultLocale: 'en'
-});
 
 beforeEach(() => {
   jest.spyOn(API, 'getPipelines').mockImplementation(() => {});
@@ -149,11 +143,9 @@ const store = mockStore({
 
 it('click add new secret and create secret UI appears', () => {
   const currentProps = {
-    error: null,
     history: {
       push: jest.fn()
     },
-    loading: false,
     secrets: [
       {
         metadata: {
@@ -195,9 +187,7 @@ it('click delete secret & modal appears', () => {
           'tekton.dev/git-0': 'https://github.ibm.com'
         }
       }
-    ],
-    loading: false,
-    error: null
+    ]
   };
 
   const { getByTestId, getByText } = renderWithRouter(
@@ -248,9 +238,7 @@ it('SecretsTable only renders tekton.dev annotations', () => {
           'tekton.dev/git-0': 'https://github.ibm.com'
         }
       }
-    ],
-    loading: false,
-    error: null
+    ]
   };
 
   const { queryByText } = renderWithRouter(
@@ -288,17 +276,11 @@ it('SecretsTable renders username in regular form (not encoded)', () => {
 });
 
 it('Secrets can be filtered on a single label filter', async () => {
-  const currentProps = {
-    loading: false,
-    error: null,
-    intl
-  };
-
   const { getByTestId, getByText, queryByText } = renderWithRouter(
     <Provider store={store}>
       <Route
         path={urls.secrets.all()}
-        render={props => <Secrets {...props} {...currentProps} />}
+        render={props => <Secrets {...props} />}
       />
     </Provider>,
     { route: urls.secrets.all() }
@@ -317,17 +299,11 @@ it('Secrets can be filtered on a single label filter', async () => {
 it('Secrets can not be created when in read-only mode', async () => {
   jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => true);
 
-  const currentProps = {
-    loading: false,
-    error: null,
-    intl
-  };
-
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
       <Route
         path={urls.secrets.all()}
-        render={props => <Secrets {...props} {...currentProps} />}
+        render={props => <Secrets {...props} />}
       />
     </Provider>,
     { route: urls.secrets.all() }
@@ -339,17 +315,11 @@ it('Secrets can not be created when in read-only mode', async () => {
 it('Secrets can be created when not in read-only mode', async () => {
   jest.spyOn(selectors, 'isReadOnly').mockImplementation(() => false);
 
-  const currentProps = {
-    loading: false,
-    error: null,
-    intl
-  };
-
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
       <Route
         path={urls.secrets.all()}
-        render={props => <Secrets {...props} {...currentProps} />}
+        render={props => <Secrets {...props} />}
       />
     </Provider>,
     { route: urls.secrets.all() }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When testing against a container / component that already uses
`injectIntl`, there's no need to manually provide the `intl`
prop when using `renderWithIntl` or `renderWithRouter` as these
already wrap the component with an `IntlProvider`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
