### PR TITLE
Reduce size of static resource bundles

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -38,5 +38,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "sideEffects": ["*.scss"]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,5 +23,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Set `sideEffects` flag on the sub-packages to enable additional
tree-shaking and dead code elimination in the webpack build.

Exclude SCSS files so they're not incorrectly pruned.

This change reduces the size of the vendor bundle from ~2.95MiB to ~1.7MiB,
with minor savings in some of the other bundles.

There are additional savings to be made with an upcoming Carbon release,
as well as by making changes to how we load the Carbon styles.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
