### PR TITLE
Set important css rule for log component format

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.scss
+++ b/packages/components/src/components/LogFormat/LogFormat.scss
@@ -34,7 +34,7 @@ $colors: (
 .tkn--ansi--color-fg- {
   @each $name, $value in $colors {
     &-#{$name} {
-      color: $value;
+      color: $value !important;
     }
   }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Ansi styles should override the font color of links. 

Example npm install log https://raw.githubusercontent.com/stevesoaress/test-ansi/master/npm-install.txt

<img width="773" alt="Screen Shot 2020-08-19 at 7 31 32 PM" src="https://user-images.githubusercontent.com/31323257/90699978-9d271000-e252-11ea-8a89-f2e1fe64bf88.png">

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
