### PR TITLE
Remove unnecessary use of cleanup in unit tests

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -12,12 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import {
-  cleanup,
-  fireEvent,
-  wait,
-  waitForElement
-} from 'react-testing-library';
+import { fireEvent, wait, waitForElement } from 'react-testing-library';
 
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
@@ -242,7 +237,6 @@ const selectPipeline1AndFillSpec = async ({
 };
 
 describe('CreatePipelineRun', () => {
-  afterEach(cleanup);
   beforeEach(() => {
     jest
       .spyOn(ServiceAccountsAPI, 'getServiceAccounts')

--- a/src/containers/CreateTaskRun/CreateTaskRun.test.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.js
@@ -12,12 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import {
-  cleanup,
-  fireEvent,
-  wait,
-  waitForElement
-} from 'react-testing-library';
+import { fireEvent, wait, waitForElement } from 'react-testing-library';
 
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
@@ -282,7 +277,6 @@ const selectTask1AndFillSpec = async ({
 };
 
 describe('CreateTaskRun', () => {
-  afterEach(cleanup);
   beforeEach(() => {
     jest
       .spyOn(ServiceAccountsAPI, 'getServiceAccounts')


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Remove unnecessary use of `react-testing-library` cleanup in `afterEach`
since it's already registered globally in `setupTests.js`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
