### PR TITLE
Reduce scope of uninstall command to resource kinds used by dashboard

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -427,12 +427,21 @@ install() {
   kubectl apply -f $TMP_FILE
 }
 
-# uninstall invokes kubectl delete with the built manifest.
 uninstall() {
   echo "Uninstalling ..."
-  kubectl delete deployments -l=app.kubernetes.io/instance=default,app.kubernetes.io/part-of=tekton-dashboard --all-namespaces
-  kubectl api-resources --verbs=delete -o name | \
-    xargs -n 1 kubectl delete --ignore-not-found -l=app.kubernetes.io/instance=default,app.kubernetes.io/part-of=tekton-dashboard --all-namespaces
+  resourceKinds=(
+    "deployments.apps"
+    "serviceaccounts"
+    "services"
+    "customresourcedefinitions.apiextensions.k8s.io"
+    "clusterrolebindings.rbac.authorization.k8s.io"
+    "clusterroles.rbac.authorization.k8s.io"
+    "rolebindings.rbac.authorization.k8s.io"
+  )
+  for resourceKind in "${resourceKinds[@]}";do
+    echo "Deleting ${resourceKind}"
+    kubectl delete ${resourceKind} --ignore-not-found -l=app.kubernetes.io/instance=default,app.kubernetes.io/part-of=tekton-dashboard --all-namespaces
+  done
 }
 
 build() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
There have been a number of instances recently where PR integration
tests have taken a very long time to complete. A large part of this
is spent on the uninstall step.

Reduce the scope of the uninstall command to only attempt deleting
resource kinds we know are created by the dashboard, i.e. there's
no point attempting to delete networkpolicies, daemonsets, etc. as
the dashboard install never creates resources of these kinds. There's
no need to process 60+ resource kinds when the dashboard only ever
deals with 7.

This should speed up the integration tests when they hit the slow
performance issues, and should also provide benefit where there are
a large number of namespaces / resources on the cluster..

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
