### PR TITLE
Add support for resources using `generateName` in Import Resources

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -81,12 +81,13 @@ export function getWebSocketURL() {
 }
 
 export function importResources({
-  repositoryURL,
-  applyDirectory,
-  namespace,
+  importerNamespace,
   labels,
-  serviceAccount,
-  importerNamespace
+  method,
+  namespace,
+  path,
+  repositoryURL,
+  serviceAccount
 }) {
   const taskSpec = {
     resources: {
@@ -99,14 +100,8 @@ export function importResources({
     },
     params: [
       {
-        name: 'pathToResourceFiles',
-        description: 'The path to the resource files to apply',
-        default: '/workspace/git-source',
-        type: 'string'
-      },
-      {
-        name: 'apply-directory',
-        description: 'The directory from which resources are to be applied',
+        name: 'path',
+        description: 'The path from which resources are to be imported',
         default: '.',
         type: 'string'
       },
@@ -120,13 +115,13 @@ export function importResources({
     ],
     steps: [
       {
-        name: 'kubectl-apply',
+        name: 'import',
         image: 'lachlanevenson/k8s-kubectl:latest',
         command: ['kubectl'],
         args: [
-          'apply',
+          method,
           '-f',
-          '$(params.pathToResourceFiles)/$(params.apply-directory)',
+          '$(resources.inputs.git-source.path)/$(params.path)',
           '-n',
           '$(params.target-namespace)'
         ]
@@ -143,14 +138,8 @@ export function importResources({
     ],
     params: [
       {
-        name: 'pathToResourceFiles',
-        description: 'The path to the resource files to apply',
-        default: '/workspace/git-source',
-        type: 'string'
-      },
-      {
-        name: 'apply-directory',
-        description: 'The directory from which resources are to be applied',
+        name: 'path',
+        description: 'The path from which resources are to be imported',
         default: '.',
         type: 'string'
       },
@@ -168,12 +157,8 @@ export function importResources({
         taskSpec,
         params: [
           {
-            name: 'pathToResourceFiles',
-            value: '$(params.pathToResourceFiles)'
-          },
-          {
-            name: 'apply-directory',
-            value: '$(params.apply-directory)'
+            name: 'path',
+            value: '$(params.path)'
           },
           {
             name: 'target-namespace',
@@ -216,8 +201,8 @@ export function importResources({
     ],
     params: [
       {
-        name: 'apply-directory',
-        value: applyDirectory
+        name: 'path',
+        value: path
       },
       {
         name: 'target-namespace',

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -101,17 +101,19 @@ it('importResources', () => {
     .spyOn(Date, 'now')
     .mockImplementation(() => 'fake-timestamp');
   const repositoryURL = 'https://github.com/test/testing';
-  const applyDirectory = 'fake-directory';
+  const path = 'fake-directory';
   const namespace = 'fake-namespace';
   const serviceAccount = 'fake-serviceAccount';
   const importerNamespace = 'fake-importer-namespace';
+  const method = 'apply';
 
   const payload = {
-    repositoryURL,
-    applyDirectory,
+    importerNamespace,
+    method,
     namespace,
-    serviceAccount,
-    importerNamespace
+    path,
+    repositoryURL,
+    serviceAccount
   };
   const data = {
     apiVersion: 'tekton.dev/v1beta1',
@@ -126,7 +128,7 @@ it('importResources', () => {
     spec: {
       params: [
         {
-          name: 'apply-directory',
+          name: 'path',
           value: 'fake-directory'
         },
         {
@@ -137,15 +139,9 @@ it('importResources', () => {
       pipelineSpec: {
         params: [
           {
-            default: '/workspace/git-source',
-            description: 'The path to the resource files to apply',
-            name: 'pathToResourceFiles',
-            type: 'string'
-          },
-          {
             default: '.',
-            description: 'The directory from which resources are to be applied',
-            name: 'apply-directory',
+            description: 'The path from which resources are to be imported',
+            name: 'path',
             type: 'string'
           },
           {
@@ -167,12 +163,8 @@ it('importResources', () => {
             name: 'import-resources',
             params: [
               {
-                name: 'pathToResourceFiles',
-                value: '$(params.pathToResourceFiles)'
-              },
-              {
-                name: 'apply-directory',
-                value: '$(params.apply-directory)'
+                name: 'path',
+                value: '$(params.path)'
               },
               {
                 name: 'target-namespace',
@@ -190,16 +182,10 @@ it('importResources', () => {
             taskSpec: {
               params: [
                 {
-                  default: '/workspace/git-source',
-                  description: 'The path to the resource files to apply',
-                  name: 'pathToResourceFiles',
-                  type: 'string'
-                },
-                {
                   default: '.',
                   description:
-                    'The directory from which resources are to be applied',
-                  name: 'apply-directory',
+                    'The path from which resources are to be imported',
+                  name: 'path',
                   type: 'string'
                 },
                 {
@@ -221,15 +207,15 @@ it('importResources', () => {
               steps: [
                 {
                   args: [
-                    'apply',
+                    method,
                     '-f',
-                    '$(params.pathToResourceFiles)/$(params.apply-directory)',
+                    '$(resources.inputs.git-source.path)/$(params.path)',
                     '-n',
                     '$(params.target-namespace)'
                   ],
                   command: ['kubectl'],
                   image: 'lachlanevenson/k8s-kubectl:latest',
-                  name: 'kubectl-apply'
+                  name: 'import'
                 }
               ]
             }

--- a/src/containers/ImportResources/ImportResources.scss
+++ b/src/containers/ImportResources/ImportResources.scss
@@ -20,6 +20,7 @@ limitations under the License.
   }
 
   .bx--combo-box.bx--list-box,
+  .bx--dropdown.bx--list-box,
   .bx--text-input__field-wrapper {
     width: 50%;
     min-width: 300px;

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -158,12 +158,12 @@ describe('ImportResources component', () => {
       .spyOn(API, 'importResources')
       .mockImplementation(
         ({
-          repositoryURL,
-          applyDirectory,
-          namespace,
+          importerNamespace,
           labels,
-          serviceAccount,
-          importerNamespace
+          namespace,
+          path,
+          repositoryURL,
+          serviceAccount
         }) => {
           const labelsShouldEqual = {
             gitOrg: 'test',
@@ -172,7 +172,7 @@ describe('ImportResources component', () => {
           };
 
           expect(repositoryURL).toEqual('https://github.com/test/testing');
-          expect(applyDirectory).toEqual('');
+          expect(path).toEqual('');
           expect(namespace).toEqual('default');
           expect(labels).toEqual(labelsShouldEqual);
           expect(serviceAccount).toEqual('');

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "Import resources from repository",
     "dashboard.importResources.importApplyButton": "Import and Apply",
     "dashboard.importResources.importerNamespace.helperText": "The namespace in which the PipelineRun fetching the repository and creating the resources will run",
+    "dashboard.importResources.method.helperText": "If any of the resources being imported use 'generateName' rather than 'name' in their metadata, select 'create' so they can be imported correctly.",
+    "dashboard.importResources.method.label": "Method",
     "dashboard.importResources.path.helperText": "The path of the Tekton resources to import from the repository. Leave blank if the resources are at the top-level directory.",
     "dashboard.importResources.path.labelText": "Repository path (optional)",
     "dashboard.importResources.path.placeholder": "Enter repository path",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -120,6 +120,8 @@
     "dashboard.importResources.heading": "",
     "dashboard.importResources.importApplyButton": "",
     "dashboard.importResources.importerNamespace.helperText": "",
+    "dashboard.importResources.method.helperText": "",
+    "dashboard.importResources.method.label": "",
     "dashboard.importResources.path.helperText": "",
     "dashboard.importResources.path.labelText": "",
     "dashboard.importResources.path.placeholder": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1552

Add a 'method' dropdown in the Import Resources UI to allow users to
choose between the default `kubectl apply` and `kubectl create` if
they're importing resources using `generateName` instead of `name`
in the resource metadata.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
