### PR TITLE
Refactor TaskRun / PipelineRun component trees to separate definitions from runtime data

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.js
@@ -74,7 +74,7 @@ class DetailsHeader extends Component {
     let statusLabel;
 
     if (type === 'taskRun') {
-      ({ reason, succeeded: status } = taskRun);
+      ({ reason, status } = getStatus(taskRun));
       statusLabel =
         reason ||
         intl.formatMessage({

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
@@ -15,16 +15,12 @@ import React from 'react';
 
 import DetailsHeader from './DetailsHeader';
 
-const getTaskRun = ({ reason, succeeded, taskReason, taskStatus }) => ({
-  id: 'task',
-  taskName: 'A Task',
-  succeeded,
-  reason,
+const getTaskRun = ({ reason, status }) => ({
   status: {
     conditions: [
       {
-        reason: taskReason,
-        status: taskStatus,
+        reason,
+        status,
         type: 'Succeeded'
       }
     ]
@@ -51,7 +47,7 @@ export const Running = args => (
   <DetailsHeader
     status="running"
     stepName="build"
-    taskRun={getTaskRun({ reason: 'Running', succeeded: 'Unknown' })}
+    taskRun={getTaskRun({ reason: 'Running', status: 'Unknown' })}
     {...args}
   />
 );
@@ -61,7 +57,7 @@ export const Completed = args => (
     reason="Completed"
     status="terminated"
     stepName="build"
-    taskRun={getTaskRun({ reason: 'Succeeded', succeeded: 'True' })}
+    taskRun={getTaskRun({ reason: 'Succeeded', status: 'True' })}
     {...args}
   />
 );
@@ -71,14 +67,14 @@ export const Failed = args => (
     reason="Error"
     status="terminated"
     stepName="build"
-    taskRun={getTaskRun({ reason: 'Failed', succeeded: 'False' })}
+    taskRun={getTaskRun({ reason: 'Failed', status: 'False' })}
     {...args}
   />
 );
 
 export const Pending = args => (
   <DetailsHeader
-    taskRun={getTaskRun({ taskReason: 'Pending', taskStatus: 'Unknown' })}
+    taskRun={getTaskRun({ reason: 'Pending', status: 'Unknown' })}
     {...args}
   />
 );

--- a/packages/components/src/components/Log/Log.stories.js
+++ b/packages/components/src/components/Log/Log.stories.js
@@ -40,7 +40,6 @@ export const Completed = () => (
   <Log
     stepStatus={{ terminated: { reason: 'Completed' } }}
     fetchLogs={() => 'A log message'}
-    status="Completed"
   />
 );
 
@@ -48,7 +47,6 @@ export const Failed = () => (
   <Log
     stepStatus={{ terminated: { reason: 'Error' } }}
     fetchLogs={() => 'A log message'}
-    status="Error"
   />
 );
 
@@ -56,7 +54,6 @@ export const ANSICodes = () => (
   <Log
     stepStatus={{ terminated: { reason: 'Completed' } }}
     fetchLogs={() => ansiLog}
-    status="Completed"
   />
 );
 
@@ -64,7 +61,6 @@ export const Windowed = () => (
   <Log
     stepStatus={{ terminated: { reason: 'Completed' } }}
     fetchLogs={() => long}
-    status="Completed"
   />
 );
 
@@ -72,7 +68,6 @@ export const Performance = () => (
   <Log
     stepStatus={{ terminated: { reason: 'Completed' } }}
     fetchLogs={() => performanceTest}
-    status="Completed"
   />
 );
 Performance.storyName = 'performance test (<20,000 lines with ANSI)';

--- a/packages/components/src/components/RunHeader/RunHeader.stories.js
+++ b/packages/components/src/components/RunHeader/RunHeader.stories.js
@@ -21,9 +21,7 @@ const now = new Date();
 export default {
   args: {
     name: 'simple-pipeline',
-    runName: 'simple-pipeline-run-1',
-    type: 'pipelines',
-    typeLabel: 'Pipelines'
+    runName: 'simple-pipeline-run-1'
   },
   component: RunHeader,
   decorators: [StoryRouter()],

--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -14,9 +14,9 @@ limitations under the License.
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
-import { urls } from '@tektoncd/dashboard-utils';
+import { getResources, urls } from '@tektoncd/dashboard-utils';
 
-import { Param, ResourceTable, ViewYAML } from '..';
+import { ResourceTable, ViewYAML } from '..';
 
 const resourceTable = (title, namespace, resources, intl) => {
   return (
@@ -67,59 +67,29 @@ class StepDefinition extends Component {
       return null;
     }
 
+    const { namespace } = taskRun.metadata;
+    const { inputResources, outputResources } = getResources(taskRun.spec);
+
     return (
       <>
-        {taskRun.params && (
-          <ResourceTable
-            title={intl.formatMessage({
-              id: 'dashboard.parameters.title',
-              defaultMessage: 'Parameters'
-            })}
-            rows={taskRun.params.map(({ name, value }) => ({
-              id: name,
-              name,
-              value: (
-                <span title={value}>
-                  <Param>{value}</Param>
-                </span>
-              )
-            }))}
-            headers={[
-              {
-                key: 'name',
-                header: intl.formatMessage({
-                  id: 'dashboard.tableHeader.name',
-                  defaultMessage: 'Name'
-                })
-              },
-              {
-                key: 'value',
-                header: intl.formatMessage({
-                  id: 'dashboard.tableHeader.value',
-                  defaultMessage: 'Value'
-                })
-              }
-            ]}
-          />
-        )}
-        {taskRun.inputResources &&
+        {inputResources &&
           resourceTable(
             intl.formatMessage({
               id: 'dashboard.stepDefinition.inputResources',
               defaultMessage: 'Input Resources'
             }),
-            taskRun.namespace,
-            taskRun.inputResources,
+            namespace,
+            inputResources,
             intl
           )}
-        {taskRun.outputResources &&
+        {outputResources &&
           resourceTable(
             intl.formatMessage({
               id: 'dashboard.stepDefinition.outputResources',
               defaultMessage: 'Output Resources'
             }),
-            taskRun.namespace,
-            taskRun.outputResources,
+            namespace,
+            outputResources,
             intl
           )}
       </>
@@ -128,27 +98,21 @@ class StepDefinition extends Component {
 
   render() {
     const { definition, intl } = this.props;
-    const {
-      container,
-      imageID,
-      running,
-      terminated,
-      waiting,
-      ...stepDefinition
-    } = definition || {};
 
-    const resource = definition
-      ? stepDefinition
-      : intl.formatMessage({
-          id: 'dashboard.step.definitionNotAvailable',
-          defaultMessage: 'Definition not available'
-        });
-
-    const paramsResources = this.getIOTables();
+    const resources = this.getIOTables();
     return (
       <>
-        <ViewYAML resource={resource} dark />
-        {paramsResources}
+        <ViewYAML
+          resource={
+            definition ||
+            intl.formatMessage({
+              id: 'dashboard.step.definitionNotAvailable',
+              defaultMessage: 'Step definition not available'
+            })
+          }
+          dark
+        />
+        {resources}
       </>
     );
   }

--- a/packages/components/src/components/StepDefinition/StepDefinition.test.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.test.js
@@ -17,7 +17,7 @@ import StepDefinition from './StepDefinition';
 
 it('StepDefinition renders default content', () => {
   const { queryByText } = renderWithIntl(<StepDefinition taskRun={{}} />);
-  expect(queryByText(/Definition not available/i)).toBeTruthy();
+  expect(queryByText(/Step definition not available/i)).toBeTruthy();
 });
 
 it('StepDefinition renders the provided content', () => {
@@ -34,44 +34,41 @@ it('StepDefinition renders the provided content', () => {
   expect(queryByText(/test name/)).toBeTruthy();
   expect(queryByText(/Input Resources/)).toBeNull();
   expect(queryByText(/Output Resources/)).toBeNull();
-  expect(queryByText(/Parameters/)).toBeNull();
 });
 
-it('StepDefinition renders the provided content with resources and params', () => {
+it('StepDefinition renders the provided content with resources', () => {
   const inputResourceName = 'testInputResource';
   const outputResourceName = 'testOutputResource';
-  const testParamName = 'testParamName';
-  const testParam = 'testParam';
   const taskRun = {
-    namespace: 'test',
-    inputResources: [
-      {
-        resourceRef: {
-          name: inputResourceName
-        }
+    metadata: {
+      namespace: 'test'
+    },
+    spec: {
+      resources: {
+        inputs: [
+          {
+            resourceRef: {
+              name: inputResourceName
+            }
+          }
+        ],
+        outputs: [
+          {
+            name: 'referencedOutputResource',
+            resourceRef: {
+              name: outputResourceName
+            }
+          },
+          {
+            name: 'inlineOutputResource',
+            resourceSpec: {
+              name: 'testing',
+              params: 'inlineResourceParams'
+            }
+          }
+        ]
       }
-    ],
-    outputResources: [
-      {
-        name: 'referencedOutputResource',
-        resourceRef: {
-          name: outputResourceName
-        }
-      },
-      {
-        name: 'inlineOutputResource',
-        resourceSpec: {
-          name: 'testing',
-          params: 'inlineResourceParams'
-        }
-      }
-    ],
-    params: [
-      {
-        name: testParamName,
-        value: testParam
-      }
-    ]
+    }
   };
   const definition = {
     args: ['--someArg'],
@@ -86,9 +83,6 @@ it('StepDefinition renders the provided content with resources and params', () =
   expect(queryByText(/test name/)).toBeTruthy();
   expect(queryByText(/Input Resources/)).toBeTruthy();
   expect(queryByText(/Output Resources/)).toBeTruthy();
-  expect(queryByText(/Parameters/)).toBeTruthy();
-  expect(queryByText(testParamName)).toBeTruthy();
-  expect(queryByText(testParam)).toBeTruthy();
   expect(queryByText(inputResourceName)).toBeTruthy();
   expect(queryByText(outputResourceName)).toBeTruthy();
   expect(queryByText(/inlineResourceParams/)).toBeTruthy();

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -14,6 +14,8 @@ limitations under the License.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
+import { getStatus, getStepStatusReason } from '@tektoncd/dashboard-utils';
+
 import { DetailsHeader, StepDefinition, StepStatus, Tab, Tabs } from '..';
 
 import './StepDetails.scss';
@@ -26,16 +28,15 @@ const StepDetails = props => {
     intl,
     logContainer,
     onViewChange,
-    reason,
     showIO,
     stepName,
     stepStatus,
     taskRun,
     view
   } = props;
-  let { status } = props;
-  status =
-    taskRun.reason === 'TaskRunCancelled' && status !== 'terminated'
+  const { reason, status } = getStepStatusReason(stepStatus);
+  const statusValue =
+    getStatus(taskRun).reason === 'TaskRunCancelled' && status !== 'terminated'
       ? 'cancelled'
       : status;
 
@@ -48,7 +49,7 @@ const StepDetails = props => {
     <div className="tkn--step-details">
       <DetailsHeader
         reason={reason}
-        status={status}
+        status={statusValue}
         stepName={stepName}
         taskRun={taskRun}
       />

--- a/packages/components/src/components/StepDetails/StepDetails.stories.js
+++ b/packages/components/src/components/StepDetails/StepDetails.stories.js
@@ -17,11 +17,15 @@ import { Log } from '..';
 
 import StepDetails from './StepDetails';
 
-const ansiLog = '\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-git-source-skaffold-git-ml8j4 ===\n{"level":"info","ts":1553865693.943092,"logger":"fallback-logger","caller":"git-init/main.go:100","msg":"Successfully cloned https://github.com/GoogleContainerTools/skaffold @ \\"master\\" in path \\"/workspace\\""}\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-build-and-push ===\n\u001b[36mINFO\u001b[0m[0000] Downloading base image golang:1.10.1-alpine3.7\n2019/03/29 13:21:34 No matching credentials were found, falling back on anonymous\n\u001b[36mINFO\u001b[0m[0001] Executing 0 build triggers\n\u001b[36mINFO\u001b[0m[0001] Unpacking rootfs as cmd RUN go build -o /app . requires it.\n\u001b[36mINFO\u001b[0m[0010] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0015] Using files from context: [/workspace/examples/microservices/leeroy-app/app.go]\n\u001b[36mINFO\u001b[0m[0015] COPY app.go .\n\u001b[36mINFO\u001b[0m[0015] Taking snapshot of files...\n\u001b[36mINFO\u001b[0m[0015] RUN go build -o /app .\n\u001b[36mINFO\u001b[0m[0015] cmd: /bin/sh\n\u001b[36mINFO\u001b[0m[0015] args: [-c go build -o /app .]\n\u001b[36mINFO\u001b[0m[0016] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0036] CMD ["./app"]\n\u001b[36mINFO\u001b[0m[0036] COPY --from=builder /app .\n\u001b[36mINFO\u001b[0m[0036] Taking snapshot of files...\nerror pushing image: failed to push to destination gcr.io/christiewilson-catfactory/leeroy-app:latest: Get https://gcr.io/v2/token?scope=repository%3Achristiewilson-catfactory%2Fleeroy-app%3Apush%2Cpull\u0026scope=repository%3Alibrary%2Falpine%3Apull\u0026service=gcr.io exit status 1\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: nop ===\nBuild successful\n'.split(
-  '\n'
-);
+const ansiLog =
+  '\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-git-source-skaffold-git-ml8j4 ===\n{"level":"info","ts":1553865693.943092,"logger":"fallback-logger","caller":"git-init/main.go:100","msg":"Successfully cloned https://github.com/GoogleContainerTools/skaffold @ \\"master\\" in path \\"/workspace\\""}\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-build-and-push ===\n\u001b[36mINFO\u001b[0m[0000] Downloading base image golang:1.10.1-alpine3.7\n2019/03/29 13:21:34 No matching credentials were found, falling back on anonymous\n\u001b[36mINFO\u001b[0m[0001] Executing 0 build triggers\n\u001b[36mINFO\u001b[0m[0001] Unpacking rootfs as cmd RUN go build -o /app . requires it.\n\u001b[36mINFO\u001b[0m[0010] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0015] Using files from context: [/workspace/examples/microservices/leeroy-app/app.go]\n\u001b[36mINFO\u001b[0m[0015] COPY app.go .\n\u001b[36mINFO\u001b[0m[0015] Taking snapshot of files...\n\u001b[36mINFO\u001b[0m[0015] RUN go build -o /app .\n\u001b[36mINFO\u001b[0m[0015] cmd: /bin/sh\n\u001b[36mINFO\u001b[0m[0015] args: [-c go build -o /app .]\n\u001b[36mINFO\u001b[0m[0016] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0036] CMD ["./app"]\n\u001b[36mINFO\u001b[0m[0036] COPY --from=builder /app .\n\u001b[36mINFO\u001b[0m[0036] Taking snapshot of files...\nerror pushing image: failed to push to destination gcr.io/christiewilson-catfactory/leeroy-app:latest: Get https://gcr.io/v2/token?scope=repository%3Achristiewilson-catfactory%2Fleeroy-app%3Apush%2Cpull\u0026scope=repository%3Alibrary%2Falpine%3Apull\u0026service=gcr.io exit status 1\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: nop ===\nBuild successful\n';
 
-const logContainer = <Log logs={ansiLog} status="Completed" />;
+const logContainer = (
+  <Log
+    fetchLogs={() => ansiLog}
+    stepStatus={{ terminated: { reason: 'Completed' } }}
+  />
+);
 
 export default {
   component: StepDetails,
@@ -31,10 +35,10 @@ export default {
 
 export const Base = () => (
   <StepDetails
-    reason="Completed"
-    status="terminated"
-    stepName="build"
-    taskRun={{}}
+    definition="this will show the Task.spec or TaskRun.spec.taskSpec"
     logContainer={logContainer}
+    stepName="build"
+    stepStatus={{ terminated: { reason: 'Completed' } }}
+    taskRun={{}}
   />
 );

--- a/packages/components/src/components/StepDetails/StepDetails.test.js
+++ b/packages/components/src/components/StepDetails/StepDetails.test.js
@@ -26,7 +26,7 @@ describe('StepDetails', () => {
 
     renderWithRouter(
       <Provider store={store}>
-        <StepDetails />
+        <StepDetails stepStatus={{}} />
       </Provider>
     );
   });
@@ -37,7 +37,7 @@ describe('StepDetails', () => {
 
     renderWithRouter(
       <Provider store={store}>
-        <StepDetails status="terminated" />
+        <StepDetails stepStatus={{ terminated: { reason: 'Completed' } }} />
       </Provider>
     );
   });
@@ -48,7 +48,20 @@ describe('StepDetails', () => {
 
     renderWithRouter(
       <Provider store={store}>
-        <StepDetails status="False" taskRun={{ reason: 'TaskRunCancelled' }} />
+        <StepDetails
+          stepStatus={{}}
+          taskRun={{
+            status: {
+              conditions: [
+                {
+                  type: 'Succeeded',
+                  status: 'False',
+                  reason: 'TaskRunCancelled'
+                }
+              ]
+            }
+          }}
+        />
       </Provider>
     );
   });
@@ -59,7 +72,7 @@ describe('StepDetails', () => {
 
     const { getByText } = renderWithRouter(
       <Provider store={store}>
-        <StepDetails view="details" />
+        <StepDetails stepStatus={{}} view="details" />
       </Provider>
     );
 

--- a/packages/components/src/components/StepStatus/StepStatus.js
+++ b/packages/components/src/components/StepStatus/StepStatus.js
@@ -17,25 +17,18 @@ import { injectIntl } from 'react-intl';
 import { ViewYAML } from '..';
 
 const StepStatus = ({ intl, status }) => {
-  const { container, imageID, name, running, terminated, waiting } =
-    status || {};
-  const resource = status
-    ? {
-        ...(name && { name }),
-        ...(container && { container }),
-        ...(imageID && { imageID }),
-        ...(running && { running }),
-        ...(terminated && { terminated }),
-        ...(waiting && { waiting })
-      }
-    : intl.formatMessage({
-        id: 'dashboard.step.statusNotAvailable',
-        defaultMessage: 'Status not available'
-      });
-
   return (
     <div className="tkn--step-status">
-      <ViewYAML resource={resource} dark />
+      <ViewYAML
+        resource={
+          status ||
+          intl.formatMessage({
+            id: 'dashboard.step.statusNotAvailable',
+            defaultMessage: 'Status not available'
+          })
+        }
+        dark
+      />
     </div>
   );
 };

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -17,8 +17,10 @@ import {
   ChevronDown20 as ExpandIcon
 } from '@carbon/icons-react';
 import { StatusIcon, Step } from '@tektoncd/dashboard-components';
-
-import { updateUnexecutedSteps } from '@tektoncd/dashboard-utils';
+import {
+  getStepStatusReason,
+  updateUnexecutedSteps
+} from '@tektoncd/dashboard-utils';
 
 import './Task.scss';
 
@@ -55,10 +57,10 @@ class Task extends Component {
     }
     if (expanded && !selectedStepId) {
       const erroredStep = steps.find(
-        step => step.reason === 'Error' || step.reason === undefined
+        step => step.terminated?.reason === 'Error' || !step.terminated
       );
-      const { id } = erroredStep || steps[0] || {};
-      this.handleStepSelected(id);
+      const { name } = erroredStep || steps[0] || {};
+      this.handleStepSelected(name);
     }
   }
 
@@ -100,26 +102,27 @@ class Task extends Component {
         </a>
         {expanded && (
           <ol className="tkn--step-list">
-            {updateUnexecutedSteps(steps).map(
-              ({ id, reason: stepReason, status, stepName }) => {
-                const selected = selectedStepId === id;
-                const stepStatus =
-                  reason === 'TaskRunCancelled' && status !== 'terminated'
-                    ? 'cancelled'
-                    : status;
-                return (
-                  <Step
-                    id={id}
-                    key={stepName}
-                    onSelect={this.handleStepSelected}
-                    reason={stepReason}
-                    selected={selected}
-                    status={stepStatus}
-                    stepName={stepName}
-                  />
-                );
-              }
-            )}
+            {updateUnexecutedSteps(steps).map(step => {
+              const { name } = step;
+              const { status, reason: stepReason } = getStepStatusReason(step);
+
+              const selected = selectedStepId === name;
+              const stepStatus =
+                reason === 'TaskRunCancelled' && status !== 'terminated'
+                  ? 'cancelled'
+                  : status;
+              return (
+                <Step
+                  id={name}
+                  key={name}
+                  onSelect={this.handleStepSelected}
+                  reason={stepReason}
+                  selected={selected}
+                  status={stepStatus}
+                  stepName={name}
+                />
+              );
+            })}
           </ol>
         )}
       </li>

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -22,8 +22,8 @@ const props = {
 };
 
 const steps = [
-  { id: 'build', stepName: 'build', reason: 'Completed' },
-  { id: 'test', stepName: 'test', reason: 'Completed' }
+  { name: 'build', terminated: { reason: 'Completed' } },
+  { name: 'test', terminated: { reason: 'Completed' } }
 ];
 
 export default {

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -28,13 +28,13 @@ describe('Task', () => {
   });
 
   it('does not render steps in collapsed state', () => {
-    const steps = [{ stepName: 'a step' }];
+    const steps = [{ name: 'a step' }];
     const { queryByText } = renderWithIntl(<Task {...props} steps={steps} />);
     expect(queryByText(/a step/i)).toBeFalsy();
   });
 
   it('renders steps in expanded state', () => {
-    const steps = [{ id: 'step', stepName: 'a step' }];
+    const steps = [{ name: 'a step' }];
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
     );
@@ -43,8 +43,8 @@ describe('Task', () => {
 
   it('renders first step in expanded Task with no error', () => {
     const steps = [
-      { id: 'step', stepName: 'a step', reason: 'Completed' },
-      { id: 'step-two', stepName: 'a step two', reason: 'Completed' }
+      { name: 'a step', terminated: { reason: 'Completed' } },
+      { name: 'a step two', terminated: { reason: 'Completed' } }
     ];
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
@@ -60,8 +60,8 @@ describe('Task', () => {
 
   it('renders error step in expanded Task', () => {
     const steps = [
-      { id: 'step', stepName: 'a step', reason: 'Completed' },
-      { id: 'step-two', stepName: 'a step two', reason: 'Error' }
+      { name: 'a step', terminated: { reason: 'Completed' } },
+      { name: 'a step two', terminated: { reason: 'Error' } }
     ];
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
@@ -77,8 +77,8 @@ describe('Task', () => {
 
   it('renders cancelled step in expanded Task', () => {
     const steps = [
-      { id: 'step', stepName: 'a step', reason: 'Completed' },
-      { id: 'step-two', stepName: 'a step two', reason: undefined }
+      { name: 'a step', terminated: { reason: 'Completed' } },
+      { name: 'a step two', terminated: { reason: undefined } }
     ];
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
@@ -94,9 +94,9 @@ describe('Task', () => {
 
   it('renders completed steps in expanded state', () => {
     const steps = [
-      { id: 'step1', stepName: 'step 1', reason: 'Completed' },
-      { id: 'step2', stepName: 'step 2', reason: 'Error' },
-      { id: 'step3', stepName: 'step 3', reason: 'Completed' }
+      { name: 'step 1', terminated: { reason: 'Completed' } },
+      { name: 'step 2', terminated: { reason: 'Error' } },
+      { name: 'step 3', terminated: { reason: 'Completed' } }
     ];
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
@@ -128,12 +128,18 @@ describe('Task', () => {
 
   it('renders cancelled state', () => {
     renderWithIntl(
-      <Task {...props} succeeded="Unknown" reason="TaskRunCancelled" />
+      <Task
+        {...props}
+        expanded
+        succeeded="Unknown"
+        reason="TaskRunCancelled"
+        steps={[{ name: 'a step', waiting: {} }]}
+      />
     );
   });
 
   it('renders selected step state', () => {
-    const steps = [{ id: 'step', stepName: 'a step' }];
+    const steps = [{ name: 'a step' }];
     renderWithIntl(
       <Task {...props} expanded selectedStepId="some-step" steps={steps} />
     );
@@ -150,7 +156,7 @@ describe('Task', () => {
 
   it('handles click event on Step', () => {
     const onSelect = jest.fn();
-    const steps = [{ id: 'build', stepName: 'build' }];
+    const steps = [{ name: 'build' }];
     const { getByText } = renderWithIntl(
       <Task
         expanded

--- a/packages/components/src/components/Task/index.js
+++ b/packages/components/src/components/Task/index.js
@@ -10,5 +10,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 export { default } from './Task';

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -14,6 +14,7 @@ limitations under the License.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
+import { getParams } from '@tektoncd/dashboard-utils';
 
 import { DetailsHeader, Param, Tab, Table, Tabs, ViewYAML } from '..';
 
@@ -22,9 +23,9 @@ import './TaskRunDetails.scss';
 const tabs = ['params', 'status'];
 
 const TaskRunDetails = props => {
-  const { intl, onViewChange, taskRun, view } = props;
+  const { intl, onViewChange, pipelineTaskName, taskRun, view } = props;
 
-  const displayName = taskRun.pipelineTaskName || taskRun.taskRunName;
+  const displayName = pipelineTaskName || taskRun.metadata.name;
 
   const headers = [
     {
@@ -43,11 +44,12 @@ const TaskRunDetails = props => {
     }
   ];
 
-  const params = taskRun.params && taskRun.params.length && (
+  const params = getParams(taskRun.spec);
+  const paramsTable = params && params.length && (
     <Table
       size="short"
       headers={headers}
-      rows={taskRun.params.map(({ name, value }) => {
+      rows={params.map(({ name, value }) => {
         return {
           id: name,
           name,
@@ -74,7 +76,7 @@ const TaskRunDetails = props => {
         onSelectionChange={index => onViewChange(tabs[index])}
         selected={selectedTabIndex}
       >
-        {params && (
+        {paramsTable && (
           <Tab
             id={`${displayName}-details`}
             label={intl.formatMessage({
@@ -82,7 +84,7 @@ const TaskRunDetails = props => {
               defaultMessage: 'Parameters'
             })}
           >
-            <div className="tkn--step-status">{params}</div>
+            <div className="tkn--step-status">{paramsTable}</div>
           </Tab>
         )}
         <Tab

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
@@ -29,9 +29,11 @@ export default {
 export const Base = () => (
   <TaskRunDetails
     taskRun={{
-      pipelineTaskName: 'my-task',
-      params,
-      status: 'status message'
+      metadata: { name: 'my-task' },
+      spec: {
+        params
+      },
+      status: 'this will show the TaskRun.status'
     }}
   />
 );

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -22,7 +22,9 @@ describe('TaskRunDetails', () => {
     const taskRunName = 'task-run-name';
     const status = 'error';
     const { queryByText } = renderWithIntl(
-      <TaskRunDetails taskRun={{ status, taskRunName }} />
+      <TaskRunDetails
+        taskRun={{ metadata: { name: taskRunName }, spec: {}, status }}
+      />
     );
 
     expect(queryByText(taskRunName)).toBeTruthy();
@@ -36,7 +38,8 @@ describe('TaskRunDetails', () => {
     const params = [{ name: paramKey, value: paramValue }];
     const { queryByText } = renderWithIntl(
       <TaskRunDetails
-        taskRun={{ pipelineTaskName, params, taskName: 'taskName' }}
+        pipelineTaskName={pipelineTaskName}
+        taskRun={{ metadata: { name: 'task-run-name' }, spec: { params } }}
       />
     );
 
@@ -52,7 +55,9 @@ describe('TaskRunDetails', () => {
     const paramValue = 'v';
     const params = [{ name: paramKey, value: paramValue }];
     const { queryByText } = renderWithIntl(
-      <TaskRunDetails taskRun={{ status, params, taskRunName }} />
+      <TaskRunDetails
+        taskRun={{ metadata: { name: taskRunName }, spec: { params }, status }}
+      />
     );
 
     expect(queryByText(taskRunName)).toBeTruthy();
@@ -62,7 +67,8 @@ describe('TaskRunDetails', () => {
 
   it('renders selected view', () => {
     const taskRun = {
-      params: [{ name: 'fake_name', value: 'fake_value' }]
+      metadata: { name: 'task-run-name' },
+      spec: { params: [{ name: 'fake_name', value: 'fake_value' }] }
     };
     const { queryByText } = renderWithIntl(
       <TaskRunDetails taskRun={taskRun} view="status" />

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -12,16 +12,12 @@ limitations under the License.
 */
 
 import React, { Component } from 'react';
-import { sortStepsByTimestamp } from '@tektoncd/dashboard-utils';
+import { getStatus, labels as labelConstants } from '@tektoncd/dashboard-utils';
 import Task from '../Task';
 
 import './TaskTree.scss';
-
+/* eslint-disable */
 class TaskTree extends Component {
-  handleSelect = (taskId, stepId) => {
-    this.props.onSelect(taskId, stepId);
-  };
-
   render() {
     const { selectedStepId, selectedTaskId, taskRuns } = this.props;
 
@@ -29,31 +25,40 @@ class TaskTree extends Component {
       return <div />;
     }
 
+    const erroredTask = taskRuns.filter(Boolean).find(
+      taskRun => getStatus(taskRun).status === 'False'
+    );
+
     return (
       <ol className="tkn--task-tree">
         {taskRuns.map((taskRun, index) => {
           if (!taskRun) {
             return null;
           }
-          const { id, reason, steps, succeeded, pipelineTaskName } = taskRun;
-          const erroredTask = taskRuns.find(task => task.succeeded === 'False');
+          const { uid, labels, name } = taskRun.metadata;
+          const {
+            [labelConstants.PIPELINE_TASK]: pipelineTaskName,
+            [labelConstants.DASHBOARD_RETRY_NAME]: retryName
+          } = labels;
+          const { reason, status } = getStatus(taskRun);
+          const { steps } = taskRun.status;
           const expanded =
-            (!selectedTaskId && erroredTask && erroredTask.id === id) ||
-            selectedTaskId === id ||
+            (!selectedTaskId && erroredTask?.metadata.uid === uid) ||
+            selectedTaskId === uid ||
             (!erroredTask && !selectedTaskId && index === 0);
           const selectDefaultStep = !selectedTaskId;
           return (
             <Task
-              id={id}
-              key={id}
+              id={uid}
+              key={uid}
               expanded={expanded}
-              onSelect={this.handleSelect}
+              onSelect={this.props.onSelect}
               reason={reason}
               selectDefaultStep={selectDefaultStep}
               selectedStepId={selectedStepId}
-              steps={sortStepsByTimestamp(steps)}
-              succeeded={succeeded}
-              pipelineTaskName={pipelineTaskName}
+              steps={steps}
+              succeeded={status}
+              pipelineTaskName={retryName || pipelineTaskName || name}
             />
           );
         })}

--- a/packages/components/src/components/TaskTree/TaskTree.stories.js
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.js
@@ -19,32 +19,51 @@ export default {
   args: {
     taskRuns: [
       {
-        id: 'task',
-        pipelineTaskName: 'Task 1',
-        steps: [
-          { id: 'build', stepName: 'build' },
-          { id: 'test', stepName: 'test' }
-        ],
-        succeeded: 'True'
+        metadata: {
+          labels: { 'tekton.dev/pipelineTask': 'Task 1' },
+          uid: 'task'
+        },
+        status: {
+          conditions: [
+            { reason: 'Completed', status: 'True', type: 'Succeeded' }
+          ],
+          steps: [
+            { name: 'build', terminated: { reason: 'Completed' } },
+            { name: 'test', terminated: { reason: 'Completed' } }
+          ]
+        }
       },
       {
-        id: 'task2',
-        pipelineTaskName: 'Task 2',
-        steps: [
-          { id: 'step 1', stepName: 'step 1' },
-          { id: 'step 2', stepName: 'step 2' }
-        ],
-        succeeded: 'False'
+        metadata: {
+          labels: { 'tekton.dev/pipelineTask': 'Task 2' },
+          uid: 'task2'
+        },
+        status: {
+          conditions: [
+            { reason: 'Failed', status: 'False', type: 'Succeeded' }
+          ],
+          steps: [
+            { name: 'step 1', terminated: { reason: 'Error' } },
+            // The next step will be displayed as 'Not run' by the Dashboard
+            { name: 'step 2', terminated: { reason: 'Error' } }
+          ]
+        }
       },
       {
-        id: 'task3',
+        metadata: {
+          labels: { 'tekton.dev/pipelineTask': 'Task 3' },
+          uid: 'task3'
+        },
         pipelineTaskName: 'Task 3',
-        steps: [
-          { id: 'step 1', stepName: 'step 1' },
-          { id: 'step 2', stepName: 'step 2' }
-        ],
-        succeeded: 'Unknown',
-        reason: 'Running'
+        status: {
+          conditions: [
+            { reason: 'Running', status: 'Unknown', type: 'Succeeded' }
+          ],
+          steps: [
+            { name: 'step 1', terminated: { reason: 'Completed' } },
+            { name: 'step 2', running: {} }
+          ]
+        }
       }
     ]
   },

--- a/packages/components/src/components/TaskTree/TaskTree.test.js
+++ b/packages/components/src/components/TaskTree/TaskTree.test.js
@@ -16,53 +16,77 @@ import { fireEvent } from 'react-testing-library';
 import TaskTree from './TaskTree';
 import { renderWithIntl } from '../../utils/test';
 
-const props = {
+const getProps = () => ({
   onSelect: () => {},
   taskRuns: [
     {
-      id: 'task',
-      pipelineTaskName: 'A Task',
-      succeeded: 'True',
-      steps: [
-        { id: 'build', stepName: 'build' },
-        { id: 'test', stepName: 'test' }
-      ]
+      metadata: {
+        labels: {
+          'tekton.dev/pipelineTask': 'A Task'
+        },
+        uid: 'task'
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Succeeded',
+            status: 'True'
+          }
+        ],
+        steps: [{ name: 'build' }, { name: 'test' }]
+      }
     },
     {
-      id: 'task2',
-      succeeded: 'True',
-      pipelineTaskName: 'A Second Task',
-      steps: [
-        { id: 'build', stepName: 'build' },
-        { id: 'test', stepName: 'test' }
-      ]
+      metadata: {
+        labels: {
+          'tekton.dev/pipelineTask': 'A Second Task'
+        },
+        uid: 'task2'
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Succeeded',
+            status: 'True'
+          }
+        ],
+        steps: [{ name: 'build' }, { name: 'test' }]
+      }
     },
     {
-      id: 'task3',
-      succeeded: 'True',
-      pipelineTaskName: 'A Third Task',
-      steps: [
-        { id: 'build', stepName: 'build' },
-        { id: 'test', stepName: 'test' }
-      ]
+      metadata: {
+        labels: {
+          'tekton.dev/pipelineTask': 'A Third Task'
+        },
+        uid: 'task3'
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Succeeded',
+            status: 'True'
+          }
+        ],
+        steps: [{ name: 'build' }, { name: 'test' }]
+      }
     }
   ]
-};
+});
 
 it('TaskTree renders', () => {
-  renderWithIntl(<TaskTree {...props} />);
+  renderWithIntl(<TaskTree {...getProps()} />);
 });
 
 it('TaskTree renders when taskRuns is falsy', () => {
-  renderWithIntl(<TaskTree {...props} taskRuns={null} />);
+  renderWithIntl(<TaskTree {...getProps()} taskRuns={null} />);
 });
 
 it('TaskTree renders when taskRuns contains a falsy run', () => {
-  renderWithIntl(<TaskTree {...props} taskRuns={[null]} />);
+  renderWithIntl(<TaskTree {...getProps()} taskRuns={[null]} />);
 });
 
 it('TaskTree renders and expands first Task in TaskRun with no error', () => {
-  const { queryByText } = renderWithIntl(<TaskTree {...props} />);
+  const { queryByText } = renderWithIntl(<TaskTree {...getProps()} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
   expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
@@ -77,7 +101,8 @@ it('TaskTree renders and expands first Task in TaskRun with no error', () => {
 });
 
 it('TaskTree renders and expands error Task in TaskRun', () => {
-  props.taskRuns[1].succeeded = 'False';
+  const props = getProps();
+  props.taskRuns[1].status.conditions[0].status = 'False';
 
   const { queryByText } = renderWithIntl(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
@@ -94,8 +119,9 @@ it('TaskTree renders and expands error Task in TaskRun', () => {
 });
 
 it('TaskTree renders and expands first error Task in TaskRun', () => {
-  props.taskRuns[1].succeeded = 'False';
-  props.taskRuns[2].succeeded = 'False';
+  const props = getProps();
+  props.taskRuns[1].status.conditions[0].status = 'False';
+  props.taskRuns[2].status.conditions[0].status = 'False';
 
   const { queryByText } = renderWithIntl(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
@@ -114,7 +140,7 @@ it('TaskTree renders and expands first error Task in TaskRun', () => {
 it('TaskTree handles click event on Task', () => {
   const onSelect = jest.fn();
   const { getByText } = renderWithIntl(
-    <TaskTree {...props} onSelect={onSelect} />
+    <TaskTree {...getProps()} onSelect={onSelect} />
   );
   expect(onSelect).toHaveBeenCalledTimes(1);
   onSelect.mockClear();
@@ -125,7 +151,7 @@ it('TaskTree handles click event on Task', () => {
 it('TaskTree handles click event on Step', () => {
   const onSelect = jest.fn();
   const { getByText } = renderWithIntl(
-    <TaskTree {...props} selectedTaskId="task" onSelect={onSelect} />
+    <TaskTree {...getProps()} selectedTaskId="task" onSelect={onSelect} />
   );
   onSelect.mockClear();
   fireEvent.click(getByText(/build/i));

--- a/packages/utils/src/utils/constants.js
+++ b/packages/utils/src/utils/constants.js
@@ -15,6 +15,7 @@ export const labels = {
   CLUSTER_TASK: 'tekton.dev/clusterTask',
   CONDITION_CHECK: 'tekton.dev/conditionCheck',
   DASHBOARD_IMPORT: 'dashboard.tekton.dev/import',
+  DASHBOARD_RETRY_NAME: 'dashboard.tekton.dev/retryName',
   PIPELINE: 'tekton.dev/pipeline',
   PIPELINE_RUN: 'tekton.dev/pipelineRun',
   PIPELINE_TASK: 'tekton.dev/pipelineTask',

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -10,5 +10,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+/* istanbul ignore file */
 export { default } from './App';

--- a/src/containers/LogDownloadButton/LogDownloadButton.js
+++ b/src/containers/LogDownloadButton/LogDownloadButton.js
@@ -15,24 +15,13 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Download16, Launch16 } from '@carbon/icons-react';
 
-import { getPodLogURL } from '../../api';
-
-const LogDownloadButton = ({ intl, stepStatus, taskRun }) => {
-  const { container } = stepStatus;
-  const { namespace, pod } = taskRun;
-
-  const logURL = getPodLogURL({
-    container,
-    name: pod,
-    namespace
-  });
-
+const LogDownloadButton = ({ intl, name, url }) => {
   return (
     <>
       <div className="bx--btn-set">
         <a
           className="bx--copy-btn"
-          href={logURL}
+          href={url}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -45,11 +34,7 @@ const LogDownloadButton = ({ intl, stepStatus, taskRun }) => {
             </title>
           </Launch16>
         </a>
-        <a
-          className="bx--copy-btn"
-          download={`${pod}__${container}__log.txt`}
-          href={logURL}
-        >
+        <a className="bx--copy-btn" download={name} href={url}>
           <Download16>
             <title>
               {intl.formatMessage({

--- a/src/containers/LogDownloadButton/LogDownloadButton.stories.js
+++ b/src/containers/LogDownloadButton/LogDownloadButton.stories.js
@@ -21,9 +21,5 @@ export default {
 };
 
 export const Base = () => (
-  <LogDownloadButton
-    stepName="stepName"
-    stepStatus={{ container: 'containerName' }}
-    taskRun={{ namespace: 'namespaceName', pod: 'podName' }}
-  />
+  <LogDownloadButton name="some_filename.txt" url="/some/logs/url" />
 );

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -29,15 +29,11 @@ import {
   TaskTree
 } from '@tektoncd/dashboard-components';
 import {
-  getParams,
-  getResources,
   getStatus,
+  getStepDefinition,
+  getStepStatus,
   getTitle,
   queryParams as queryParamConstants,
-  reorderSteps,
-  stepsStatus,
-  taskRunStep,
-  updateUnexecutedSteps,
   urls
 } from '@tektoncd/dashboard-utils';
 
@@ -50,15 +46,15 @@ import {
   getTaskByType,
   getTaskRun,
   getTaskRunsErrorMessage,
-  isLogStreamingEnabled,
   isReadOnly,
-  isWebSocketConnected
+  isWebSocketConnected,
+  isLogStreamingEnabled as selectIsLogStreamingEnabled
 } from '../../reducers';
 
 import '@tektoncd/dashboard-components/dist/scss/Run.scss';
 import { fetchTask, fetchTaskByType } from '../../actions/tasks';
 import { fetchTaskRun } from '../../actions/taskRuns';
-import { rerunTaskRun } from '../../api';
+import { getPodLogURL, rerunTaskRun } from '../../api';
 
 const taskTypeKeys = { ClusterTask: 'clustertasks', Task: 'tasks' };
 const { STEP, TASK_RUN_DETAILS, VIEW } = queryParamConstants;
@@ -127,6 +123,46 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
     }
   }
 
+  getLogContainer({ stepName, stepStatus, taskRun }) {
+    const {
+      externalLogsURL,
+      isLogStreamingEnabled,
+      selectedStepId
+    } = this.props;
+
+    if (!selectedStepId) {
+      return null;
+    }
+
+    const logsRetriever = getLogsRetriever(
+      isLogStreamingEnabled,
+      externalLogsURL
+    );
+
+    const { container } = stepStatus;
+    const { podName } = taskRun.status;
+
+    const logURL = getPodLogURL({
+      container,
+      name: taskRun.status.podName,
+      namespace: taskRun.metadata.namespace
+    });
+
+    return (
+      <Log
+        downloadButton={
+          <LogDownloadButton
+            name={`${podName}__${container}__log.txt`}
+            url={logURL}
+          />
+        }
+        fetchLogs={() => logsRetriever(stepName, stepStatus, taskRun)}
+        key={stepName}
+        stepStatus={stepStatus}
+      />
+    );
+  }
+
   handleTaskSelected = (_, selectedStepId) => {
     const { history, location, match } = this.props;
     const queryParams = new URLSearchParams(location.search);
@@ -146,43 +182,6 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
 
     const browserURL = match.url.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
-  };
-
-  loadTaskRun = () => {
-    const { task } = this.props;
-    let { taskRun } = this.props;
-    if (!taskRun) {
-      return null;
-    }
-
-    const { steps } = taskRun.status;
-    const stepDefinitions = taskRun.spec.taskSpec
-      ? taskRun.spec.taskSpec.steps
-      : task.spec.steps;
-    const reorderedSteps = reorderSteps(steps, stepDefinitions);
-    const taskRunName = taskRun.metadata.name;
-    const taskRunNamespace = taskRun.metadata.namespace;
-    const { reason, status: succeeded } = getStatus(taskRun);
-    const runSteps = stepsStatus(reorderedSteps, taskRun.status.steps);
-    const params = getParams(taskRun.spec);
-    const { inputResources, outputResources } = getResources(taskRun.spec);
-    const { startTime } = taskRun.status;
-    taskRun = {
-      id: taskRun.metadata.uid,
-      pod: taskRun.status.podName,
-      pipelineTaskName: taskRunName,
-      reason,
-      steps: runSteps,
-      succeeded,
-      taskRunName,
-      startTime,
-      namespace: taskRunNamespace,
-      params,
-      inputResources,
-      outputResources,
-      status: taskRun.status
-    };
-    return taskRun;
   };
 
   showRerunNotification(value) {
@@ -211,6 +210,8 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       intl,
       selectedStepId,
       showTaskRunDetails,
+      task,
+      taskRun,
       view
     } = this.props;
 
@@ -229,8 +230,6 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       });
     }
 
-    const taskRun = this.loadTaskRun();
-
     if (!taskRun) {
       return TaskRunContainer.notification({
         intl,
@@ -242,48 +241,38 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       });
     }
 
-    const { definition, reason, status, stepName, stepStatus } = taskRunStep(
+    const definition = getStepDefinition({
       selectedStepId,
-      {
-        ...taskRun,
-        steps: updateUnexecutedSteps(taskRun.steps)
-      }
-    );
+      task,
+      taskRun
+    });
+
+    const stepStatus = getStepStatus({
+      selectedStepId,
+      taskRun
+    });
 
     const {
       reason: taskRunStatusReason,
-      message: taskRunStatusMessage
-    } = getStatus(this.props.taskRun);
+      message: taskRunStatusMessage,
+      status: succeeded
+    } = getStatus(taskRun);
 
-    const logsRetriever = getLogsRetriever(
-      this.props.isLogStreamingEnabled,
-      this.props.externalLogsURL
-    );
-
-    const logContainer = selectedStepId && (
-      <Log
-        downloadButton={
-          <LogDownloadButton
-            stepName={stepName}
-            stepStatus={stepStatus}
-            taskRun={taskRun}
-          />
-        }
-        fetchLogs={() => logsRetriever(stepName, stepStatus, taskRun)}
-        key={stepName}
-        stepStatus={stepStatus}
-      />
-    );
+    const logContainer = this.getLogContainer({
+      stepName: selectedStepId,
+      stepStatus,
+      taskRun
+    });
 
     const onViewChange = getViewChangeHandler(this.props);
 
     const rerun = !this.props.isReadOnly &&
-      !this.props.taskRun.metadata?.labels?.['tekton.dev/pipeline'] && (
+      !taskRun.metadata?.labels?.['tekton.dev/pipeline'] && (
         <Rerun
           getURL={({ name, namespace }) =>
             urls.taskRuns.byName({ namespace, taskRunName: name })
           }
-          run={this.props.taskRun}
+          run={taskRun}
           rerun={rerunTaskRun}
           showNotification={this.showRerunNotification}
         />
@@ -315,12 +304,12 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
           />
         )}
         <RunHeader
-          lastTransitionTime={taskRun.startTime}
+          lastTransitionTime={taskRun.status?.startTime}
           loading={loading}
           message={taskRunStatusMessage}
           reason={taskRunStatusReason}
-          runName={taskRun.taskRunName}
-          status={taskRun.succeeded}
+          runName={taskRun.metadata.name}
+          status={succeeded}
         >
           {rerun}
         </RunHeader>
@@ -328,7 +317,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
           <TaskTree
             onSelect={this.handleTaskSelected}
             selectedStepId={selectedStepId}
-            selectedTaskId={showTaskRunDetails && taskRun.id}
+            selectedTaskId={showTaskRunDetails && taskRun.metadata.uid}
             taskRuns={[taskRun]}
           />
           {(selectedStepId && (
@@ -336,10 +325,8 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
               definition={definition}
               logContainer={logContainer}
               onViewChange={onViewChange}
-              reason={reason}
               showIO
-              status={status}
-              stepName={stepName}
+              stepName={selectedStepId}
               stepStatus={stepStatus}
               taskRun={taskRun}
               view={view}
@@ -394,7 +381,7 @@ function mapStateToProps(state, ownProps) {
     isReadOnly: isReadOnly(state),
     namespace,
     selectedStepId,
-    isLogStreamingEnabled: isLogStreamingEnabled(state),
+    isLogStreamingEnabled: selectIsLogStreamingEnabled(state),
     showTaskRunDetails,
     taskRun,
     task,

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -231,7 +231,7 @@
     "dashboard.serviceAccountsDropdown.label": "Select ServiceAccount",
     "dashboard.sideNav.kubernetesResources": "Kubernetes resources",
     "dashboard.sideNav.tektonResources": "Tekton resources",
-    "dashboard.step.definitionNotAvailable": "Definition not available",
+    "dashboard.step.definitionNotAvailable": "Step definition not available",
     "dashboard.step.statusNotAvailable": "Status not available",
     "dashboard.stepDefinition.inputResources": "Input Resources",
     "dashboard.stepDefinition.outputResources": "Output Resources",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -36,13 +36,14 @@ export function typeToPlural(type) {
 }
 
 export async function followLogs(stepName, stepStatus, taskRun) {
-  const { pod, namespace } = taskRun;
+  const { namespace } = taskRun.metadata;
+  const { podName } = taskRun.status || {};
   let logs;
-  if (pod && stepStatus) {
+  if (podName && stepStatus) {
     const { container } = stepStatus;
     logs = getPodLog({
       container,
-      name: pod,
+      name: podName,
       namespace,
       stream: true
     });
@@ -51,13 +52,14 @@ export async function followLogs(stepName, stepStatus, taskRun) {
 }
 
 export async function fetchLogs(stepName, stepStatus, taskRun) {
-  const { pod, namespace } = taskRun;
+  const { namespace } = taskRun.metadata;
+  const { podName } = taskRun.status || {};
   let logs;
-  if (pod && stepStatus) {
+  if (podName && stepStatus) {
     const { container } = stepStatus;
     logs = getPodLog({
       container,
-      name: pod,
+      name: podName,
       namespace
     });
   }
@@ -70,10 +72,11 @@ function fetchLogsFallback(externalLogsURL) {
   }
 
   return (stepName, stepStatus, taskRun) => {
-    const { pod, namespace } = taskRun;
+    const { namespace } = taskRun.metadata;
+    const { podName } = taskRun.status || {};
     const { container } = stepStatus;
     return fetch(
-      `${externalLogsURL}/${namespace}/${pod}/${container}`
+      `${externalLogsURL}/${namespace}/${podName}/${container}`
     ).then(response => response.text());
   };
 }

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -80,9 +80,14 @@ it('isStale', () => {
 
 describe('fetchLogs', () => {
   it('should return the pod logs', () => {
+    const namespace = 'default';
+    const podName = 'pipeline-run-123456';
     const stepName = 'kubectl-apply';
     const stepStatus = { container: 'step-kubectl-apply' };
-    const taskRun = { pod: 'pipeline-run-123456', namespace: 'default' };
+    const taskRun = {
+      metadata: { namespace },
+      status: { podName }
+    };
 
     const logs = 'fake logs';
     jest.spyOn(API, 'getPodLog').mockImplementation(() => logs);
@@ -91,8 +96,8 @@ describe('fetchLogs', () => {
     expect(API.getPodLog).toHaveBeenCalledWith(
       expect.objectContaining({
         container: stepStatus.container,
-        name: taskRun.pod,
-        namespace: taskRun.namespace
+        name: podName,
+        namespace
       })
     );
     returnedLogs.then(data => {
@@ -103,7 +108,7 @@ describe('fetchLogs', () => {
   it('should not call the API when the pod is not specified', () => {
     const stepName = 'kubectl-apply';
     const stepStatus = { container: 'step-kubectl-apply' };
-    const taskRun = { namespace: 'default' };
+    const taskRun = { metadata: { namespace: 'default' } };
     jest.spyOn(API, 'getPodLog');
 
     fetchLogs(stepName, stepStatus, taskRun);
@@ -113,9 +118,14 @@ describe('fetchLogs', () => {
 
 describe('followLogs', () => {
   it('should return the pod logs', () => {
+    const namespace = 'default';
+    const podName = 'pipeline-run-123456';
     const stepName = 'kubectl-apply';
     const stepStatus = { container: 'step-kubectl-apply' };
-    const taskRun = { pod: 'pipeline-run-123456', namespace: 'default' };
+    const taskRun = {
+      metadata: { namespace },
+      status: { podName }
+    };
 
     const logs = new ReadableStream({
       start(controller) {
@@ -128,8 +138,8 @@ describe('followLogs', () => {
     expect(API.getPodLog).toHaveBeenCalledWith(
       expect.objectContaining({
         container: stepStatus.container,
-        name: taskRun.pod,
-        namespace: taskRun.namespace,
+        name: podName,
+        namespace,
         stream: true
       })
     );
@@ -141,7 +151,7 @@ describe('followLogs', () => {
   it('should not call the API when the pod is not specified', () => {
     const stepName = 'kubectl-apply';
     const stepStatus = { container: 'step-kubectl-apply' };
-    const taskRun = { namespace: 'default' };
+    const taskRun = { metadata: { namespace: 'default' } };
     jest.spyOn(API, 'getPodLog');
 
     followLogs(stepName, stepStatus, taskRun);

--- a/src/utils/object-is.js
+++ b/src/utils/object-is.js
@@ -10,8 +10,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
-/* istanbul ignore next */
 if (!Object.is) {
   Object.is = function objectIsPolyfill(x, y) {
     if (x === y) {

--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 import 'core-js/stable';
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/885

Update the data processing done by the TaskRun/PipelineRun containers and their component
trees to separate the Task definitions from the TaskRun runtime data instead of using
our many custom representations that combined the two in different ways depending on need.

This should help to resolve confusion around the origin of a number of fields used in the
code, make it easier to maintain in future / easier for new contributors to understand,
and also allows for additional functionality that was cumbersome or essentially impossible
to achieve before.

Since we're no longer bound by the definitions to construct the bulk of the UI, we can
now more easily display generated steps for PipelineResources etc. giving a more complete
representation of the run.

The following issues should benefit from this change, making them easier to address:
- https://github.com/tektoncd/dashboard/issues/1775
- https://github.com/tektoncd/dashboard/issues/1263

Also resolves https://github.com/tektoncd/dashboard/issues/572

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
