### PR TITLE
Wrap LogFormat output in a `code` element

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.js
+++ b/packages/components/src/components/LogFormat/LogFormat.js
@@ -267,7 +267,7 @@ const LogFormat = ({ children }) => {
     });
   };
 
-  return convert(children);
+  return <code>{convert(children)}</code>;
 };
 
 LogFormat.propTypes = {

--- a/packages/components/src/components/LogFormat/LogFormat.test.js
+++ b/packages/components/src/components/LogFormat/LogFormat.test.js
@@ -251,7 +251,7 @@ describe('LogFormat', () => {
   it('converts new lines as line breaks', () => {
     const text = 'Hello\n\nWorld';
     const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
-    expect(container.innerHTML).toBe(
+    expect(container.childNodes[0].innerHTML).toBe(
       '<div><span>Hello</span></div><br><div><span>World</span></div>'
     );
   });
@@ -260,12 +260,12 @@ describe('LogFormat', () => {
     const text =
       'Hello World\nA dashboard for Tekton! https://github.com/tektoncd/dashboard\nTekon is cool!';
     const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
-    expect(container.childNodes).toHaveLength(3);
+    expect(container.childNodes[0].childNodes).toHaveLength(3);
   });
 
   it('seperates text by new lines and carriage returns', () => {
     const text = '\r \n \r \n\r \n';
     const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
-    expect(container.childNodes).toHaveLength(4);
+    expect(container.childNodes[0].childNodes).toHaveLength(4);
   });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related: https://github.com/tektoncd/dashboard/issues/895

To make LogFormat a drop-in replacement for ansi-to-react it should
wrap its output in a `code` element.

This will then ensure we maintain the same formatting, including
font styles, as our existing log display.

The primary difference is use of the monospace font.

Before:
![image](https://user-images.githubusercontent.com/2829095/90140981-6b094000-dd72-11ea-9990-01e01ac02dd0.png)

After:
![image](https://user-images.githubusercontent.com/2829095/90140996-70668a80-dd72-11ea-9b63-2b3843c14c8a.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
