### PR TITLE
Fix secret not set on github and gitlab interceptors

### DIFF
--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -207,20 +207,24 @@ const Trigger = ({ intl, eventListenerNamespace, trigger }) => {
                 });
                 content = (
                   <>
-                    <p>{secretText}</p>
-                    <div className="tkn--trigger-interceptor-secret-details">
-                      <p>
-                        {nameText} {data.secretRef.secretName}
-                      </p>
-                      <p>
-                        {secretKeyText} {data.secretRef.secretKey}
-                      </p>
-                      {data.secretRef.namespace && (
-                        <p>
-                          {namespaceText} {data.secretRef.namespace}
-                        </p>
-                      )}
-                    </div>
+                    {data.secretRef && (
+                      <>
+                        <p>{secretText}</p>
+                        <div className="tkn--trigger-interceptor-secret-details">
+                          <p>
+                            {nameText} {data.secretRef.secretName}
+                          </p>
+                          <p>
+                            {secretKeyText} {data.secretRef.secretKey}
+                          </p>
+                          {data.secretRef.namespace && (
+                            <p>
+                              {namespaceText} {data.secretRef.namespace}
+                            </p>
+                          )}
+                        </div>
+                      </>
+                    )}
                     <p>Event Types: {eventTypes}</p>
                   </>
                 );


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes an error when displaying event listeners using github or gitlab interceptors and no secret have been set.

/cc @AlanGreene @a-roberts 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
