### PR TITLE
Improve docs readability of bash commands

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -60,7 +60,7 @@ See the [Example: Register a CronJob extension](#example-register-a-cronjob-exte
 To create an `Extension` resource for `CronJob`s run the following command:
 
 ```bash
-cat <<EOF | kubectl apply -n tekton-pipelines -f -
+kubectl apply -n tekton-pipelines -f - <<EOF
 apiVersion: dashboard.tekton.dev/v1alpha1
 kind: Extension
 metadata:
@@ -85,7 +85,7 @@ Simply create a `ClusterRole` with the necessary permissions and add the `rbac.d
 To add the necessary permissions for your cronjobs extension to work, run the following command:
 
 ```bash
-cat <<EOF | kubectl apply -f -
+kubectl apply -f - <<EOF
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -129,7 +129,7 @@ You can also look at the [webhooks-extension](https://github.com/tektoncd/experi
 To begin, you will create a simple Node.js backend, deploy it in a pod and expose it through a service that will be detected by the Tekton Dashboard.
 
 ```bash
-cat <<EOF | kubectl apply -n tekton-pipelines -f -
+kubectl apply -n tekton-pipelines -f - <<EOF
 kind: Service
 apiVersion: v1
 metadata:
@@ -210,7 +210,7 @@ This can be done manually or using an ES module bundler such as [Rollup](https:/
 To deploy the service based extension with frontend code run the following command:
 
 ```bash
-cat <<EOF | kubectl apply -n tekton-pipelines -f -
+kubectl apply -n tekton-pipelines -f - <<EOF
 kind: Service
 apiVersion: v1
 metadata:

--- a/docs/install.md
+++ b/docs/install.md
@@ -161,7 +161,7 @@ Assuming you have an [ingress controller](https://kubernetes.io/docs/concepts/se
 # replace DASHBOARD_URL with the hostname you want for your dashboard
 # the hostname should be setup to point to your ingress controller
 DASHBOARD_URL=dashboard.domain.tld
-cat <<EOF | kubectl apply -n tekton-pipelines -f -
+kubectl apply -n tekton-pipelines -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/docs/walkthrough/walkthrough-kind.md
+++ b/docs/walkthrough/walkthrough-kind.md
@@ -31,7 +31,7 @@ Kind is an easy solution to run a local cluster, all it needs is to have `docker
 Create a cluster by running the following command:
 
 ```bash
-cat <<EOF | kind create cluster --name walkthrough --config -
+kind create cluster --name walkthrough --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -155,7 +155,7 @@ For the sake of simplicity we will use the freely available [`nip.io`](https://n
 Assuming the following url `http://tekton-dashboard.127.0.0.1.nip.io`, run the following command to create the ingress rule:
 
 ```bash
-cat <<EOF | kubectl apply -n tekton-pipelines -f -
+kubectl apply -n tekton-pipelines -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/docs/walkthrough/walkthrough-logs.md
+++ b/docs/walkthrough/walkthrough-logs.md
@@ -42,7 +42,7 @@ Note that `minio` exposes other APIs similar to other cloud storage providers to
 To deploy `minio` in your cluster, run the following command to install the `minio` helm chart:
 
 ```bash
-cat <<EOF | helm upgrade --install --wait --create-namespace --namespace tools minio stable/minio --values -
+helm upgrade --install --wait --create-namespace --namespace tools minio stable/minio --values - <<EOF
 nameOverride: minio
 fullnameOverride: minio
 
@@ -94,7 +94,7 @@ To start collecting logs you will need to create the logs pipeline using the ava
 - `Logging` will deploy the necessary fluentd/fluentbit workloads:
 
 ```bash
-cat <<EOF | kubectl -n tools apply -f -
+kubectl -n tools apply -f - <<EOF
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: Logging
 metadata:
@@ -111,7 +111,7 @@ This is a very simple deployment, please note that the position database and buf
 - `ClusterOutput` defines the output of the logs pipeline. In our case AWS S3 (through `minio`):
 
 ```bash
-cat <<EOF | kubectl -n tools apply -f -
+kubectl -n tools apply -f - <<EOF
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: ClusterOutput
 metadata:
@@ -145,7 +145,7 @@ The `ClusterOutput` above will stream logs to our `minio` storage in a `tekton-l
 - `ClusterFlow` defines how the collected logs are dispatched to the outputs:
 
 ```bash
-cat <<EOF | kubectl -n tools apply -f -
+kubectl -n tools apply -f - <<EOF
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: ClusterFlow
 metadata:
@@ -163,7 +163,7 @@ The `ClusterFlow` above takes all logs from pods that have the `app.kubernetes.i
 Running the `PipelineRun` below should produce logs and you should see corresponding objects being added in `minio` as logs get collected and stored by the logs pipeline.
 
 ```bash
-cat <<EOF | kubectl -n tekton-pipelines create -f -
+kubectl -n tekton-pipelines create -f - <<EOF
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -206,7 +206,7 @@ Given a `namespace`, `pod` and `container`, the service will list files from s3,
 Run the command below to create the kubernetes `Deployment` to serve your logs:
 
 ```bash
-cat <<EOF | kubectl apply -n tools -f -
+kubectl apply -n tools -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -286,7 +286,7 @@ Then it will run a web server exposing the `'/logs/:namespace/:pod/:container'` 
 To make this available you will need to deploy a `Service` and an `Ingress` rule to expose the `Deployment`:
 
 ```bash
-cat <<EOF | kubectl apply -n tools -f -
+kubectl apply -n tools -f - <<EOF
 kind: Service
 apiVersion: v1
 metadata:

--- a/docs/walkthrough/walkthrough-oauth2-proxy.md
+++ b/docs/walkthrough/walkthrough-oauth2-proxy.md
@@ -74,7 +74,7 @@ To install the chart, set the `Client ID` and `Client Secret` you just obtained 
 CLIENT_ID=__THE_CLIENT_ID_OF_YOUR_GITHUB_OAUTH_APP__
 CLIENT_SECRET=__THE_CLIENT_SECRET_OF_YOUR_GITHUB_OAUTH_APP__
 
-cat <<EOF | helm upgrade --install --wait --create-namespace --namespace tools oauth2-proxy stable/oauth2-proxy --values -
+helm upgrade --install --wait --create-namespace --namespace tools oauth2-proxy stable/oauth2-proxy --values - <<EOF
 config:
   clientID: $CLIENT_ID
   clientSecret: $CLIENT_SECRET
@@ -123,7 +123,7 @@ Two annotations are used here:
 To apply the ingress annotations run the command below:
 
 ```bash
-cat <<EOF | kubectl apply -n tekton-pipelines -f -
+kubectl apply -n tekton-pipelines -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -17,7 +17,7 @@ CLUSTERNAME=dashboard
 DEFAULT_OPTIONS="--log-format console --stream-logs --ingress-url tekton-dashboard.127.0.0.1.nip.io"
 
 create_cluster() {
-cat <<EOF | kind create cluster --name $CLUSTERNAME --config -
+kind create cluster --name $CLUSTERNAME --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR improve docs readability of bash commands when passing a file content.

Before:
```bash
cat <<EOF | kind create cluster --name walkthrough --config -
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  kubeadmConfigPatches:
  - |
    kind: InitConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        node-labels: "ingress-ready=true"
  extraPortMappings:
  - containerPort: 80
    hostPort: 80
    protocol: TCP
  - containerPort: 443
    hostPort: 443
    protocol: TCP
EOF
```

After:
```bash
kind create cluster --name walkthrough --config - <<EOF
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  kubeadmConfigPatches:
  - |
    kind: InitConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        node-labels: "ingress-ready=true"
  extraPortMappings:
  - containerPort: 80
    hostPort: 80
    protocol: TCP
  - containerPort: 443
    hostPort: 443
    protocol: TCP
EOF
```

No need for the `cat` command and the real command is more visible.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
