### PR TITLE
Make uninstall not requiring install options

### DIFF
--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -189,18 +189,8 @@ The `installer` script can create an ingress for your Dashboard service, to enab
 
 To uninstall the Dashboard, use the `uninstall` instead of the `install` command.
 
-**IMPORTANT NOTE:** this is VERY important when you uninstall using the `installer` script that you provide the same options that were given to the script at install time. This is needed for the script to know what was created at install time and must be deleted by the `uninstall` command.
-Uninstalling with the wrong options could lead to resources not being deleted (`Ingress` or `RoleBinding`s) or uninstall to fail completely (trying to uninstall for the incorrect platform or not in the good namespace).
-
 ```bash
-# for kubernetes
 ./scripts/installer uninstall
-
-# for openshift / openshift pipelines operator
-./scripts/installer uninstall --openshift
-
-# for openshift / manifests
-./scripts/installer uninstall --openshift --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines
 ```
 
 ## Build command

--- a/scripts/installer
+++ b/scripts/installer
@@ -438,7 +438,9 @@ install() {
 # uninstall invokes kubectl delete with the built manifest.
 uninstall() {
   echo "Uninstalling ..."
-  kubectl delete -f $TMP_FILE
+  kubectl delete deployments -l=app.kubernetes.io/instance=default,app.kubernetes.io/part-of=tekton-dashboard --all-namespaces
+  kubectl api-resources --verbs=delete -o name | \
+    xargs -n 1 kubectl delete --ignore-not-found -l=app.kubernetes.io/instance=default,app.kubernetes.io/part-of=tekton-dashboard --all-namespaces
 }
 
 build() {
@@ -513,8 +515,8 @@ case $1 in
     shift
     ;;
   'uninstall'|u)
-    ACTION="uninstall"
-    shift
+    uninstall
+    exit 0
     ;;
   'build'|b)
     ACTION="build"

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -69,10 +69,10 @@ case $1 in
     install_triggers
     ./scripts/installer install $DEFAULT_OPTIONS $@
     ;;
-    ;;
   'update'|u)
     shift
     ./scripts/installer install $DEFAULT_OPTIONS $@
+    ;;
   'delete'|d)
     delete_cluster
     ;;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR make the uninstall command not requiring install options.

The uninstall command loops through all api resources and deletes the resources having the dashboard labels.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
