### PR TITLE
Handle missing step definition when Task deleted but TaskRun remains

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -51,9 +51,9 @@ export function getStepDefinition({ selectedStepId, task, taskRun }) {
     return null;
   }
 
-  const stepDefinitions = taskRun.spec?.taskSpec
-    ? taskRun.spec.taskSpec.steps
-    : task.spec?.steps;
+  const stepDefinitions =
+    (taskRun.spec?.taskSpec ? taskRun.spec.taskSpec.steps : task.spec?.steps) ||
+    [];
 
   const definition = stepDefinitions?.find(
     step => step.name === selectedStepId

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -328,6 +328,18 @@ describe('getStepDefinition', () => {
     const definition = getStepDefinition({ selectedStepId, task, taskRun });
     expect(definition).toEqual(step);
   });
+
+  it('handles deleted Task spec', () => {
+    const selectedStepId = 'unnamed-1';
+    const task = {};
+    const taskRun = {
+      status: {
+        steps: [{ name: 'a-step' }, { name: 'unnamed-1' }]
+      }
+    };
+    const definition = getStepDefinition({ selectedStepId, task, taskRun });
+    expect(definition).toBeUndefined();
+  });
 });
 
 it('getStepStatus', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Follow up to https://github.com/tektoncd/dashboard/pull/1814

When the UI attempts to render the list of steps in the TaskTree,
it attempts to find the Task definition (whether a separate resource
or inline spec in the TaskRun) to capture the step definition for
display on the Details tab.

When the Task definition was provided by a Task resource that has
since been deleted, the code fails to handle the resulting null
array of steps. Provide a fallback empty array so the array filter
and other operations on unnamed steps can proceed without error.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
