### PR TITLE
Rename 'credentials' to 'secrets' for consistency

### DIFF
--- a/src/actions/secrets.js
+++ b/src/actions/secrets.js
@@ -12,10 +12,10 @@ limitations under the License.
 */
 
 import {
-  createCredential,
-  deleteCredential,
-  getCredential,
-  getCredentials,
+  createSecret as createSecretAPI,
+  deleteSecret as deleteSecretAPI,
+  getSecret,
+  getSecrets,
   getServiceAccounts,
   patchServiceAccount,
   updateServiceAccountSecrets
@@ -34,13 +34,13 @@ export function fetchSecretsSuccess(data) {
 }
 
 export function fetchSecrets({ namespace } = {}) {
-  return fetchNamespacedCollection('Secret', getCredentials, {
+  return fetchNamespacedCollection('Secret', getSecrets, {
     namespace
   });
 }
 
 export function fetchSecret({ name, namespace }) {
-  const secret = fetchNamespacedResource('Secret', getCredential, {
+  const secret = fetchNamespacedResource('Secret', getSecret, {
     namespace,
     name
   });
@@ -120,11 +120,11 @@ export function deleteSecret(secrets, cancelMethod) {
       });
     });
 
-    // This is where we delete the credentials (kube secrets) themselves
+    // This is where we delete the kube secrets themselves
     const timeoutLength = secrets.length * 1000;
     const deletePromises = secrets.map(secret => {
       const { name, namespace } = secret;
-      const response = deleteCredential(name, namespace);
+      const response = deleteSecretAPI(name, namespace);
       const timeout = new Promise((resolve, reject) => {
         setTimeout(() => {
           reject(new Error('An error occurred deleting the secret(s).'));
@@ -155,7 +155,7 @@ export function createSecret(postData, namespace) {
     });
     dispatch({ type: 'SECRET_CREATE_REQUEST' });
     try {
-      await createCredential(postData, namespace);
+      await createSecretAPI(postData, namespace);
       dispatch({
         type: 'SECRET_CREATE_SUCCESS'
       });

--- a/src/actions/secrets.test.js
+++ b/src/actions/secrets.test.js
@@ -121,7 +121,7 @@ it('fetchSecrets', async () => {
   jest
     .spyOn(selectors, 'getSelectedNamespace')
     .mockImplementation(() => namespace);
-  jest.spyOn(SecretsAPI, 'getCredentials').mockImplementation(() => data);
+  jest.spyOn(SecretsAPI, 'getSecrets').mockImplementation(() => data);
 
   const expectedActions = [
     { type: 'SECRETS_FETCH_REQUEST' },
@@ -142,7 +142,7 @@ it('fetchSecrets error', async () => {
   jest
     .spyOn(selectors, 'getSelectedNamespace')
     .mockImplementation(() => namespace);
-  jest.spyOn(SecretsAPI, 'getCredentials').mockImplementation(() => {
+  jest.spyOn(SecretsAPI, 'getSecrets').mockImplementation(() => {
     throw error;
   });
 
@@ -165,7 +165,7 @@ it('fetchSecret', () => {
   fetchSecret({ name, namespace });
   expect(creators.fetchNamespacedResource).toHaveBeenCalledWith(
     'Secret',
-    SecretsAPI.getCredential,
+    SecretsAPI.getSecret,
     { name, namespace }
   );
 });
@@ -189,7 +189,7 @@ it('deleteSecret', async () => {
   jest
     .spyOn(ServiceAccountsAPI, 'updateServiceAccountSecrets')
     .mockImplementation(() => {});
-  jest.spyOn(SecretsAPI, 'deleteCredential').mockImplementation(() => {});
+  jest.spyOn(SecretsAPI, 'deleteSecret').mockImplementation(() => {});
 
   const expectedActions = [
     { type: 'CLEAR_SECRET_ERROR_NOTIFICATION' },
@@ -216,7 +216,7 @@ it('deleteSecret error', async () => {
     .spyOn(ServiceAccountsAPI, 'updateServiceAccountSecrets')
     .mockImplementation(() => {});
   jest
-    .spyOn(SecretsAPI, 'deleteCredential')
+    .spyOn(SecretsAPI, 'deleteSecret')
     .mockImplementation(() => Promise.reject());
 
   const expectedActions = [
@@ -240,8 +240,8 @@ it('createSecret', async () => {
     .spyOn(selectors, 'getSelectedNamespace')
     .mockImplementation(() => namespace);
 
-  jest.spyOn(SecretsAPI, 'getCredentials').mockImplementation(() => data);
-  jest.spyOn(SecretsAPI, 'createCredential').mockImplementation(() => response);
+  jest.spyOn(SecretsAPI, 'getSecrets').mockImplementation(() => data);
+  jest.spyOn(SecretsAPI, 'createSecret').mockImplementation(() => response);
 
   const expectedActions = [
     { type: 'CLEAR_SECRET_ERROR_NOTIFICATION' },
@@ -268,11 +268,11 @@ it('createSecret error', async () => {
     }
   };
 
-  jest.spyOn(SecretsAPI, 'createCredential').mockImplementation(() => {
+  jest.spyOn(SecretsAPI, 'createSecret').mockImplementation(() => {
     throw error;
   });
 
-  jest.spyOn(SecretsAPI, 'getAllCredentials').mockImplementation(() => data);
+  jest.spyOn(SecretsAPI, 'getAllSecrets').mockImplementation(() => data);
 
   const expectedActions = [
     { type: 'CLEAR_SECRET_ERROR_NOTIFICATION' },

--- a/src/api/secrets.js
+++ b/src/api/secrets.js
@@ -14,32 +14,32 @@ limitations under the License.
 import { deleteRequest, get, post, put } from './comms';
 import { checkData, getKubeAPI } from './utils';
 
-export function getCredentials({ namespace } = {}) {
+export function getSecrets({ namespace } = {}) {
   const uri = getKubeAPI('secrets', { namespace });
   return get(uri).then(checkData);
 }
 
-export function getAllCredentials(namespace) {
+export function getAllSecrets(namespace) {
   const uri = getKubeAPI('secrets', namespace);
   return get(uri);
 }
 
-export function getCredential(name, namespace) {
+export function getSecret(name, namespace) {
   const uri = getKubeAPI('secrets', name, namespace);
   return get(uri);
 }
 
-export function createCredential({ id, ...rest }, namespace) {
+export function createSecret({ id, ...rest }, namespace) {
   const uri = getKubeAPI('secrets', { namespace });
   return post(uri, { id, ...rest });
 }
 
-export function updateCredential({ id, ...rest }, namespace) {
+export function updateSecret({ id, ...rest }, namespace) {
   const uri = getKubeAPI('secrets', { name: id, namespace });
   return put(uri, { id, ...rest });
 }
 
-export function deleteCredential(id, namespace) {
+export function deleteSecret(id, namespace) {
   const uri = getKubeAPI('secrets', { name: id, namespace });
   return deleteRequest(uri);
 }

--- a/src/api/secrets.test.js
+++ b/src/api/secrets.test.js
@@ -15,40 +15,40 @@ import fetchMock from 'fetch-mock';
 import * as API from './secrets';
 import { mockCSRFToken } from '../utils/test';
 
-it('getCredentials', () => {
+it('getSecrets', () => {
   const data = {
-    items: 'credentials'
+    items: 'secrets'
   };
   fetchMock.get(/secrets/, data);
-  return API.getCredentials().then(response => {
+  return API.getSecrets().then(response => {
     expect(response).toEqual(data.items);
     fetchMock.restore();
   });
 });
 
-it('getAllCredentials', () => {
+it('getAllSecrets', () => {
   const data = {
-    items: 'credentials'
+    items: 'secrets'
   };
   fetchMock.get(/secrets/, data);
-  return API.getAllCredentials().then(response => {
+  return API.getAllSecrets().then(response => {
     expect(response).toEqual(data);
     fetchMock.restore();
   });
 });
 
-it('getCredential', () => {
-  const credentialId = 'foo';
+it('getSecret', () => {
+  const secretId = 'foo';
   const namespace = 'default';
-  const data = { fake: 'credential' };
+  const data = { fake: 'secret' };
   fetchMock.get(/secrets/, data);
-  return API.getCredential(credentialId, namespace).then(credential => {
-    expect(credential).toEqual(data);
+  return API.getSecret(secretId, namespace).then(secret => {
+    expect(secret).toEqual(data);
     fetchMock.restore();
   });
 });
 
-it('createCredential', () => {
+it('createSecret', () => {
   const id = 'id';
   const username = 'username';
   const password = 'password';
@@ -57,7 +57,7 @@ it('createCredential', () => {
   const data = { fake: 'data' };
   mockCSRFToken();
   fetchMock.post('*', data);
-  return API.createCredential(payload).then(response => {
+  return API.createSecret(payload).then(response => {
     expect(response).toEqual(data);
     expect(fetchMock.lastOptions()).toMatchObject({
       body: JSON.stringify(payload)
@@ -66,7 +66,7 @@ it('createCredential', () => {
   });
 });
 
-it('updateCredential', () => {
+it('updateSecret', () => {
   const id = 'id';
   const username = 'username';
   const password = 'password';
@@ -75,7 +75,7 @@ it('updateCredential', () => {
   const data = { fake: 'data' };
   mockCSRFToken();
   fetchMock.put('*', data);
-  return API.updateCredential(payload).then(response => {
+  return API.updateSecret(payload).then(response => {
     expect(response).toEqual(data);
     expect(fetchMock.lastOptions()).toMatchObject({
       body: JSON.stringify(payload)
@@ -84,12 +84,12 @@ it('updateCredential', () => {
   });
 });
 
-it('deleteCredential', () => {
-  const credentialId = 'fake credential id';
+it('deleteSecret', () => {
+  const secretId = 'fake secret id';
   const data = { fake: 'data' };
   mockCSRFToken();
   fetchMock.delete('*', data);
-  return API.deleteCredential(credentialId).then(response => {
+  return API.deleteSecret(secretId).then(response => {
     expect(response).toEqual(data);
     fetchMock.restore();
   });

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -161,7 +161,7 @@ it('click add new secret and create secret UI appears', () => {
     ]
   };
 
-  jest.spyOn(SecretsAPI, 'getCredentials').mockImplementation(() => []);
+  jest.spyOn(SecretsAPI, 'getSecrets').mockImplementation(() => []);
   jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
   jest
     .spyOn(ServiceAccountsAPI, 'getServiceAccounts')


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
'credentials' is a legacy name from before we adopted the Kubernetes
Secret kind.

The UI and APIs have all been updated to reference Secret, so it makes
sense to rename remaining references to 'credential(s)' for consistency
and avoid unnecessary dev confusion.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
