### PR TITLE
Fix for websocket connection blocked by CSP in Safari

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -16,9 +16,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const contentSecurityPolicy = {
   development:
-    "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-eval'; style-src blob:; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;",
+    "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-eval'; style-src blob:; connect-src 'self' wss: ws:; font-src 'self' https://fonts.gstatic.com;",
   production:
-    "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com;"
+    "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' wss: ws:; font-src 'self' https://fonts.gstatic.com;"
 };
 
 module.exports = ({ mode }) => ({


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/1836

Safari has not correctly implemented the `connect-src` directive
according to the (updated) Content Security Policy specification.

This means that `connect-src: 'self'` does not include websocket
connections to the same host.

See https://github.com/w3c/webappsec-csp/issues/7 and
https://bugs.webkit.org/show_bug.cgi?id=201591 for details.

Explicitly allow `ws:` and `wss:` in `connect-src` to work around
this for now. Hopefully we can revisit this and remove them when
Safari updates their implementation to follow the spec for this case.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
