### PR TITLE
Use pipelineTask name for PipelineRun URL addressability

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -337,7 +337,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     const logContainer = selectedStepId && (
       <Log
         downloadButton={
-          LogDownloadButton && (
+          LogDownloadButton &&
+          stepStatus && (
             <LogDownloadButton
               stepName={stepName}
               stepStatus={stepStatus}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/487

Instead of using the TaskRun uid + pod name in the URL to address
a specific TaskRun retry, use the more user-friendly pipeline task
name and a separate numeric retry parameter.

This produces a more user-friendly URL, is more easily constructed
by pipeline authors, and doesn't rely as much on kubernetes-isms
(i.e. pod name).

This change is based on feedback from preview users.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
