### PR TITLE
Speed up npm install by skipping lerna ci cleanup step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "bootstrap:ci": "lerna bootstrap && lerna run prepare",
+    "bootstrap:ci": "lerna bootstrap --no-ci && lerna run prepare",
     "build": "webpack --config webpack.prod.js",
     "build:analyze": "webpack --config webpack.prod.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json",
     "build_ko": "webpack --config webpack.prod.js --output-path='./cmd/dashboard/kodata' ",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Since we're running `npm ci` ourselves we don't need `lerna bootstrap`
to do this again. A simple `npm install` will suffice to ensure
the packages are linked and any additional dependencies are installed.
This behaviour is triggered by passing the `--no-ci` flag to the
`bootstrap command`.

This should speed up all presubmit jobs relying on npm.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
