### PR TITLE
Fix modal + notifications for Import Resources and Create PipelineRun/TaskRun

### DIFF
--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -46,19 +46,31 @@ export function getPatchHeaders(headers = {}) {
   };
 }
 
+function parseBody(response) {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength === '0') {
+    return null;
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('text/plain')) {
+    return response.text();
+  }
+  return response.json();
+}
+
 export function checkStatus(response = {}) {
   if (response.ok) {
     switch (response.status) {
       case 201:
-        return response.headers;
+        return {
+          headers: response.headers,
+          body: parseBody(response)
+        };
       case 204:
         return {};
       default:
-        const contentType = response.headers.get('content-type');
-        if (contentType && contentType.includes('text/plain')) {
-          return response.text();
-        }
-        return response.json();
+        return parseBody(response);
     }
   }
 

--- a/src/api/comms.test.js
+++ b/src/api/comms.test.js
@@ -96,9 +96,28 @@ describe('checkStatus', () => {
   });
 
   it('returns headers on successful create', () => {
+    const headers = { get: jest.fn() };
     const status = 201;
-    const headers = { fake: 'headers' };
-    expect(checkStatus({ ok: true, headers, status })).toEqual(headers);
+    const response = {
+      headers,
+      json: jest.fn(),
+      ok: true,
+      status
+    };
+    expect(checkStatus(response)).toEqual(expect.objectContaining({ headers }));
+  });
+
+  it('handles empty response body', () => {
+    const headers = { get: () => '0' };
+    const status = 201;
+    const response = {
+      headers,
+      ok: true,
+      status
+    };
+    expect(checkStatus(response)).toEqual(
+      expect.objectContaining({ body: null, headers })
+    );
   });
 
   it('throws an error on failure', () => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -224,7 +224,7 @@ export function createPipelineRun({
     payload.spec.timeout = timeout;
   }
   const uri = getTektonAPI('pipelineruns', { namespace });
-  return post(uri, payload);
+  return post(uri, payload).then(({ body }) => body);
 }
 
 export function getClusterTasks({ filters = [] } = {}) {
@@ -325,7 +325,7 @@ export function getPodLog({ container, name, namespace }) {
 
 export function rerunPipelineRun(namespace, payload) {
   const uri = getAPI('rerun', { namespace });
-  return post(uri, payload);
+  return post(uri, payload).then(({ headers }) => headers);
 }
 
 export function getCredentials({ namespace } = {}) {
@@ -587,7 +587,7 @@ export function createTaskRun({
     payload.spec.timeout = timeout;
   }
   const uri = getTektonAPI('taskruns', { namespace });
-  return post(uri, payload);
+  return post(uri, payload).then(({ body }) => body);
 }
 
 export function importResources({
@@ -755,5 +755,5 @@ export function importResources({
   }
 
   const uri = getTektonAPI('pipelineruns', { namespace: importerNamespace });
-  return post(uri, payload);
+  return post(uri, payload).then(({ body }) => body);
 }

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -463,7 +463,7 @@ it('createPipelineRun', () => {
     }
   };
   mockCSRFToken();
-  fetchMock.post('*', data);
+  fetchMock.post('*', { body: data, status: 201 });
   return index.createPipelineRun(payload).then(response => {
     expect(response).toEqual(data);
     expect(fetchMock.lastOptions()).toMatchObject({
@@ -525,7 +525,7 @@ it('createPipelineRun with nodeSelector', () => {
     }
   };
   mockCSRFToken();
-  fetchMock.post('*', data);
+  fetchMock.post('*', { body: data, status: 201 });
   return index.createPipelineRun(payload).then(response => {
     expect(response).toEqual(data);
     expect(fetchMock.lastOptions()).toMatchObject({
@@ -821,13 +821,16 @@ it('deleteTaskRun', () => {
 
 it('rerunPipelineRun', () => {
   const namespace = 'namespace';
-  const data = { fake: 'pipelineRun' };
+  const body = { fake: 'pipelineRun' };
+  const headerName = 'fake_headerName';
+  const headerValue = 'fake_headerValue';
+  const headers = { [headerName]: headerValue };
   mockCSRFToken();
-  fetchMock.post(`end:/rerun/`, data);
+  fetchMock.post(`end:/rerun/`, { body, headers, status: 201 });
   return index
     .rerunPipelineRun(namespace, { fake: 'existingPipelineRun' })
-    .then(pipelineRun => {
-      expect(pipelineRun).toEqual(data);
+    .then(data => {
+      expect(data.get(headerName)).toEqual(headerValue);
       fetchMock.restore();
     });
 });
@@ -835,7 +838,7 @@ it('rerunPipelineRun', () => {
 it('createTaskRun uses correct kubernetes information', () => {
   const data = { fake: 'createtaskrun' };
   mockCSRFToken();
-  fetchMock.post(/taskruns/, data);
+  fetchMock.post(/taskruns/, { body: data, status: 201 });
   return index.createTaskRun({}).then(response => {
     expect(response).toEqual(data);
     const sentBody = JSON.parse(fetchMock.lastOptions().body);
@@ -1127,7 +1130,7 @@ it('importResources', () => {
   };
 
   mockCSRFToken();
-  fetchMock.post('*', data);
+  fetchMock.post('*', { body: data, status: 201 });
   return index.importResources(payload).then(response => {
     expect(response).toEqual(data);
     expect(JSON.parse(fetchMock.lastOptions().body)).toMatchObject(data);

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -171,8 +171,8 @@ export class ImportResources extends Component {
       serviceAccount,
       importerNamespace
     })
-      .then(headers => {
-        const pipelineRunName = headers.metadata.name;
+      .then(body => {
+        const pipelineRunName = body.metadata.name;
 
         const finalURL = urls.pipelineRuns.byName({
           namespace: importerNamespace,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In Dashboard 0.7.1 and earlier we were not correctly setting the response status
code on proxied responses from the API server. This meant that requests to create
PipelineRuns were returning with a status code 200 on success, instead of the
expected 201 for this API.

With the updated proxy approach we're now correctly setting the status code
on responses, meaning that we triggered a different code path in the front end
for parsing the response. This code path was not expecting a response body with 201,
so the response body remained unread and code relying on it was not properly executed.

As a result, the dialogs were not dismissed and notifications were not displayed
on successful creation of the PipelineRun / TaskRun on these pages.

Update the frontend code to handle 201 responses both with and without response body,
and update unit tests to more accurately test the behaviour of the affected APIs.

Thanks to @eddycharly for helping to debug this one.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
