### PR TITLE
Update release pipeline to make publishing as latest optional

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -13,7 +13,7 @@ These tasks run on your local cluster, and then copy the release artifacts - doc
 First, ensure that your credentials are set up correctly. You will need an account with access to [Google Cloud Platform](https://console.cloud.google.com). Your account must have 'proper authorization to release the images and yamls' in the [`tekton-releases` GCP project](https://github.com/tektoncd/plumbing#prow). Your account must have `Permission iam.serviceAccountKeys.create`. Contact @bobcatfish or @dlorenc if you are going to be creating dashboard releases and require this authorization.
 
 - You will need to install the [`gcloud` CLI](https://cloud.google.com/sdk/gcloud/) in order to get keys out of Google Cloud and into your local cluster. These credentials will be patched onto the service account to be used by the Tekton PipelineRuns. You do not need to create a new GCP project or pay Google any money.
-- It's convenient to use the ['tkn' CLI](https://github.com/tektoncd/cli) to kick off builds, so grab that as well.
+- It's convenient to use the Tekton Dashboard to kick off builds, alternatively you can use the ['tkn' CLI](https://github.com/tektoncd/cli) so you may want to grab that as well.
 
 ```bash
 KEY_FILE=release.json
@@ -88,13 +88,13 @@ Run a test release:
 ```bash
 VERSION_TAG=test-1
 PIPELINE_NAMESPACE=tekton-pipelines
-tkn pipeline start dashboard-release -p versionTag=$VERSION_TAG -r dashboard-source-repo=tekton-dashboard-git -r bucket-for-dashboard=tekton-bucket-dashboard -r builtDashboardImage=dashboard-image -n $PIPELINE_NAMESPACE -s $SERVICE_ACCOUNT -p bucketName=mytestbucket
+tkn pipeline start dashboard-release -p versionTag=$VERSION_TAG -r dashboard-source-repo=tekton-dashboard-git -r bucket-for-dashboard=tekton-bucket-dashboard -r builtDashboardImage=dashboard-image -n $PIPELINE_NAMESPACE -s $SERVICE_ACCOUNT -p releaseAsLatest=false
 ```
 
-This will result in release artifacts appearing in the Google Cloud bucket `gs://tekton-releases/dashboard/mytestbucket/test-1`. If you need to run a second build, incremement $VERSION_TAG. Once you're finished, clean up:
+This will result in release artifacts appearing in the Google Cloud bucket `gs://tekton-releases/dashboard/test-release/test-1`. If you need to run a second build, incremement $VERSION_TAG. Once you're finished, clean up:
 
-- delete /mytestbucket from the PipelineResource and reapply your changes
-- delete the temporary /mytestbucket bucket in Google Cloud
+- delete /test-release from the PipelineResource and reapply your changes
+- delete the temporary /test-release bucket in Google Cloud
 
 ## Running a release build
 
@@ -103,7 +103,7 @@ Now you can kick off the release build:
 ```bash
 VERSION_TAG=vX.Y.Z
 PIPELINE_NAMESPACE=tekton-pipelines
-tkn pipeline start dashboard-release -p versionTag=$VERSION_TAG -r dashboard-source-repo=tekton-dashboard-git -r bucket-for-dashboard=tekton-bucket-dashboard -r builtDashboardImage=dashboard-image -n $PIPELINE_NAMESPACE -s $SERVICE_ACCOUNT -p bucketName=latest
+tkn pipeline start dashboard-release -p versionTag=$VERSION_TAG -r dashboard-source-repo=tekton-dashboard-git -r bucket-for-dashboard=tekton-bucket-dashboard -r builtDashboardImage=dashboard-image -n $PIPELINE_NAMESPACE -s $SERVICE_ACCOUNT -p releaseAsLatest=true
 ```
 
 Monitor the build logs to see the image coordinates that the image is pushed to. The release yaml files should appear under https://console.cloud.google.com/storage/browser/tekton-releases/dashboard.
@@ -157,8 +157,7 @@ Then, install the Tekton resources from the `openshift` folder:
 We have a number of tasks that are yet to be automated:
 
 - Write the release notes
-- Attach `.yaml` files from https://console.cloud.google.com/storage/browser/tekton-releases/dashboard - be sure you copy the locked down image ones (look under `previous`): any containers such as `kubectl` and `oauth-proxy` should reference an image sha and not a tag such as `latest`
+- Attach `.yaml` files from https://console.cloud.google.com/storage/browser/tekton-releases/dashboard - any containers such as `oauth-proxy` should reference an image sha and not a tag such as `latest`
 - Note that the image pinning, if doing the release on OpenShift, has not yet been implemented - so you'll have to do this manually until then. That work should be done under https://github.com/tektoncd/dashboard/issues/1384
-- Optionally repeat for the Webhooks Extension
 - Update `/README.md` to add an entry in the table for the new release
 - Publish the GitHub release

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -12,12 +12,9 @@ spec:
       description: TODO(#569) This is a hack to make it easy for folks to switch the registry being used by the many many image outputs
     - name: pathToProject
       description: The path to the folder in the go/src dir that contains the project, which is used by `ko` to name the resulting images
-    - name: bucketName
-      description: Use latest if it's a real release, otherwise the name of a test bucket you've made on GCS
-      # For example, you may have made Buckets/tekton-releases/dashboard/mytestbucket for testing and then you'll get
-      # lockdown.py, a folder called previous, and a folder called test-release if you run with
-      # tkn pipeline start dashboard-release -p versionTag=$VERSION_TAG -r dashboard-source-repo=tekton-dashboard-git -r bucket=tekton-bucket-dashboard -r builtDashboardImage=dashboard-image -n $PIPELINE_NAMESPACE -s $SERVICE_ACCOUNT -p bucketName=test-release
-      # mytestbucket is specified in resources.yaml as the location value for the storage bucket
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as the latest
+      default: "true"
   resources:
     inputs:
       - name: dashboard-source-repo
@@ -43,8 +40,8 @@ spec:
       command: ["mkdir"]
       args:
         - "-p"
-        - "/workspace/output/bucket-for-dashboard/$(params.bucketName)/"
-        - "/workspace/output/bucket-for-dashboard/previous/"
+        - "/workspace/output/bucket-for-dashboard/latest/"
+        - "/workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/"
     - name: dashboard-run-ko
       # TODO(#639) we should be able to use the image built by an upstream Task here instead of hardcoding
       # Want to use your own plumbing image? Change this
@@ -82,7 +79,6 @@ spec:
           # Rewrite "devel" to params.versionTag
           sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/300-deployment.yaml
           sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/300-service.yaml
-          # sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/overlays/patches/dashboard-service.yaml
           sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/overlays/resources/openshift/internal-service.yaml
 
           # Publish images and create release.yamls
@@ -90,39 +86,25 @@ spec:
           ko version
           kustomize version # Tested with 3.5.4
 
+          OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket-for-dashboard/previous/$(params.versionTag)"
+
           # add installer script in the release
-          cp /workspace/go/src/github.com/tektoncd/dashboard/scripts/installer /workspace/output/bucket-for-dashboard/$(params.bucketName)/installer
+          cp /workspace/go/src/github.com/tektoncd/dashboard/scripts/installer $OUTPUT_BUCKET_RELEASE_DIR/installer
 
           # build manifests for installer
-          kustomize build overlays/installer/k8s/read-write --load_restrictor none        | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/installer-tekton-dashboard-release.yaml
-          kustomize build overlays/installer/k8s/read-only  --load_restrictor none        | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/installer-tekton-dashboard-release-readonly.yaml
-          kustomize build overlays/installer/openshift/read-write --load_restrictor none  | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/installer-openshift-tekton-dashboard-release.yaml
-          kustomize build overlays/installer/openshift/read-only  --load_restrictor none  | ko resolve --preserve-import-paths -f - > /workspace/output/bucket-for-dashboard/$(params.bucketName)/installer-openshift-tekton-dashboard-release-readonly.yaml
+          kustomize build overlays/installer/k8s/read-write --load_restrictor none        | ko resolve --preserve-import-paths -f - > $OUTPUT_BUCKET_RELEASE_DIR/installer-tekton-dashboard-release.yaml
+          kustomize build overlays/installer/k8s/read-only  --load_restrictor none        | ko resolve --preserve-import-paths -f - > $OUTPUT_BUCKET_RELEASE_DIR/installer-tekton-dashboard-release-readonly.yaml
+          kustomize build overlays/installer/openshift/read-write --load_restrictor none  | ko resolve --preserve-import-paths -f - > $OUTPUT_BUCKET_RELEASE_DIR/installer-openshift-tekton-dashboard-release.yaml
+          kustomize build overlays/installer/openshift/read-only  --load_restrictor none  | ko resolve --preserve-import-paths -f - > $OUTPUT_BUCKET_RELEASE_DIR/installer-openshift-tekton-dashboard-release-readonly.yaml
 
           # build pre configured manifests
-          ./scripts/installer release --debug                         --output /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml
-          ./scripts/installer release --debug --read-only             --output /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml
-          ./scripts/installer release --debug --openshift             --output /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml
-          ./scripts/installer release --debug --openshift --read-only --output /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml
+          ./scripts/installer release --debug                         --output $OUTPUT_BUCKET_RELEASE_DIR/tekton-dashboard-release.yaml
+          ./scripts/installer release --debug --read-only             --output $OUTPUT_BUCKET_RELEASE_DIR/tekton-dashboard-release-readonly.yaml
+          ./scripts/installer release --debug --openshift             --output $OUTPUT_BUCKET_RELEASE_DIR/openshift-tekton-dashboard-release.yaml
+          ./scripts/installer release --debug --openshift --read-only --output $OUTPUT_BUCKET_RELEASE_DIR/openshift-tekton-dashboard-release-readonly.yaml
       volumeMounts:
         - name: gcp-secret
           mountPath: /secret
-
-    - name: copy-to-tagged-bucket
-      image: busybox
-      workingDir: "/workspace/output/bucket-for-dashboard"
-      command:
-        - /bin/sh
-      args:
-        - -ce
-        - |
-          set -x
-          find .
-          mkdir -p /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release-readonly.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
-          cp /workspace/output/bucket-for-dashboard/$(params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/
 
     - name: tag-external-images
       image: python
@@ -135,13 +117,29 @@ spec:
           curl https://raw.githubusercontent.com/tektoncd/dashboard/master/tekton/scripts/lockdown.py --output lockdown.py
           chmod +x lockdown.py
           pip install docker
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/tekton-dashboard-release.yaml
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/tekton-dashboard-release-readonly.yaml
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/openshift-tekton-dashboard-release.yaml
-          ./lockdown.py --omit dashboard --path /workspace/output/bucket-for-dashboard/previous/$(params.versionTag)/openshift-tekton-dashboard-release-readonly.yaml
+          OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket-for-dashboard/previous/$(params.versionTag)"
+
+          for MANIFEST in $OUTPUT_BUCKET_RELEASE_DIR/*.yaml
+          do
+            ./lockdown.py --omit dashboard --path $MANIFEST
+          done
       volumeMounts:
         - name: docker-socket
           mountPath: /var/run/docker.sock
+
+    - name: copy-to-latest-bucket
+      image: busybox
+      workingDir: "/workspace/output/bucket-for-dashboard"
+      script: |
+        #!/bin/sh
+        set -ex
+        find .
+        if [[ "$(params.releaseAsLatest)" == "true" ]]
+        then
+          OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket-for-dashboard/previous/$(params.versionTag)"
+          OUTPUT_BUCKET_LATEST_DIR="/workspace/output/bucket-for-dashboard/latest"
+          cp $OUTPUT_BUCKET_RELEASE_DIR/* $OUTPUT_BUCKET_LATEST_DIR/
+        fi
 
     - name: tag-images
       image: google/cloud-sdk
@@ -164,7 +162,7 @@ spec:
             $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtDashboardImage.url)
           )
           # Parse the built images from the release.yaml generated by ko
-          BUILT_IMAGES=( $(/usr/bin/koparse.py --path /workspace/output/bucket-for-dashboard/$(params.bucketName)/tekton-dashboard-release.yaml --base $(params.imageRegistry)/$(params.pathToProject) --images ${IMAGES[@]}) )
+          BUILT_IMAGES=( $(/usr/bin/koparse.py --path /workspace/output/bucket-for-dashboard/latest/tekton-dashboard-release.yaml --base $(params.imageRegistry)/$(params.pathToProject) --images ${IMAGES[@]}) )
 
           # Auth with account credentials
           gcloud auth activate-service-account --key-file=/secret/release.json
@@ -173,14 +171,23 @@ spec:
           for IMAGE in "${BUILT_IMAGES[@]}"
           do
             IMAGE_WITHOUT_SHA=${IMAGE%%@*}
-            gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:$(params.bucketName)
+            if [[ "$(inputs.params.releaseAsLatest)" == "true" ]]
+            then
+              gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:latest
+            fi
             gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:$(params.versionTag)
             for REGION in "${REGIONS[@]}"
             do
-              for TAG in "$(params.bucketName)" $(params.versionTag)
-              do
+              if [[ "$(inputs.params.releaseAsLatest)" == "true" ]]
+              then
+                for TAG in "latest" $(params.versionTag)
+                do
+                  gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:$TAG
+                done
+              else
+                TAG="$(params.versionTag)"
                 gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:$TAG
-              done
+              fi
             done
           done
   volumes:

--- a/tekton/release-pipeline.yml
+++ b/tekton/release-pipeline.yml
@@ -12,8 +12,9 @@ spec:
       default: gcr.io/tekton-releases
     - name: versionTag
       description: The X.Y.Z version that the artifacts should be tagged with
-    - name: bucketName
-      description: The name of the bucket to use
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as the latest
+      default: "true"
   resources:
     - name: dashboard-source-repo
       type: git
@@ -43,8 +44,8 @@ spec:
           value: $(params.versionTag)
         - name: imageRegistry
           value: $(params.imageRegistry)
-        - name: bucketName
-          value: $(params.bucketName)
+        - name: releaseAsLatest
+          value: $(params.releaseAsLatest)
       resources:
         inputs:
           - name: dashboard-source-repo

--- a/tekton/scripts/lockdown.py
+++ b/tekton/scripts/lockdown.py
@@ -27,6 +27,7 @@ def scan_release(omit: List[str], path: str) -> List[str]:
     print("scan_release")
     images = []
     with open(path) as f:
+        print("path: " + path)
         for line in f:
             match = re.search("image:" + ".*" + "latest", line)
             if match:
@@ -58,7 +59,7 @@ def replace_images(org: List[str], new: List[str], path: str):
     """Replace original images with new images in the release.yaml at path
     Args:
         org: The list of original images that are replaced by the new images
-        new: The list of new images 
+        new: The list of new images
         path: The path to the file (release.yaml) that will contain the built images
     """
     print("replace_image")
@@ -88,5 +89,5 @@ if __name__ == "__main__":
     taggedimages = lockdown_image(images)
     replace_images(images, taggedimages, args.path)
 
-    print("\nDone.")
+    print("Done.\n")
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Closes https://github.com/tektoncd/dashboard/issues/1505

Publish artifacts to the versioned location first, and optionally
copy all artifacts to 'latest'. The `releaseAsLatest` param controls
both this and tagging the images as 'latest'.

Include the installer manifests in the lockdown.py post-processing
so the oauth-proxy image includes the SHA instead of pointing at
'latest'.

This is more consistent with the approach taken by other Tekton
projects and avoids the need for manual intervention to copy
files to the correct locations after cutting a release.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
