### PR TITLE
Fix flaky nightly releases

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -55,7 +55,7 @@ spec:
           value: $(params.imageRegistry)
         - name: GOPATH
           value: /workspace/go
-        - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+        - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secret/release.json
         - name: GO111MODULE
           value:
@@ -67,7 +67,10 @@ spec:
           set -e
           set -x
 
-          # Auth with CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+          # Activate service account
+          gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+          # Setup docker auth
           gcloud auth configure-docker
 
           # ko requires this variable to be set in order to set image creation timestamps correctly https://github.com/google/go-containerregistry/pull/146


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The dashboard nightly has failed 2 out of the last 3 runs due to the same
credentials related issue that was affecting the pipeline and triggers releases
(see tektoncd/pipeline#2838).

This commit fixes the build by replacing the problematic environment variable
with an explicit call to activate the service account (just like
tektoncd/pipeline#2847).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
