### PR TITLE
Display RunHeader with error details instead of 'No TaskRuns found' message

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -17,7 +17,7 @@ import {
   InlineNotification,
   StructuredListSkeleton
 } from 'carbon-components-react';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import {
   getErrorMessage,
   getParams,
@@ -320,15 +320,6 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       this.sortTaskRuns(taskRuns);
     }
 
-    if (taskRuns.length === 0) {
-      return (
-        <FormattedMessage
-          id="dashboard.taskRun.noTaskRuns"
-          defaultMessage="No TaskRuns found for this PipelineRun yet…"
-        />
-      );
-    }
-
     const taskRun = selectedTaskRun(selectedTaskId, taskRuns) || {};
 
     const { definition, reason, status, stepName, stepStatus } = taskRunStep(
@@ -372,35 +363,37 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           {rerun}
         </RunHeader>
         {customNotification}
-        <div className="tkn--tasks">
-          <TaskTree
-            onSelect={handleTaskSelected}
-            selectedTaskId={selectedTaskId}
-            selectedStepId={selectedStepId}
-            taskRuns={taskRuns}
-          />
-          {(selectedStepId && (
-            <StepDetails
-              definition={definition}
-              logContainer={logContainer}
-              onViewChange={onViewChange}
-              reason={reason}
-              showIO={showIO}
-              status={status}
-              stepName={stepName}
-              stepStatus={stepStatus}
-              taskRun={taskRun}
-              view={view}
+        {taskRuns.length > 0 && (
+          <div className="tkn--tasks">
+            <TaskTree
+              onSelect={handleTaskSelected}
+              selectedTaskId={selectedTaskId}
+              selectedStepId={selectedStepId}
+              taskRuns={taskRuns}
             />
-          )) ||
-            (selectedTaskId && (
-              <TaskRunDetails
+            {(selectedStepId && (
+              <StepDetails
+                definition={definition}
+                logContainer={logContainer}
                 onViewChange={onViewChange}
+                reason={reason}
+                showIO={showIO}
+                status={status}
+                stepName={stepName}
+                stepStatus={stepStatus}
                 taskRun={taskRun}
                 view={view}
               />
-            ))}
-        </div>
+            )) ||
+              (selectedTaskId && (
+                <TaskRunDetails
+                  onViewChange={onViewChange}
+                  taskRun={taskRun}
+                  view={view}
+                />
+              ))}
+          </div>
+        )}
       </>
     );
   }

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -255,7 +255,6 @@
     "dashboard.tableHeader.value": "Value",
     "dashboard.taskRun.errorLoading": "Error loading TaskRun",
     "dashboard.taskRun.logs": "Logs",
-    "dashboard.taskRun.noTaskRuns": "No TaskRuns found for this PipelineRun yet…",
     "dashboard.taskRun.params": "Parameters",
     "dashboard.taskRun.status": "Status",
     "dashboard.taskRun.status.cancelled": "Cancelled",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In some cases a PipelineRun fails to create any TaskRuns. In these cases
we display a plain text error message 'No TaskRuns found for this PipelineRun
yet...' that looks like an incomplete page load.

Update the PipelineRun component to display the RunHeader in these cases
so that we surface the error reason and message to users and the page
doesn't look like it failed to load fully.

Before:
![image](https://user-images.githubusercontent.com/2829095/88851358-932a6800-d1e4-11ea-8287-ccec3183f3d2.png)

After:
![image](https://user-images.githubusercontent.com/2829095/88851377-97ef1c00-d1e4-11ea-90fb-ac21f7a90f54.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
