### PR TITLE
Add additionalPrinterColumns on extension CRD

### DIFF
--- a/base/202-extension-crd.yaml
+++ b/base/202-extension-crd.yaml
@@ -49,6 +49,19 @@ spec:
       - ext
       - exts
   scope: Namespaced
+  additionalPrinterColumns:
+    - name: API version
+      type: string
+      JSONPath: .spec.apiVersion
+    - name: Kind
+      type: string
+      JSONPath: .spec.name
+    - name: Display name
+      type: string
+      JSONPath: .spec.displayname
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
   # Opt into the status subresource so metadata.generation
   # starts to increment
   subresources:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds `additionalPrinterColumns` stanza on the Extension CRD.

This improves `kubectl` output.

Before:
```bash
NAMESPACE          NAME
tekton-pipelines   cronjobs
```

After:
```bash
NAMESPACE          NAME       API VERSION     NAME       DISPLAY NAME
tekton-pipelines   cronjobs   batch/v1beta1   cronjobs   k8s cronjobs
```

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
