### PR TITLE
Fix dropdown styles on Create screens after latest theme and Carbon updates

### DIFF
--- a/src/components/CreatePipelineResource/UniversalFields.js
+++ b/src/components/CreatePipelineResource/UniversalFields.js
@@ -71,7 +71,6 @@ const UniversalFields = props => {
           id: 'dashboard.createPipelineResource.namespaceError',
           defaultMessage: 'Namespace required'
         })}
-        light
       />
       <Dropdown
         id="type"

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -451,6 +451,7 @@ class CreatePipelineRun extends React.Component {
                 id: 'dashboard.createRun.invalidNamespace',
                 defaultMessage: 'Namespace cannot be empty'
               })}
+              light
               selectedItem={namespace ? { id: namespace, text: namespace } : ''}
               onChange={this.handleNamespaceChange}
             />
@@ -462,6 +463,7 @@ class CreatePipelineRun extends React.Component {
                 id: 'dashboard.createPipelineRun.invalidPipeline',
                 defaultMessage: 'Pipeline cannot be empty'
               })}
+              light
               selectedItem={
                 pipelineRef ? { id: pipelineRef, text: pipelineRef } : ''
               }
@@ -572,6 +574,7 @@ class CreatePipelineRun extends React.Component {
                     id: 'dashboard.createRun.invalidPipelineResources',
                     defaultMessage: 'PipelineResources cannot be empty'
                   })}
+                  light
                   selectedItem={(() => {
                     const value = this.state.resources[resourceSpec.name];
                     return value ? { id: value, text: value } : '';
@@ -625,6 +628,7 @@ class CreatePipelineRun extends React.Component {
                 defaultMessage:
                   'Ensure the selected ServiceAccount (or the default if none selected) has permissions for creating PipelineRuns and for anything else your PipelineRun interacts with.'
               })}
+              light
               namespace={namespace}
               selectedItem={
                 serviceAccount

--- a/src/containers/CreateTaskRun/CreateTaskRun.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.js
@@ -491,6 +491,7 @@ class CreateTaskRun extends React.Component {
                 id: 'dashboard.createRun.invalidNamespace',
                 defaultMessage: 'Namespace cannot be empty'
               })}
+              light
               selectedItem={namespace ? { id: namespace, text: namespace } : ''}
               onChange={this.handleNamespaceChange}
             />
@@ -503,6 +504,7 @@ class CreateTaskRun extends React.Component {
                   id: 'dashboard.createTaskRun.invalidTask',
                   defaultMessage: 'Task cannot be empty'
                 })}
+                light
                 selectedItem={taskRef ? { id: taskRef, text: taskRef } : ''}
                 disabled={namespace === ''}
                 onChange={this.handleTaskChange}
@@ -517,6 +519,7 @@ class CreateTaskRun extends React.Component {
                   id: 'dashboard.createTaskRun.invalidTask',
                   defaultMessage: 'Task cannot be empty'
                 })}
+                light
                 selectedItem={taskRef ? { id: taskRef, text: taskRef } : ''}
                 onChange={this.handleTaskChange}
               />
@@ -623,6 +626,7 @@ class CreateTaskRun extends React.Component {
                     id: 'dashboard.createRun.invalidPipelineResources',
                     defaultMessage: 'PipelineResources cannot be empty'
                   })}
+                  light
                   selectedItem={(() => {
                     let value = '';
                     if (resources.inputs !== undefined) {
@@ -653,6 +657,7 @@ class CreateTaskRun extends React.Component {
                     id: 'dashboard.createRun.invalidPipelineResources',
                     defaultMessage: 'PipelineResources cannot be empty'
                   })}
+                  light
                   selectedItem={(() => {
                     let value = '';
                     if (resources.outputs !== undefined) {
@@ -707,6 +712,7 @@ class CreateTaskRun extends React.Component {
                 defaultMessage:
                   'Ensure the selected ServiceAccount (or the default if none selected) has permissions for creating TaskRuns and for anything else your TaskRun interacts with.'
               })}
+              light
               namespace={namespace}
               selectedItem={
                 serviceAccount

--- a/src/scss/Create.scss
+++ b/src/scss/Create.scss
@@ -52,9 +52,4 @@ limitations under the License.
     margin-bottom: $carbon--spacing-06;
     max-width: 40rem;
   }
-
-  .bx--list-box__menu,
-  .bx--list-box {
-    background-color: $ui-background;
-  }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The `light` prop on dropdowns needs to be switched to account for the
latest theme update as well as the Carbon 10.16 update.

The standalone pages now have a gray10 background, so the dropdowns
should have a white background to make them clearer.

On the remaining create dialogs the dropdowns should still have a gray
background since the dialog background is white.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
