### PR TITLE
Fix logs persistence walkthrough

### DIFF
--- a/docs/walkthrough/walkthrough-logs.md
+++ b/docs/walkthrough/walkthrough-logs.md
@@ -84,8 +84,10 @@ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
 
 helm repo update
 
-helm upgrade --install --wait --create-namespace --namespace tools logging-operator banzaicloud-stable/logging-operator --set createCustomResource=false
+helm upgrade --install --version 3.6.0 --wait --create-namespace --namespace tools logging-operator banzaicloud-stable/logging-operator --set createCustomResource=false
 ```
+
+**NOTE**: This will install `logging-operator` version `3.6.0`, there was a [breaking change](https://github.com/banzaicloud/logging-operator/releases/tag/3.6.0) in this release. The walkthrough will not work with earlier versions.
 
 The `logging operator` should now be deployed in your cluster.
 
@@ -151,10 +153,12 @@ kind: ClusterFlow
 metadata:
   name: flow
 spec:
-  outputRefs:
+  globalOutputRefs:
     - s3
-  selectors:
-    app.kubernetes.io/managed-by: tekton-pipelines
+  match:
+    - select:
+        labels:
+          app.kubernetes.io/managed-by: tekton-pipelines
 EOF
 ```
 


### PR DESCRIPTION
#Changes

This PR fixes the logs persistence walkthrough.

Due to a breaking change in the `logging-operator` version `3.6.0` the walkthrough did not work anymore.

I adapted the walkthrough, pinned the `logging-operator` version and added a note about the breaking change.

Fixes #1715 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
