### PR TITLE
Fix loading of CRD extensions when a specific namespace is selected

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -30,7 +30,12 @@ import {
   LogoutButton,
   PageErrorBoundary
 } from '@tektoncd/dashboard-components';
-import { getErrorMessage, paths, urls } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  getErrorMessage,
+  paths,
+  urls
+} from '@tektoncd/dashboard-utils';
 
 import {
   About,
@@ -159,7 +164,7 @@ export /* istanbul ignore next */ class App extends Component {
       }
 
       this.props.fetchExtensions({
-        namespace: this.props.tenantNamespace
+        namespace: this.props.tenantNamespace || ALL_NAMESPACES
       });
     }
   }

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -16,6 +16,7 @@ import { Provider } from 'react-redux';
 import { render, waitForElement } from 'react-testing-library';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { App } from './App';
 import * as PipelinesAPI from '../../api/pipelines';
@@ -227,7 +228,7 @@ describe('App', () => {
     expect(fetchExtensions).toHaveBeenCalledWith({ namespace: 'fake' });
   });
 
-  it('calls fetchExtensions without namespace in full cluster mode', async () => {
+  it('calls fetchExtensions with ALL_NAMESPACES in full cluster mode', async () => {
     const middleware = [thunk];
     const mockStore = configureStore(middleware);
     const store = mockStore({
@@ -253,7 +254,7 @@ describe('App', () => {
     );
 
     await waitForElement(() => queryByText('Tekton resources'));
-    expect(fetchExtensions).toHaveBeenCalledWith({});
+    expect(fetchExtensions).toHaveBeenCalledWith({ namespace: ALL_NAMESPACES });
     expect(fetchNamespaces).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1800

The side nav should always display extensions, regardless of the
globally selected namespace. The resulting UI produced by the extension
will be subject to the filter, but its presence/absence in the nav
should not depend on this.

Since we already check for the single namespace mode, we can safely
change the fallback to query all namespaces (i.e. use the non-namespaced
API call) instead of using the globally selected namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
