### PR TITLE
Display duration on TaskRun and step details

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.js
@@ -16,11 +16,44 @@ import { ChevronRight24 as DefaultIcon } from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
 import { getStatus } from '@tektoncd/dashboard-utils';
 
-import { StatusIcon } from '..';
+import { FormattedDuration, StatusIcon } from '..';
 
 import './DetailsHeader.scss';
 
 class DetailsHeader extends Component {
+  getDuration() {
+    const { intl, stepStatus, taskRun } = this.props;
+    let { completionTime: endTime, startTime } = taskRun.status || {};
+    if (stepStatus) {
+      ({ finishedAt: endTime, startedAt: startTime } =
+        stepStatus.terminated || {});
+    }
+
+    if (!startTime || !endTime) {
+      return null;
+    }
+
+    return (
+      <span className="tkn--run-details-time">
+        {intl.formatMessage(
+          {
+            id: 'dashboard.run.duration',
+            defaultMessage: 'Duration: {duration}'
+          },
+          {
+            duration: (
+              <FormattedDuration
+                milliseconds={
+                  new Date(endTime).getTime() - new Date(startTime).getTime()
+                }
+              />
+            )
+          }
+        )}
+      </span>
+    );
+  }
+
   statusLabel() {
     const { intl, reason, status, taskRun } = this.props;
     const { reason: taskReason, status: taskStatus } = getStatus(taskRun);
@@ -69,9 +102,11 @@ class DetailsHeader extends Component {
   }
 
   render() {
-    const { stepName, taskRun, type = 'step', intl } = this.props;
+    const { intl, stepName, taskRun, type = 'step' } = this.props;
     let { reason, status } = this.props;
     let statusLabel;
+
+    const duration = this.getDuration();
 
     if (type === 'taskRun') {
       ({ reason, status } = getStatus(taskRun));
@@ -103,6 +138,7 @@ class DetailsHeader extends Component {
           </span>
           <span className="tkn--status-label">{statusLabel}</span>
         </h2>
+        {duration}
       </header>
     );
   }

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -59,6 +59,12 @@ limitations under the License.
     }
   }
 
+  .tkn--run-details-time {
+    display: inline-block;
+    margin-left: 2.25rem;
+    margin-top: .5rem;
+  }
+
   &[data-status] {
     .tkn--status-label {
       color: $not-run;

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,87 +19,151 @@ const props = {
   stepName: 'test name'
 };
 
-it('DetailsHeader renders the provided content', () => {
-  const { queryByText } = renderWithIntl(<DetailsHeader {...props} />);
-  expect(queryByText(/test name/i)).toBeTruthy();
-});
+describe('DetailsHeader', () => {
+  it('renders the provided content', () => {
+    const { queryByText } = renderWithIntl(<DetailsHeader {...props} />);
+    expect(queryByText(/test name/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the running state', () => {
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} status="running" />
-  );
-  expect(queryByText(/running/i)).toBeTruthy();
-});
+  it('renders the running state', () => {
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} status="running" />
+    );
+    expect(queryByText(/running/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the completed state', () => {
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} status="terminated" reason="Completed" />
-  );
-  expect(queryByText(/completed/i)).toBeTruthy();
-});
+  it('renders the completed state', () => {
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} status="terminated" reason="Completed" />
+    );
+    expect(queryByText(/completed/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the cancelled state', () => {
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} status="cancelled" />
-  );
-  expect(queryByText(/Cancelled/i)).toBeTruthy();
-});
+  it('renders the cancelled state', () => {
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} status="cancelled" />
+    );
+    expect(queryByText(/Cancelled/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the cancelled state for TaskRunCancelled', () => {
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} status="terminated" reason="TaskRunCancelled" />
-  );
-  expect(queryByText(/Cancelled/i)).toBeTruthy();
-});
+  it('renders the cancelled state for TaskRunCancelled', () => {
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} status="terminated" reason="TaskRunCancelled" />
+    );
+    expect(queryByText(/Cancelled/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the cancelled state for TaskRunTimeout', () => {
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} status="terminated" reason="TaskRunTimeout" />
-  );
-  expect(queryByText(/Cancelled/i)).toBeTruthy();
-});
+  it('renders the cancelled state for TaskRunTimeout', () => {
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} status="terminated" reason="TaskRunTimeout" />
+    );
+    expect(queryByText(/Cancelled/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the failed state', () => {
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} status="terminated" />
-  );
-  expect(queryByText(/failed/i)).toBeTruthy();
-});
+  it('renders the failed state', () => {
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} status="terminated" />
+    );
+    expect(queryByText(/failed/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the pending state', () => {
-  const taskRun = {
-    status: {
-      conditions: [
-        {
-          type: 'Succeeded',
-          status: 'Unknown',
-          reason: 'Pending'
-        }
-      ]
-    }
-  };
+  it('renders the pending state for a step', () => {
+    const taskRun = {
+      status: {
+        conditions: [
+          {
+            reason: 'Pending',
+            status: 'Unknown',
+            type: 'Succeeded'
+          }
+        ]
+      }
+    };
 
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} taskRun={taskRun} />
-  );
-  expect(queryByText(/waiting/i)).toBeTruthy();
-});
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} taskRun={taskRun} />
+    );
+    expect(queryByText(/waiting/i)).toBeTruthy();
+  });
 
