### PR TITLE
feat: Create an ansi text parser w/ links support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5076,9 +5076,11 @@
         "d3-path": "^1.0.8",
         "elkjs": "^0.5.1",
         "js-yaml": "^3.13.0",
+        "linkify-it": "^3.0.2",
         "prop-types": "^15.7.2",
         "react-intl-formatted-duration": "^4.0.0",
-        "react-window": "^1.8.5"
+        "react-window": "^1.8.5",
+        "tlds": "^1.208.0"
       },
       "dependencies": {
         "@formatjs/intl-relativetimeformat": {
@@ -15778,6 +15780,14 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -21339,6 +21349,11 @@
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
       "dev": true
     },
+    "tlds": {
+      "version": "1.208.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.208.0.tgz",
+      "integrity": "sha512-6kbY7GJpRQXwBddSOAbVUZXjObbCGFXliWWN+kOSEoRWIOyRWLB6zdeKC/Tguwwenl/KsUx016XR50EdHYsxZw=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -21562,6 +21577,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,9 +19,11 @@
     "d3-path": "^1.0.8",
     "elkjs": "^0.5.1",
     "js-yaml": "^3.13.0",
+    "linkify-it": "^3.0.2",
     "prop-types": "^15.7.2",
     "react-intl-formatted-duration": "^4.0.0",
-    "react-window": "^1.8.5"
+    "react-window": "^1.8.5",
+    "tlds": "^1.208.0"
   },
   "peerDependencies": {
     "@carbon/icons-react": "^10.14.0",
@@ -39,5 +41,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": ["*.scss"]
+  "sideEffects": [
+    "*.scss"
+  ]
 }

--- a/packages/components/src/components/LogFormat/LogFormat.js
+++ b/packages/components/src/components/LogFormat/LogFormat.js
@@ -1,0 +1,274 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import tlds from 'tlds';
+import LinkifyIt from 'linkify-it';
+import { colors, textStyles } from './defaults';
+
+const linkifyIt = LinkifyIt().tlds(tlds);
+
+// eslint-disable-next-line no-control-regex
+const ansiRegex = new RegExp('^\u001b([@-_])(.*?)([@-~])');
+const characterRegex = new RegExp('.', 'm');
+
+const LogFormat = ({ children }) => {
+  let properties = {
+    foregroundColor: null,
+    backgroundColor: null,
+    bold: false,
+    italic: false,
+    underline: false,
+    conceal: false,
+    cross: false
+  };
+
+  let styles = {};
+  let text = '';
+  let line = [];
+
+  const reset = () => {
+    properties = {
+      foregroundColor: null,
+      backgroundColor: null,
+      bold: false,
+      italic: false,
+      underline: false,
+      conceal: false,
+      cross: false
+    };
+  };
+
+  const enable = flag => {
+    properties[flag] = true;
+  };
+
+  const disable = flag => {
+    properties[flag] = false;
+  };
+
+  const getXtermColor = commandStack => {
+    if (commandStack.length >= 2 && commandStack[0] === '5') {
+      commandStack.shift();
+      const colorIndex = +commandStack.shift();
+      if (colorIndex >= 0 && colorIndex <= 255) {
+        return colors[colorIndex];
+      }
+    }
+    return null;
+  };
+
+  const getTermColor = (colorIndex, type) => {
+    if (colorIndex > 7) {
+      return null;
+    }
+    if (type === 'light') {
+      return colors[colorIndex + 8];
+    }
+    return colors[colorIndex];
+  };
+
+  const setFGColor = (type, command) => {
+    properties.foregroundColor = getTermColor(type, command);
+  };
+
+  const setBGColor = (type, command) => {
+    properties.backgroundColor = getTermColor(type, command);
+  };
+
+  const setFGColor256 = commandStack => {
+    properties.foregroundColor = getXtermColor(commandStack);
+  };
+
+  const setBGColor256 = commandStack => {
+    properties.backgroundColor = getXtermColor(commandStack);
+  };
+
+  const setProperties = {
+    0: () => reset(),
+    1: () => enable('bold'),
+    3: () => enable('italic'),
+    4: () => enable('underline'),
+    8: () => enable('conceal'),
+    9: () => enable('cross'),
+
+    21: () => disable('bold'),
+    22: () => disable('bold'),
+    23: () => disable('italic'),
+    24: () => disable('underline'),
+    28: () => disable('conceal'),
+    29: () => disable('cross'),
+
+    30: () => setFGColor(0),
+    31: () => setFGColor(1),
+    32: () => setFGColor(2),
+    33: () => setFGColor(3),
+    34: () => setFGColor(4),
+    35: () => setFGColor(5),
+    36: () => setFGColor(6),
+    37: () => setFGColor(7),
+    38: s => setFGColor256(s),
+    39: () => setFGColor(9),
+
+    40: () => setBGColor(0),
+    41: () => setBGColor(1),
+    42: () => setBGColor(2),
+    43: () => setBGColor(3),
+    44: () => setBGColor(4),
+    45: () => setBGColor(5),
+    46: () => setBGColor(6),
+    47: () => setBGColor(7),
+    48: s => setBGColor256(s),
+    49: () => setBGColor(9),
+
+    90: () => setFGColor(0, 'light'),
+    91: () => setFGColor(1, 'light'),
+    92: () => setFGColor(2, 'light'),
+    93: () => setFGColor(3, 'light'),
+    94: () => setFGColor(4, 'light'),
+    95: () => setFGColor(5, 'light'),
+    96: () => setFGColor(6, 'light'),
+    97: () => setFGColor(7, 'light'),
+
+    100: () => setBGColor(0, 'light'),
+    101: () => setBGColor(1, 'light'),
+    102: () => setBGColor(2, 'light'),
+    103: () => setBGColor(3, 'light'),
+    104: () => setBGColor(4, 'light'),
+    105: () => setBGColor(5, 'light'),
+    106: () => setBGColor(6, 'light'),
+    107: () => setBGColor(7, 'light')
+  };
+
+  const setStyle = (command, stack) => {
+    if (setProperties[command]) {
+      setProperties[command](stack);
+    }
+  };
+
+  const evaluateCommandStack = stack => {
+    const command = stack.shift();
+    if (!command) {
+      return;
+    }
+    setStyle(command, stack);
+    evaluateCommandStack(stack);
+  };
+
+  const linkify = (str, styleObj) => {
+    if (!str) {
+      return null;
+    }
+    const matches = linkifyIt.match(str);
+    if (!matches) {
+      return <span style={styleObj}>{str}</span>;
+    }
+    const elements = [];
+    let offset = 0;
+    matches.forEach(match => {
+      if (match.index > offset) {
+        const string = str.substring(offset, match.index);
+        elements.push(<span style={styleObj}>{string}</span>);
+      }
+      elements.push(
+        <a
+          href={match.url}
+          style={styleObj}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {match.text}
+        </a>
+      );
+      offset = match.lastIndex;
+    });
+
+    if (str.length > offset) {
+      const string = str.substring(offset, str.length);
+      elements.push(<span style={styleObj}>{string}</span>);
+    }
+    return elements;
+  };
+
+  const handleSequence = s => {
+    const indicator = s[1];
+    const commands = s[2].split(';');
+    const terminator = s[3];
+
+    if (indicator !== '[' && terminator !== 'm') {
+      return;
+    }
+
+    const tag = linkify(text, styles);
+    if (tag) {
+      line = line.concat(tag);
+    }
+
+    text = '';
+    styles = {};
+
+    if (commands.length === 0) {
+      reset();
+    }
+
+    evaluateCommandStack(commands);
+
+    styles = {
+      color: properties.foregroundColor,
+      backgroundColor: properties.backgroundColor
+    };
+
+    Object.keys(textStyles).forEach(style => {
+      if (properties[style]) {
+        const [[key, value]] = Object.entries(textStyles[style]);
+        styles[key] = value;
+      }
+    });
+  };
+
+  const parse = (ansi, index) => {
+    let offset = 0;
+    while (offset !== ansi.length) {
+      const str = ansi.substring(offset);
+      const controlSequence = str.match(ansiRegex);
+      if (controlSequence) {
+        offset += controlSequence.index + controlSequence[0].length;
+        handleSequence(controlSequence);
+      } else {
+        const character = str.match(characterRegex);
+        text += character[0];
+        offset += 1;
+      }
+    }
+    if (text) {
+      line.push(linkify(text, styles));
+    }
+    return <div key={index}>{line}</div>;
+  };
+
+  const convert = ansi => {
+    return ansi.split(/\r?\n/).map((part, index) => {
+      text = '';
+      line = [];
+      return parse(part, index);
+    });
+  };
+
+  return convert(children);
+};
+
+LogFormat.propTypes = {
+  children: PropTypes.string.isRequired
+};
+
+export default LogFormat;

--- a/packages/components/src/components/LogFormat/LogFormat.stories.js
+++ b/packages/components/src/components/LogFormat/LogFormat.stories.js
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import LogFormat from './LogFormat';
+
+const ansiColors = (() => {
+  let text = '';
+  [38, 48].forEach(seq => {
+    for (let i = 0; i < 256; i += 1) {
+      text += `\u001b[${seq};5;${i}m${i}  \u001b[0m`;
+      if ((i + 1) % 6 === 4) {
+        text += '\n';
+      }
+    }
+    text += '\n';
+  });
+  return text;
+})();
+
+const ansiTextStyles = (() => {
+  const textStyles = {
+    bold: 1,
+    italic: 3,
+    underline: 4,
+    conceal: 8,
+    cross: 9
+  };
+
+  let text = '';
+  Object.entries(textStyles).forEach(([key, value]) => {
+    text += `\u001b[${value}m${key}\u001b[0m\n`;
+  });
+  return text;
+})();
+
+export default {
+  component: LogFormat,
+  decorators: [storyFn => <div style={{ width: '500px' }}>{storyFn()}</div>],
+  title: 'Experimental/Components/Log/LogFormat'
+};
+
+export const Colors = () => <LogFormat>{ansiColors}</LogFormat>;
+export const TextStyles = () => <LogFormat>{ansiTextStyles}</LogFormat>;

--- a/packages/components/src/components/LogFormat/LogFormat.test.js
+++ b/packages/components/src/components/LogFormat/LogFormat.test.js
@@ -1,0 +1,263 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { renderWithIntl } from '../../utils/test';
+import LogFormat from './LogFormat';
+
+const getElement = (text, query) => {
+  const { queryByText } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+  const queryRegex = new RegExp(query, 'i');
+  return queryByText(queryRegex);
+};
+
+describe('LogFormat', () => {
+  it('displays text', () => {
+    const element = getElement('Hello World', 'Hello World');
+    expect(element).toBeTruthy();
+  });
+
+  it('displays green text', () => {
+    const element = getElement('\u001b[32mHello World\u001b[0m', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(0, 128, 0);">Hello World</span>'
+    );
+  });
+
+  it('displays red text', () => {
+    const element = getElement('\u001b[31mHello World\u001b[0m', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(128, 0, 0);">Hello World</span>'
+    );
+  });
+
+  it('displays yellow text', () => {
+    const element = getElement('\u001b[33mHello World\u001b[0m', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(128, 128, 0);">Hello World</span>'
+    );
+  });
+
+  it('displays blue text', () => {
+    const element = getElement('\u001b[34mHello World\u001b[0m', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(0, 0, 128);">Hello World</span>'
+    );
+  });
+
+  it('displays a cyan background', () => {
+    const element = getElement('\u001b[46mHello World\u001b[0m', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="background-color: rgb(0, 128, 128);">Hello World</span>'
+    );
+  });
+
+  it('displays a silver background', () => {
+    const element = getElement('\u001b[47mHello World', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="background-color: rgb(192, 192, 192);">Hello World</span>'
+    );
+  });
+
+  it('displays a purple background', () => {
+    const element = getElement('\u001b[45mHello World', 'Hello World');
+    expect(element.outerHTML).toBe(
+      '<span style="background-color: rgb(128, 0, 128);">Hello World</span>'
+    );
+  });
+
+  it('displays red text without a trailing reset', () => {
+    const element = getElement('\u001b[36mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(0, 128, 128);">Hello</span>'
+    );
+  });
+
+  it('displays red text on a blue background', () => {
+    const element = getElement('\u001b[31;44mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(128, 0, 0); background-color: rgb(0, 0, 128);">Hello</span>'
+    );
+  });
+
+  it('resets colors after red text on blue background', () => {
+    const element = getElement('\u001b[31;44mHello\u001b[0m world', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(128, 0, 0); background-color: rgb(0, 0, 128);">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+  });
+
+  it('performs a color change from red/blue to yellow/blue', () => {
+    const element = getElement('\u001b[31;44mHello\u001b[33m world', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(128, 0, 0); background-color: rgb(0, 0, 128);">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe(
+      '<span style="color: rgb(128, 128, 0); background-color: rgb(0, 0, 128);"> world</span>'
+    );
+  });
+
+  it('performs color change from red/blue to yellow/blue', () => {
+    const element = getElement(
+      '\u001b[31;44mHello\u001b[33;42m world',
+      'Hello'
+    );
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(128, 0, 0); background-color: rgb(0, 0, 128);">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe(
+      '<span style="color: rgb(128, 128, 0); background-color: rgb(0, 128, 0);"> world</span>'
+    );
+  });
+
+  it('ignores unsupported codes', () => {
+    const element = getElement('\u001b[51mHello\u001b[0m', 'Hello');
+    expect(element.outerHTML).toBe('<span>Hello</span>');
+  });
+
+  it('displays light red text', () => {
+    const element = getElement('\u001b[91mHello\u001b[0m', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(255, 0, 0);">Hello</span>'
+    );
+  });
+
+  it('displays light red background', () => {
+    const element = getElement('\u001b[101mHello\u001b[0m', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="background-color: rgb(255, 0, 0);">Hello</span>'
+    );
+  });
+
+  it('displays a xterm color as a background', () => {
+    const element = getElement('\u001b[48;5;200mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="background-color: rgb(255, 0, 215);">Hello</span>'
+    );
+  });
+
+  it('displays a xterm color as a foreground', () => {
+    const element = getElement('\u001b[38;5;100mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="color: rgb(135, 135, 0);">Hello</span>'
+    );
+  });
+
+  it('displays bold text', () => {
+    const element = getElement('\u001b[1mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="font-weight: bold;">Hello</span>'
+    );
+  });
+
+  it('can reset bold text', () => {
+    const element = getElement('\u001b[1mHello\u001b[21m world', 'Hello');
+    const element2 = getElement('\u001b[1mHello\u001b[22m world', 'Hello');
+    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+    expect(element2.nextElementSibling.outerHTML).toBe('<span> world</span>');
+  });
+
+  it('displays italic text', () => {
+    const element = getElement('\u001b[3mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="font-style: italic;">Hello</span>'
+    );
+  });
+
+  it('can reset italic text', () => {
+    const element = getElement('\u001b[3mHello\u001b[23m world', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="font-style: italic;">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+  });
+
+  it('displays underline text', () => {
+    const element = getElement('\u001b[4mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="text-decoration: underline;">Hello</span>'
+    );
+  });
+
+  it('can resets underline text', () => {
+    const element = getElement('\u001b[4mHello\u001b[24m world', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="text-decoration: underline;">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+  });
+
+  it('displays concealed text', () => {
+    const element = getElement('\u001b[8mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="visibility: hidden;">Hello</span>'
+    );
+  });
+
+  it('can resets concealed text', () => {
+    const element = getElement('\u001b[8mHello\u001b[28m world', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="visibility: hidden;">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+  });
+
+  it('displays crossed text', () => {
+    const element = getElement('\u001b[9mHello', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="text-decoration: line-through;">Hello</span>'
+    );
+  });
+
+  it('can reset crossed-out text', () => {
+    const element = getElement('\u001b[9mHello\u001b[29m world', 'Hello');
+    expect(element.outerHTML).toBe(
+      '<span style="text-decoration: line-through;">Hello</span>'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+  });
+
+  it('displays links', () => {
+    const element = getElement(
+      'A dashboard for Tekton! https://github.com/tektoncd/dashboard',
+      'A dashboard for Tekton!'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe(
+      '<a href="https://github.com/tektoncd/dashboard" target="_blank" rel="noopener noreferrer">https://github.com/tektoncd/dashboard</a>'
+    );
+  });
+
+  it('displays links with styles', () => {
+    const element = getElement(
+      'A dashboard for Tekton!\u001b[9m\u001b[48;5;194mhttps://github.com/tektoncd/dashboard',
+      'A dashboard for Tekton!'
+    );
+    expect(element.nextElementSibling.outerHTML).toBe(
+      '<a href="https://github.com/tektoncd/dashboard" style="background-color: rgb(215, 255, 215); text-decoration: line-through;" target="_blank" rel="noopener noreferrer">https://github.com/tektoncd/dashboard</a>'
+    );
+  });
+
+  it('seperates text by new lines', () => {
+    const text =
+      'Hello World\nA dashboard for Tekton! https://github.com/tektoncd/dashboard\nTekon is cool!';
+    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    expect(container.childNodes).toHaveLength(3);
+  });
+
+  it('seperates text by new lines and carriage returns', () => {
+    const text = '\r \n \r \n\r \n';
+    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    expect(container.childNodes).toHaveLength(4);
+  });
+});

--- a/packages/components/src/components/LogFormat/defaults.js
+++ b/packages/components/src/components/LogFormat/defaults.js
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// 256 Xterm colors https://jonasjacek.github.io/colors/
+const colors = [
+  'rgb(0, 0, 0)',
+  'rgb(128, 0, 0)',
+  'rgb(0, 128, 0)',
+  'rgb(128, 128, 0)',
+  'rgb(0, 0, 128)',
+  'rgb(128, 0, 128)',
+  'rgb(0, 128, 128)',
+  'rgb(192,192,192)',
+  'rgb(128,128,128)',
+  'rgb(255,0,0)',
+  'rgb(0, 255, 0)',
+  'rgb(255, 255, 0)',
+  'rgb(0, 0, 255)',
+  'rgb(255, 0, 255)',
+  'rgb(0, 255, 255)',
+  'rgb(255, 255, 255)'
+];
+
+const levels = [0, 95, 135, 175, 215, 255];
+for (let r = 0; r < 6; r += 1) {
+  for (let g = 0; g < 6; g += 1) {
+    for (let b = 0; b < 6; b += 1) {
+      const rgb = `rgb(${levels[r]}, ${levels[g]}, ${levels[b]})`;
+      colors.push(rgb);
+    }
+  }
+}
+
+let level = 8;
+for (let i = 0; i < 24; i += 1, level += 10) {
+  const rgb = `rgb(${level}, ${level}, ${level})`;
+  colors.push(rgb);
+}
+
+const textStyles = {
+  bold: {
+    fontWeight: 'bold'
+  },
+  italic: {
+    fontStyle: 'italic'
+  },
+  conceal: {
+    visibility: 'hidden'
+  },
+  underline: {
+    textDecoration: 'underline'
+  },
+  cross: {
+    textDecoration: 'line-through'
+  }
+};
+
+export { colors, textStyles };

--- a/packages/components/src/components/LogFormat/index.js
+++ b/packages/components/src/components/LogFormat/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { default } from './LogFormat';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Creates an ANSI parser. 
- Convert all text urls to html links.

While investigating using linkify-it package, I noticed that the currently ansi-to-react package does not correctly parse ANSI codes. For example, `echo -e "\u001b[32mgreen and bold text\u001b[0m\n"` should be green text with a  bold style. https://en.wikipedia.org/wiki/ANSI_escape_code
Reference https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/gitlab/ci/ansi2html.rb#L163

Additionally, the new Ansi code utilizes linkify-it and tlds to convert text to clickable URLs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
