### PR TITLE
Handle edge case where TaskRun resource not available on PipelineRun page

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -63,6 +63,10 @@ export function getStepDefinition({ selectedStepId, task, taskRun }) {
     return definition;
   }
 
+  if (!taskRun.status) {
+    return null;
+  }
+
   // handle unnamed steps
   // unnamed step numbering skips named steps, so we could have for example:
   // ['unnamed-2', 'unnamed-4']

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -366,6 +366,19 @@ describe('getStepDefinition', () => {
     const definition = getStepDefinition({ selectedStepId, task, taskRun });
     expect(definition).toBeUndefined();
   });
+
+  it('handles empty TaskRun', () => {
+    const selectedStepId = 'unnamed-1';
+    const step = { name: '' };
+    const task = {
+      spec: {
+        steps: [{ name: 'a-step' }, step]
+      }
+    };
+    const taskRun = {};
+    const definition = getStepDefinition({ selectedStepId, task, taskRun });
+    expect(definition).toBeNull();
+  });
 });
 
 it('getStepStatus', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Handle an edge case where a TaskRun resource owned by the currently
displayed PipelineRun resource is not available in the front end,
whether due to a dropped websocket connection or other issue, to
ensure that we continue to display the available information instead
of triggering an error boundary and hiding the entire TaskTree.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
