### PR TITLE
Fix OverflowMenu focus and keyboard nav issue

### DIFF
--- a/packages/components/src/components/RunDropdown/RunDropdown.js
+++ b/packages/components/src/components/RunDropdown/RunDropdown.js
@@ -54,6 +54,7 @@ class RunDropdown extends Component {
           iconDescription={title}
           data-testid="overflowmenu"
           flipped
+          selectorPrimaryFocus="button:not([disabled])"
         >
           {items.map(item => {
             const {
@@ -73,7 +74,6 @@ class RunDropdown extends Component {
                 onClick={() =>
                   this.handleShow(() => action(resource), modalProperties)
                 }
-                primaryFocus={!disabled}
                 requireTitle
               />
             );


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The latest Carbon update marked the `primaryFocus` prop on OverflowMenuItem
as deprecated, however it's actually not used anymore. This means that when
an OverflowMenu is opened, nothing gets focus by default breaking keyboard
nav.

Use the `selectorPrimaryFocus` prop on the OverflowMenu instead. The default
value does not match anything, so set it to match the first enabled button.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
