### PR TITLE
Add log related flags to the installer

### DIFF
--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -49,6 +49,8 @@ Accepted commands:
 
 Accepted options:
         [--debug]                               Prints additional messages in the console
+        [--log-format]                          JSON or console
+        [--log-level]                           Change log level
         [--version]                             Will download manifests for specified version or build everything using kustomize/ko
         [--csrf-secure-cookie]                  Enable secure CSRF cookie
         [--openshift]                           Will build manifests for openshift

--- a/scripts/installer
+++ b/scripts/installer
@@ -468,6 +468,8 @@ help () {
   echo -e ""
   echo -e "Accepted options:"
   echo -e "\t[--debug]\t\t\t\tPrints additional messages in the console"
+  echo -e "\t[--log-format]\t\t\t\tJSON or console"
+  echo -e "\t[--log-level]\t\t\t\tChange log level"
   echo -e "\t[--version]\t\t\t\tWill download manifests for specified version or build everything using kustomize/ko"
   echo -e "\t[--csrf-secure-cookie]\t\t\tEnable secure CSRF cookie"
   echo -e "\t[--openshift]\t\t\t\tWill build manifests for openshift"
@@ -549,6 +551,14 @@ while [[ $# -gt 0 ]]; do
     '--namespace')
       shift
       export OVERRIDE_NAMESPACE="${1}"
+      ;;
+    '--log-format')
+      shift
+      LOG_FORMAT="${1}"
+      ;;
+    '--log-level')
+      shift
+      LOG_LEVEL="${1}"
       ;;
     '--pipelines-namespace')
       shift

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -66,7 +66,7 @@ case $1 in
     install_ingress_nginx
     install_pipelines
     install_triggers
-    ./scripts/installer install $@
+    ./scripts/installer install --log-format console $@
     ;;
   'delete'|d)
     delete_cluster


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds `--log-format` and `--log-level` options to the installer.

It also sets console log format by default in the `prepare-king-cluster` script because the script is used when working locally and console logs are easier to read.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
