### PR TITLE
Update string on Import Resource success notification

### DIFF
--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -378,7 +378,7 @@ export class ImportResources extends Component {
               title={intl.formatMessage({
                 id: 'dashboard.importResources.triggeredNotification',
                 defaultMessage:
-                  'Triggered PipelineRun to apply Tekton resources'
+                  'Triggered PipelineRun to import Tekton resources'
               })}
               subtitle=""
               onCloseButtonClick={this.resetSuccess}

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -153,7 +153,7 @@ describe('ImportResources component', () => {
 
     fireEvent.click(getByText('Import and Apply'));
     await waitForElement(() =>
-      getByText(/Triggered PipelineRun to apply Tekton resources/i)
+      getByText(/Triggered PipelineRun to import Tekton resources/i)
     );
 
     expect(

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -132,7 +132,7 @@
     "dashboard.importResources.targetNamespace.helperText": "The namespace in which the resources will be created",
     "dashboard.importResources.targetNamespace.titleText": "Target namespace",
     "dashboard.importResources.title": "Import resources",
-    "dashboard.importResources.triggeredNotification": "Triggered PipelineRun to apply Tekton resources",
+    "dashboard.importResources.triggeredNotification": "Triggered PipelineRun to import Tekton resources",
     "dashboard.keyValueList.add": "Add",
     "dashboard.keyValueList.remove": "Remove",
     "dashboard.labelFilter.addFilterButton": "Add Filter",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related issue that would make this string more visible: https://github.com/tektoncd/dashboard/issues/1773

The string currently reads:
'Triggered PipelineRun to apply Tekton resources'

however with recent changes to add support for `generateName`
via the `kubectl create` command this is no longer accurate.

Update the string to replace 'apply' with 'import' to cover
both existing and potential future cases.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
