### PR TITLE
Use a real proxy instead of relying on k8s client

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -122,6 +122,11 @@ func main() {
 		logging.Log.Errorf("Error building route clientset: %s", err.Error())
 	}
 
+	transport, err := rest.TransportFor(cfg)
+	if err != nil {
+		logging.Log.Errorf("Error building rest transport: %s", err.Error())
+	}
+
 	options := endpoints.Options{
 		InstallNamespace:   installNamespace,
 		PipelinesNamespace: *pipelinesNamespace,
@@ -133,6 +138,8 @@ func main() {
 	}
 
 	resource := endpoints.Resource{
+		Config:                 cfg,
+		HttpClient:             &http.Client{Transport: transport},
 		DashboardClient:        dashboardClient,
 		PipelineClient:         pipelineClient,
 		PipelineResourceClient: pipelineResourceClient,

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 )
 
 require (
+	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/csrf v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,7 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
+github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clarketm/json v1.13.4/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -1,11 +1,14 @@
 package endpoints
 
 import (
+	"net/http"
+
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	dashboardclientset "github.com/tektoncd/dashboard/pkg/client/clientset/versioned"
 	pipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	resourceclientset "github.com/tektoncd/pipeline/pkg/client/resource/clientset/versioned"
 	k8sclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // Options for enpoints
@@ -42,6 +45,8 @@ func (o Options) GetTriggersNamespace() string {
 // Store all types here that are reused throughout files
 // Wrapper around all necessary clients used for endpoints
 type Resource struct {
+	Config                 *rest.Config
+	HttpClient             *http.Client
 	DashboardClient        dashboardclientset.Interface
 	PipelineClient         pipelineclientset.Interface
 	PipelineResourceClient resourceclientset.Interface

--- a/pkg/utils/flushwriter.go
+++ b/pkg/utils/flushwriter.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"io"
+	"net/http"
+)
+
+type flushWriter struct {
+	flusher http.Flusher
+	writer  io.Writer
+}
+
+func (fw *flushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.writer.Write(p)
+	if fw.flusher != nil {
+		fw.flusher.Flush()
+	}
+	return
+}
+
+func MakeFlushWriter(writer io.Writer) io.Writer {
+	if flusher, ok := writer.(http.Flusher); ok {
+		return &flushWriter{
+			writer:  writer,
+			flusher: flusher,
+		}
+	}
+
+	return writer
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR changes the proxy implementation to be closer to a real proxy than the current one relying on k8s client.

The incoming requests are executed on the api server and the response is then streamed into the original response.
This will allow us to follow logs instead of periodically polling them.

NOTE: the request context is forwarded from the original request to the api server request, allowing the child request to stop when the parent request is closed.

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