-it('DetailsHeader renders the pending state', () => {
-  const taskRun = {
-    status: {
-      conditions: [
-        {
-          type: 'Succeeded',
-          status: 'Unknown',
-          reason: 'Pending'
-        }
-      ]
-    }
-  };
+  it('renders the pending state for a TaskRun', () => {
+    const taskRun = {
+      status: {
+        conditions: [
+          {
+            reason: 'Pending',
+            status: 'Unknown',
+            type: 'Succeeded'
+          }
+        ]
+      }
+    };
 
-  const { queryByText } = renderWithIntl(
-    <DetailsHeader {...props} taskRun={taskRun} type="taskRun" />
-  );
-  expect(queryByText(/pending/i)).toBeTruthy();
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} taskRun={taskRun} type="taskRun" />
+    );
+    expect(queryByText(/pending/i)).toBeTruthy();
+  });
+
+  it('renders no duration for a running step', () => {
+    const stepStatus = {
+      running: {
+        startedAt: new Date()
+      }
+    };
+
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} stepStatus={stepStatus} />
+    );
+    expect(queryByText(/duration/i)).toBeFalsy();
+  });
+
+  it('renders the duration for a terminated step', () => {
+    const date = new Date();
+    const stepStatus = {
+      terminated: {
+        finishedAt: date,
+        startedAt: date
+      }
+    };
+
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} stepStatus={stepStatus} />
+    );
+    expect(queryByText(/duration/i)).toBeTruthy();
+    expect(queryByText(/0 seconds/i)).toBeTruthy();
+  });
+
+  it('renders no duration for a waiting step', () => {
+    const stepStatus = {
+      waiting: {}
+    };
+
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} stepStatus={stepStatus} />
+    );
+    expect(queryByText(/duration/i)).toBeFalsy();
+  });
+
+  it('renders the duration for a TaskRun', () => {
+    const date = new Date();
+    const taskRun = {
+      status: {
+        completionTime: date,
+        conditions: [
+          {
+            reason: 'Completed',
+            status: 'True',
+            type: 'Succeeded'
+          }
+        ],
+        startTime: date
+      }
+    };
+
+    const { queryByText } = renderWithIntl(
+      <DetailsHeader {...props} taskRun={taskRun} type="taskRun" />
+    );
+    expect(queryByText(/duration/i)).toBeTruthy();
+  });
 });

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -55,7 +55,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       selectedTaskId
     } = this.props;
 
-    if (!selectedStepId) {
+    if (!selectedStepId || !stepStatus) {
       return null;
     }
 
@@ -84,11 +84,10 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
         return 0;
       }
 
