### PR TITLE
Remove GitHub restriction on Import Resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13187,20 +13187,18 @@
       }
     },
     "git-up": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
-      "dev": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+      "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
       "requires": {
         "is-ssh": "^1.3.0",
         "parse-url": "^5.0.0"
       }
     },
     "git-url-parse": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
-      "dev": true,
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.3.0.tgz",
+      "integrity": "sha512-i3XNa8IKmqnUqWBcdWBjOcnyZYfN3C1WRvnKI6ouFWwsXCZEnlgbwbm55ZpJ3OJMhfEP/ryFhqW8bBhej3C5Ug==",
       "requires": {
         "git-up": "^4.0.0"
       }
@@ -14692,10 +14690,9 @@
       "dev": true
     },
     "is-ssh": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
-      "dev": true,
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
       "requires": {
         "protocols": "^1.1.0"
       }
@@ -18646,10 +18643,9 @@
       "dev": true
     },
     "parse-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
-      "dev": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
+      "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
       "requires": {
         "is-ssh": "^1.3.0",
         "protocols": "^1.4.0"
@@ -18662,10 +18658,9 @@
       "dev": true
     },
     "parse-url": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
-      "dev": true,
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+      "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
       "requires": {
         "is-ssh": "^1.3.0",
         "normalize-url": "^3.3.0",
@@ -18676,8 +18671,7 @@
         "normalize-url": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-          "dev": true
+          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
         }
       }
     },
@@ -19321,10 +19315,9 @@
       "dev": true
     },
     "protocols": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
-      "dev": true
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
     },
     "protoduck": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "classnames": "^2.2.6",
     "core-js": "^3.6.5",
     "es6-promise": "^4.2.8",
+    "git-url-parse": "^11.3.0",
     "history": "^4.10.1",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.14.0",

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -62,7 +62,7 @@ describe('ImportResources component', () => {
     );
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
+    await waitForElement(() => getByText(/Please enter a valid Git URL/i));
     await waitForElement(() => getByText(/Please select a namespace/i));
   });
 
