### PR TITLE
Support both polling and streaming logs

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -52,6 +52,7 @@ var (
 	tenantNamespace    = flag.String("namespace", "", "If set, limits the scope of resources watched to this namespace only")
 	logLevel           = flag.String("log-level", "info", "Minimum log level output by the logger")
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
+	streamLogs         = flag.Bool("stream-logs", false, "Enable log streaming instead of polling")
 )
 
 func getCSRFAuthKey() []byte {
@@ -139,6 +140,7 @@ func main() {
 		ReadOnly:           *readOnly,
 		IsOpenShift:        *isOpenshift,
 		LogoutURL:          *logoutUrl,
+		StreamLogs:         *streamLogs,
 	}
 
 	resource := endpoints.Resource{

--- a/config_frontend/setupTests.js
+++ b/config_frontend/setupTests.js
@@ -13,8 +13,13 @@ limitations under the License.
 
 import 'react-testing-library/cleanup-after-each';
 import fetchMock from 'fetch-mock';
+import { TextDecoder, TextEncoder } from 'util';
+import { ReadableStream } from 'web-streams-polyfill/es6';
 
 fetchMock.catch();
 fetchMock.config.overwriteRoutes = true;
 
 window.HTMLElement.prototype.scrollIntoView = function scrollIntoViewTestStub() {};
+window.TextDecoder = TextDecoder;
+window.TextEncoder = TextEncoder;
+window.ReadableStream = ReadableStream;

--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -62,6 +62,7 @@ Accepted options:
         [--tenant-namespace <namespace>]        Will limit the visibility to the specified namespace only
         [--ingress-url <url>]                   Will create an additional ingress with the specified url
         [--ingress-secret <secret>]             Will add ssl support to the ingress
+        [--stream-logs]                         Will enable log streaming instead of polling
         [--output <file>]                       Will output built manifests in the file instead of in the console
 ```
 

--- a/overlays/patches/installer/deployment-patch.yaml
+++ b/overlays/patches/installer/deployment-patch.yaml
@@ -49,3 +49,7 @@
   path: /spec/template/spec/containers/0/args/-
   value:
     --openshift=--openshift
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --stream-logs=--stream-logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -21931,6 +21931,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "web-streams-polyfill": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
+      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==",
+      "dev": true
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "sass-loader": "^8.0.2",
     "storybook-react-router": "^1.0.8",
     "style-loader": "^0.23.1",
+    "web-streams-polyfill": "^2.1.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",

--- a/packages/components/src/components/Log/Log.test.js
+++ b/packages/components/src/components/Log/Log.test.js
@@ -66,4 +66,58 @@ describe('Log', () => {
 
     await waitForElement(() => getByText(/Line 1/i));
   });
+
+  it('renders the provided content when streaming logs', async () => {
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Completed' } }}
+        fetchLogs={() =>
+          Promise.resolve(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('testing'));
+              }
+            })
+          )
+        }
+      />
+    );
+    await waitForElement(() => getByText(/testing/i));
+  });
+
+  it('renders trailer when streaming logs', async () => {
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Completed' } }}
+        fetchLogs={() =>
+          Promise.resolve(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('testing'));
+              }
+            })
+          )
+        }
+      />
+    );
+    await waitForElement(() => getByText(/step completed/i));
+  });
+
+  it('renders error trailer when streaming logs', async () => {
+    const { getByText } = renderWithIntl(
+      <Log
+        stepStatus={{ terminated: { reason: 'Error' } }}
+        fetchLogs={() =>
+          Promise.resolve(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('testing'));
+              }
+            })
+          )
+        }
+      />
+    );
+    await waitForElement(() => getByText(/step failed/i));
+  });
 });

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -43,6 +43,7 @@ type Properties struct {
 	ReadOnly           bool   `json:"ReadOnly"`
 	LogoutURL          string `json:"LogoutURL,omitempty"`
 	TenantNamespace    string `json:"TenantNamespace,omitempty"`
+	StreamLogs         bool   `json:"StreamLogs"`
 }
 
 const (
@@ -205,6 +206,7 @@ func (r Resource) GetProperties(request *restful.Request, response *restful.Resp
 		ReadOnly:           r.Options.ReadOnly,
 		LogoutURL:          r.Options.LogoutURL,
 		TenantNamespace:    r.Options.TenantNamespace,
+		StreamLogs:         r.Options.StreamLogs,
 	}
 
 	isTriggersInstalled := isTriggersInstalled(r, triggersNamespace)

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -20,6 +20,7 @@ type Options struct {
 	ReadOnly           bool
 	IsOpenShift        bool
 	LogoutURL          string
+	StreamLogs         bool
 }
 
 // GetPipelinesNamespace returns the PipelinesNamespace property if set

--- a/scripts/installer
+++ b/scripts/installer
@@ -26,6 +26,7 @@ CSRF_SECURE_COOKIE="false"
 LOG_LEVEL="info"
 LOG_FORMAT="json"
 TENANT_NAMESPACE=""
+STREAM_LOGS="false"
 BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard/previous"
 
 # additional options passed to ko resolve
@@ -172,6 +173,7 @@ patch() {
   replace "--read-only=--read-only" "--read-only=$READONLY"
   replace "--namespace=--tenant-namespace" "--namespace=$TENANT_NAMESPACE"
   replace "--openshift=--openshift" "--openshift=$OPENSHIFT"
+  replace "--stream-logs=--stream-logs" "--stream-logs=$STREAM_LOGS"
   replace "namespace: tekton-dashboard" "namespace: $INSTALL_NAMESPACE"
 
   if [ "$OPENSHIFT" == "true" ] && [ "$IMAGE_STREAM" == "true" ]; then
@@ -482,6 +484,7 @@ help () {
   echo -e "\t[--tenant-namespace <namespace>]\tWill limit the visibility to the specified namespace only"
   echo -e "\t[--ingress-url <url>]\t\t\tWill create an additional ingress with the specified url"
   echo -e "\t[--ingress-secret <secret>]\t\tWill add ssl support to the ingress"
+  echo -e "\t[--stream-logs]\t\t\t\tWill enable log streaming instead of polling"
   echo -e "\t[--output <file>]\t\t\tWill output built manifests in the file instead of in the console"
 }
 
@@ -545,6 +548,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     '--read-only')
       READONLY="true"
+      ;;
+    '--stream-logs')
+      STREAM_LOGS="true"
       ;;
     '--csrf-secure-cookie')
       CSRF_SECURE_COOKIE="true"

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -63,7 +63,9 @@ export function getKubeAPI(
     '/',
     encodeURIComponent(name),
     subResource ? `/${subResource}` : '',
-    queryParams ? `?${new URLSearchParams(queryParams).toString()}` : ''
+    queryParams && Object.keys(queryParams).length > 0
+      ? `?${new URLSearchParams(queryParams).toString()}`
+      : ''
   ].join('');
 }
 
@@ -305,11 +307,11 @@ export function getCondition({ name, namespace }) {
   return get(uri);
 }
 
-export function getPodLogURL({ container, name, namespace }) {
-  let queryParams;
-  if (container) {
-    queryParams = { container };
-  }
+export function getPodLogURL({ container, name, namespace, follow }) {
+  const queryParams = {
+    ...(container && { container }),
+    ...(follow && { follow })
+  };
   const uri = `${getKubeAPI(
     'pods',
     { name, namespace, subResource: 'log' },
@@ -318,9 +320,9 @@ export function getPodLogURL({ container, name, namespace }) {
   return uri;
 }
 
-export function getPodLog({ container, name, namespace }) {
-  const uri = getPodLogURL({ container, name, namespace });
-  return get(uri, { Accept: 'text/plain' });
+export function getPodLog({ container, name, namespace, stream }) {
+  const uri = getPodLogURL({ container, name, namespace, follow: stream });
+  return get(uri, { Accept: 'text/plain' }, { stream });
 }
 
 export function rerunPipelineRun(namespace, payload) {

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -28,6 +28,7 @@ import {
   getTaskRunsErrorMessage,
   getTasks,
   getTasksErrorMessage,
+  isLogStreamingEnabled,
   isReadOnly,
   isWebSocketConnected
 } from '../../reducers';
@@ -37,7 +38,7 @@ import { fetchClusterTasks, fetchTasks } from '../../actions/tasks';
 import { fetchTaskRuns } from '../../actions/taskRuns';
 import { rerunPipelineRun } from '../../api';
 
-import { fetchLogs, getViewChangeHandler } from '../../utils';
+import { fetchLogs, followLogs, getViewChangeHandler } from '../../utils';
 
 export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   constructor(props) {
@@ -171,6 +172,10 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       />
     );
 
+    const logsRetriever = this.props.isLogStreamingEnabled
+      ? followLogs
+      : fetchLogs;
+
     return (
       <>
         {showRerunNotification && (
@@ -198,7 +203,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
         )}
         <PipelineRun
           error={error}
-          fetchLogs={fetchLogs}
+          fetchLogs={logsRetriever}
           handleTaskSelected={this.handleTaskSelected}
           loading={loading}
           logDownloadButton={LogDownloadButton}
@@ -250,6 +255,7 @@ function mapStateToProps(state, ownProps) {
     }),
     selectedStepId,
     selectedTaskId,
+    isLogStreamingEnabled: isLogStreamingEnabled(state),
     tasks: getTasks(state, { namespace }),
 
     taskRuns: getTaskRunsByPipelineRunName(

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -38,13 +38,15 @@ import {
   updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
-import { fetchLogs, getViewChangeHandler } from '../../utils';
+import { fetchLogs, followLogs, getViewChangeHandler } from '../../utils';
+
 import { LogDownloadButton } from '..';
 import {
   getSelectedNamespace,
   getTaskByType,
   getTaskRun,
   getTaskRunsErrorMessage,
+  isLogStreamingEnabled,
   isWebSocketConnected
 } from '../../reducers';
 
@@ -229,6 +231,10 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       message: taskRunStatusMessage
     } = getStatus(this.props.taskRun);
 
+    const logsRetriever = this.props.isLogStreamingEnabled
+      ? followLogs
+      : fetchLogs;
+
     const logContainer = selectedStepId && selectedStepId !== NO_STEP && (
       <Log
         downloadButton={
@@ -238,7 +244,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
             taskRun={taskRun}
           />
         }
-        fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
+        fetchLogs={() => logsRetriever(stepName, stepStatus, taskRun)}
         key={stepName}
         stepStatus={stepStatus}
       />
@@ -323,6 +329,7 @@ function mapStateToProps(state, ownProps) {
     error: getTaskRunsErrorMessage(state),
     namespace,
     selectedStepId,
+    isLogStreamingEnabled: isLogStreamingEnabled(state),
     taskRun,
     task,
     view,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -550,3 +550,7 @@ export function getTriggersVersion(state) {
 export function getTenantNamespace(state) {
   return propertiesSelectors.getTenantNamespace(state.properties);
 }
+
+export function isLogStreamingEnabled(state) {
+  return propertiesSelectors.isLogStreamingEnabled(state.properties);
+}

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -61,6 +61,7 @@ import {
   isFetchingSecrets,
   isFetchingTaskRuns,
   isFetchingTasks,
+  isLogStreamingEnabled,
   isOpenShift,
   isReadOnly,
   isTriggersInstalled
@@ -662,6 +663,16 @@ it('getTenantNamespace', () => {
     .mockImplementation(() => 'x');
   expect(getTenantNamespace(state)).toBe('x');
   expect(propertiesSelectors.getTenantNamespace).toHaveBeenCalledWith(
+    state.properties
+  );
+});
+
+it('isLogStreamingEnabled', () => {
+  jest
+    .spyOn(propertiesSelectors, 'isLogStreamingEnabled')
+    .mockImplementation(() => true);
+  expect(isLogStreamingEnabled(state)).toBe(true);
+  expect(propertiesSelectors.isLogStreamingEnabled).toHaveBeenCalledWith(
     state.properties
   );
 });

--- a/src/reducers/properties.js
+++ b/src/reducers/properties.js
@@ -65,4 +65,8 @@ export function getTenantNamespace(state) {
   return state.TenantNamespace;
 }
 
+export function isLogStreamingEnabled(state) {
+  return state.StreamLogs;
+}
+
 export default properties;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -35,6 +35,21 @@ export function typeToPlural(type) {
   return `${snakeCase(type).toUpperCase()}S`;
 }
 
+export async function followLogs(stepName, stepStatus, taskRun) {
+  const { pod, namespace } = taskRun;
+  let logs;
+  if (pod) {
+    const { container } = stepStatus;
+    logs = getPodLog({
+      container,
+      name: pod,
+      namespace,
+      stream: true
+    });
+  }
+  return logs;
+}
+
 export async function fetchLogs(stepName, stepStatus, taskRun) {
   const { pod, namespace } = taskRun;
   let logs;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds support for streaming logs instead of polling.

The proxy now supports streaming responses, this allows us to stream logs instead of polling.
Polling is still the default, the user has to enable streaming to use it.

The `Logs` component has been reworked to adapt to both streaming and polling use cases.
A flag was introduced to allow the frontend switching to streaming when enabled.
The installer and overlays were updated.
Doc was updated with the new flag.

I reverted the changes i did with the log lines limit.

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
