### PR TITLE
Remove unused Tabs styles

### DIFF
--- a/packages/components/src/components/StepDetails/StepDetails.scss
+++ b/packages/components/src/components/StepDetails/StepDetails.scss
@@ -18,11 +18,6 @@ limitations under the License.
   align-items: stretch;
   overflow: hidden;
 
-  .bx--tabs {
-    margin-top: 0.4rem;
-    min-height: 2.5rem;
-  }
-
   .bx--data-table-container th{
     width: 50%;
   }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
@@ -18,11 +18,6 @@ limitations under the License.
   align-items: stretch;
   overflow: hidden;
 
-  .bx--tabs {
-    margin-top: 0.4rem;
-    min-height: 2.5rem;
-  }
-
   .bx--data-table-container th{
     width: 50%;
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Since updating Carbon in #1826, the `.bx--tabs` styles are no
longer used. Remove them to avoid confusion and bloat.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
