### PR TITLE
Update design of the TaskTree component

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.js
@@ -96,6 +96,7 @@ class DetailsHeader extends Component {
             DefaultIcon={type === 'step' ? DefaultIcon : null}
             reason={reason}
             status={status}
+            {...(type === 'step' ? { type: 'inverse' } : null)}
           />
           <span className="tkn--run-details-name" title={stepName}>
             {stepName}

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -42,23 +42,20 @@ limitations under the License.
 
     > .tkn--status-icon {
       vertical-align: top;
-      margin-right: 0.85rem;
+      margin-right: 0.75rem;
       width: 24px;
       height: 24px;
 
       &.tkn--spinner {
         position: relative;
-        top: -0.1rem;
-        left: -0.1rem;
-        width: 1.75rem;
-        height: 1.75rem;
-        margin-right: 0.6rem;
+        top: -1px;
+        left: -1px;
       }
     }
 
     > .tkn--status-label {
       font-size: 0.9rem;
-      margin-left: 0.8rem;
+      margin-left: 0.75rem;
     }
   }
 

--- a/packages/components/src/components/Spinner/Spinner.js
+++ b/packages/components/src/components/Spinner/Spinner.js
@@ -13,21 +13,10 @@ limitations under the License.
 
 import React from 'react';
 
+import { Renew20 as SpinnerIcon } from '@carbon/icons-react';
+
 import './Spinner.scss';
 
 export default function Spinner({ className }) {
-  return (
-    <svg
-      aria-label="running"
-      className={`tkn--spinner ${className}`}
-      viewBox="0 0 16 16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M3.5,8c0,1.199,0.4,2.299,1.3,3.1l-0.7,0.699c-1-1-1.6-2.398-1.6-3.799C2.5,5,5,2.5,8,2.5h0.3L7,1.2l0.8-0.7
-        L10.3,3L7.8,5.5L7,4.8l1.3-1.3H8C5.5,3.5,3.5,5.5,3.5,8 M13.5,8c0-1.4-0.6-2.8-1.6-3.8l-0.7,0.699C12,5.7,12.5,6.899,12.5,8
-        c0,2.5-2,4.5-4.5,4.5H7.8L9,11.299L8.3,10.5L5.8,13l2.5,2.5L9,14.799L7.8,13.5h0.3C11.1,13.5,13.5,11,13.5,8"
-      />
-    </svg>
-  );
+  return <SpinnerIcon className={`tkn--spinner ${className}`} />;
 }

--- a/packages/components/src/components/Spinner/Spinner.scss
+++ b/packages/components/src/components/Spinner/Spinner.scss
@@ -12,8 +12,6 @@ limitations under the License.
 */
 
 .tkn--spinner {
-  width: 20px;
-  height: 20px;
   animation-name: tkn--rotateThis;
   animation-duration: 1.9s;
   animation-iteration-count: infinite;
@@ -22,11 +20,9 @@ limitations under the License.
 
 @keyframes tkn--rotateThis {
   0% {
-    transform: rotate(0deg);
-    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg) scaleX(-1);
   }
   100% {
-    transform: rotate(360deg);
-    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg) scaleX(-1);
   }
 }

--- a/packages/components/src/components/StatusIcon/StatusIcon.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.js
@@ -18,35 +18,55 @@ import React from 'react';
 import classNames from 'classnames';
 import {
   CheckmarkFilled20 as CheckmarkFilled,
+  CheckmarkOutline20 as CheckmarkOutline,
   CloseFilled20 as CloseFilled,
+  CloseOutline20 as CloseOutline,
   Time20 as Time
 } from '@carbon/icons-react';
 import { isRunning } from '@tektoncd/dashboard-utils';
 
 import { Spinner } from '..';
 
