### PR TITLE
Ensure FormattedDate always provides a tooltip with the absolute date/time

### DIFF
--- a/packages/components/src/components/FormattedDate/FormattedDate.js
+++ b/packages/components/src/components/FormattedDate/FormattedDate.js
@@ -19,35 +19,41 @@ const FormattedDateWrapper = ({ date, intl, relative }) => {
     return null;
   }
 
+  let content;
+
   if (relative && Intl.RelativeTimeFormat) {
-    return (
-      <span
-        title={intl.formatDate(date, {
-          day: 'numeric',
-          month: 'long',
-          year: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric'
-        })}
-      >
-        <FormattedRelativeTime
-          numeric="auto"
-          updateIntervalInSeconds={10}
-          value={(new Date(date).getTime() - Date.now()) / 1000}
-        />
-      </span>
+    content = (
+      <FormattedRelativeTime
+        numeric="auto"
+        updateIntervalInSeconds={10}
+        value={(new Date(date).getTime() - Date.now()) / 1000}
+      />
+    );
+  } else {
+    content = (
+      <FormattedDate
+        value={date}
+        day="numeric"
+        month="long"
+        year="numeric"
+        hour="numeric"
+        minute="numeric"
+      />
     );
   }
 
   return (
-    <FormattedDate
-      value={date}
-      day="numeric"
-      month="long"
-      year="numeric"
-      hour="numeric"
-      minute="numeric"
-    />
+    <span
+      title={intl.formatDate(date, {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric'
+      })}
+    >
+      {content}
+    </span>
   );
 };
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the FormattedDate component to ensure it always provides a tooltip
containing the absolute date/time regardless of whether the main display
value is absolute / relative.

This is import when the value is being displayed in a table with many
columns or other similar cases where wrapping is undesirable and horizontal
space may be constrained. Since the displayed value may be truncated,
the tooltip provides a way to view the full value. This is consistent with
other fields already displayed in tables and elsewhere in the dashboard.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
