### PR TITLE
Update `getLogDownloadButton` params to match `fetchLogs`

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -59,16 +59,12 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       return null;
     }
 
-    const { container } = stepStatus;
-    const { namespace } = taskRun.metadata;
-    const { podName } = taskRun.status;
-
     return (
       <Log
         downloadButton={
           getLogDownloadButton &&
           stepStatus &&
-          getLogDownloadButton({ container, namespace, podName })
+          getLogDownloadButton({ stepName, stepStatus, taskRun })
         }
         fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
         key={`${selectedTaskId}:${selectedStepId}`}

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -14,11 +14,7 @@ limitations under the License.
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-  LogDownloadButton,
-  PipelineRun,
-  Rerun
-} from '@tektoncd/dashboard-components';
+import { PipelineRun, Rerun } from '@tektoncd/dashboard-components';
 import {
   getTitle,
   labels as labelConstants,
@@ -45,9 +41,13 @@ import {
 import { fetchPipelineRun } from '../../actions/pipelineRuns';
 import { fetchClusterTasks, fetchTasks } from '../../actions/tasks';
 import { fetchTaskRuns } from '../../actions/taskRuns';
-import { getPodLogURL, rerunPipelineRun } from '../../api';
+import { rerunPipelineRun } from '../../api';
 
-import { getLogsRetriever, getViewChangeHandler } from '../../utils';
+import {
+  getLogDownloadButton,
+  getLogsRetriever,
+  getViewChangeHandler
+} from '../../utils';
 
 const { PIPELINE_TASK, RETRY, STEP, VIEW } = queryParamConstants;
 
@@ -287,20 +287,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           )}
           handleTaskSelected={this.handleTaskSelected}
           loading={loading}
-          getLogDownloadButton={({ container, namespace, podName }) => {
-            const logURL = getPodLogURL({
-              container,
-              name: podName,
-              namespace
-            });
-
-            return (
-              <LogDownloadButton
-                name={`${podName}__${container}__log.txt`}
-                url={logURL}
-              />
-            );
-          }}
+          getLogDownloadButton={getLogDownloadButton}
           onViewChange={getViewChangeHandler(this.props)}
           pipelineRun={pipelineRun}
           rerun={rerun}

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -22,7 +22,6 @@ import {
 } from 'carbon-components-react';
 import {
   Log,
-  LogDownloadButton,
   Rerun,
   RunHeader,
   StepDetails,
@@ -38,7 +37,11 @@ import {
   urls
 } from '@tektoncd/dashboard-utils';
 
-import { getLogsRetriever, getViewChangeHandler } from '../../utils';
+import {
+  getLogDownloadButton,
+  getLogsRetriever,
+  getViewChangeHandler
+} from '../../utils';
 
 import {
   getExternalLogsURL,
@@ -54,7 +57,7 @@ import {
 import '@tektoncd/dashboard-components/dist/scss/Run.scss';
 import { fetchTask, fetchTaskByType } from '../../actions/tasks';
 import { fetchTaskRun } from '../../actions/taskRuns';
-import { getPodLogURL, rerunTaskRun } from '../../api';
+import { rerunTaskRun } from '../../api';
 
 const taskTypeKeys = { ClusterTask: 'clustertasks', Task: 'tasks' };
 const { STEP, TASK_RUN_DETAILS, VIEW } = queryParamConstants;
@@ -139,23 +142,9 @@ export /* istanbul ignore next */ class TaskRunContainer extends Component {
       externalLogsURL
     );
 
-    const { container } = stepStatus;
-    const { podName } = taskRun.status;
-
-    const logURL = getPodLogURL({
-      container,
-      name: taskRun.status.podName,
-      namespace: taskRun.metadata.namespace
-    });
-
     return (
       <Log
-        downloadButton={
-          <LogDownloadButton
-            name={`${podName}__${container}__log.txt`}
-            url={logURL}
-          />
-        }
+        downloadButton={getLogDownloadButton({ stepStatus, taskRun })}
         fetchLogs={() => logsRetriever(stepName, stepStatus, taskRun)}
         key={stepName}
         stepStatus={stepStatus}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,8 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React from 'react';
 import snakeCase from 'lodash.snakecase';
-import { getPodLog } from '../api';
+import { LogDownloadButton } from '@tektoncd/dashboard-components';
+
+import { getPodLog, getPodLogURL } from '../api';
 
 export function sortRunsByStartTime(runs) {
   runs.sort((a, b) => {
@@ -130,4 +133,23 @@ export function getViewChangeHandler({ history, location, match }) {
     const browserURL = match.url.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   };
+}
+
+export function getLogDownloadButton({ stepStatus, taskRun }) {
+  const { container } = stepStatus;
+  const { namespace } = taskRun.metadata;
+  const { podName } = taskRun.status;
+
+  const logURL = getPodLogURL({
+    container,
+    name: podName,
+    namespace
+  });
+
+  return (
+    <LogDownloadButton
+      name={`${podName}__${container}__log.txt`}
+      url={logURL}
+    />
+  );
 }

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -16,6 +16,7 @@ import * as API from '../api';
 import {
   fetchLogs,
   followLogs,
+  getLogDownloadButton,
   getViewChangeHandler,
   isStale,
   sortRunsByStartTime,
@@ -170,4 +171,22 @@ it('getViewChangeHandler', () => {
   expect(history.push).toHaveBeenCalledWith(
     `${url}?nonViewQueryParam=someValue&view=${view}`
   );
+});
+
+it('getLogDownloadButton', () => {
+  const container = 'fake_container';
+  const namespace = 'fake_namespace';
+  const podName = 'fake_podname';
+  const stepStatus = { container };
+  const taskRun = { metadata: { namespace }, status: { podName } };
+  jest.spyOn(API, 'getPodLogURL');
+
+  const logDownloadButton = getLogDownloadButton({ stepStatus, taskRun });
+
+  expect(API.getPodLogURL).toHaveBeenCalledWith({
+    container,
+    name: podName,
+    namespace
+  });
+  expect(logDownloadButton).toBeTruthy();
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the `getLogDownloadButton` function to receive the same
params we send to `fetchLogs`. This makes it more consistent and
also more useful for 3rd-party consumers who may want to conditionally
display the button(s) based on the step / TaskRun status.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
