### PR TITLE
Remove `step=__` from URL for PipelineRun and TaskRun details pages

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -23,7 +23,6 @@ import {
   getParams,
   getResources,
   getStatus,
-  NO_STEP,
   reorderSteps,
   selectedTask,
   selectedTaskRun,
@@ -335,7 +334,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       }
     );
 
-    const logContainer = selectedStepId && selectedStepId !== NO_STEP && (
+    const logContainer = selectedStepId && (
       <Log
         downloadButton={
           LogDownloadButton && (
@@ -374,7 +373,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
             selectedStepId={selectedStepId}
             taskRuns={taskRuns}
           />
-          {(selectedStepId && selectedStepId !== NO_STEP && (
+          {(selectedStepId && (
             <StepDetails
               definition={definition}
               logContainer={logContainer}

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -19,7 +19,7 @@ import {
 } from '@carbon/icons-react';
 import { Spinner, Step } from '@tektoncd/dashboard-components';
 
-import { NO_STEP, updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
+import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
 
 import './Task.scss';
 
@@ -44,13 +44,16 @@ class Task extends Component {
 
   handleTaskSelected = event => {
     event?.preventDefault(); // eslint-disable-line no-unused-expressions
-    this.setState({ selectedStepId: NO_STEP }, () => {
+    this.setState({ selectedStepId: null }, () => {
       this.handleClick();
     });
   };
 
   selectDefaultStep() {
-    const { expanded, selectedStepId, steps } = this.props;
+    const { expanded, selectDefaultStep, selectedStepId, steps } = this.props;
+    if (!selectDefaultStep) {
+      return;
+    }
     if (expanded && !selectedStepId) {
       const erroredStep = steps.find(
         step => step.reason === 'Error' || step.reason === undefined
@@ -93,10 +96,7 @@ class Task extends Component {
         className="tkn--task"
         data-succeeded={succeeded}
         data-reason={reason}
-        data-selected={
-          (expanded && (!selectedStepId || selectedStepId === NO_STEP)) ||
-          undefined
-        }
+        data-selected={(expanded && !selectedStepId) || undefined}
       >
         <a
           className="tkn--task-link"

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent, waitForElement } from 'react-testing-library';
-import { NO_STEP } from '@tektoncd/dashboard-utils';
 import Task from './Task';
 import { renderWithIntl } from '../../utils/test';
 
@@ -133,8 +132,11 @@ describe('Task', () => {
     );
   });
 
-  it('renders NO_STEP state', () => {
-    renderWithIntl(<Task {...props} expanded selectedStepId={NO_STEP} />);
+  it('renders selected step state', () => {
+    const steps = [{ id: 'step', stepName: 'a step' }];
+    renderWithIntl(
+      <Task {...props} expanded selectedStepId="some-step" steps={steps} />
+    );
   });
 
   it('handles click event', () => {
@@ -157,7 +159,8 @@ describe('Task', () => {
         steps={steps}
       />
     );
-    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+
     onSelect.mockClear();
     fireEvent.click(getByText(/build/i));
     expect(onSelect).toHaveBeenCalledTimes(1);

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -41,6 +41,7 @@ class TaskTree extends Component {
             (!selectedTaskId && erroredTask && erroredTask.id === id) ||
             selectedTaskId === id ||
             (!erroredTask && !selectedTaskId && index === 0);
+          const selectDefaultStep = !selectedTaskId;
           return (
             <Task
               id={id}
@@ -48,6 +49,7 @@ class TaskTree extends Component {
               expanded={expanded}
               onSelect={this.handleSelect}
               reason={reason}
+              selectDefaultStep={selectDefaultStep}
               selectedStepId={selectedStepId}
               steps={sortStepsByTimestamp(steps)}
               succeeded={succeeded}

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -16,7 +16,6 @@ export { paths, urls } from './router';
 export { getStatus } from './status';
 
 export const ALL_NAMESPACES = '*';
-export const NO_STEP = '__';
 
 /* istanbul ignore next */
 export const copyToClipboard = text => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Eliminate the need for the `step=__` query param to view the TaskRun
details on both the PipelineRun and TaskRun details pages.

Maintain the default behaviour of selecting the first / first failed
step when loading these pages, but still allow for URL addressability
of the TaskRun details view showing params / status.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
