### PR TITLE
Set runAsUser uid for nonroot distroless image

### DIFF
--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -50,6 +50,7 @@ spec:
       volumes: []
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
       containers:
         - name: tekton-dashboard
           image: dashboardImage


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Port of tektoncd/pipeline#3342:

The distroless nonroot image define a user with the uid 65532. The
deployment should use that uid to make sure it works anywhere.

Pipeline and Triggers are planning on doing patch releases with this fix. I think dashboard should consider doing this as well.
See user issue in slack: https://tektoncd.slack.com/archives/CHTHGRQBC/p1602174933009300

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
