### PR TITLE
Rename pipelineTaskName to displayName in Task components

### DIFF
--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -67,7 +67,7 @@ class Task extends Component {
   render() {
     const {
       expanded,
-      pipelineTaskName,
+      displayName,
       reason,
       selectedStepId,
       steps,
@@ -89,7 +89,7 @@ class Task extends Component {
         <a
           className="tkn--task-link"
           href="#"
-          title={pipelineTaskName}
+          title={displayName}
           onClick={this.handleTaskSelected}
         >
           <StatusIcon
@@ -97,7 +97,7 @@ class Task extends Component {
             reason={reason}
             status={succeeded}
           />
-          <span className="tkn--task-link--name">{pipelineTaskName}</span>
+          <span className="tkn--task-link--name">{displayName}</span>
           {expandIcon}
         </a>
         {expanded && (

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -17,7 +17,7 @@ import { action } from '@storybook/addon-actions';
 import Task from './Task';
 
 const props = {
-  pipelineTaskName: 'A Task',
+  displayName: 'A Task',
   onSelect: action('selected')
 };
 

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -18,7 +18,7 @@ import { renderWithIntl } from '../../utils/test';
 
 const props = {
   onSelect: () => {},
-  pipelineTaskName: 'A Task'
+  displayName: 'A Task'
 };
 
 describe('Task', () => {
@@ -148,7 +148,7 @@ describe('Task', () => {
   it('handles click event', () => {
     const onSelect = jest.fn();
     const { getByText } = renderWithIntl(
-      <Task pipelineTaskName="build" onSelect={onSelect} />
+      <Task displayName="build" onSelect={onSelect} />
     );
     fireEvent.click(getByText(/build/i));
     expect(onSelect).toHaveBeenCalledTimes(1);
@@ -158,12 +158,7 @@ describe('Task', () => {
     const onSelect = jest.fn();
     const steps = [{ name: 'build' }];
     const { getByText } = renderWithIntl(
-      <Task
-        expanded
-        onSelect={onSelect}
-        pipelineTaskName="A Task"
-        steps={steps}
-      />
+      <Task displayName="A Task" expanded onSelect={onSelect} steps={steps} />
     );
     expect(onSelect).not.toHaveBeenCalled();
 

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -23,9 +23,8 @@ import './TaskRunDetails.scss';
 const tabs = ['params', 'status'];
 
 const TaskRunDetails = props => {
-  const { intl, onViewChange, pipelineTaskName, taskRun, view } = props;
-
-  const displayName = pipelineTaskName || taskRun.metadata.name;
+  const { intl, onViewChange, taskRun, view } = props;
+  const displayName = taskRun.metadata.name;
 
   const headers = [
     {

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -31,23 +31,6 @@ describe('TaskRunDetails', () => {
     expect(queryByText(status)).toBeTruthy();
   });
 
-  it('renders pipeline task name and inputs', () => {
-    const pipelineTaskName = 'my-pipeline-task';
-    const paramKey = 'k';
-    const paramValue = 'v';
-    const params = [{ name: paramKey, value: paramValue }];
-    const { queryByText } = renderWithIntl(
-      <TaskRunDetails
-        pipelineTaskName={pipelineTaskName}
-        taskRun={{ metadata: { name: 'task-run-name' }, spec: { params } }}
-      />
-    );
-
-    expect(queryByText(pipelineTaskName)).toBeTruthy();
-    expect(queryByText(paramKey)).toBeTruthy();
-    expect(queryByText(paramValue)).toBeTruthy();
-  });
-
   it('renders task name and inputs', () => {
     const taskRunName = 'task-run-name';
     const status = 'error';

--- a/packages/components/src/components/TaskTree/TaskTree.js
+++ b/packages/components/src/components/TaskTree/TaskTree.js
@@ -11,61 +11,57 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Component } from 'react';
+import React from 'react';
 import { getStatus, labels as labelConstants } from '@tektoncd/dashboard-utils';
 import Task from '../Task';
 
 import './TaskTree.scss';
-/* eslint-disable */
-class TaskTree extends Component {
-  render() {
-    const { selectedStepId, selectedTaskId, taskRuns } = this.props;
 
-    if (!taskRuns) {
-      return <div />;
-    }
-
-    const erroredTask = taskRuns.filter(Boolean).find(
-      taskRun => getStatus(taskRun).status === 'False'
-    );
-
-    return (
-      <ol className="tkn--task-tree">
-        {taskRuns.map((taskRun, index) => {
-          if (!taskRun) {
-            return null;
-          }
-          const { uid, labels, name } = taskRun.metadata;
-          const {
-            [labelConstants.PIPELINE_TASK]: pipelineTaskName,
-            [labelConstants.DASHBOARD_RETRY_NAME]: retryName
-          } = labels;
-          const { reason, status } = getStatus(taskRun);
-          const { steps } = taskRun.status;
-          const expanded =
-            (!selectedTaskId && erroredTask?.metadata.uid === uid) ||
-            selectedTaskId === uid ||
-            (!erroredTask && !selectedTaskId && index === 0);
-          const selectDefaultStep = !selectedTaskId;
-          return (
-            <Task
-              id={uid}
-              key={uid}
-              expanded={expanded}
-              onSelect={this.props.onSelect}
-              reason={reason}
-              selectDefaultStep={selectDefaultStep}
-              selectedStepId={selectedStepId}
-              steps={steps}
-              succeeded={status}
-              pipelineTaskName={retryName || pipelineTaskName || name}
-            />
-          );
-        })}
-      </ol>
-    );
+const TaskTree = ({ onSelect, selectedStepId, selectedTaskId, taskRuns }) => {
+  if (!taskRuns) {
+    return <div />;
   }
-}
+
+  const erroredTask = taskRuns
+    .filter(Boolean)
+    .find(taskRun => getStatus(taskRun).status === 'False');
+
+  return (
+    <ol className="tkn--task-tree">
+      {taskRuns.map((taskRun, index) => {
+        if (!taskRun) {
+          return null;
+        }
+        const { uid, labels, name } = taskRun.metadata;
+        const {
+          [labelConstants.PIPELINE_TASK]: pipelineTaskName,
+          [labelConstants.DASHBOARD_RETRY_NAME]: retryName
+        } = labels;
+        const { reason, status } = getStatus(taskRun);
+        const { steps } = taskRun.status;
+        const expanded =
+          (!selectedTaskId && erroredTask?.metadata.uid === uid) ||
+          selectedTaskId === uid ||
+          (!erroredTask && !selectedTaskId && index === 0);
+        const selectDefaultStep = !selectedTaskId;
+        return (
+          <Task
+            displayName={retryName || pipelineTaskName || name}
+            expanded={expanded}
+            id={uid}
+            key={uid}
+            onSelect={onSelect}
+            reason={reason}
+            selectDefaultStep={selectDefaultStep}
+            selectedStepId={selectedStepId}
+            steps={steps}
+            succeeded={status}
+          />
+        );
+      })}
+    </ol>
+  );
+};
 
 TaskTree.defaultProps = {
   taskRuns: []


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/885

Rename the `pipelineTaskName` prop in the `Task` component to
`displayName` since it may not be rendered in the context of a
Pipeline/PipelineRun at all, `pipelineTaskName` is just one possible
source for the displayed name.

Also remove the unused `pipelineTaskName` prop from `TaskRunDetails`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
