### PR TITLE
Rename `stepName` to `displayName` in DetailsHeader component

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.js
@@ -102,7 +102,7 @@ class DetailsHeader extends Component {
   }
 
   render() {
-    const { intl, stepName, taskRun, type = 'step' } = this.props;
+    const { intl, displayName, taskRun, type = 'step' } = this.props;
     let { reason, status } = this.props;
     let statusLabel;
 
@@ -133,8 +133,8 @@ class DetailsHeader extends Component {
             status={status}
             {...(type === 'step' ? { type: 'inverse' } : null)}
           />
-          <span className="tkn--run-details-name" title={stepName}>
-            {stepName}
+          <span className="tkn--run-details-name" title={displayName}>
+            {displayName}
           </span>
           <span className="tkn--status-label">{statusLabel}</span>
         </h2>

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
@@ -46,7 +46,7 @@ export default {
 export const Running = args => (
   <DetailsHeader
     status="running"
-    stepName="build"
+    displayName="build"
     taskRun={getTaskRun({ reason: 'Running', status: 'Unknown' })}
     {...args}
   />
@@ -56,7 +56,7 @@ export const Completed = args => (
   <DetailsHeader
     reason="Completed"
     status="terminated"
-    stepName="build"
+    displayName="build"
     taskRun={getTaskRun({ reason: 'Succeeded', status: 'True' })}
     {...args}
   />
@@ -66,7 +66,7 @@ export const Failed = args => (
   <DetailsHeader
     reason="Error"
     status="terminated"
-    stepName="build"
+    displayName="build"
     taskRun={getTaskRun({ reason: 'Failed', status: 'False' })}
     {...args}
   />

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
@@ -16,7 +16,7 @@ import DetailsHeader from './DetailsHeader';
 import { renderWithIntl } from '../../utils/test';
 
 const props = {
-  stepName: 'test name'
+  displayName: 'test name'
 };
 
 describe('DetailsHeader', () => {

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -48,9 +48,9 @@ const StepDetails = props => {
   return (
     <div className="tkn--step-details">
       <DetailsHeader
+        displayName={stepName}
         reason={reason}
         status={statusValue}
-        stepName={stepName}
         stepStatus={stepStatus}
         taskRun={taskRun}
       />

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -69,7 +69,11 @@ const TaskRunDetails = props => {
 
   return (
     <div className="tkn--step-details">
-      <DetailsHeader stepName={displayName} taskRun={taskRun} type="taskRun" />
+      <DetailsHeader
+        displayName={displayName}
+        taskRun={taskRun}
+        type="taskRun"
+      />
       <Tabs
         aria-label="TaskRun details"
         onSelectionChange={index => onViewChange(tabs[index])}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Similar to the [change recently made in the Task component](https://github.com/tektoncd/dashboard/pull/1821), rename
the misleading `stepName` prop to `displayName` since the name
displayed is not always that of a step.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
