### PR TITLE
Update backend to use v1beta1 Pipelines client

### DIFF
--- a/pkg/controllers/tekton/clustertask.go
+++ b/pkg/controllers/tekton/clustertask.go
@@ -27,7 +27,7 @@ func NewClusterTaskController(sharedTektonInformerFactory tektoninformer.SharedI
 
 	utils.NewController(
 		"ClusterTask",
-		sharedTektonInformerFactory.Tekton().V1alpha1().ClusterTasks().Informer(),
+		sharedTektonInformerFactory.Tekton().V1beta1().ClusterTasks().Informer(),
 		broadcaster.ClusterTaskCreated,
 		broadcaster.ClusterTaskUpdated,
 		broadcaster.ClusterTaskDeleted,

--- a/pkg/controllers/tekton/pipeline.go
+++ b/pkg/controllers/tekton/pipeline.go
@@ -27,7 +27,7 @@ func NewPipelineController(sharedTektonInformerFactory tektoninformer.SharedInfo
 
 	utils.NewController(
 		"Pipeline",
-		sharedTektonInformerFactory.Tekton().V1alpha1().Pipelines().Informer(),
+		sharedTektonInformerFactory.Tekton().V1beta1().Pipelines().Informer(),
 		broadcaster.PipelineCreated,
 		broadcaster.PipelineUpdated,
 		broadcaster.PipelineDeleted,

--- a/pkg/controllers/tekton/pipelinerun.go
+++ b/pkg/controllers/tekton/pipelinerun.go
@@ -27,7 +27,7 @@ func NewPipelineRunController(sharedTektonInformerFactory tektoninformer.SharedI
 
 	utils.NewController(
 		"PipelineRun",
-		sharedTektonInformerFactory.Tekton().V1alpha1().PipelineRuns().Informer(),
+		sharedTektonInformerFactory.Tekton().V1beta1().PipelineRuns().Informer(),
 		broadcaster.PipelineRunCreated,
 		broadcaster.PipelineRunUpdated,
 		broadcaster.PipelineRunDeleted,

--- a/pkg/controllers/tekton/task.go
+++ b/pkg/controllers/tekton/task.go
@@ -27,7 +27,7 @@ func NewTaskController(sharedTektonInformerFactory tektoninformer.SharedInformer
 
 	utils.NewController(
 		"Task",
-		sharedTektonInformerFactory.Tekton().V1alpha1().Tasks().Informer(),
+		sharedTektonInformerFactory.Tekton().V1beta1().Tasks().Informer(),
 		broadcaster.TaskCreated,
 		broadcaster.TaskUpdated,
 		broadcaster.TaskDeleted,

--- a/pkg/controllers/tekton/taskrun.go
+++ b/pkg/controllers/tekton/taskrun.go
@@ -27,7 +27,7 @@ func NewTaskRunController(sharedTektonInformerFactory tektoninformer.SharedInfor
 
 	utils.NewController(
 		"TaskRun",
-		sharedTektonInformerFactory.Tekton().V1alpha1().TaskRuns().Informer(),
+		sharedTektonInformerFactory.Tekton().V1beta1().TaskRuns().Informer(),
 		broadcaster.TaskRunCreated,
 		broadcaster.TaskRunUpdated,
 		broadcaster.TaskRunDeleted,

--- a/pkg/endpoints/pipeline.go
+++ b/pkg/endpoints/pipeline.go
@@ -22,7 +22,7 @@ import (
 	restful "github.com/emicklei/go-restful"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"github.com/tektoncd/dashboard/pkg/utils"
-	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,8 +31,8 @@ type RerunRequest struct {
 	PIPELINERUNNAME string `json:"pipelinerunname"`
 }
 
-func (r Resource) Rerun(name, namespace string) (*v1alpha1.PipelineRun, error) {
-	pipelineRuns := r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace)
+func (r Resource) Rerun(name, namespace string) (*v1beta1.PipelineRun, error) {
+	pipelineRuns := r.PipelineClient.TektonV1beta1().PipelineRuns(namespace)
 	pipelineRun, err := pipelineRuns.Get(name, metav1.GetOptions{})
 
 	if err != nil {
@@ -61,7 +61,7 @@ func (r Resource) Rerun(name, namespace string) (*v1alpha1.PipelineRun, error) {
 		newPipelineRunData.SetLabels(currentLabels)
 	}
 
-	rebuiltRun, err := r.PipelineClient.TektonV1alpha1().PipelineRuns(pipelineRun.Namespace).Create(newPipelineRunData)
+	rebuiltRun, err := r.PipelineClient.TektonV1beta1().PipelineRuns(pipelineRun.Namespace).Create(newPipelineRunData)
 
 	if err != nil {
 		logging.Log.Errorf("an error occurred rerunning the PipelineRun %s in namespace %s: %s", name, namespace, err)
@@ -95,7 +95,7 @@ func generateNewNameForRerun(name string) string {
    TODO eventually this would be great to take different params too as users may want to run the \
 	 same pipeline just with different inputs */
 
-func (r Resource) rerunImpl(existingPipelineRun *v1alpha1.PipelineRun, existingPipelineRunName, namespace string) (*v1alpha1.PipelineRun, error) {
+func (r Resource) rerunImpl(existingPipelineRun *v1beta1.PipelineRun, existingPipelineRunName, namespace string) (*v1beta1.PipelineRun, error) {
 	if existingPipelineRunName != "" {
 		rebuiltRun, err := r.Rerun(existingPipelineRunName, namespace)
 		if err != nil {
@@ -105,7 +105,7 @@ func (r Resource) rerunImpl(existingPipelineRun *v1alpha1.PipelineRun, existingP
 	}
 
 	if existingPipelineRun != nil {
-		madeRun, err := r.PipelineClient.TektonV1alpha1().PipelineRuns(existingPipelineRun.Namespace).Create(existingPipelineRun)
+		madeRun, err := r.PipelineClient.TektonV1beta1().PipelineRuns(existingPipelineRun.Namespace).Create(existingPipelineRun)
 		if err != nil {
 			logging.Log.Errorf("error creating a new PipelineRun from spec: %s", err)
 			return nil, err

--- a/pkg/endpoints/websocket_test.go
+++ b/pkg/endpoints/websocket_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tektoncd/dashboard/pkg/testutils"
 	"github.com/tektoncd/dashboard/pkg/websocket"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -283,7 +284,7 @@ func CUDPipelineResources(r *Resource, t *testing.T, namespace string) {
 func CUDPipelines(r *Resource, t *testing.T, namespace string) {
 	resourceVersion := "1"
 
-	pipeline := v1alpha1.Pipeline{
+	pipeline := v1beta1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "pipeline",
 			ResourceVersion: resourceVersion,
@@ -291,7 +292,7 @@ func CUDPipelines(r *Resource, t *testing.T, namespace string) {
 	}
 
 	t.Log("Creating pipeline")
-	_, err := r.PipelineClient.TektonV1alpha1().Pipelines(namespace).Create(&pipeline)
+	_, err := r.PipelineClient.TektonV1beta1().Pipelines(namespace).Create(&pipeline)
 	if err != nil {
 		t.Fatalf("Error creating pipeline: %s: %s\n", pipeline.Name, err.Error())
 	}
@@ -299,13 +300,13 @@ func CUDPipelines(r *Resource, t *testing.T, namespace string) {
 	newVersion := "2"
 	pipeline.ResourceVersion = newVersion
 	t.Log("Updating pipeline")
-	_, err = r.PipelineClient.TektonV1alpha1().Pipelines(namespace).Update(&pipeline)
+	_, err = r.PipelineClient.TektonV1beta1().Pipelines(namespace).Update(&pipeline)
 	if err != nil {
 		t.Fatalf("Error updating pipeline: %s: %s\n", pipeline.Name, err.Error())
 	}
 
 	t.Log("Deleting pipeline")
-	err = r.PipelineClient.TektonV1alpha1().Pipelines(namespace).Delete(pipeline.Name, &metav1.DeleteOptions{})
+	err = r.PipelineClient.TektonV1beta1().Pipelines(namespace).Delete(pipeline.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Error deleting pipeline: %s: %s\n", pipeline.Name, err.Error())
 	}
@@ -314,7 +315,7 @@ func CUDPipelines(r *Resource, t *testing.T, namespace string) {
 func CUDPipelineRuns(r *Resource, t *testing.T, namespace string) {
 	resourceVersion := "1"
 
-	pipelineRun := v1alpha1.PipelineRun{
+	pipelineRun := v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "pipelineRun",
 			ResourceVersion: resourceVersion,
@@ -322,7 +323,7 @@ func CUDPipelineRuns(r *Resource, t *testing.T, namespace string) {
 	}
 
 	t.Log("Creating pipelineRun")
-	_, err := r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace).Create(&pipelineRun)
+	_, err := r.PipelineClient.TektonV1beta1().PipelineRuns(namespace).Create(&pipelineRun)
 	if err != nil {
 		t.Fatalf("Error creating pipelineRun: %s: %s\n", pipelineRun.Name, err.Error())
 	}
@@ -330,13 +331,13 @@ func CUDPipelineRuns(r *Resource, t *testing.T, namespace string) {
 	newVersion := "2"
 	pipelineRun.ResourceVersion = newVersion
 	t.Log("Updating pipelineRun")
-	_, err = r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace).Update(&pipelineRun)
+	_, err = r.PipelineClient.TektonV1beta1().PipelineRuns(namespace).Update(&pipelineRun)
 	if err != nil {
 		t.Fatalf("Error updating pipelineRun: %s: %s\n", pipelineRun.Name, err.Error())
 	}
 
 	t.Log("Deleting pipelineRun")
-	err = r.PipelineClient.TektonV1alpha1().PipelineRuns(namespace).Delete(pipelineRun.Name, &metav1.DeleteOptions{})
+	err = r.PipelineClient.TektonV1beta1().PipelineRuns(namespace).Delete(pipelineRun.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Error deleting pipelineRun: %s: %s\n", pipelineRun.Name, err.Error())
 	}
@@ -345,7 +346,7 @@ func CUDPipelineRuns(r *Resource, t *testing.T, namespace string) {
 func CUDTasks(r *Resource, t *testing.T, namespace string) {
 	resourceVersion := "1"
 
-	task := v1alpha1.Task{
+	task := v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "task",
 			ResourceVersion: resourceVersion,
@@ -353,7 +354,7 @@ func CUDTasks(r *Resource, t *testing.T, namespace string) {
 	}
 
 	t.Log("Creating task")
-	_, err := r.PipelineClient.TektonV1alpha1().Tasks(namespace).Create(&task)
+	_, err := r.PipelineClient.TektonV1beta1().Tasks(namespace).Create(&task)
 	if err != nil {
 		t.Fatalf("Error creating task: %s: %s\n", task.Name, err.Error())
 	}
@@ -361,13 +362,13 @@ func CUDTasks(r *Resource, t *testing.T, namespace string) {
 	newVersion := "2"
 	task.ResourceVersion = newVersion
 	t.Log("Updating task")
-	_, err = r.PipelineClient.TektonV1alpha1().Tasks(namespace).Update(&task)
+	_, err = r.PipelineClient.TektonV1beta1().Tasks(namespace).Update(&task)
 	if err != nil {
 		t.Fatalf("Error updating task: %s: %s\n", task.Name, err.Error())
 	}
 
 	t.Log("Deleting task")
-	err = r.PipelineClient.TektonV1alpha1().Tasks(namespace).Delete(task.Name, &metav1.DeleteOptions{})
+	err = r.PipelineClient.TektonV1beta1().Tasks(namespace).Delete(task.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Error deleting task: %s: %s\n", task.Name, err.Error())
 	}
@@ -376,7 +377,7 @@ func CUDTasks(r *Resource, t *testing.T, namespace string) {
 func CUDClusterTasks(r *Resource, t *testing.T) {
 	resourceVersion := "1"
 
-	clusterTask := v1alpha1.ClusterTask{
+	clusterTask := v1beta1.ClusterTask{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "clusterTask",
 			ResourceVersion: resourceVersion,
@@ -384,7 +385,7 @@ func CUDClusterTasks(r *Resource, t *testing.T) {
 	}
 
 	t.Log("Creating clusterTask")
-	_, err := r.PipelineClient.TektonV1alpha1().ClusterTasks().Create(&clusterTask)
+	_, err := r.PipelineClient.TektonV1beta1().ClusterTasks().Create(&clusterTask)
 	if err != nil {
 		t.Fatalf("Error creating clusterTask: %s: %s\n", clusterTask.Name, err.Error())
 	}
@@ -392,13 +393,13 @@ func CUDClusterTasks(r *Resource, t *testing.T) {
 	newVersion := "2"
 	clusterTask.ResourceVersion = newVersion
 	t.Log("Updating clusterTask")
-	_, err = r.PipelineClient.TektonV1alpha1().ClusterTasks().Update(&clusterTask)
+	_, err = r.PipelineClient.TektonV1beta1().ClusterTasks().Update(&clusterTask)
 	if err != nil {
 		t.Fatalf("Error updating clusterTask: %s: %s\n", clusterTask.Name, err.Error())
 	}
 
 	t.Log("Deleting clusterTask")
-	err = r.PipelineClient.TektonV1alpha1().ClusterTasks().Delete(clusterTask.Name, &metav1.DeleteOptions{})
+	err = r.PipelineClient.TektonV1beta1().ClusterTasks().Delete(clusterTask.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Error deleting clusterTask: %s: %s\n", clusterTask.Name, err.Error())
 	}
@@ -407,7 +408,7 @@ func CUDClusterTasks(r *Resource, t *testing.T) {
 func CUDTaskRuns(r *Resource, t *testing.T, namespace string) {
 	resourceVersion := "1"
 
-	taskRun := v1alpha1.TaskRun{
+	taskRun := v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "taskRun",
 			ResourceVersion: resourceVersion,
@@ -415,7 +416,7 @@ func CUDTaskRuns(r *Resource, t *testing.T, namespace string) {
 	}
 
 	t.Log("Creating taskRun")
-	_, err := r.PipelineClient.TektonV1alpha1().TaskRuns(namespace).Create(&taskRun)
+	_, err := r.PipelineClient.TektonV1beta1().TaskRuns(namespace).Create(&taskRun)
 	if err != nil {
 		t.Fatalf("Error creating taskRun: %s: %s\n", taskRun.Name, err.Error())
 	}
@@ -423,13 +424,13 @@ func CUDTaskRuns(r *Resource, t *testing.T, namespace string) {
 	newVersion := "2"
 	taskRun.ResourceVersion = newVersion
 	t.Log("Updating taskRun")
-	_, err = r.PipelineClient.TektonV1alpha1().TaskRuns(namespace).Update(&taskRun)
+	_, err = r.PipelineClient.TektonV1beta1().TaskRuns(namespace).Update(&taskRun)
 	if err != nil {
 		t.Fatalf("Error updating taskRun: %s: %s\n", taskRun.Name, err.Error())
 	}
 
 	t.Log("Deleting taskRun")
-	err = r.PipelineClient.TektonV1alpha1().TaskRuns(namespace).Delete(taskRun.Name, &metav1.DeleteOptions{})
+	err = r.PipelineClient.TektonV1beta1().TaskRuns(namespace).Delete(taskRun.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Error deleting taskRun: %s: %s\n", taskRun.Name, err.Error())
 	}

--- a/pkg/router/routes_test.go
+++ b/pkg/router/routes_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/tektoncd/dashboard/pkg/router"
 	"github.com/tektoncd/dashboard/pkg/testutils"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -174,35 +175,35 @@ func makeFake(t *testing.T, r *endpoints.Resource, resourceType, namespace, reso
 	t.Logf("Making fake resource %s with name %s\n", resourceType, resourceName)
 	switch resourceType {
 	case "task":
-		task := v1alpha1.Task{
+		task := v1beta1.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceName,
 				Namespace: namespace,
 			},
 		}
-		_, err := r.PipelineClient.TektonV1alpha1().Tasks(namespace).Create(&task)
+		_, err := r.PipelineClient.TektonV1beta1().Tasks(namespace).Create(&task)
 		if err != nil {
 			t.Fatalf("Error creating task: %v\n", err)
 		}
 	case "taskrun":
-		taskRun := v1alpha1.TaskRun{
+		taskRun := v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceName,
 				Namespace: namespace,
 			},
 		}
-		_, err := r.PipelineClient.TektonV1alpha1().TaskRuns(namespace).Create(&taskRun)
+		_, err := r.PipelineClient.TektonV1beta1().TaskRuns(namespace).Create(&taskRun)
 		if err != nil {
 			t.Fatalf("Error creating taskRun: %v\n", err)
 		}
 	case "pipeline":
-		pipeline := v1alpha1.Pipeline{
+		pipeline := v1beta1.Pipeline{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceName,
 				Namespace: namespace,
 			},
 		}
-		_, err := r.PipelineClient.TektonV1alpha1().Pipelines(namespace).Create(&pipeline)
+		_, err := r.PipelineClient.TektonV1beta1().Pipelines(namespace).Create(&pipeline)
 		if err != nil {
 			t.Fatalf("Error creating pipeline: %v\n", err)
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update backend code to use the Pipelines v1beta1 client for
v1beta1 resources, e.g. Pipeline, PipelineRun, ClusterTask

PipelineResources and other v1alpha1 CRDs still use the v1alpha1 client.

This cuts out a large amount of noise in the logs due to failed
conversion of resources from v1beta1 to v1alpha1 to be served to
the frontend.

Originally reported in [Slack](https://tektoncd.slack.com/archives/CHTHGRQBC/p1596135326021700)

Messages similar to this are being spammed in the logs at a high rate:
`E0730 18:41:05.108729       1 reflector.go:123] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:96: Failed to list *v1alpha1.PipelineRun: conversion webhook`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
