### PR TITLE
Fix release installer build command

### DIFF
--- a/scripts/release-installer
+++ b/scripts/release-installer
@@ -82,7 +82,7 @@ case $1 in
     shift
     install $VERSION $@
     ;;
-  'build'|i)
+  'build'|b)
     shift
     VERSION="${1}"
     shift


### PR DESCRIPTION
# Changes

This PR fixes the release installer build command (wrong short name `i` instead of `b`).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
