### PR TITLE
Add guard to log fetchers for missing step status

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -38,7 +38,7 @@ export function typeToPlural(type) {
 export async function followLogs(stepName, stepStatus, taskRun) {
   const { pod, namespace } = taskRun;
   let logs;
-  if (pod) {
+  if (pod && stepStatus) {
     const { container } = stepStatus;
     logs = getPodLog({
       container,
@@ -53,7 +53,7 @@ export async function followLogs(stepName, stepStatus, taskRun) {
 export async function fetchLogs(stepName, stepStatus, taskRun) {
   const { pod, namespace } = taskRun;
   let logs;
-  if (pod) {
+  if (pod && stepStatus) {
     const { container } = stepStatus;
     logs = getPodLog({
       container,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
```
TypeError: Cannot destructure property 'container' of 'stepStatus' as it is undefined.
    at fetchLogs (webpack-internal:///./src/utils/index.js:89)
```

I've only seen an error like this when running the dashboard in dev mode, but adding
the guard since it may just be a timing issue exposed by slower processing in dev.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
