### PR TITLE
Improve URL addressability of TaskRun and PipelineRun details pages

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -23,6 +23,7 @@ import {
   getParams,
   getResources,
   getStatus,
+  NO_STEP,
   reorderSteps,
   selectedTask,
   selectedTaskRun,
@@ -214,13 +215,15 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       intl,
       loading,
       logDownloadButton: LogDownloadButton,
+      onViewChange,
       pollingInterval,
       rerun,
       selectedStepId,
       selectedTaskId,
       showIO,
       sortTaskRuns,
-      triggerHeader
+      triggerHeader,
+      view
     } = this.props;
 
     if (loading) {
@@ -334,7 +337,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       }
     );
 
-    const logContainer = (
+    const logContainer = selectedStepId && selectedStepId !== NO_STEP && (
       <Log
         downloadButton={
           LogDownloadButton && (
@@ -370,21 +373,30 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           <TaskTree
             onSelect={handleTaskSelected}
             selectedTaskId={selectedTaskId}
+            selectedStepId={selectedStepId}
             taskRuns={taskRuns}
           />
-          {(selectedStepId && (
+          {(selectedStepId && selectedStepId !== NO_STEP && (
             <StepDetails
               definition={definition}
               logContainer={logContainer}
+              onViewChange={onViewChange}
               reason={reason}
               showIO={showIO}
               status={status}
               stepName={stepName}
               stepStatus={stepStatus}
               taskRun={taskRun}
+              view={view}
             />
           )) ||
-            (selectedTaskId && <TaskRunDetails taskRun={taskRun} />)}
+            (selectedTaskId && (
+              <TaskRunDetails
+                onViewChange={onViewChange}
+                taskRun={taskRun}
+                view={view}
+              />
+            ))}
         </div>
       </>
     );
@@ -392,16 +404,21 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 }
 
 PipelineRunContainer.propTypes = {
-  handleTaskSelected: PropTypes.func.isRequired,
+  handleTaskSelected: PropTypes.func,
+  onViewChange: PropTypes.func,
   selectedStepId: PropTypes.string,
   selectedTaskId: PropTypes.string,
-  sortTaskRuns: PropTypes.bool
+  sortTaskRuns: PropTypes.bool,
+  view: PropTypes.string
 };
 
 PipelineRunContainer.defaultProps = {
+  handleTaskSelected: /* istanbul ignore next */ () => {},
+  onViewChange: /* istanbul ignore next */ () => {},
   selectedStepId: null,
   selectedTaskId: null,
-  sortTaskRuns: false
+  sortTaskRuns: false,
+  view: null
 };
 
 export default injectIntl(PipelineRunContainer);

--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import PipelineRun from '.';
@@ -148,14 +148,24 @@ storiesOf('Components/PipelineRun', module)
       {story()}
     </div>
   ))
-  .add('default', () => (
-    <PipelineRun
-      pipelineRun={pipelineRun}
-      taskRuns={[taskRun]}
-      tasks={[task]}
-      fetchLogs={() => 'sample log output'}
-      rerunPipelineRun={() => {}}
-    />
-  ))
+  .add('default', () => {
+    const [selectedStepId, setSelectedStepId] = useState();
+    const [selectedTaskId, setSelectedTaskId] = useState();
+    return (
+      <PipelineRun
+        fetchLogs={() => 'sample log output'}
+        handleTaskSelected={(taskId, stepId) => {
+          setSelectedStepId(stepId);
+          setSelectedTaskId(taskId);
+        }}
+        pipelineRun={pipelineRun}
+        rerunPipelineRun={() => {}}
+        selectedStepId={selectedStepId}
+        selectedTaskId={selectedTaskId}
+        taskRuns={[taskRun]}
+        tasks={[task]}
+      />
+    );
+  })
   .add('empty', () => <PipelineRun />)
   .add('error', () => <PipelineRun error="Internal server error" />);

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -11,28 +11,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { injectIntl } from 'react-intl';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 import { DetailsHeader, StepDefinition, StepStatus, Tab, Tabs } from '..';
 
 import './StepDetails.scss';
+
+const tabs = ['logs', 'status', 'details'];
 
 const StepDetails = props => {
   const {
     definition,
     intl,
     logContainer,
+    onViewChange,
     reason,
     showIO,
     stepName,
     stepStatus,
-    taskRun
+    taskRun,
+    view
   } = props;
   let { status } = props;
   status =
     taskRun.reason === 'TaskRunCancelled' && status !== 'terminated'
       ? 'cancelled'
       : status;
+
+  let selectedTabIndex = tabs.indexOf(view);
+  if (selectedTabIndex === -1) {
+    selectedTabIndex = 0;
+  }
+
   return (
     <div className="tkn--step-details">
       <DetailsHeader
@@ -41,7 +52,11 @@ const StepDetails = props => {
         stepName={stepName}
         taskRun={taskRun}
       />
-      <Tabs aria-label="Step details">
+      <Tabs
+        aria-label="Step details"
+        onSelectionChange={index => onViewChange(tabs[index])}
+        selected={selectedTabIndex}
+      >
         <Tab
           id={`${stepName}-logs`}
           label={intl.formatMessage({
@@ -78,7 +93,14 @@ const StepDetails = props => {
   );
 };
 
+StepDetails.propTypes = {
+  onViewChange: PropTypes.func,
+  showIO: PropTypes.bool,
+  taskRun: PropTypes.shape({})
+};
+
 StepDetails.defaultProps = {
+  onViewChange: /* istanbul ignore next */ () => {},
   showIO: false,
   taskRun: {}
 };

--- a/packages/components/src/components/StepDetails/StepDetails.test.js
+++ b/packages/components/src/components/StepDetails/StepDetails.test.js
@@ -14,39 +14,55 @@ limitations under the License.
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { fireEvent } from 'react-testing-library';
 import { renderWithRouter } from '../../utils/test';
 
 import StepDetails from './StepDetails';
 
-it('StepDetails renders', () => {
-  const mockStore = configureStore();
-  const store = mockStore({ namespaces: { selected: 'default' } });
+describe('StepDetails', () => {
+  it('renders', () => {
+    const mockStore = configureStore();
+    const store = mockStore({ namespaces: { selected: 'default' } });
 
-  renderWithRouter(
-    <Provider store={store}>
-      <StepDetails />
-    </Provider>
-  );
-});
+    renderWithRouter(
+      <Provider store={store}>
+        <StepDetails />
+      </Provider>
+    );
+  });
 
-it('StepDetails renders terminated state', () => {
-  const mockStore = configureStore();
-  const store = mockStore({ namespaces: { selected: 'default' } });
+  it('renders terminated state', () => {
+    const mockStore = configureStore();
+    const store = mockStore({ namespaces: { selected: 'default' } });
 
-  renderWithRouter(
-    <Provider store={store}>
-      <StepDetails status="terminated" />
-    </Provider>
-  );
-});
+    renderWithRouter(
+      <Provider store={store}>
+        <StepDetails status="terminated" />
+      </Provider>
+    );
+  });
 
-it('StepDetails renders cancelled state', () => {
-  const mockStore = configureStore();
-  const store = mockStore({ namespaces: { selected: 'default' } });
+  it('renders cancelled state', () => {
+    const mockStore = configureStore();
+    const store = mockStore({ namespaces: { selected: 'default' } });
 
-  renderWithRouter(
-    <Provider store={store}>
-      <StepDetails status="False" taskRun={{ reason: 'TaskRunCancelled' }} />
-    </Provider>
-  );
+    renderWithRouter(
+      <Provider store={store}>
+        <StepDetails status="False" taskRun={{ reason: 'TaskRunCancelled' }} />
+      </Provider>
+    );
+  });
+
+  it('renders with selected view', () => {
+    const mockStore = configureStore();
+    const store = mockStore({ namespaces: { selected: 'default' } });
+
+    const { getByText } = renderWithRouter(
+      <Provider store={store}>
+        <StepDetails view="details" />
+      </Provider>
+    );
+
+    fireEvent.click(getByText(/status/i));
+  });
 });

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import {
 } from '@carbon/icons-react';
 import { Spinner, Step } from '@tektoncd/dashboard-components';
 
-import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
+import { NO_STEP, updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
 
 import './Task.scss';
 
@@ -30,11 +30,7 @@ class Task extends Component {
     this.selectDefaultStep();
   }
 
-  handleClick = event => {
-    if (event) {
-      event.preventDefault();
-    }
-
+  handleClick = () => {
     const { id } = this.props;
     const { selectedStepId } = this.state;
     this.props.onSelect(id, selectedStepId);
@@ -47,17 +43,14 @@ class Task extends Component {
   };
 
   handleTaskSelected = event => {
-    if (event) {
-      event.preventDefault();
-    }
-    this.setState({ selectedStepId: null }, () => {
+    event?.preventDefault(); // eslint-disable-line no-unused-expressions
+    this.setState({ selectedStepId: NO_STEP }, () => {
       this.handleClick();
     });
   };
 
   selectDefaultStep() {
-    const { expanded, steps } = this.props;
-    const { selectedStepId } = this.state;
+    const { expanded, selectedStepId, steps } = this.props;
     if (expanded && !selectedStepId) {
       const erroredStep = steps.find(
         step => step.reason === 'Error' || step.reason === undefined
@@ -85,15 +78,25 @@ class Task extends Component {
   }
 
   render() {
-    const { expanded, reason, succeeded, steps, pipelineTaskName } = this.props;
-    const { selectedStepId } = this.state;
+    const {
+      expanded,
+      pipelineTaskName,
+      reason,
+      selectedStepId,
+      steps,
+      succeeded
+    } = this.props;
     const icon = this.icon();
+
     return (
       <li
         className="tkn--task"
         data-succeeded={succeeded}
         data-reason={reason}
-        data-selected={(expanded && !selectedStepId) || undefined}
+        data-selected={
+          (expanded && (!selectedStepId || selectedStepId === NO_STEP)) ||
+          undefined
+        }
       >
         <a
           className="tkn--task-link"

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -37,4 +37,15 @@ storiesOf('Components/Task', module)
   .add('running', () => (
     <Task {...props} succeeded="Unknown" reason="Running" />
   ))
-  .add('expanded', () => <Task {...props} expanded steps={steps} />);
+  .add('expanded', () => {
+    const [selectedStepId, setSelectedStepId] = useState();
+    return (
+      <Task
+        {...props}
+        onSelect={(_, stepId) => setSelectedStepId(stepId)}
+        selectedStepId={selectedStepId}
+        expanded
+        steps={steps}
+      />
+    );
+  });

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,8 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent } from 'react-testing-library';
+import { fireEvent, waitForElement } from 'react-testing-library';
+import { NO_STEP } from '@tektoncd/dashboard-utils';
 import Task from './Task';
 import { renderWithIntl } from '../../utils/test';
 
@@ -21,129 +22,144 @@ const props = {
   pipelineTaskName: 'A Task'
 };
 
-it('Task renders default content', () => {
-  const { queryByText } = renderWithIntl(<Task {...props} />);
-  expect(queryByText(/a task/i)).toBeTruthy();
-});
+describe('Task', () => {
+  it('renders default content', () => {
+    const { queryByText } = renderWithIntl(<Task {...props} />);
+    expect(queryByText(/a task/i)).toBeTruthy();
+  });
 
-it('Task does not render steps in collapsed state', () => {
-  const steps = [{ stepName: 'a step' }];
-  const { queryByText } = renderWithIntl(<Task {...props} steps={steps} />);
-  expect(queryByText(/a step/i)).toBeFalsy();
-});
+  it('does not render steps in collapsed state', () => {
+    const steps = [{ stepName: 'a step' }];
+    const { queryByText } = renderWithIntl(<Task {...props} steps={steps} />);
+    expect(queryByText(/a step/i)).toBeFalsy();
+  });
 
-it('Task renders steps in expanded state', () => {
-  const steps = [{ id: 'step', stepName: 'a step' }];
-  const { queryByText } = renderWithIntl(
-    <Task {...props} expanded steps={steps} />
-  );
-  expect(queryByText(/a step/i)).toBeTruthy();
-});
+  it('renders steps in expanded state', () => {
+    const steps = [{ id: 'step', stepName: 'a step' }];
+    const { queryByText } = renderWithIntl(
+      <Task {...props} expanded steps={steps} />
+    );
+    expect(queryByText(/a step/i)).toBeTruthy();
+  });
 
-it('Task renders first step in expanded Task with no error', () => {
-  const steps = [
-    { id: 'step', stepName: 'a step', reason: 'Completed' },
-    { id: 'step-two', stepName: 'a step two', reason: 'Completed' }
-  ];
-  const { queryByText } = renderWithIntl(
-    <Task {...props} expanded steps={steps} />
-  );
-  expect(
-    queryByText('a step').parentNode.parentNode.getAttribute('data-selected')
-  ).toBeTruthy();
-});
+  it('renders first step in expanded Task with no error', () => {
+    const steps = [
+      { id: 'step', stepName: 'a step', reason: 'Completed' },
+      { id: 'step-two', stepName: 'a step two', reason: 'Completed' }
+    ];
+    const { queryByText } = renderWithIntl(
+      <Task {...props} expanded steps={steps} />
+    );
+    waitForElement(() =>
+      queryByText(
+        (content, element) =>
+          content === 'a step' &&
+          element.parentNode.parentNode.getAttribute('data-selected')
+      )
+    );
+  });
 
-it('Task renders error step in expanded Task', () => {
-  const steps = [
-    { id: 'step', stepName: 'a step', reason: 'Completed' },
-    { id: 'step-two', stepName: 'a step two', reason: 'Error' }
-  ];
-  const { queryByText } = renderWithIntl(
-    <Task {...props} expanded steps={steps} />
-  );
-  expect(
-    queryByText('a step two').parentNode.parentNode.getAttribute(
-      'data-selected'
-    )
-  ).toBeTruthy();
-});
+  it('renders error step in expanded Task', () => {
+    const steps = [
+      { id: 'step', stepName: 'a step', reason: 'Completed' },
+      { id: 'step-two', stepName: 'a step two', reason: 'Error' }
+    ];
+    const { queryByText } = renderWithIntl(
+      <Task {...props} expanded steps={steps} />
+    );
+    waitForElement(() =>
+      queryByText(
+        (content, element) =>
+          content === 'a step two' &&
+          element.parentNode.parentNode.getAttribute('data-selected')
+      )
+    );
+  });
 
-it('Task renders cancelled step in expanded Task', () => {
-  const steps = [
-    { id: 'step', stepName: 'a step', reason: 'Completed' },
-    { id: 'step-two', stepName: 'a step two', reason: undefined }
-  ];
-  const { queryByText } = renderWithIntl(
-    <Task {...props} expanded steps={steps} />
-  );
-  expect(
-    queryByText('a step two').parentNode.parentNode.getAttribute(
-      'data-selected'
-    )
-  ).toBeTruthy();
-});
+  it('renders cancelled step in expanded Task', () => {
+    const steps = [
+      { id: 'step', stepName: 'a step', reason: 'Completed' },
+      { id: 'step-two', stepName: 'a step two', reason: undefined }
+    ];
+    const { queryByText } = renderWithIntl(
+      <Task {...props} expanded steps={steps} />
+    );
+    waitForElement(() =>
+      queryByText(
+        (content, element) =>
+          content === 'a step two' &&
+          element.parentNode.parentNode.getAttribute('data-selected')
+      )
+    );
+  });
 
-it('Task renders completed steps in expanded state', () => {
-  const steps = [
-    { id: 'step1', stepName: 'step 1', reason: 'Completed' },
-    { id: 'step2', stepName: 'step 2', reason: 'Error' },
-    { id: 'step3', stepName: 'step 3', reason: 'Completed' }
-  ];
-  const { queryByText } = renderWithIntl(
-    <Task {...props} expanded steps={steps} />
-  );
-  expect(queryByText(/step 1/i)).toBeTruthy();
-  expect(queryByText(/step 2/i)).toBeTruthy();
-  expect(queryByText(/step 3/i)).toBeTruthy();
-});
+  it('renders completed steps in expanded state', () => {
+    const steps = [
+      { id: 'step1', stepName: 'step 1', reason: 'Completed' },
+      { id: 'step2', stepName: 'step 2', reason: 'Error' },
+      { id: 'step3', stepName: 'step 3', reason: 'Completed' }
+    ];
+    const { queryByText } = renderWithIntl(
+      <Task {...props} expanded steps={steps} />
+    );
+    expect(queryByText(/step 1/i)).toBeTruthy();
+    expect(queryByText(/step 2/i)).toBeTruthy();
+    expect(queryByText(/step 3/i)).toBeTruthy();
+  });
 
-it('Task renders success state', () => {
-  renderWithIntl(<Task {...props} succeeded="True" />);
-});
+  it('renders success state', () => {
+    renderWithIntl(<Task {...props} succeeded="True" />);
+  });
 
-it('Task renders failure state', () => {
-  renderWithIntl(<Task {...props} succeeded="False" />);
-});
+  it('renders failure state', () => {
+    renderWithIntl(<Task {...props} succeeded="False" />);
+  });
 
-it('Task renders unknown state', () => {
-  renderWithIntl(<Task {...props} succeeded="Unknown" />);
-});
+  it('renders unknown state', () => {
+    renderWithIntl(<Task {...props} succeeded="Unknown" />);
+  });
 
-it('Task renders unknown state', () => {
-  renderWithIntl(<Task {...props} succeeded="Unknown" reason="Pending" />);
-});
+  it('renders pending state', () => {
+    renderWithIntl(<Task {...props} succeeded="Unknown" reason="Pending" />);
+  });
 
-it('Task renders cancelled state', () => {
-  renderWithIntl(
-    <Task {...props} succeeded="Unknown" reason="TaskRunCancelled" />
-  );
-});
+  it('renders running state', () => {
+    renderWithIntl(<Task {...props} succeeded="Unknown" reason="Running" />);
+  });
 
-it('Task handles click event', () => {
-  const onSelect = jest.fn();
-  const { getByText } = renderWithIntl(
-    <Task pipelineTaskName="build" onSelect={onSelect} />
-  );
-  fireEvent.click(getByText(/build/i));
-  expect(onSelect).toHaveBeenCalledTimes(1);
-});
+  it('renders cancelled state', () => {
+    renderWithIntl(
+      <Task {...props} succeeded="Unknown" reason="TaskRunCancelled" />
+    );
+  });
 
-it('Task handle click event on Step', () => {
-  const onStepSelect = jest
-    .fn()
-    .mockImplementation(event => event.preventDefault());
-  const onSelect = jest.fn();
-  const steps = [{ id: 'build', stepName: 'build', onSelect: onStepSelect }];
-  const { getByText } = renderWithIntl(
-    <Task
-      expanded
-      onSelect={onSelect}
-      pipelineTaskName="A Task"
-      steps={steps}
-    />
-  );
-  expect(onSelect).toHaveBeenCalledTimes(1);
-  onSelect.mockClear();
-  fireEvent.click(getByText(/build/i));
-  expect(onSelect).toHaveBeenCalledTimes(1);
+  it('renders NO_STEP state', () => {
+    renderWithIntl(<Task {...props} expanded selectedStepId={NO_STEP} />);
+  });
+
+  it('handles click event', () => {
+    const onSelect = jest.fn();
+    const { getByText } = renderWithIntl(
+      <Task pipelineTaskName="build" onSelect={onSelect} />
+    );
+    fireEvent.click(getByText(/build/i));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles click event on Step', () => {
+    const onSelect = jest.fn();
+    const steps = [{ id: 'build', stepName: 'build' }];
+    const { getByText } = renderWithIntl(
+      <Task
+        expanded
+        onSelect={onSelect}
+        pipelineTaskName="A Task"
+        steps={steps}
+      />
+    );
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    onSelect.mockClear();
+    fireEvent.click(getByText(/build/i));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -11,15 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { injectIntl } from 'react-intl';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 
 import { DetailsHeader, Tab, Table, Tabs, ViewYAML, WithLineBreaks } from '..';
 
 import './TaskRunDetails.scss';
 
+const tabs = ['params', 'status'];
+
 const TaskRunDetails = props => {
-  const { intl, taskRun } = props;
+  const { intl, onViewChange, taskRun, view } = props;
 
   const displayName = taskRun.pipelineTaskName || taskRun.taskRunName;
 
@@ -58,10 +61,19 @@ const TaskRunDetails = props => {
     />
   );
 
+  let selectedTabIndex = tabs.indexOf(view);
+  if (selectedTabIndex === -1) {
+    selectedTabIndex = 0;
+  }
+
   return (
     <div className="tkn--step-details">
       <DetailsHeader stepName={displayName} taskRun={taskRun} type="taskRun" />
-      <Tabs aria-label="TaskRun details">
+      <Tabs
+        aria-label="TaskRun details"
+        onSelectionChange={index => onViewChange(tabs[index])}
+        selected={selectedTabIndex}
+      >
         {params && (
           <Tab
             id={`${displayName}-details`}
@@ -89,7 +101,13 @@ const TaskRunDetails = props => {
   );
 };
 
+TaskRunDetails.propTypes = {
+  onViewChange: PropTypes.func,
+  taskRun: PropTypes.shape({})
+};
+
 TaskRunDetails.defaultProps = {
+  onViewChange: /* istanbul ignore next */ () => {},
   taskRun: {}
 };
 

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -12,48 +12,64 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl } from '../../utils/test';
+import { fireEvent } from 'react-testing-library';
 
+import { renderWithIntl } from '../../utils/test';
 import TaskRunDetails from './TaskRunDetails';
 
-it('TaskRunStatus renders task name and error state', () => {
-  const taskRunName = 'task-run-name';
-  const status = 'error';
-  const { queryByText } = renderWithIntl(
-    <TaskRunDetails taskRun={{ status, taskRunName }} />
-  );
+describe('TaskRunDetails', () => {
+  it('renders task name and error state', () => {
+    const taskRunName = 'task-run-name';
+    const status = 'error';
+    const { queryByText } = renderWithIntl(
+      <TaskRunDetails taskRun={{ status, taskRunName }} />
+    );
 
-  expect(queryByText(taskRunName)).toBeTruthy();
-  expect(queryByText(status)).toBeTruthy();
-});
+    expect(queryByText(taskRunName)).toBeTruthy();
+    expect(queryByText(status)).toBeTruthy();
+  });
 
-it('TaskRunDetails renders pipeline task name and inputs', () => {
-  const pipelineTaskName = 'my-pipeline-task';
-  const paramKey = 'k';
-  const paramValue = 'v';
-  const params = [{ name: paramKey, value: paramValue }];
-  const { queryByText } = renderWithIntl(
-    <TaskRunDetails
-      taskRun={{ pipelineTaskName, params, taskName: 'taskName' }}
-    />
-  );
+  it('renders pipeline task name and inputs', () => {
+    const pipelineTaskName = 'my-pipeline-task';
+    const paramKey = 'k';
+    const paramValue = 'v';
+    const params = [{ name: paramKey, value: paramValue }];
+    const { queryByText } = renderWithIntl(
+      <TaskRunDetails
+        taskRun={{ pipelineTaskName, params, taskName: 'taskName' }}
+      />
+    );
 
-  expect(queryByText(pipelineTaskName)).toBeTruthy();
-  expect(queryByText(paramKey)).toBeTruthy();
-  expect(queryByText(paramValue)).toBeTruthy();
-});
+    expect(queryByText(pipelineTaskName)).toBeTruthy();
+    expect(queryByText(paramKey)).toBeTruthy();
+    expect(queryByText(paramValue)).toBeTruthy();
+  });
 
-it('TaskRunDetails renders task name and inputs', () => {
-  const taskRunName = 'task-run-name';
-  const status = 'error';
-  const paramKey = 'k';
-  const paramValue = 'v';
-  const params = [{ name: paramKey, value: paramValue }];
-  const { queryByText } = renderWithIntl(
-    <TaskRunDetails taskRun={{ status, params, taskRunName }} />
-  );
+  it('renders task name and inputs', () => {
+    const taskRunName = 'task-run-name';
+    const status = 'error';
+    const paramKey = 'k';
+    const paramValue = 'v';
+    const params = [{ name: paramKey, value: paramValue }];
+    const { queryByText } = renderWithIntl(
+      <TaskRunDetails taskRun={{ status, params, taskRunName }} />
+    );
 
-  expect(queryByText(taskRunName)).toBeTruthy();
-  expect(queryByText(paramKey)).toBeTruthy();
-  expect(queryByText(paramValue)).toBeTruthy();
+    expect(queryByText(taskRunName)).toBeTruthy();
+    expect(queryByText(paramKey)).toBeTruthy();
+    expect(queryByText(paramValue)).toBeTruthy();
+  });
+
+  it('renders selected view', () => {
+    const taskRun = {
+      params: [{ name: 'fake_name', value: 'fake_value' }]
+    };
+    const { queryByText } = renderWithIntl(
+      <TaskRunDetails taskRun={taskRun} view="status" />
+    );
+    expect(queryByText(/status/i)).toBeTruthy();
+    expect(queryByText('fake_name')).toBeFalsy();
+    fireEvent.click(queryByText(/parameters/i));
+    expect(queryByText('fake_name')).toBeTruthy();
+  });
 });

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -23,7 +23,7 @@ class TaskTree extends Component {
   };
 
   render() {
-    const { selectedTaskId, taskRuns } = this.props;
+    const { selectedStepId, selectedTaskId, taskRuns } = this.props;
 
     if (!taskRuns) {
       return <div />;
@@ -48,6 +48,7 @@ class TaskTree extends Component {
               expanded={expanded}
               onSelect={this.handleSelect}
               reason={reason}
+              selectedStepId={selectedStepId}
               steps={sortStepsByTimestamp(steps)}
               succeeded={succeeded}
               pipelineTaskName={pipelineTaskName}

--- a/packages/components/src/components/TaskTree/TaskTree.stories.js
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -41,16 +41,17 @@ storiesOf('Components/TaskTree', module).add('default', () => {
   class TaskTreeWrapper extends Component {
     state = { selectedTaskId: null };
 
-    onSelect = selectedTaskId => {
-      this.setState({ selectedTaskId });
+    onSelect = (selectedTaskId, selectedStepId) => {
+      this.setState({ selectedStepId, selectedTaskId });
     };
 
     render() {
-      const { selectedTaskId } = this.state;
+      const { selectedStepId, selectedTaskId } = this.state;
       return (
         <TaskTree
           {...props}
           onSelect={this.onSelect}
+          selectedStepId={selectedStepId}
           selectedTaskId={selectedTaskId}
         />
       );

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -16,6 +16,7 @@ export { paths, urls } from './router';
 export { getStatus } from './status';
 
 export const ALL_NAMESPACES = '*';
+export const NO_STEP = '__';
 
 /* istanbul ignore next */
 export const copyToClipboard = text => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/487

Add support for URL addressability of TaskRuns (including retries),
steps, and the logs/details/etc. tabs on the PipelineRun and TaskRun
details pages.

When no query params are present on the URL the components will
perform their default behaviour as they do today, i.e. select the
first failed TaskRun + step, or first TaskRun + step if no errors.

When `stepName=__`, select the TaskRun details instead of
selecting a step. '__' was chosen as these are not valid
characters in a step name.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
