### PR TITLE
Fix connection closed when streaming logs

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -116,7 +116,11 @@ export class LogContainer extends Component {
     }
     return this.reader
       .read()
-      .then(result => this.readChunks(result, decoder, logs));
+      .then(result => this.readChunks(result, decoder, logs))
+      .catch(error => {
+        console.error(error); // eslint-disable-line no-console
+        return this.loadLog();
+      });
   };
 
   loadLog = async () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes connection closed when streaming logs.

When streaming logs, the connection can be closed when there is no activity on the stream.
The current implementation will catch the error and restart streaming logs but with a delay (same mechanism as when the pod didn't start yet).
With this fix, the streaming is restarted immediately.

Closes #1698 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
