### PR TITLE
Don't copy ignored files when bootstrapping packages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "main": "./dist/components/index.js",
   "scripts": {
-    "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --copy-files --root-mode upward --ignore \"src/**/*.test.js,src/**/*.stories.js\"",
+    "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --copy-files --root-mode upward --ignore \"src/**/*.test.js,src/**/*.stories.js\" --no-copy-ignored",
     "clean": "rimraf dist",
     "prepare": "npm run build"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "main": "./dist/utils/index.js",
   "scripts": {
-    "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --root-mode upward --ignore \"src/**/*.test.js,src/**/*.stories.js\"",
+    "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --root-mode upward --ignore \"src/**/*.test.js,src/**/*.stories.js\" --no-copy-ignored",
     "clean": "rimraf dist",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Babel is configured to ignore test and story files when building
the `packages/*`, but those files are still copied to the output
directory `dist/`. Add the `--no-copy-ignored` flag so these files
are not copied since they're not needed for publishing or by consumers.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
