### PR TITLE
Fix rerun of cancelled runs

### DIFF
--- a/src/api/pipelineRuns.js
+++ b/src/api/pipelineRuns.js
@@ -116,6 +116,7 @@ export function rerunPipelineRun(pipelineRun) {
   delete payload.metadata.labels['tekton.dev/pipeline'];
 
   delete payload.status;
+  delete payload.spec?.status;
 
   const uri = getTektonAPI('pipelineruns', { namespace });
   return post(uri, payload).then(({ body }) => body);

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -199,11 +199,22 @@ it('getPipelineRuns With Query Params', () => {
 });
 
 it('rerunPipelineRun', () => {
-  const originalPipelineRun = { metadata: { name: 'fake_pipelineRun' } };
+  const filter = 'end:/pipelineruns/';
+  const originalPipelineRun = {
+    metadata: { name: 'fake_pipelineRun' },
+    spec: { status: 'fake_status' },
+    status: 'fake_status'
+  };
   const newPipelineRun = { metadata: { name: 'fake_pipelineRun_rerun' } };
   mockCSRFToken();
-  fetchMock.post(`end:/pipelineruns/`, { body: newPipelineRun, status: 201 });
+  fetchMock.post(filter, { body: newPipelineRun, status: 201 });
   return API.rerunPipelineRun(originalPipelineRun).then(data => {
+    const body = JSON.parse(fetchMock.lastCall(filter)[1].body);
+    expect(body.metadata.generateName).toMatch(
+      new RegExp(originalPipelineRun.metadata.name)
+    );
+    expect(body.status).toBeUndefined();
+    expect(body.spec.status).toBeUndefined();
     expect(data).toEqual(newPipelineRun);
     fetchMock.restore();
   });

--- a/src/api/taskRuns.js
+++ b/src/api/taskRuns.js
@@ -131,6 +131,7 @@ export function rerunTaskRun(taskRun) {
   delete payload.metadata.labels['tekton.dev/task'];
 
   delete payload.status;
+  delete payload.spec?.status;
 
   const uri = getTektonAPI('taskruns', { namespace });
   return post(uri, payload).then(({ body }) => body);

--- a/src/api/taskRuns.test.js
+++ b/src/api/taskRuns.test.js
@@ -214,11 +214,22 @@ it('getTaskRuns With Query Params', () => {
 });
 
 it('rerunTaskRun', () => {
-  const originalTaskRun = { metadata: { name: 'fake_taskRun' } };
+  const filter = 'end:/taskruns/';
+  const originalTaskRun = {
+    metadata: { name: 'fake_taskRun' },
+    spec: { status: 'fake_status' },
+    status: 'fake_status'
+  };
   const newTaskRun = { metadata: { name: 'fake_taskRun_rerun' } };
   mockCSRFToken();
-  fetchMock.post(`end:/taskruns/`, { body: newTaskRun, status: 201 });
+  fetchMock.post(filter, { body: newTaskRun, status: 201 });
   return API.rerunTaskRun(originalTaskRun).then(data => {
+    const body = JSON.parse(fetchMock.lastCall(filter)[1].body);
+    expect(body.metadata.generateName).toMatch(
+      new RegExp(originalTaskRun.metadata.name)
+    );
+    expect(body.status).toBeUndefined();
+    expect(body.spec.status).toBeUndefined();
     expect(data).toEqual(newTaskRun);
     fetchMock.restore();
   });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1788

Tekton Pipelines now includes the PipelineRunStatus or TaskRunStatus
in the PipelineRun or TaskRun spec.

Remove the additional status from the payload submitted for the
rerun so the new run doesn't start in a cancelled state.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
