### PR TITLE
Ensure label / annotation forms fully support keyboard navigation

### DIFF
--- a/packages/components/src/components/KeyValueList/KeyValueList.js
+++ b/packages/components/src/components/KeyValueList/KeyValueList.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Button, TextInput } from 'carbon-components-react';
-import { AddAlt24 as Add, CloseOutline20 as Remove } from '@carbon/icons-react';
+import { AddAlt24 as Add, SubtractAlt16 as Remove } from '@carbon/icons-react';
 
 import './KeyValueList.scss';
 
@@ -74,10 +74,15 @@ const KeyValueList = props => {
             autoComplete="off"
           />
           {keyValues.length > minKeyValues && (
-            <Remove
-              className="tkn--keyvalue-remove"
+            <Button
+              hasIconOnly
+              iconDescription={removeTitle}
+              kind="ghost"
               onClick={() => onRemove(index)}
-              title={removeTitle}
+              renderIcon={Remove}
+              size="field"
+              tooltipAlignment="center"
+              tooltipPosition="bottom"
             />
           )}
         </div>

--- a/packages/components/src/components/KeyValueList/KeyValueList.scss
+++ b/packages/components/src/components/KeyValueList/KeyValueList.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -49,9 +49,12 @@ limitations under the License.
       margin-right: $spacing-07;
     }
 
-    .tkn--keyvalue-remove {
-      fill: $interactive-01;
-      cursor: pointer;
+    .bx--btn--ghost.bx--btn--icon-only {
+      &:focus, &:hover {
+        svg, path {
+          fill: #ad1625;
+        }
+      }
     }
   }
 }

--- a/packages/components/src/components/KeyValueList/KeyValueList.test.js
+++ b/packages/components/src/components/KeyValueList/KeyValueList.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -150,7 +150,7 @@ it('KeyValueList add and remove buttons work', () => {
     onAdd: jest.fn(),
     onRemove: jest.fn()
   };
-  const { getByText, getByTitle } = renderWithIntl(<KeyValueList {...props} />);
+  const { getByText } = renderWithIntl(<KeyValueList {...props} />);
 
   const addButton = getByText(/Add/i);
 
@@ -160,9 +160,9 @@ it('KeyValueList add and remove buttons work', () => {
   fireEvent.click(addButton);
   fireEvent.click(addButton);
 
-  fireEvent.click(getByTitle(/Remove/i));
-  fireEvent.click(getByTitle(/Remove/i));
-  fireEvent.click(getByTitle(/Remove/i));
+  fireEvent.click(getByText(/Remove/i));
+  fireEvent.click(getByText(/Remove/i));
+  fireEvent.click(getByText(/Remove/i));
 
   expect(props.onAdd).toHaveBeenCalledTimes(5);
   expect(props.onRemove).toHaveBeenCalledTimes(3);

--- a/src/components/CreateSecret/CreateSecret.scss
+++ b/src/components/CreateSecret/CreateSecret.scss
@@ -56,6 +56,7 @@ limitations under the License.
 
   .tkn--annotationDiv {
     display: flex;
+    align-items: center;
     width: 50%;
     .bx--dropdown__wrapper {
       width: 40%;
@@ -65,10 +66,12 @@ limitations under the License.
       flex-grow: 1;
       margin-right: $spacing-05;
     }
-    .tkn--createsecret-removeIcon {
-      margin-top: 34px;
-      fill: $interactive-01;
-      cursor: pointer;
+    .bx--btn--ghost.bx--btn--icon-only {
+      &:focus, &:hover {
+        svg, path {
+          fill: #ad1625;
+        }
+      }
     }
   }
 }

--- a/src/components/CreateSecret/Form/Annotations.js
+++ b/src/components/CreateSecret/Form/Annotations.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Button, Dropdown, TextInput } from 'carbon-components-react';
-import { AddAlt24 as Add, CloseOutline20 as Remove } from '@carbon/icons-react';
+import { AddAlt24 as Add, SubtractAlt16 as Remove } from '@carbon/icons-react';
 import { getTranslateWithId } from '@tektoncd/dashboard-utils';
 
 const itemToString = item => (item ? item.text : '');
@@ -38,6 +38,11 @@ const Annotations = props => {
   const dockerIntlText = intl.formatMessage({
     id: 'dashboard.createSecret.accessToDocker',
     defaultMessage: 'Docker Registry'
+  });
+
+  const removeTitle = intl.formatMessage({
+    id: 'dashboard.keyValueList.remove',
+    defaultMessage: 'Remove'
   });
 
   return (
@@ -93,11 +98,17 @@ const Annotations = props => {
               disabled={loading}
             />
             {annotations.length !== 1 && (
-              <Remove
-                className="tkn--createsecret-removeIcon"
+              <Button
                 data-testid="removeIcon"
-                onClick={() => handleRemove(index)}
                 disabled={loading}
+                hasIconOnly
+                iconDescription={removeTitle}
+                kind="ghost"
+                onClick={() => handleRemove(index)}
+                renderIcon={Remove}
+                size="field"
+                tooltipAlignment="center"
+                tooltipPosition="bottom"
               />
             )}
           </div>

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -473,12 +473,7 @@ describe('CreatePipelineRun', () => {
   });
 
   it('renders labels', () => {
-    const {
-      getByText,
-      getByPlaceholderText,
-      getByTitle,
-      queryByValue
-    } = renderWithIntl(
+    const { getByText, getByPlaceholderText, queryByValue } = renderWithIntl(
       <Provider store={mockStore(testStore)}>
         <CreatePipelineRun open namespace="" />
       </Provider>
@@ -492,7 +487,7 @@ describe('CreatePipelineRun', () => {
     });
     expect(queryByValue(/foo/i)).toBeTruthy();
     expect(queryByValue(/bar/i)).toBeTruthy();
-    fireEvent.click(getByTitle(/Remove/i));
+    fireEvent.click(getByText(/Remove/i));
     expect(queryByValue(/foo/i)).toBeFalsy();
     expect(queryByValue(/bar/i)).toBeFalsy();
   });

--- a/src/containers/CreateTaskRun/CreateTaskRun.test.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.js
@@ -496,12 +496,7 @@ describe('CreateTaskRun', () => {
   });
 
   it('renders labels', () => {
-    const {
-      getByText,
-      getByPlaceholderText,
-      getByTitle,
-      queryByValue
-    } = renderWithIntl(
+    const { getByText, getByPlaceholderText, queryByValue } = renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun open namespace="" />
       </Provider>
@@ -515,7 +510,7 @@ describe('CreateTaskRun', () => {
     });
     expect(queryByValue(/foo/i)).toBeTruthy();
     expect(queryByValue(/bar/i)).toBeTruthy();
-    fireEvent.click(getByTitle(/Remove/i));
+    fireEvent.click(getByText(/Remove/i));
     expect(queryByValue(/foo/i)).toBeFalsy();
     expect(queryByValue(/bar/i)).toBeFalsy();
   });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The 'remove' action on the label and annotation lists in Create Secret,
Create PipelineRun, and Create TaskRun was an icon and therefore
not focusable by keyboard by default. This is both an accessibility
and general usability problem.

Replace the icon with an icon button. This is keyboard navigable
by default, and will be handled correctly by screenreaders and
other assistive technologies.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
