### PR TITLE
Use a brighter blue in the logs

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.scss
+++ b/packages/components/src/components/LogFormat/LogFormat.scss
@@ -16,7 +16,7 @@ $colors: (
   "red": rgb(187, 0, 0),
   "green": rgb(0, 187, 0),
   "yellow": rgb(187, 187, 0),
-  "blue": rgb(0, 0, 187),
+  "blue": rgb(85, 85, 255),
   "magenta": rgb(187, 0, 187),
   "cyan": rgb(0, 187, 187),
   "white": rgb(187, 187, 187),
@@ -25,7 +25,7 @@ $colors: (
   "bright-red": rgb(255, 85, 85),
   "bright-green": rgb(0, 255, 0),
   "bright-yellow": rgb(255, 255, 85),
-  "bright-blue": rgb(85, 85, 255),
+  "bright-blue": rgb(136, 136, 255),
   "bright-magenta": rgb(255, 85, 255),
   "bright-cyan": rgb(85, 255, 255),
   "bright-white": rgb(255, 255, 255)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Colour contrast of the blue ANSI-formatted text in the log container
is too low to be easily readable on the dark background. Update it
to use a brighter blue.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
