### PR TITLE
Fix path used for `previous` release artifacts

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -118,11 +118,11 @@ spec:
         - |
           set -x
           find .
-          mkdir -p /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/
+          mkdir -p /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
+          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
+          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
+          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
+          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
 
     - name: tag-external-images
       image: python
@@ -135,10 +135,10 @@ spec:
           curl https://raw.githubusercontent.com/tektoncd/dashboard/master/tekton/scripts/lockdown.py --output lockdown.py
           chmod +x lockdown.py
           pip install docker
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/tekton-dashboard-release.yaml
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/tekton-dashboard-release-readonly.yaml
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/openshift-tekton-dashboard-release.yaml
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/$(params.bucketName)/previous/$(params.versionTag)/openshift-tekton-dashboard-release-readonly.yaml
+          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/tekton-dashboard-release.yaml
+          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/tekton-dashboard-release-readonly.yaml
+          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/openshift-tekton-dashboard-release.yaml
+          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/openshift-tekton-dashboard-release-readonly.yaml
       volumeMounts:
         - name: docker-socket
           mountPath: /var/run/docker.sock


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1505

Fix the path used for versioned release artifacts under `previous`
so they appear at the correct location, i.e.:
`dashboard/previous/<version>/`
instead of
`dashboard/latest/previous/<version>/`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
