### PR TITLE
Remove legacy exceptions from the Content Security Policy settings

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,7 +18,7 @@ const contentSecurityPolicy = {
   development:
     "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-eval'; style-src blob:; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;",
   production:
-    "default-src 'none'; img-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;"
+    "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;"
 };
 
 module.exports = ({ mode }) => ({


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1763

Remove the `script-src: blob:;` and `style-src: 'unsafe-inline';`
exceptions from the production CSP value.

These were originally added in https://github.com/tektoncd/dashboard/pull/1312
to work around an issue with the webhooks-extension build.

Since the webhooks-extension is deprecated, and unsupported with
dashboard builds later than 0.7, these exceptions are no longer
required and can be safely removed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
