### PR TITLE
Update webpack devserver proxy config for remote backends

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -39,10 +39,12 @@ module.exports = merge(common({ mode }), {
     proxy: {
       ...(process.env.EXTENSIONS_LOCAL_DEV ? extensionConfig : {}),
       '/v1': {
+        secure: false,
         target: process.env.API_DOMAIN || API_DOMAIN,
         ws: true
       },
       '/proxy': {
+        secure: false,
         target: process.env.API_DOMAIN || API_DOMAIN,
         ws: true
       }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1809

Update the webpack devserver proxy config to enable testing local
UI changes against a remote backend server.

The `secure: false` flag on the proxy rules disables strict
certificate checks, allowing for example the use of self-signed
certificates in test environments.

This should only impact developers running `npm start` with the
`API_DOMAIN` environment variable configured to point to a remote
backend deployed with HTTPS enabled.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
