### PR TITLE
bug: Empty Lines should be separated

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.js
+++ b/packages/components/src/components/LogFormat/LogFormat.js
@@ -237,6 +237,9 @@ const LogFormat = ({ children }) => {
   };
 
   const parse = (ansi, index) => {
+    if (ansi.length === 0) {
+      return <br />;
+    }
     let offset = 0;
     while (offset !== ansi.length) {
       const str = ansi.substring(offset);

--- a/packages/components/src/components/LogFormat/LogFormat.test.js
+++ b/packages/components/src/components/LogFormat/LogFormat.test.js
@@ -248,6 +248,14 @@ describe('LogFormat', () => {
     );
   });
 
+  it('converts new lines as line breaks', () => {
+    const text = 'Hello\n\nWorld';
+    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    expect(container.innerHTML).toBe(
+      '<div><span>Hello</span></div><br><div><span>World</span></div>'
+    );
+  });
+
   it('seperates text by new lines', () => {
     const text =
       'Hello World\nA dashboard for Tekton! https://github.com/tektoncd/dashboard\nTekon is cool!';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the LogFormat component, new line characters should be converted to a `<br />. `

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
