### PR TITLE
Fix missing icons for PipelineRunStopping and PipelineRunCouldntCancel reasons

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.scss
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.scss
@@ -47,9 +47,18 @@ limitations under the License.
     }
   }
 
-  &[data-status='Unknown'][data-reason='Running'] {
-    .tkn--status-icon {
-      fill: $running;
+  &[data-status='Unknown'] {
+    &[data-reason='Running'],
+    &[data-reason='PipelineRunStopping'] {
+      .tkn--status-icon {
+        fill: $running;
+      }
+    }
+
+    &[data-reason='PipelineRunCouldntCancel'] {
+      .tkn--status-icon {
+        fill: $failed;
+      }
     }
   }
 }

--- a/packages/components/src/components/RunHeader/RunHeader.scss
+++ b/packages/components/src/components/RunHeader/RunHeader.scss
@@ -91,13 +91,15 @@ limitations under the License.
     }
   }
 
-  &[data-succeeded='False'] {
+  &[data-succeeded='False'],
+  &[data-succeeded='Unknown'][data-reason='PipelineRunCouldntCancel'] {
     .tkn--status-label {
       color: $failed;
     }
   }
 
-  &[data-succeeded='Unknown'][data-reason='Running'] {
+  &[data-succeeded='Unknown'][data-reason='Running'],
+  &[data-succeeded='Unknown'][data-reason='PipelineRunStopping'] {
     .tkn--status-label {
       color: $running;
     }

--- a/packages/components/src/components/StatusIcon/StatusIcon.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.js
@@ -36,6 +36,8 @@ export default function StatusIcon({ reason, status }) {
     Icon = CheckmarkFilled;
   } else if (status === 'False') {
     Icon = CloseFilled;
+  } else if (status === 'Unknown' && reason === 'PipelineRunCouldntCancel') {
+    Icon = CloseFilled;
   }
 
   return Icon ? <Icon className="tkn--status-icon" /> : null;

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -156,7 +156,10 @@ export function reorderSteps(unorderedSteps, orderedSteps) {
 }
 
 export function isRunning(reason, status) {
-  return status === 'Unknown' && reason === 'Running';
+  return (
+    status === 'Unknown' &&
+    (reason === 'Running' || reason === 'PipelineRunStopping')
+  );
 }
 
 // Generates a unique id

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -167,6 +167,7 @@ it('getStatus with no status', () => {
 
 it('isRunning', () => {
   expect(isRunning('Running', 'Unknown')).toBe(true);
+  expect(isRunning('PipelineRunStopping', 'Unknown')).toBe(true);
   expect(isRunning('?', 'Unknown')).toBe(false);
   expect(isRunning('Running', '?')).toBe(false);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1549

PipelineRunStopping is a new reason introduced in Pipelines 0.14. It should be
considered as a 'running' state and continue to display the spinner.

PipelineRunCouldntCancel should be considered an error state and display the red
'X' icon.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
