### PR TITLE
Update DetailsHeader stories to include `type` control

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
@@ -15,45 +15,70 @@ import React from 'react';
 
 import DetailsHeader from './DetailsHeader';
 
-const taskRun = {
+const getTaskRun = ({ reason, succeeded, taskReason, taskStatus }) => ({
   id: 'task',
   taskName: 'A Task',
+  succeeded,
+  reason,
   status: {
     conditions: [
       {
-        reason: 'Pending',
-        status: 'Unknown',
+        reason: taskReason,
+        status: taskStatus,
         type: 'Succeeded'
       }
     ]
   }
-};
+});
 
 export default {
+  args: {
+    type: 'step'
+  },
+  argTypes: {
+    type: {
+      control: {
+        type: 'inline-radio',
+        options: ['step', 'taskRun']
+      }
+    }
+  },
   component: DetailsHeader,
   title: 'Components/DetailsHeader'
 };
 
-export const Running = () => (
-  <DetailsHeader status="running" stepName="build" taskRun={taskRun} />
+export const Running = args => (
+  <DetailsHeader
+    status="running"
+    stepName="build"
+    taskRun={getTaskRun({ reason: 'Running', succeeded: 'Unknown' })}
+    {...args}
+  />
 );
 
-export const Completed = () => (
+export const Completed = args => (
   <DetailsHeader
     reason="Completed"
     status="terminated"
     stepName="build"
-    taskRun={taskRun}
+    taskRun={getTaskRun({ reason: 'Succeeded', succeeded: 'True' })}
+    {...args}
   />
 );
 
-export const Failed = () => (
+export const Failed = args => (
   <DetailsHeader
     reason="Error"
     status="terminated"
     stepName="build"
-    taskRun={taskRun}
+    taskRun={getTaskRun({ reason: 'Failed', succeeded: 'False' })}
+    {...args}
   />
 );
 
-export const Pending = () => <DetailsHeader taskRun={taskRun} />;
+export const Pending = args => (
+  <DetailsHeader
+    taskRun={getTaskRun({ taskReason: 'Pending', taskStatus: 'Unknown' })}
+    {...args}
+  />
+);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1796
~~Depends on https://github.com/tektoncd/dashboard/pull/1787~~

Add radio button control to the DetailsHeader stories to allow the
user to set the value of the `type` prop, switching between `step`
and `taskRun`.

Update the test data used in the stories to more accurately reflect
the content actually consumed at runtime.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