@@ -78,7 +78,7 @@ describe('ImportResources component', () => {
     fireEvent.click(getByText(namespace));
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
+    await waitForElement(() => getByText(/Please enter a valid Git URL/i));
   });
 
   it('Displays an error when Namespace is empty', async () => {
@@ -95,57 +95,6 @@ describe('ImportResources component', () => {
 
     fireEvent.click(getByText('Import and Apply'));
     await waitForElement(() => getByText(/Please select a namespace/i));
-  });
-
-  it('Displays an error when Repository URL starts with the incorrect term', async () => {
-    const { getByTestId, getByText } = await renderWithIntl(
-      <Provider store={store}>
-        <ImportResourcesContainer />
-      </Provider>
-    );
-
-    const repoURLField = getByTestId('repository-url-field');
-    fireEvent.change(repoURLField, {
-      target: { value: 'incorrecthttps://github.com/test/testing' }
-    });
-
-    fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please select a namespace/i));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
-  });
-
-  it('Displays an error when Repository URL doesnt contain github', async () => {
-    const { getByTestId, getByText } = await renderWithIntl(
-      <Provider store={store}>
-        <ImportResourcesContainer />
-      </Provider>
-    );
-
-    const repoURLField = getByTestId('repository-url-field');
-    fireEvent.change(repoURLField, {
-      target: { value: 'https://cat.com/test/testing' }
-    });
-
-    fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please select a namespace/i));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
-  });
-
-  it('Displays an error when Repository URL doesnt contain a .', async () => {
-    const { getByTestId, getByText } = await renderWithIntl(
-      <Provider store={store}>
-        <ImportResourcesContainer />
-      </Provider>
-    );
-
-    const repoURLField = getByTestId('repository-url-field');
-    fireEvent.change(repoURLField, {
-      target: { value: 'https://cat-com/test/testing' }
-    });
-
-    fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please select a namespace/i));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
   });
 
   it('Valid data submit displays success notification ', async () => {
@@ -167,7 +116,7 @@ describe('ImportResources component', () => {
         }) => {
           const labelsShouldEqual = {
             gitOrg: 'test',
-            gitRepo: 'testing.git',
+            gitRepo: 'testing',
             gitServer: 'github.com'
           };
 
@@ -242,18 +191,7 @@ describe('ImportResources component', () => {
     fireEvent.click(getByText('namespace1'));
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
-  });
-
-  it('Failure to populate required field displays error', async () => {
-    const { getByText } = await renderWithIntl(
-      <Provider store={store}>
-        <ImportResourcesContainer />
-      </Provider>
-    );
-
-    fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please submit a valid URL/i));
+    await waitForElement(() => getByText(/Please enter a valid Git URL/i));
   });
 
   it('URL TextInput handles onChange event', async () => {

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -126,7 +126,7 @@
     "dashboard.importResources.path.labelText": "Repository path (optional)",
     "dashboard.importResources.path.placeholder": "Enter repository path",
     "dashboard.importResources.repo.helperText": "The location of the YAML definitions to be applied (Git URLs supported)",
-    "dashboard.importResources.repo.invalidText": "Please submit a valid URL",
+    "dashboard.importResources.repo.invalidText": "Please enter a valid Git URL",
     "dashboard.importResources.repo.labelText": "Repository URL",
     "dashboard.importResources.serviceAccount.helperText": "The ServiceAccount that the PipelineRun applying resources will run under (from the namespace above). Ensure the selected ServiceAccount (or the default if none selected) has permissions for creating PipelineRuns and for anything else your PipelineRun interacts with, including any Tekton resources in the Git repository.",
     "dashboard.importResources.targetNamespace.helperText": "The namespace in which the resources will be created",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -105,22 +105,6 @@ export function isStale(resource, state, resourceIdField = 'uid') {
   return existingVersion > incomingVersion;
 }
 
-export function getGitValues(url) {
-  let copyUrl;
-
-  copyUrl = url.toLowerCase().replace(/https?:\/\//, '');
-
-  copyUrl = copyUrl.split('/');
-  const numSlashes = copyUrl.length;
-  if (numSlashes < 2) {
-    return {};
-  }
-
-  const [gitServer, gitOrg, gitRepo] = copyUrl;
-
-  return { gitServer, gitOrg, gitRepo: `${gitRepo}.git` };
-}
-
 // K8s label documentation comes from here:
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 const labelKeyRegex = new RegExp(

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -16,7 +16,6 @@ import * as API from '../api';
 import {
   fetchLogs,
   followLogs,
-  getGitValues,
   getViewChangeHandler,
   isStale,
   sortRunsByStartTime,
@@ -147,28 +146,6 @@ describe('followLogs', () => {
 
     followLogs(stepName, stepStatus, taskRun);
     expect(API.getPodLog).not.toHaveBeenCalled();
-  });
-});
-
-describe('getGitValues', () => {
-  it('should return an object describing the parts of the git URL', () => {
-    const url = 'https://github.com/user/repo';
-
-    const returnedValue = getGitValues(url);
-
-    expect(returnedValue).toStrictEqual({
-      gitOrg: 'user',
-      gitRepo: 'repo.git',
-      gitServer: 'github.com'
-    });
-  });
-
-  it('should return an empty object if the URL is not a valid git URL', () => {
-    const url = 'foo';
-
-    const returnedValue = getGitValues(url);
-
-    expect(returnedValue).toEqual({});
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Fixes https://github.com/tektoncd/dashboard/issues/1743

The frontend validation on the Import Resources page expected
a `https` GitHub URL for the 'Repository URL' field. This is
unnecessarily restrictive as the PipelineResource type git used
under the covers now supports more than just GitHub.

Switch out the validation to remove the GitHub restriction and
use a well-tested library for parsing the URL to extract the
required fields to use for the PipelineRun labels (name, owner,
host).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
