### PR TITLE
Handle missing TaskRun status in TaskRunDetails component

### DIFF
--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -93,7 +93,16 @@ const TaskRunDetails = props => {
           })}
         >
           <div className="tkn--step-status">
-            <ViewYAML resource={taskRun.status} dark />
+            <ViewYAML
+              resource={
+                taskRun.status ||
+                intl.formatMessage({
+                  id: 'dashboard.taskRuns.status.pending',
+                  defaultMessage: 'Pending'
+                })
+              }
+              dark
+            />
           </div>
         </Tab>
       </Tabs>

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -68,6 +68,7 @@ describe('TaskRunDetails', () => {
       <TaskRunDetails taskRun={taskRun} view="status" />
     );
     expect(queryByText(/status/i)).toBeTruthy();
+    expect(queryByText(/pending/i)).toBeTruthy();
     expect(queryByText('fake_name')).toBeFalsy();
     fireEvent.click(queryByText(/parameters/i));
     expect(queryByText('fake_name')).toBeTruthy();


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1784

The TaskRunDetails component displays the `taskRun.status`
in the status tab. However, if the status is not available for
any reason, it instead displays the 'undefined' YAML tag.

Replace this with a 'Pending' message until the status is available.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
