### PR TITLE
Fix alignment of TaskRun / step header

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -14,7 +14,7 @@ limitations under the License.
 @import '~@tektoncd/dashboard-components/dist/scss/vars';
 
 .tkn--step-details-header {
-  padding: 1.3rem 1.6rem 0;
+  padding: 1rem 1rem 0;
 
   h2 {
     height: 1.7rem;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The content of the TaskRun / step details header should be aligned
with the tabs below rather than being inset past the start of the first tab.

Before:
![image](https://user-images.githubusercontent.com/2829095/89915796-b7c40e00-dbee-11ea-954a-1c9ec4080d5b.png)

After:
![image](https://user-images.githubusercontent.com/2829095/89915809-bc88c200-dbee-11ea-8097-8584d44bb079.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