-export default function StatusIcon({ DefaultIcon, inverse, reason, status }) {
-  let Icon = DefaultIcon;
+const icons = {
+  normal: {
+    cancelled: CloseFilled,
+    error: CloseFilled,
+    pending: Time,
+    running: Spinner,
+    success: CheckmarkFilled
+  },
+  inverse: {
+    cancelled: CloseOutline,
+    error: CloseOutline,
+    pending: Time,
+    running: Spinner,
+    success: CheckmarkOutline
+  }
+};
+
+export default function StatusIcon({
+  DefaultIcon,
+  type = 'normal',
+  reason,
+  status
+}) {
   let statusClass;
   if (
     (!status && !DefaultIcon) ||
     (status === 'Unknown' && reason === 'Pending')
   ) {
-    Icon = Time;
+    statusClass = 'pending';
   } else if (isRunning(reason, status)) {
-    Icon = Spinner;
     statusClass = 'running';
   } else if (
     status === 'True' ||
     (status === 'terminated' && reason === 'Completed')
   ) {
-    Icon = CheckmarkFilled;
     statusClass = 'success';
   } else if (
     status === 'False' &&
     (reason === 'PipelineRunCancelled' || reason === 'TaskRunCancelled')
   ) {
-    Icon = CloseFilled;
     statusClass = 'cancelled';
   } else if (
     status === 'False' ||
@@ -54,15 +74,15 @@ export default function StatusIcon({ DefaultIcon, inverse, reason, status }) {
     status === 'terminated' ||
     (status === 'Unknown' && reason === 'PipelineRunCouldntCancel')
   ) {
-    Icon = CloseFilled;
     statusClass = 'error';
   }
+
+  const Icon = icons[type]?.[statusClass] || DefaultIcon;
 
   return Icon ? (
     <Icon
       className={classNames('tkn--status-icon', {
-        [`tkn--status-icon--${statusClass}`]: statusClass,
-        'tkn--status-icon--inverse': inverse
+        [`tkn--status-icon--${statusClass}`]: statusClass
       })}
     />
   ) : null;

--- a/packages/components/src/components/StatusIcon/StatusIcon.scss
+++ b/packages/components/src/components/StatusIcon/StatusIcon.scss
@@ -15,6 +15,8 @@ limitations under the License.
 
 .tkn--status-icon {
   fill: $not-run;
+  width: 20px;
+  height: 20px;
 
   &--cancelled {
     fill: $ui-04;
@@ -30,9 +32,5 @@ limitations under the License.
 
   &--success {
     fill: $success;
-  }
-
-  &--inverse {
-    fill: white;
   }
 }

--- a/packages/components/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.stories.js
@@ -17,7 +17,15 @@ import StatusIcon from './StatusIcon';
 
 export default {
   component: StatusIcon,
-  args: { inverse: false },
+  args: { type: 'normal' },
+  argTypes: {
+    type: {
+      control: {
+        type: 'inline-radio',
+        options: ['normal', 'inverse']
+      }
+    }
+  },
   title: 'Components/StatusIcon'
 };
 

--- a/packages/components/src/components/Step/Step.js
+++ b/packages/components/src/components/Step/Step.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
-import { ChevronRight16 as DefaultIcon } from '@carbon/icons-react';
+import { ChevronRight20 as DefaultIcon } from '@carbon/icons-react';
 
 import StatusIcon from '../StatusIcon';
 
@@ -92,6 +92,7 @@ class Step extends Component {
         >
           <StatusIcon
             DefaultIcon={DefaultIcon}
+            type="inverse"
             reason={reason}
             status={status}
           />

--- a/packages/components/src/components/Step/Step.scss
+++ b/packages/components/src/components/Step/Step.scss
@@ -24,43 +24,32 @@ limitations under the License.
     text-decoration: none;
   }
 
-  &[data-selected] > a.tkn--step-link:after {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    border-top: 1.1rem solid transparent;
-    border-right: 0.8rem solid white;
-    border-bottom: 1.1rem solid transparent;
+  &:hover > a.tkn--step-link,
+  > a.tkn--step-link:hover {
+    border-left-color: $hover-ui;
+  }
+
+  &[data-selected] > a.tkn--step-link {
+    background-color: transparent;
+    border-left: 3px solid $interactive-04;
   }
 
   > a.tkn--step-link {
     display: flex;
     align-items: baseline;
     position: relative;
-    padding: 0 2.25rem;
-    margin: 1px 0;
+    padding: 0 1rem 0 .75rem;
     line-height: 2.2rem;
     font-size: 0.78rem;
     letter-spacing: 0.02rem;
     text-decoration: none;
+    border-left: 3px solid white;
   }
 
   .tkn--status-icon {
     flex-shrink: 0;
     align-self: center;
-    margin-right: 0.55rem;
-    &:not(.tkn--spinner) {
-      width: 16px;
-      height: 16px;
-    }
-
-    &.tkn--spinner {
-      position: relative;
-      top: -0.1rem;
-      left: -0.1rem;
-    }
+    margin-right: 0.75rem;
   }
 
   .tkn--step-name {
@@ -72,14 +61,9 @@ limitations under the License.
 
   .tkn--status-label {
     flex-shrink: 0;
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
     font-size: 0.7rem;
     letter-spacing: 0.01rem;
-  }
-
-  &[data-status] > a.tkn--step-link {
-    // default status
-    opacity: 0.75;
   }
 
   &[data-status='running'] > a.tkn--step-link {

--- a/packages/components/src/components/StepDetails/StepDetails.scss
+++ b/packages/components/src/components/StepDetails/StepDetails.scss
@@ -27,6 +27,10 @@ limitations under the License.
     width: 50%;
   }
 
+  .bx--tab-content {
+    padding-left: 0;
+  }
+
   .bx--tab-content .tkn--table .bx--data-table.bx--data-table--short {
     td.cell-value {
       max-width: unset;

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -12,7 +12,10 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
-import { ChevronRight16 as DefaultIcon } from '@carbon/icons-react';
+import {
+  ChevronRight20 as DefaultIcon,
+  ChevronDown20 as ExpandIcon
+} from '@carbon/icons-react';
 import { StatusIcon, Step } from '@tektoncd/dashboard-components';
 
 import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
@@ -69,12 +72,17 @@ class Task extends Component {
       succeeded
     } = this.props;
 
+    const expandIcon = expanded ? null : (
+      <ExpandIcon className="tkn--task--expand-icon" />
+    );
+
     return (
       <li
         className="tkn--task"
         data-succeeded={succeeded}
         data-reason={reason}
         data-selected={(expanded && !selectedStepId) || undefined}
+        data-active={expanded || undefined}
       >
         <a
           className="tkn--task-link"
@@ -84,13 +92,11 @@ class Task extends Component {
         >
           <StatusIcon
             DefaultIcon={DefaultIcon}
-            inverse={
-              succeeded !== 'Unknown' || (reason && reason !== 'Pending')
-            }
             reason={reason}
             status={succeeded}
           />
-          {pipelineTaskName}
+          <span className="tkn--task-link--name">{pipelineTaskName}</span>
+          {expandIcon}
         </a>
         {expanded && (
           <ol className="tkn--step-list">

--- a/packages/components/src/components/Task/Task.scss
+++ b/packages/components/src/components/Task/Task.scss
@@ -17,99 +17,69 @@ limitations under the License.
   list-style-type: none;
 
   > a.tkn--task-link {
-    color: $text-01;
+    display: flex;
+    align-items: center;
+    position: relative;
+    padding: 0 1rem 0 .75rem;
+    font-size: 0.76rem;
+    letter-spacing: 0.06rem;
+    font-weight: bold;
+    line-height: 2.2rem;
     text-decoration: none;
+    color: inherit;
+    margin: 1rem 1rem 0 0;
+    white-space: nowrap;
+    background-color: white;
+    border-left: 3px solid white;
+
+    > .tkn--status-icon {
+      margin-right: 0.75rem;
+    }
 
     &:focus, &:hover {
+      background-color: $hover-ui;
       text-decoration: none;
+      border-left-color: $hover-ui;
+    }
+
+    .tkn--task-link--name {
+      flex-grow: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    > .tkn--status-icon,
+    > .tkn--task--expand-icon {
+      flex-shrink: 0;
     }
   }
 
-  &[data-selected] > a.tkn--task-link:after {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    border-top: 1.1rem solid transparent;
-    border-right: 0.8rem solid white;
-    border-bottom: 1.1rem solid transparent;
+  &[data-selected] > a.tkn--task-link {
+    border-left: 3px solid $interactive-04;
+    margin-right: 0;
   }
 
-  &[data-selected]:not([data-succeeded]) > a.tkn--task-link,
-    &[data-selected][data-succeeded='Unknown'] > a.tkn--task-link {
-    background-color: $hover-ui;
+  &[data-active] > a.tkn--task-link {
+    margin-right: 0;
+
+    .tkn--task--expand-icon {
+      /* needed when we support expanding multiple tasks */
+      margin-right: 1rem;
+    }
   }
 
   &:not([data-succeeded]) > a.tkn--task-link {
-    background-color: $waiting-bg;
-    color: $waiting-fg;
     &:hover {
       color: $waiting-fg;
       background-color: $waiting-bg-hover;
-    }
-    &:after {
-      height: 1px;
-      left: -1px;
-      right: -1px;
-    }
-  }
-  &[data-succeeded='True'] > a.tkn--task-link {
-    background-color: $success-bg;
-    color: $success-fg;
-    &:focus, &:hover {
-      color: $success-fg;
-      background-color: $success-bg-hover;
-    }
-  }
-  &[data-succeeded='False'] > a.tkn--task-link {
-    background-color: $failed-bg;
-    color: $failed-fg;
-    &:focus, &:hover {
-      color: $failed-fg;
-      background-color: $failed-bg-hover;
-    }
-  }
-  &[data-succeeded='Unknown'][data-reason='Running'] > a.tkn--task-link {
-    background-color: $running-bg;
-    color: $running-fg;
-    &:focus, &:hover {
-      color: $running-fg;
-      background-color: $running-bg-hover;
-    }
-  }
-
-  > a.tkn--task-link {
-    display: block;
-    position: relative;
-    padding: 0 1.25rem;
-    text-decoration: none;
-    color: inherit;
-    margin: 1px 0;
-    line-height: 2.2rem;
-    white-space: nowrap;
-    font-size: 0.76rem;
-    letter-spacing: 0.06rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    > .tkn--status-icon {
-      vertical-align: text-top;
-      margin-right: 0.7rem;
-      width: 16px;
-      height: 16px;
-
-      &.tkn--spinner {
-        position: relative;
-        top: -0.1rem;
-        left: -0.1rem;
-        width: 20px;
-        height: 20px;
-      }
     }
   }
 
   &:first-child > a.tkn--task-link {
     margin-top: 0;
+  }
+
+  .tkn--step-list {
+    background-color: white;
   }
 }

--- a/packages/components/src/components/TaskTree/TaskTree.scss
+++ b/packages/components/src/components/TaskTree/TaskTree.scss
@@ -14,7 +14,6 @@ limitations under the License.
 @import '~carbon-components/scss/globals/scss/vars';
 
 .tkn--task-tree {
-  border-right: 1px solid $ui-03;
   width: 21%;
   min-width: 15rem;
 }

--- a/packages/components/src/components/TaskTree/TaskTree.stories.js
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.js
@@ -43,7 +43,8 @@ export default {
           { id: 'step 1', stepName: 'step 1' },
           { id: 'step 2', stepName: 'step 2' }
         ],
-        succeeded: 'Unknown'
+        succeeded: 'Unknown',
+        reason: 'Running'
       }
     ]
   },

--- a/packages/components/src/components/TaskTree/TaskTree.test.js
+++ b/packages/components/src/components/TaskTree/TaskTree.test.js
@@ -65,9 +65,15 @@ it('TaskTree renders and expands first Task in TaskRun with no error', () => {
   const { queryByText } = renderWithIntl(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
-  expect(queryByText('A Task').parentNode.childNodes).toHaveLength(2);
-  expect(queryByText('A Second Task').parentNode.childNodes).toHaveLength(1);
-  expect(queryByText('A Third Task').parentNode.childNodes).toHaveLength(1);
+  expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
+    2
+  );
+  expect(
+    queryByText('A Second Task').parentNode.parentNode.childNodes
+  ).toHaveLength(1);
+  expect(
+    queryByText('A Third Task').parentNode.parentNode.childNodes
+  ).toHaveLength(1);
 });
 
 it('TaskTree renders and expands error Task in TaskRun', () => {
@@ -76,9 +82,15 @@ it('TaskTree renders and expands error Task in TaskRun', () => {
   const { queryByText } = renderWithIntl(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
-  expect(queryByText('A Task').parentNode.childNodes).toHaveLength(1);
-  expect(queryByText('A Second Task').parentNode.childNodes).toHaveLength(2);
-  expect(queryByText('A Third Task').parentNode.childNodes).toHaveLength(1);
+  expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
+    1
+  );
+  expect(
+    queryByText('A Second Task').parentNode.parentNode.childNodes
+  ).toHaveLength(2);
+  expect(
+    queryByText('A Third Task').parentNode.parentNode.childNodes
+  ).toHaveLength(1);
 });
 
 it('TaskTree renders and expands first error Task in TaskRun', () => {
@@ -88,9 +100,15 @@ it('TaskTree renders and expands first error Task in TaskRun', () => {
   const { queryByText } = renderWithIntl(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
-  expect(queryByText('A Task').parentNode.childNodes).toHaveLength(1);
-  expect(queryByText('A Second Task').parentNode.childNodes).toHaveLength(2);
-  expect(queryByText('A Third Task').parentNode.childNodes).toHaveLength(1);
+  expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
+    1
+  );
+  expect(
+    queryByText('A Second Task').parentNode.parentNode.childNodes
+  ).toHaveLength(2);
+  expect(
+    queryByText('A Third Task').parentNode.parentNode.childNodes
+  ).toHaveLength(1);
 });
 
 it('TaskTree handles click event on Task', () => {

--- a/packages/components/src/scss/Run.scss
+++ b/packages/components/src/scss/Run.scss
@@ -18,14 +18,15 @@ limitations under the License.
   flex-wrap: nowrap;
   min-height: calc(100vh - 16rem);
   align-items: stretch;
-  background-color: white;
 
   .tkn--task-tree {
     flex-shrink: 0;
   }
 
   .tkn--step-details {
+    background-color: white;
     flex-grow: 1;
+    padding-left: 1rem;
   }
 
   .bx--data-table {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1775
~~Depends on https://github.com/tektoncd/dashboard/pull/1787~~

Remove use of bold block background colours for the TaskRun status
and switch to a more Carbon-compliant design with icons consistent
with use elsewhere in the Dashboard.

Simplify the styles and remove obsolete vendor prefixes.

Before:
![image](https://user-images.githubusercontent.com/2829095/97494739-a45b5000-195e-11eb-92f8-9340199cd453.png)

After:
![image](https://user-images.githubusercontent.com/2829095/97494754-aa513100-195e-11eb-9fc8-3b3c52d3bdef.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
