### PR TITLE
Add stream-logs and ingress-url options by default to prepare-kind-cluster

### DIFF
--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -14,7 +14,7 @@
 set -e
 
 CLUSTERNAME=dashboard
-DEFAULT_OPTIONS="--log-format console"
+DEFAULT_OPTIONS="--log-format console --stream-logs --ingress-url tekton-dashboard.127.0.0.1.nip.io"
 
 create_cluster() {
 cat <<EOF | kind create cluster --name $CLUSTERNAME --config -


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR add stream-logs and ingress-url options by default to prepare-kind-cluster.

/cc @AlanGreene @a-roberts 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
