### PR TITLE
Fix cluster-scoped Kubernetes resource extensions

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -247,3 +247,16 @@ export function importResources({
   const uri = getTektonAPI('pipelineruns', { namespace: importerNamespace });
   return post(uri, payload).then(({ body }) => body);
 }
+
+export function getAPIResource({ group, version, type }) {
+  const uri = [
+    apiRoot,
+    group === 'core'
+      ? `/proxy/api/${version}`
+      : `/proxy/apis/${group}/${version}`
+  ].join('');
+
+  return get(uri).then(({ resources }) =>
+    resources.find(({ name }) => name === type)
+  );
+}

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -266,3 +266,31 @@ it('importResources', () => {
     mockDateNow.mockRestore();
   });
 });
+
+describe('getAPIResource', () => {
+  it('handles non-core group', () => {
+    const group = 'testgroup';
+    const version = 'testversion';
+    const type = 'testtype';
+    const apiResource = { name: type };
+    const data = { resources: [apiResource] };
+    fetchMock.get(`end:/proxy/apis/${group}/${version}`, data);
+    return API.getAPIResource({ group, version, type }).then(resource => {
+      expect(resource).toEqual(apiResource);
+      fetchMock.restore();
+    });
+  });
+
+  it('handles core group', () => {
+    const group = 'core';
+    const version = 'testversion';
+    const type = 'testtype';
+    const apiResource = { name: type };
+    const data = { resources: [apiResource] };
+    fetchMock.get(`end:/proxy/api/${version}`, data);
+    return API.getAPIResource({ group, version, type }).then(resource => {
+      expect(resource).toEqual(apiResource);
+      fetchMock.restore();
+    });
+  });
+});

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -70,7 +70,9 @@ export function getResourcesAPI(
 ) {
   return [
     apiRoot,
-    `/proxy/apis/${group}/${version}/`,
+    group === 'core'
+      ? `/proxy/api/${version}/`
+      : `/proxy/apis/${group}/${version}/`,
     namespace && namespace !== ALL_NAMESPACES
       ? `namespaces/${encodeURIComponent(namespace)}/`
       : '',

--- a/src/api/utils.test.js
+++ b/src/api/utils.test.js
@@ -69,7 +69,7 @@ describe('getTektonAPI', () => {
   });
 });
 
-describe('getResourceAPI', () => {
+describe('getResourcesAPI', () => {
   it('returns a URI containing the given type', () => {
     const uri = utils.getResourcesAPI({
       group: 'test.dev',
@@ -104,6 +104,24 @@ describe('getResourceAPI', () => {
       name: 'testname'
     });
     expect(uri).toContain('test.dev');
+    expect(uri).toContain('testversion');
+    expect(uri).toContain('testtype');
+    expect(uri).toContain('testname');
+    expect(uri).toContain('namespaces');
+    expect(uri).toContain('testnamespace');
+  });
+
+  it('handles the core group correctly', () => {
+    const uri = utils.getResourcesAPI({
+      group: 'core',
+      version: 'testversion',
+      type: 'testtype',
+      namespace: 'testnamespace',
+      name: 'testname'
+    });
+    expect(uri).not.toContain('core');
+    expect(uri).toContain('api');
+    expect(uri).not.toContain('apis');
     expect(uri).toContain('testversion');
     expect(uri).toContain('testtype');
     expect(uri).toContain('testname');


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Fixes https://github.com/tektoncd/dashboard/issues/1731

When a Kubernetes resource extension is created for a cluster-scoped
resource, in some cases this fails to load in the dashboard UI when
the namespace dropdown has selected a value other than 'All Namespaces'.

Update the API layer to check whether the API resource is namespaced
and use this to construct the API request accordingly.

Also update the UI to hide the namespace column for cluster-scoped
resources in the default extension list view `ResourceList`.

Update the API layer to correctly handle extensions displaying
Kubernetes resources from the `core` group, since the API root
is `/api` instead of `/apis/${group}` for these resources.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
