### PR TITLE
Remove unnecessary border on Table filters

### DIFF
--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -90,7 +90,6 @@ limitations under the License.
       overflow: visible;
       flex-direction: row;
       background-color: $ui-01;
-      border-bottom: 1px solid $ui-03;
 
       .bx--multi-select__wrapper {
         .bx--combo-box {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Recent Carbon update has changed the styles of these components
and the added border-bottom is no longer necessary.

When present, the border can cause a scrollbar to appear when combined with the
table batch action toolbar (e.g. when selecting multiple resources from the table).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
