### PR TITLE
Suppress fetch-mock warning on fallback

### DIFF
--- a/config_frontend/setupTests.js
+++ b/config_frontend/setupTests.js
@@ -23,6 +23,7 @@ if (!global.fetch) {
 
 fetchMock.catch();
 fetchMock.config.overwriteRoutes = true;
+fetchMock.config.warnOnFallback = false;
 
 window.HTMLElement.prototype.scrollIntoView = function scrollIntoViewTestStub() {};
 window.TextDecoder = TextDecoder;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1793

By default, `fetch-mock` will output a warning when a request
is handled by one of its fallback mechanisms, e.g. [`.catch()`](https://github.com/tektoncd/dashboard/blob/eda29a57002c053c80f778049cd3abe349aafaee/config_frontend/setupTests.js#L24)

In our use this provides very little benefit and adds a lot of
noise to the unit test logs. Disable the warning in the test setup.

This makes a much bigger impact on the logs than I expected,
for reference the unit tests for the previous merged PR output
**4041 lines** of logs, and this PR with the config change has just
**2085 lines** for the exact same set of unit tests ❗ 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
