### PR TITLE
Use globally selected namespace by default on Create pages

### DIFF
--- a/src/containers/CreatePipelineResource/CreatePipelineResource.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.js
@@ -15,11 +15,17 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { Button, InlineNotification } from 'carbon-components-react';
-import { getErrorMessage, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  getErrorMessage,
+  getTitle,
+  urls
+} from '@tektoncd/dashboard-utils';
 
 import GitResourceFields from '../../components/CreatePipelineResource/GitResourceFields';
 import UniversalFields from '../../components/CreatePipelineResource/UniversalFields';
 import { createPipelineResource } from '../../api';
+import { getSelectedNamespace } from '../../reducers';
 
 import '../../scss/Create.scss';
 
@@ -50,10 +56,11 @@ function validateInputs(value, id) {
 export /* istanbul ignore next */ class CreatePipelineResource extends Component {
   constructor(props) {
     super(props);
+    const { defaultNamespace } = props;
     this.state = {
       creating: false,
       name: '',
-      namespace: '',
+      namespace: defaultNamespace === ALL_NAMESPACES ? '' : defaultNamespace,
       type: 'Git',
       url: '',
       revision: '',
@@ -318,11 +325,18 @@ export /* istanbul ignore next */ class CreatePipelineResource extends Component
   }
 }
 
+/* istanbul ignore next */
+function mapStateToProps(state) {
+  return {
+    defaultNamespace: getSelectedNamespace(state)
+  };
+}
+
 const mapDispatchToProps = {
   createPipelineResource
 };
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(injectIntl(CreatePipelineResource));

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
@@ -17,7 +17,7 @@ import { fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import CreatePipelineResource from '.';
 import * as API from '../../api';
@@ -45,7 +45,7 @@ const namespaces = {
   },
   errorMessage: null,
   isFetching: false,
-  selected: 'default'
+  selected: ALL_NAMESPACES
 };
 
 const store = mockStore({

--- a/src/containers/CreateSecret/CreateSecret.js
+++ b/src/containers/CreateSecret/CreateSecret.js
@@ -11,7 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { generateId, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  generateId,
+  getTitle,
+  urls
+} from '@tektoncd/dashboard-utils';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -23,6 +28,7 @@ import {
   getPatchSecretsErrorMessage,
   getSecrets,
   getSecretsErrorMessage,
+  getSelectedNamespace,
   getServiceAccounts,
   isFetchingSecrets,
   isFetchingServiceAccounts,
@@ -68,9 +74,10 @@ function validateInputs(value, id) {
 export /* istanbul ignore next */ class CreateSecret extends Component {
   constructor(props) {
     super(props);
+    const { defaultNamespace } = props;
     this.state = {
       name: '',
-      namespace: '',
+      namespace: defaultNamespace === ALL_NAMESPACES ? '' : defaultNamespace,
       username: '',
       password: '',
       accessToken: '',
@@ -409,8 +416,10 @@ export /* istanbul ignore next */ class CreateSecret extends Component {
   }
 }
 
+/* istanbul ignore next */
 function mapStateToProps(state) {
   return {
+    defaultNamespace: getSelectedNamespace(state),
     errorMessageCreated: getSecretsErrorMessage(state),
     errorMessagePatched: getPatchSecretsErrorMessage(state),
     webSocketConnected: isWebSocketConnected(state),

--- a/src/containers/CreateSecret/CreateSecret.test.js
+++ b/src/containers/CreateSecret/CreateSecret.test.js
@@ -16,6 +16,7 @@ import { fireEvent, waitForElement } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 import CreateSecret from '.';
 import * as API from '../../api';
@@ -44,7 +45,7 @@ const namespaces = {
   },
   errorMessage: null,
   isFetching: false,
-  selected: 'default'
+  selected: ALL_NAMESPACES
 };
 
 const serviceAccountsByNamespace = {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1304

When opening the Create PipelineResource or Create Secret page,
if the global namespaces dropdown has selected a value other than
All Namespaces, use this as the default selected namespace in
the create page.

If the global namespaces dropdown is set to All Namespaces, do
not select a default namespace in the create page.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
