### PR TITLE
Document an oauth-proxy issue workaround

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -188,6 +188,10 @@ Simply browse the url returned by running the following command to access your D
 kubectl get route tekton-dashboard -n openshift-pipelines
 ```
 
+**Known issue:**
+
+If the default ingress certificate in the OpenShift cluster was changed, for example via [this procedure](https://docs.openshift.com/container-platform/4.3/authentication/certificates/replacing-default-ingress-certificate.html), then the oauth-proxy sidecar might not recognize its certificate, and you might arrive at a "500 Internal Error" page instead of the dashboard. Refer to [this workaround](./oauth-certificate-workaround.md) for a procedure to resolve the issue.
+
 ## Uninstalling the Dashboard on Kubernetes
 
 The Dashboard can be uninstalled by running the following command:

--- a/docs/oauth-certificate-workaround.md
+++ b/docs/oauth-certificate-workaround.md
@@ -1,0 +1,61 @@
+# 500 Internal Error page when accessing the dashboard on OpenShift
+
+If the default ingress certificate in the OpenShift cluster was changed, then the certificate the OpenShift OAuth server uses might no longer be recognized automatically by the `oauth-proxy` container deployed as a sidecar with the dashboard. In this situation, you may see a "500 Internal Error" page when trying to access the dashboard, with an error message containing "certificate signed by unknown authority". The logs of the `oauth-proxy` container might also show errors like this:
+```
+2020/07/07 11:12:13 oauthproxy.go:645: error redeeming code (client: [ IP address elided ]): Post https://oauth-openshift.apps.[ url elided ]/oauth/token: x509: certificate signed by unknown authority
+2020/07/07 11:12:13 oauthproxy.go:438: ErrorPage 500 Internal Error Internal Error
+```
+
+## Workaround
+
+OpenShift can populate a ConfigMap containing certificates that should be trusted by applications in the cluster. More information on that proccess can be found here: https://docs.openshift.com/container-platform/4.3/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki.
+
+To create that ConfigMap, create a file named "ocp-ca-bundle-configmap.yaml" with these contents:
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ocp-ca-bundle
+  namespace: tekton-pipelines
+```
+
+And apply it to the cluster via `oc create -f ocp-ca-bundle-configmap.yaml`.
+
+Then, create a file named "dashboard-patch.yaml" with these contents:
+```
+spec:
+  template:
+    spec:
+      containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --skip-provider-button=true
+            - --openshift-service-account=tekton-dashboard
+            - --upstream=http://localhost:9097
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - --skip-auth-regex=^/v1/extensions/.*\.js
+            - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --openshift-ca=/etc/ocp-injected-certs/tls-ca-bundle.pem
+          volumeMounts:
+            - mountPath: /etc/ocp-injected-certs
+              name: ocp-injected-certs
+      volumes:
+        - name: ocp-injected-certs
+          configMap:
+            name: ocp-ca-bundle
+            defaultMode: 420
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+```
+
+And apply it to the dashboard deployment via:
+```
+oc -n tekton-pipelines patch deployment tekton-dashboard --patch "$(cat dashboard-patch.yaml)" 
+```


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This documents a workaround for https://github.com/tektoncd/dashboard/issues/1603, where the dashboard is not accessible on OpenShift after some certificates have changed in the cluster. It describes a patch which can be used to inject trusted certificates into the oauth-proxy container, resolving the `certificate signed by unknown authority` error.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
