### PR TITLE
Fix highlighting colour on taskRun in taskTree when focus moves away

### DIFF
--- a/packages/components/src/components/Task/Task.scss
+++ b/packages/components/src/components/Task/Task.scss
@@ -36,6 +36,11 @@ limitations under the License.
     border-bottom: 1.1rem solid transparent;
   }
 
+  &[data-selected]:not([data-succeeded]) > a.tkn--task-link,
+    &[data-selected][data-succeeded='Unknown'] > a.tkn--task-link {
+    background-color: $hover-ui;
+  }
+
   &:not([data-succeeded]) > a.tkn--task-link {
     background-color: $waiting-bg;
     color: $waiting-fg;
@@ -84,11 +89,6 @@ limitations under the License.
     .tkn--task-icon {
       fill: $running-fg;
     }
-  }
-
-  &[data-selected]:not([data-succeeded]) > a.tkn--task-link,
-    &[data-selected][data-succeeded='Unknown'] > a.tkn--task-link {
-    background-color: $hover-ui;
   }
 
   > a.tkn--task-link {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Closes https://github.com/tektoncd/dashboard/issues/1755

Fixes highlighting for running taskRuns in task tree where it loses focus

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- na - styling change. Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- na - styling change. Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
