### PR TITLE
Fix installer requiring ko and kustomize for remote releases

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -50,12 +50,12 @@ verifySupported() {
     exit 1
   fi
 
-  if ! type "kustomize" > /dev/null 2>&1; then
+  if [ -z "$VERSION" ] && ! type "kustomize" > /dev/null 2>&1; then
     echo "kustomize is required"
     exit 1
   fi
 
-  if ! type "ko" > /dev/null 2>&1; then
+  if [ -z "$VERSION" ] && ! type "ko" > /dev/null 2>&1; then
     echo "ko is required"
     exit 1
   fi


### PR DESCRIPTION
# Changes

This PR fix an issue with the installer requiring `ko` and `kustomize` when installing a remote release.

Related PR https://github.com/tektoncd/dashboard/pull/1716

/cc @AlanGreene 
/cc @a-rothwell 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
