### PR TITLE
Remove deprecated storybook config

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,7 +17,6 @@ import Container from './Container';
 
 export const parameters = {
   options: {
-    showRoots: true,
     storySort: (a, b) =>
       a[1].kind === b[1].kind
         ? 0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1766

The `showRoots` field in preview.js is deprecated and instead
should be configured in manager.js instead. However, the default
value in Storybook 6 is true so it can be left out entirely.

Warning appearing in browser console:
parameters.options.showRoots is deprecated and will be removed in Storybook 7.0.
To change this setting, use `addons.setConfig`. See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-immutable-options-parameters

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
