### PR TITLE
Add build command support to release-installer script

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -450,7 +450,6 @@ uninstall() {
 }
 
 build() {
-  echo "Build ..."
   if [ -z "$OUTPUT_FILE" ]; then
     cat $TMP_FILE
   else

--- a/scripts/release-installer
+++ b/scripts/release-installer
@@ -29,6 +29,15 @@ getReleaseURL() {
   fi
 }
 
+build() {
+  local VERSION=$1
+  if type "curl" > /dev/null 2>&1; then
+    curl -sL $(getReleaseURL $VERSION)/installer | bash -s -- build --version $@
+  elif type "wget" > /dev/null 2>&1; then
+    wget -q $(getReleaseURL $VERSION)/installer | bash -s -- build --version $@
+  fi
+}
+
 install() {
   local VERSION=$1
   if type "curl" > /dev/null 2>&1; then
@@ -73,6 +82,12 @@ case $1 in
     shift
     install $VERSION $@
     ;;
+  'build'|i)
+    shift
+    VERSION="${1}"
+    shift
+    build $VERSION $@
+    ;;
   'uninstall'|u)
     shift
     VERSION="${1}"
@@ -81,7 +96,7 @@ case $1 in
     ;;
   *)
     echo "Unknown command: $1"
-    echo "Please use: help, install, or uninstall"
+    echo "Please use: help, build, install, or uninstall"
     exit 1
     ;;
 esac


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds support for the build command to the release-installer script.
This is useful to pipe the output to `kustomize`, `istioctl`, etc...

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
