### PR TITLE
Stop loading the entirety of the Carbon styles

### DIFF
--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '~carbon-components/scss/globals/scss/styles';
+@import './carbon';
 
 body {
   background-color: #f4f7fb;

--- a/src/components/App/_carbon.scss
+++ b/src/components/App/_carbon.scss
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+$css--font-face: true;
+$css--helpers: true;
+$css--body: true;
+$css--reset: true;
+$css--default-type: true;
+$css--plex: true;
+
+@import '~carbon-components/scss/globals/scss/_css--reset.scss';
+@import '~carbon-components/scss/globals/scss/_css--font-face.scss';
+@import '~carbon-components/scss/globals/scss/_css--helpers.scss';
+@import '~carbon-components/scss/globals/scss/_css--body.scss';
+
+@import '~carbon-components/scss/components/button/button';
+@import '~carbon-components/scss/components/copy-button/copy-button';
+@import '~carbon-components/scss/components/checkbox/checkbox';
+@import '~carbon-components/scss/components/combo-box/combo-box';
+@import '~carbon-components/scss/components/radio-button/radio-button';
+@import '~carbon-components/scss/components/search/search';
+@import '~carbon-components/scss/components/text-input/text-input';
+@import '~carbon-components/scss/components/form/form';
+@import '~carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/components/data-table/data-table';
+@import '~carbon-components/scss/components/code-snippet/code-snippet';
+@import '~carbon-components/scss/components/overflow-menu/overflow-menu';
+@import '~carbon-components/scss/components/dropdown/dropdown';
+@import '~carbon-components/scss/components/loading/loading';
+@import '~carbon-components/scss/components/modal/modal';
+@import '~carbon-components/scss/components/notification/inline-notification';
+@import '~carbon-components/scss/components/notification/toast-notification';
+@import '~carbon-components/scss/components/tooltip/tooltip';
+@import '~carbon-components/scss/components/tabs/tabs';
+@import '~carbon-components/scss/components/tag/tag';
+@import '~carbon-components/scss/components/accordion/accordion';
+@import '~carbon-components/scss/components/skeleton/skeleton';
+@import '~carbon-components/scss/components/inline-loading/inline-loading';
+@import '~carbon-components/scss/components/ui-shell/ui-shell';

--- a/src/containers/SideNav/SideNav.scss
+++ b/src/containers/SideNav/SideNav.scss
@@ -11,8 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '~carbon-components/scss/globals/scss/vars';
-
 .bx--header ~ {
   nav.bx--side-nav {
     .bx--list-box__wrapper {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Load only the Carbon styles we use, also separating the Carbon
import from our styles for improved recompile performance during development.

This is a first pass and reduces the main CSS bundle from 386KiB to 300KiB.
We should be able to reduce this even further by addressing the Plex imports,
as well as minor refactoring of some of our component usage.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
