### PR TITLE
Update LogFormat conceal styles so text can still be selected / copied

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.test.js
+++ b/packages/components/src/components/LogFormat/LogFormat.test.js
@@ -201,14 +201,14 @@ describe('LogFormat', () => {
   it('displays concealed text', () => {
     const element = getElement('\u001b[8mHello', 'Hello');
     expect(element.outerHTML).toBe(
-      '<span style="visibility: hidden;">Hello</span>'
+      '<span style="color: transparent;">Hello</span>'
     );
   });
 
   it('can resets concealed text', () => {
     const element = getElement('\u001b[8mHello\u001b[28m world', 'Hello');
     expect(element.outerHTML).toBe(
-      '<span style="visibility: hidden;">Hello</span>'
+      '<span style="color: transparent;">Hello</span>'
     );
     expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
   });

--- a/packages/components/src/components/LogFormat/defaults.js
+++ b/packages/components/src/components/LogFormat/defaults.js
@@ -55,7 +55,7 @@ const textStyles = {
     fontStyle: 'italic'
   },
   conceal: {
-    visibility: 'hidden'
+    color: 'transparent'
   },
   underline: {
     textDecoration: 'underline'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In environments where the 'conceal' style is supported it is typically
implemented by setting the foreground colour equal to the background
colour. This means that the content can still be viewed by selecting it,
and can also be copy/pasted if needed.

Switch from `visibility: hidden` (which means the content cannot be copied)
to `color: transparent` to match typical implementations.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
