### PR TITLE
Fix update handlers in extensions and ClusterTasks reducers

### DIFF
--- a/src/reducers/clusterTasks.js
+++ b/src/reducers/clusterTasks.js
@@ -28,7 +28,7 @@ function byName(state = {}, action) {
       if (isStale(action.payload, state, 'name')) {
         return state;
       }
-      return { [action.payload.metadata.name]: action.payload, ...state };
+      return { ...state, [action.payload.metadata.name]: action.payload };
     case 'ClusterTaskDeleted':
       const newState = { ...state };
       delete newState[action.payload.metadata.name];

--- a/src/reducers/clusterTasks.test.js
+++ b/src/reducers/clusterTasks.test.js
@@ -101,7 +101,7 @@ it('ClusterTask Events', () => {
     payload: updatedClusterTask
   };
 
-  const updatedState = clusterTasksReducer({}, updateAction);
+  const updatedState = clusterTasksReducer(state, updateAction);
   expect(selectors.getClusterTasks(updatedState)).toEqual([updatedClusterTask]);
   expect(selectors.isFetchingClusterTasks(updatedState)).toBe(false);
 

--- a/src/reducers/extensions.js
+++ b/src/reducers/extensions.js
@@ -47,12 +47,12 @@ function byName(state = {}, action) {
     case 'ResourceExtensionCreated':
     case 'ResourceExtensionUpdated': {
       const extension = mapResourceExtension(action.payload);
-      return { [extension.name]: extension, ...state };
+      return { ...state, [extension.name]: extension };
     }
     case 'ServiceExtensionCreated':
     case 'ServiceExtensionUpdated': {
       const extension = mapServiceExtension(action.payload);
-      return { [extension.name]: extension, ...state };
+      return { ...state, [extension.name]: extension };
     }
     case 'ResourceExtensionDeleted': {
       const newState = { ...state };

--- a/src/reducers/extensions.test.js
+++ b/src/reducers/extensions.test.js
@@ -89,7 +89,7 @@ it('ResourceExtension Events', () => {
     payload: updatedExtension
   };
 
-  const updatedState = extensionsReducer({}, updateAction);
+  const updatedState = extensionsReducer(state, updateAction);
   expect(selectors.getExtensions(updatedState)).toEqual([
     selectors.mapResourceExtension(updatedExtension)
   ]);
@@ -134,7 +134,7 @@ it('ServiceExtension Events', () => {
     payload: updatedExtension
   };
 
-  const updatedState = extensionsReducer({}, updateAction);
+  const updatedState = extensionsReducer(state, updateAction);
   expect(selectors.getExtensions(updatedState)).toEqual([
     selectors.mapServiceExtension(updatedExtension)
   ]);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1770 and https://github.com/tektoncd/dashboard/issues/1771
Tests for the 'UPDATED' case in the extensions and ClusterTasks
reducers were starting with an empty state rather than having
an existing resource to ensure the update was being handled
correctly. As a result we missed the fact that the updates were
not being applied as expected, instead in most cases any changes
would immediately be overwritten by the previous state.

This lead to inconsistent updates of the ClusterTask details
page as well as extensions in some cases.

Fix the tests to ensure an existing resource is present in the
state before testing the update (verified this failed on previous
implementation) and fix the reducers to ensure the update resource
is applied on top of the existing state.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
