### PR TITLE
Fix key prop warning on LogFormat component

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.js
+++ b/packages/components/src/components/LogFormat/LogFormat.js
@@ -241,7 +241,7 @@ const LogFormat = ({ children }) => {
 
   const parse = (ansi, index) => {
     if (ansi.length === 0) {
-      return <br />;
+      return <br key={index} />;
     }
     let offset = 0;
     while (offset !== ansi.length) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1793

The LogFormat component is emitting a warning in dev mode
(including the tests) due to a missing `key` prop in the
`parse` function.

Add the missing `key` prop on the `<br />` element.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