-      const firstStepA = taskRunA.status?.steps[0];
-      const firstStepB = taskRunB.status?.steps[0];
+      const firstStepA = taskRunA.status?.steps?.[0];
+      const firstStepB = taskRunB.status?.steps?.[0];
 
       if (!firstStepA || !firstStepB) {
-        // shouldn't be able to reach this state (both tasks requiring at least one step)
         return 0;
       }
 

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -51,6 +51,7 @@ const StepDetails = props => {
         reason={reason}
         status={statusValue}
         stepName={stepName}
+        stepStatus={stepStatus}
         taskRun={taskRun}
       />
       <Tabs

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -22,8 +22,10 @@ const props = {
 };
 
 const steps = [
-  { name: 'build', terminated: { reason: 'Completed' } },
-  { name: 'test', terminated: { reason: 'Completed' } }
+  { name: 'lint', terminated: { reason: 'Completed' } },
+  { name: 'test', terminated: { reason: 'Completed' } },
+  { name: 'build', running: {} },
+  { name: 'deploy', running: {} }
 ];
 
 export default {
@@ -59,6 +61,7 @@ export const Expanded = () => {
       onSelect={(_, stepId) => setSelectedStepId(stepId)}
       selectedStepId={selectedStepId}
       expanded
+      reason="Running"
       steps={steps}
       succeeded="Unknown"
     />

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -81,6 +81,10 @@ export function getStepStatus({ selectedStepId, taskRun }) {
 }
 
 export function getStepStatusReason(step) {
+  if (!step) {
+    return {};
+  }
+
   let status;
   let reason;
   if (step.terminated) {
@@ -124,7 +128,7 @@ export function formatLabels(labelsRaw) {
   return formattedLabelsToRender;
 }
 
-// Update the status of steps that follow a step with an error
+// Update the status of steps that follow a step with an error or a running step
 export function updateUnexecutedSteps(steps) {
   if (!steps) {
     return steps;
@@ -135,10 +139,8 @@ export function updateUnexecutedSteps(steps) {
       errorIndex = Math.min(index, errorIndex);
     }
     if (index > errorIndex) {
-      return {
-        ...step,
-        terminated: undefined
-      };
+      const { running, terminated, ...rest } = step;
+      return { ...rest };
     }
     return step;
   });

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -116,53 +116,79 @@ it('formatLabels', () => {
   ]);
 });
 
-it('updateUnexecutedSteps no steps', () => {
-  const steps = [];
-  const wantUpdatedSteps = [];
-  const gotUpdatedSteps = updateUnexecutedSteps(steps);
-  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
-});
+describe('updateUnexecutedSteps', () => {
+  it('no steps', () => {
+    const steps = [];
+    const wantUpdatedSteps = [];
+    const gotUpdatedSteps = updateUnexecutedSteps(steps);
+    expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+  });
 
-it('updateUnexecutedSteps undefined steps', () => {
-  let steps;
-  let wantUpdatedSteps;
-  const gotUpdatedSteps = updateUnexecutedSteps(steps);
-  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
-});
+  it('undefined steps', () => {
+    let steps;
+    let wantUpdatedSteps;
+    const gotUpdatedSteps = updateUnexecutedSteps(steps);
+    expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+  });
 
-it('updateUnexecutedSteps no error steps', () => {
-  const steps = [{ terminated: { reason: 'Completed' } }, { running: {} }];
-  const wantUpdatedSteps = [...steps];
-  const gotUpdatedSteps = updateUnexecutedSteps(steps);
-  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
-});
+  it('no error steps', () => {
+    const steps = [{ terminated: { reason: 'Completed' } }, { running: {} }];
+    const wantUpdatedSteps = [...steps];
+    const gotUpdatedSteps = updateUnexecutedSteps(steps);
+    expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+  });
 
-it('updateUnexecutedSteps error step', () => {
-  const steps = [
-    {
-      terminated: { reason: 'Completed' }
-    },
-    {
-      terminated: { reason: 'Error' }
-    },
-    {
-      terminated: { reason: 'Completed' }
-    }
-  ];
-  const wantUpdatedSteps = [
-    {
-      terminated: { reason: 'Completed' }
-    },
-    {
-      terminated: { reason: 'Error' }
-    },
-    {
-      terminated: undefined
-    }
-  ];
+  it('error step', () => {
+    const steps = [
+      {
+        terminated: { reason: 'Completed' }
+      },
+      {
+        terminated: { reason: 'Error' }
+      },
+      {
+        terminated: { reason: 'Completed' }
+      }
+    ];
+    const wantUpdatedSteps = [
+      {
+        terminated: { reason: 'Completed' }
+      },
+      {
+        terminated: { reason: 'Error' }
+      },
+      {}
+    ];
 
-  const gotUpdatedSteps = updateUnexecutedSteps(steps);
-  expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+    const gotUpdatedSteps = updateUnexecutedSteps(steps);
+    expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+  });
+
+  it('running step', () => {
+    const steps = [
+      {
+        terminated: { reason: 'Completed' }
+      },
+      {
+        running: {}
+      },
+      {
+        running: {}
+      }
+    ];
+    const wantUpdatedSteps = [
+      {
+        terminated: { reason: 'Completed' }
+      },
+      {
+        running: {}
+      },
+      {}
+    ];
+
+    const gotUpdatedSteps = updateUnexecutedSteps(steps);
+    expect(gotUpdatedSteps).toEqual(wantUpdatedSteps);
+  });
 });
 
 it('getFilters', () => {
@@ -372,4 +398,5 @@ it('getStepStatusReason', () => {
     reason: undefined,
     status: undefined
   });
+  expect(getStepStatusReason()).toEqual({});
 });

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -118,7 +118,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       return retryStatus && taskRun.metadata.uid + retryStatus.podName;
     }
 
-    return taskRun.metadata.uid + taskRun.status.podName;
+    return taskRun.metadata.uid + taskRun.status?.podName;
   }
 
   getSelectedTaskRun(selectedTaskId) {

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -130,7 +130,7 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       selectedStepId
     } = this.props;
 
-    if (!selectedStepId) {
+    if (!selectedStepId || !stepStatus) {
       return null;
     }
 

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "No resources for type {type}.",
     "dashboard.resourceList.errorLoading": "Error loading {type}",
     "dashboard.resourceList.viewDetails": "View {resource}",
+    "dashboard.run.duration": "Duration: {duration}",
     "dashboard.run.rerunStatusMessage": "View status",
     "dashboard.secret.errorLoading": "Error loading Secret",
     "dashboard.secret.failed": "Cannot load Secret",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "{type}のリソースがありません",
     "dashboard.resourceList.errorLoading": "{type}のロード中にエラーが発生しました",
     "dashboard.resourceList.viewDetails": "{resource}を表示",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "ステータスを表示",
     "dashboard.secret.errorLoading": "Secretのロード中にエラーが発生しました",
     "dashboard.secret.failed": "Secretを読み込めません",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -209,6 +209,7 @@
     "dashboard.resourceList.emptyState": "",
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewDetails": "",
+    "dashboard.run.duration": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.secret.errorLoading": "",
     "dashboard.secret.failed": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/1775

Add duration below the name header on TaskRun and step details
views so the user doesn't have to compute the value themselves
from the start / end timestamps in the 'Status' tab.

![image](https://user-images.githubusercontent.com/2829095/98746022-953bbf80-23ac-11eb-96f0-80c426c5be6f.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
