### PR TITLE
Stop polling logs when run is terminated

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -33,7 +33,11 @@ export class LogContainer extends Component {
 
   componentDidMount() {
     this.loadLog();
-    this.initPolling();
+    this.updatePolling();
+  }
+
+  componentDidUpdate() {
+    this.updatePolling();
   }
 
   componentWillUnmount() {
@@ -93,13 +97,15 @@ export class LogContainer extends Component {
   };
 
   /* istanbul ignore next */
-  initPolling = () => {
+  updatePolling = () => {
     const { stepStatus, pollingInterval } = this.props;
     if (!this.timer && stepStatus && !stepStatus.terminated) {
       this.timer = setInterval(() => this.loadLog(), pollingInterval);
     }
     if (this.timer && stepStatus && stepStatus.terminated) {
       clearInterval(this.timer);
+      delete this.timer;
+      this.loadLog();
     }
   };
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR stops polling logs when the run is terminated.

As we didn't react to state changes, polling was initiated but not stopped when run terminated.

/cc @a-roberts @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
