### PR TITLE
Fix oauth2 proxy walkthrough

### DIFF
--- a/docs/walkthrough/walkthrough-oauth2-proxy.md
+++ b/docs/walkthrough/walkthrough-oauth2-proxy.md
@@ -161,7 +161,7 @@ To configure the Dashboard logout URL, pass the `--logout-url http://auth.127.0.
 ```bash
 DASHBOARD_VERSION=v0.8.2
 curl -sL https://raw.githubusercontent.com/tektoncd/dashboard/master/scripts/release-installer | \
-   bash -s -- install $DASHBOARD_VERSION --ingress-url tekton-dashboard.127.0.0.1.nip.io --logout-url http://auth.127.0.0.1.nip.io/oauth2/sign_out
+   bash -s -- install $DASHBOARD_VERSION --logout-url http://auth.127.0.0.1.nip.io/oauth2/sign_out
 
 kubectl wait -n tekton-pipelines \
   --for=condition=ready pod \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes oauth2 proxy walkthrough when using the installer script.
The `--ingress-url` should not be passed to the installer script as it will remove the authentication related annotations making the ingress not secured anymore.

/cc @AlanGreene 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
