### PR TITLE
Add release-installer script to ease install of dashboard release

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -51,8 +51,8 @@ In a nutshell, invoking the `installer` will look something like this:
 
 ```bash
 DASHBOARD_VERSION=v0.8.0
-curl -sL https://storage.googleapis.com/tekton-releases/dashboard/previous/$DASHBOARD_VERSION/installer | \
-   bash -s -- install --read-only --version $DASHBOARD_VERSION
+curl -sL https://raw.githubusercontent.com/tektoncd/dashboard/master/scripts/release-installer | \
+   bash -s -- install $DASHBOARD_VERSION --read-only
 ```
 
 Of course, you can still use the generated manifests as detailed below.

--- a/scripts/release-installer
+++ b/scripts/release-installer
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Tekton Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard/previous"
+
+verifySupported() {
+  if ! type "curl" > /dev/null 2>&1 && ! type "wget" > /dev/null 2>&1; then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+}
+
+install() {
+  VERSION=$1
+  if type "curl" > /dev/null 2>&1; then
+    curl -sL $BASE_RELEASE_URL/$VERSION/installer | bash -s -- install --version $@
+  elif type "wget" > /dev/null 2>&1; then
+    wget -q $BASE_RELEASE_URL/$VERSION/installer | bash -s -- install --version $@
+  fi
+}
+
+uninstall() {
+  VERSION=$1
+  if type "curl" > /dev/null 2>&1; then
+    curl -sL $BASE_RELEASE_URL/$VERSION/installer | bash -s -- uninstall --version $@
+  elif type "wget" > /dev/null 2>&1; then
+    wget -q $BASE_RELEASE_URL/$VERSION/installer | bash -s -- uninstall --version $@
+  fi
+}
+
+# help provides possible cli installation arguments
+help () {
+  VERSION=$1
+  if type "curl" > /dev/null 2>&1; then
+    curl -sL $BASE_RELEASE_URL/$VERSION/installer | bash -s -- "help"
+  elif type "wget" > /dev/null 2>&1; then
+    wget -q $BASE_RELEASE_URL/$VERSION/installer | bash -s -- "help"
+  fi
+}
+
+set -e
+
+verifySupported
+
+# Parsing command
+case $1 in
+  'help'|h)
+    help
+    exit 0
+    ;;
+  'install'|i)
+    shift
+    VERSION="${1}"
+    shift
+    install $VERSION $@
+    ;;
+  'uninstall'|u)
+    shift
+    VERSION="${1}"
+    shift
+    uninstall $VERSION $@
+    ;;
+  *)
+    help
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds a release installer script to ease install of a dashboard release.

Using the installer script directly requires to specify the version twice (once to download the installer script itself from the gcs bucket, and also to pass the version option to the script).

This is error prone and not very pleasant.
The release installer script will take care of downloading the installer from gcs and will inject the version in the command line.
This script will stay in github and doesn't need to be embedded in the release.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
