### PR TITLE
Fix SideNav submenu font colour

### DIFF
--- a/src/containers/SideNav/SideNav.scss
+++ b/src/containers/SideNav/SideNav.scss
@@ -24,9 +24,7 @@ limitations under the License.
     }
 
     .bx--side-nav__submenu {
-      &[aria-haspopup=true] {
-        color: $gray-10;
-      }
+      color: $gray-10;
 
       &:focus {
         outline-color: white;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Carbon 10.16 introduced some changes to the DOM structure that
affected our style overrides for the side nav.

Update the colour for the submenu element so they're legible
on the dark background.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
