### PR TITLE
Update installer script prereq checks

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -43,27 +43,27 @@ initOS() {
 }
 
 verifySupported() {
-  if ! type "kubectl" > /dev/null; then
+  if ( [ "$ACTION" == "install" ] || [ "$ACTION" == "uninstall" ] ) && ! type "kubectl" > /dev/null 2>&1; then
     echo "kubectl is required"
     exit 1
   fi
 
-  if ! type "kustomize" > /dev/null; then
+  if ! type "kustomize" > /dev/null 2>&1; then
     echo "kustomize is required"
     exit 1
   fi
 
-  if ! type "ko" > /dev/null; then
+  if ! type "ko" > /dev/null 2>&1; then
     echo "ko is required"
     exit 1
   fi
 
-  if ! type "sed" > /dev/null; then
+  if ! type "sed" > /dev/null 2>&1; then
     echo "sed is required"
     exit 1
   fi
 
-  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then
+  if ! type "curl" > /dev/null 2>&1 && ! type "wget" > /dev/null 2>&1; then
     echo "Either curl or wget is required"
     exit 1
   fi
@@ -118,9 +118,9 @@ download() {
 
   debug "Downloading $url -> $TMP_FILE ..."
 
-  if type "curl" > /dev/null; then
+  if type "curl" > /dev/null 2>&1; then
     curl -s "$url" -o "$TMP_FILE"
-  elif type "wget" > /dev/null; then
+  elif type "wget" > /dev/null 2>&1; then
     wget -q -O "$TMP_FILE" "$url"
   fi
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Nightly builds are failing on the installer script as `kubectl`
is not available for some reason. Since `kubectl` is only required
for the install / uninstall actions, ensure it is only checked for
those actions.

Update the prereq checks to avoid unnecessary noise in the logs.

See for example: https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns/dashboard-release-nightly-vxgsf

```
+ ./scripts/installer release --debug --output /workspace/output/bucket-for-dashboard/latest/tekton-dashboard-release.yaml
Detected OS: linux
kubectl is required
./scripts/installer: line 46: type: kubectl: not found
```

In parallel we should figure out why `kubectl` isn't available.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
