### PR TITLE
Add margin between duration and tabs container

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -61,8 +61,7 @@ limitations under the License.
 
   .tkn--run-details-time {
     display: inline-block;
-    margin-left: 2.25rem;
-    margin-top: .5rem;
+    margin: 0.5rem 0 0.5rem 2.25rem;
   }
 
   &[data-status] {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Increase space between the duration and the tabs container so the
text isn't sitting directly on the selected tab outline.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
