### PR TITLE
Remove duplicate test utils

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
+
 import DetailsHeader from './DetailsHeader';
 import { renderWithIntl } from '../../utils/test';
 

--- a/packages/components/src/components/FormattedDuration/FormattedDuration.test.js
+++ b/packages/components/src/components/FormattedDuration/FormattedDuration.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
+import { renderWithIntl } from '../../utils/test';
 import FormattedDuration from './FormattedDuration';
 
 describe('FormattedDuration', () => {
@@ -23,7 +23,7 @@ describe('FormattedDuration', () => {
     expect(getByText(/1 second/i)).toBeTruthy();
     expect(getByTitle(/1 second/i)).toBeTruthy();
 
-    rerenderWithIntl(rerender, <FormattedDuration milliseconds={2000} />);
+    renderWithIntl(<FormattedDuration milliseconds={2000} />, { rerender });
     expect(getByText(/2 seconds/i)).toBeTruthy();
     expect(getByTitle(/2 seconds/i)).toBeTruthy();
   });

--- a/packages/components/src/utils/test.js
+++ b/packages/components/src/utils/test.js
@@ -12,53 +12,41 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import React from 'react';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
+import { BrowserRouter } from 'react-router-dom';
 import { render } from 'react-testing-library';
 import { IntlProvider } from 'react-intl';
 
-export function renderWithRouter(
-  ui,
-  {
-    route = '/',
-    history = createMemoryHistory({ initialEntries: [route] }),
-    container
-  } = {}
-) {
-  return {
-    ...render(
-      <Router history={history}>
-        <IntlProvider locale="en" defaultLocale="en" messages={{}}>
-          {ui}
-        </IntlProvider>
-      </Router>,
-      {
-        container
-      }
-    ),
-    // adding `history` to the returned utilities to allow us
-    // to reference it in our tests (just try to avoid using
-    // this to test implementation details).
-    history
-  };
+function RouterWrapper({ children }) {
+  return (
+    <BrowserRouter>
+      <IntlProvider locale="en" defaultLocale="en" messages={{}}>
+        {children}
+      </IntlProvider>
+    </BrowserRouter>
+  );
 }
 
-export function wrapWithIntl(ui) {
+export function renderWithRouter(
+  ui,
+  { rerender, route = '/', ...otherOptions } = {}
+) {
+  window.history.pushState({}, 'Test page', route);
+
+  return (rerender || render)(ui, {
+    route,
+    wrapper: RouterWrapper,
+    ...otherOptions
+  });
+}
+
+function IntlWrapper({ children }) {
   return (
     <IntlProvider locale="en" defaultLocale="en" messages={{}}>
-      {ui}
+      {children}
     </IntlProvider>
   );
 }
 
-export function renderWithIntl(ui) {
-  return {
-    ...render(wrapWithIntl(ui))
-  };
-}
-
-export function rerenderWithIntl(rerender, ui) {
-  return {
-    ...rerender(wrapWithIntl(ui))
-  };
+export function renderWithIntl(ui, { rerender } = {}) {
+  return (rerender || render)(ui, { wrapper: IntlWrapper });
 }

--- a/src/components/CreateSecret/Form/AccessTokenType.test.js
+++ b/src/components/CreateSecret/Form/AccessTokenType.test.js
@@ -15,8 +15,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl } from '../../../utils/test';
 import AccessTokenType from './AccessTokenType';
 
 const middleware = [thunk];

--- a/src/components/CreateSecret/Form/Annotations.test.js
+++ b/src/components/CreateSecret/Form/Annotations.test.js
@@ -16,7 +16,8 @@ import { fireEvent, waitForElement } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl, rerenderWithIntl } from '../../../utils/test';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import Annotations from './Annotations';
 
 const middleware = [thunk];
@@ -78,11 +79,11 @@ it('Annotations response correctly to add/remove actions', async () => {
     id: `annotation1-poid`
   });
 
-  rerenderWithIntl(
-    rerender,
+  renderWithIntl(
     <Provider store={store}>
       <Annotations {...props} />
-    </Provider>
+    </Provider>,
+    { rerender }
   );
 
   expect(handleAdd).toHaveBeenCalledTimes(1);
@@ -94,11 +95,11 @@ it('Annotations response correctly to add/remove actions', async () => {
 
   props.annotations.pop();
 
-  rerenderWithIntl(
-    rerender,
+  renderWithIntl(
     <Provider store={store}>
       <Annotations {...props} />
-    </Provider>
+    </Provider>,
+    { rerender }
   );
 
   // Change value and placeholder back to github (both annotations should update)

--- a/src/components/CreateSecret/Form/PasswordType.test.js
+++ b/src/components/CreateSecret/Form/PasswordType.test.js
@@ -15,8 +15,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl } from '../../../utils/test';
 import PasswordType from './PasswordType';
 
 const middleware = [thunk];

--- a/src/components/CreateSecret/Form/UniversalFields.test.js
+++ b/src/components/CreateSecret/Form/UniversalFields.test.js
@@ -15,8 +15,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl } from '../../../utils/test';
 import UniversalFields from './UniversalFields';
 
 const middleware = [thunk];

--- a/src/components/CreateSecret/Form/index.test.js
+++ b/src/components/CreateSecret/Form/index.test.js
@@ -16,8 +16,8 @@ import { Provider } from 'react-redux';
 import { fireEvent } from 'react-testing-library';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl, rerenderWithIntl } from '../../../utils/test';
 import Form from './index';
 
 const middleware = [thunk];
@@ -121,11 +121,11 @@ it('Form show Password fields when radio button clicked', async () => {
 
   props.secretType = 'password';
 
-  rerenderWithIntl(
-    rerender,
+  renderWithIntl(
     <Provider store={store}>
       <Form {...props} />
-    </Provider>
+    </Provider>,
+    { rerender }
   );
 
   expect(queryByLabelText(/Username/i)).toBeTruthy();
@@ -166,11 +166,11 @@ it('Form show access token fields when radio button clicked', async () => {
 
   props.secretType = 'accessToken';
 
-  rerenderWithIntl(
-    rerender,
+  renderWithIntl(
     <Provider store={store}>
       <Form {...props} />
-    </Provider>
+    </Provider>,
+    { rerender }
   );
 
   expect(queryByLabelText(/Username/i)).toBeFalsy();

--- a/src/components/CreateSecret/ServiceAccountSelector.test.js
+++ b/src/components/CreateSecret/ServiceAccountSelector.test.js
@@ -16,7 +16,8 @@ import { fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '../../utils/test';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import ServiceAccountSelector from './ServiceAccountSelector';
 
 const middleware = [thunk];

--- a/src/components/SecretsDeleteModal/SecretsDeleteModal.test.js
+++ b/src/components/SecretsDeleteModal/SecretsDeleteModal.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,8 +13,8 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from 'react-testing-library';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 import SecretsDeleteModal from './SecretsDeleteModal';
 
 it('SecretsDeleteModal renders with one passed secret', () => {
@@ -66,7 +66,7 @@ it('Test SecretsDeleteModal click events', () => {
   );
   fireEvent.click(queryByText('Delete'));
   expect(handleDelete).toHaveBeenCalledTimes(1);
-  rerenderWithIntl(rerender, <SecretsDeleteModal {...props} open={false} />);
+  renderWithIntl(<SecretsDeleteModal {...props} open={false} />, { rerender });
   fireEvent.click(queryByText('Delete'));
   expect(handleClick).toHaveBeenCalledTimes(0);
 });

--- a/src/containers/About/About.test.js
+++ b/src/containers/About/About.test.js
@@ -15,8 +15,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl } from '../../utils/test';
 import About from '.';
 
 const dashboardSelector = { selector: '#tkn--about--dashboard-table *' };

--- a/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.test.js
+++ b/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.test.js
@@ -16,10 +16,10 @@ import { fireEvent, getNodeText } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
 import ClusterTasksDropdown from './ClusterTasksDropdown';
 import * as API from '../../api/clusterTasks';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 
 const props = {
   id: 'clustertasks-dropdown',
@@ -123,22 +123,22 @@ describe('ClusterTasksDropdown', () => {
     );
     expect(queryByDisplayValue(/clustertask-1/i)).toBeTruthy();
     // Select item 'clustertask-2'
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <ClusterTasksDropdown
           {...props}
           selectedItem={{ text: 'clustertask-2' }}
         />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByDisplayValue(/clustertask-2/i)).toBeTruthy();
     // No selected item (select item '')
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} selectedItem="" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
   });

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.test.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.test.js
@@ -16,9 +16,9 @@ import { Route } from 'react-router-dom';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
 import { ClusterTriggerBindingContainer } from './ClusterTriggerBinding';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.test.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.test.js
@@ -17,8 +17,9 @@ import { Provider } from 'react-redux';
 import { Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import ClusterTriggerBindings from '.';
-import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/clusterTriggerBindings';
 
 const middleware = [thunk];

--- a/src/containers/Condition/Condition.test.js
+++ b/src/containers/Condition/Condition.test.js
@@ -14,8 +14,9 @@ limitations under the License.
 import React from 'react';
 import { waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import { ConditionContainer } from './Condition';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',
@@ -84,13 +85,13 @@ describe('ConditionContainer', () => {
     await waitForElement(() => getByText('Error loading resource'));
     expect(fetchConditionSpy).toHaveBeenCalledTimes(1);
 
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <ConditionContainer
         intl={intl}
         match={match}
         fetchCondition={fetchConditionSpy}
-      />
+      />,
+      { rerender }
     );
     // nothing has changed so fetchData shouldn't be called
     expect(fetchConditionSpy).toHaveBeenCalledTimes(1);
@@ -101,13 +102,13 @@ describe('ConditionContainer', () => {
         namespace: 'updated_namespace'
       }
     };
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <ConditionContainer
         intl={intl}
         match={matchWithUpdatedNamespace}
         fetchCondition={fetchConditionSpy}
-      />
+      />,
+      { rerender }
     );
     expect(fetchConditionSpy).toHaveBeenCalledTimes(2);
 
@@ -117,25 +118,25 @@ describe('ConditionContainer', () => {
         conditionName: 'updated_conditionName'
       }
     };
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <ConditionContainer
         intl={intl}
         match={matchWithUpdatedConditionName}
         fetchCondition={fetchConditionSpy}
         webSocketConnected={false}
-      />
+      />,
+      { rerender }
     );
     expect(fetchConditionSpy).toHaveBeenCalledTimes(3);
 
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <ConditionContainer
         intl={intl}
         match={matchWithUpdatedConditionName}
         fetchCondition={fetchConditionSpy}
         webSocketConnected
-      />
+      />,
+      { rerender }
     );
     expect(fetchConditionSpy).toHaveBeenCalledTimes(4);
   });

--- a/src/containers/Conditions/Conditions.test.js
+++ b/src/containers/Conditions/Conditions.test.js
@@ -18,7 +18,8 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { Route } from 'react-router-dom';
 import { paths, urls } from '@tektoncd/dashboard-utils';
-import { renderWithRouter } from '../../utils/test';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import * as API from '../../api/conditions';
 import ConditionsContainer from './Conditions';
 

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
@@ -18,7 +18,11 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
-import { renderWithIntl, renderWithRouter } from '../../utils/test';
+import {
+  renderWithIntl,
+  renderWithRouter
+} from '@tektoncd/dashboard-components/src/utils/test';
+
 import CreatePipelineResource from '.';
 import * as API from '../../api';
 

--- a/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
@@ -15,7 +15,8 @@ import { fireEvent, waitForElement } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '../../utils/test';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import CreatePipelineResource from '.';
 import * as API from '../../api';
 import * as PipelineResourcesAPI from '../../api/pipelineResources';

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -18,7 +18,8 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import CreatePipelineRun from './CreatePipelineRun';
 import * as PipelineResourcesAPI from '../../api/pipelineResources';
 import * as PipelineRunsAPI from '../../api/pipelineRuns';
@@ -270,11 +271,11 @@ describe('CreatePipelineRun', () => {
       </Provider>
     );
 
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
 
     await selectPipeline1AndFillSpec({
@@ -317,11 +318,11 @@ describe('CreatePipelineRun', () => {
       </Provider>
     );
 
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
 
     await selectPipeline1AndFillSpec({
@@ -408,11 +409,11 @@ describe('CreatePipelineRun', () => {
       </Provider>
     );
 
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
 
     expect(queryByDisplayValue(/namespace-1/i)).toBeTruthy();
@@ -453,11 +454,11 @@ describe('CreatePipelineRun', () => {
       </Provider>
     );
 
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open pipelineRef="pipeline-1" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
 
     await waitForElement(() => getByValue(/pipeline-1/i));
@@ -499,11 +500,11 @@ describe('CreatePipelineRun', () => {
         <CreatePipelineRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     fireEvent.click(getByPlaceholderText(/select pipeline/i));
     fireEvent.click(await waitForElement(() => getByTitle(/pipeline-1/i)));
@@ -543,11 +544,11 @@ describe('CreatePipelineRun', () => {
         <CreatePipelineRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByValue(/namespace-1/i)).toBeTruthy();
     // Select pipeline-1 and verify spec details are displayed
@@ -704,11 +705,11 @@ describe('CreatePipelineRun', () => {
         <CreatePipelineRun {...props} pipelineRef={badPipelineRef} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockStore(testStore)}>
         <CreatePipelineRun {...props} open pipelineRef={badPipelineRef} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByText('pipeline-thisDoesNotExist')).toBeFalsy();
     expect(getByPlaceholderText(/select pipeline/i)).toBeTruthy();
@@ -730,11 +731,11 @@ describe('CreatePipelineRun', () => {
         <CreatePipelineRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // Select task-1 and verify spec details are displayed
     await selectPipeline1({ getByPlaceholderText, getByText });

--- a/src/containers/CreateSecret/CreateSecret.test.js
+++ b/src/containers/CreateSecret/CreateSecret.test.js
@@ -17,7 +17,8 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import CreateSecret from '.';
 import * as API from '../../api';
 import * as ServiceAccountsAPI from '../../api/serviceAccounts';
@@ -139,11 +140,11 @@ it('Test CreateSecret click events', () => {
   fireEvent.click(queryByText('Cancel'));
   expect(history.push).toHaveBeenCalled();
 
-  rerenderWithIntl(
-    rerender,
+  renderWithIntl(
     <Provider store={store}>
       <CreateSecret {...props} />
-    </Provider>
+    </Provider>,
+    { rerender }
   );
   expect(queryByText(nameValidationErrorMsgRegExp)).toBeFalsy();
   fireEvent.click(queryByText('Create'));

--- a/src/containers/CreateTaskRun/CreateTaskRun.test.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.js
@@ -18,7 +18,8 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import CreateTaskRun from './CreateTaskRun';
 import * as PipelineResourcesAPI from '../../api/pipelineResources';
 import * as ServiceAccountsAPI from '../../api/serviceAccounts';
@@ -308,11 +309,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     await selectTask1AndFillSpec({
       getAllByPlaceholderText,
@@ -351,11 +352,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     await selectTask1AndFillSpec({
       getAllByPlaceholderText,
@@ -436,11 +437,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByDisplayValue(/namespace-1/i)).toBeTruthy();
     // Select task-1 and verify spec details are displayed
@@ -477,11 +478,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} taskRef="task-1" />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open taskRef="task-1" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     await waitForElement(() => getByValue(/task-1/i));
     expect(queryByLabelText(/namespace/i)).toBeTruthy();
@@ -520,11 +521,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     fireEvent.click(getByPlaceholderText(/select task/i));
     fireEvent.click(await waitForElement(() => getByTitle(/task-1/i)));
@@ -562,11 +563,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByValue(/namespace-1/i)).toBeTruthy();
     // Select task-1 and verify spec details are displayed
@@ -723,11 +724,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} taskRef={badTaskRef} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open taskRef={badTaskRef} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByText('task-thisDoesNotExist')).toBeFalsy();
     expect(getByPlaceholderText(/select task/i)).toBeTruthy();
@@ -747,11 +748,11 @@ describe('CreateTaskRun', () => {
         <CreateTaskRun {...props} />
       </Provider>
     );
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} open />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // Select task-1 and verify spec details are displayed
     await selectTask1({ getByPlaceholderText, getByText });

--- a/src/containers/EventListener/EventListener.test.js
+++ b/src/containers/EventListener/EventListener.test.js
@@ -14,8 +14,9 @@ limitations under the License.
 import React from 'react';
 import { waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import { EventListenerContainer } from './EventListener';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/EventListeners/EventListeners.test.js
+++ b/src/containers/EventListeners/EventListeners.test.js
@@ -17,8 +17,9 @@ import { Provider } from 'react-redux';
 import { Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import EventListeners from '.';
-import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/eventListeners';
 
 const middleware = [thunk];

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -17,8 +17,11 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { ALL_NAMESPACES, urls } from '@tektoncd/dashboard-utils';
+import {
+  renderWithIntl,
+  renderWithRouter
+} from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import ImportResourcesContainer from './ImportResources';
 import * as API from '../../api';
 

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
@@ -16,8 +16,9 @@ import { fireEvent, getNodeText } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import NamespacesDropdown from './NamespacesDropdown';
-import { renderWithIntl } from '../../utils/test';
 
 const props = {
   id: 'namespaces-dropdown',

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -16,10 +16,10 @@ import { fireEvent, getNodeText } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
 import PipelineResourcesDropdown from './PipelineResourcesDropdown';
 import * as API from '../../api/pipelineResources';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 
 const props = {
   id: 'pipeline-resources-dropdown',
@@ -167,11 +167,11 @@ describe('PipelineResourcesDropdown', () => {
     expect(queryByText(/pipeline-resource-1/i)).toBeTruthy();
     expect(queryByText(/pipeline-resource-2/i)).toBeFalsy();
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} type="type-2" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // View items
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
@@ -210,11 +210,11 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={greenStore}>
         <PipelineResourcesDropdown {...props} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // View items
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
@@ -242,22 +242,22 @@ describe('PipelineResourcesDropdown', () => {
     );
     expect(queryByValue(/pipeline-resource-1/i)).toBeTruthy();
     // Select item 'pipeline-resource-2'
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <PipelineResourcesDropdown
           {...props}
           selectedItem={{ text: 'pipeline-resource-2' }}
         />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByValue(/pipeline-resource-2/i)).toBeTruthy();
     // No selected item (select item '')
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} selectedItem="" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
   });

--- a/src/containers/PipelineRun/PipelineRun.test.js
+++ b/src/containers/PipelineRun/PipelineRun.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2020 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,8 +14,9 @@ limitations under the License.
 import React from 'react';
 import { waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import { PipelineRunContainer } from './PipelineRun';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -18,7 +18,8 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
-import { renderWithRouter } from '../../utils/test';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import * as PipelineResourcesAPI from '../../api/pipelineResources';
 import * as PipelinesAPI from '../../api/pipelines';
 import * as PipelineRunsAPI from '../../api/pipelineRuns';

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
@@ -17,10 +17,10 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
 import PipelinesDropdown from './PipelinesDropdown';
 import * as API from '../../api/pipelines';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 
 const props = {
   id: 'pipelines-dropdown',
@@ -171,11 +171,11 @@ describe('PipelinesDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={greenStore}>
         <PipelinesDropdown {...props} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // View items
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
@@ -204,19 +204,19 @@ describe('PipelinesDropdown', () => {
     );
     expect(queryByDisplayValue(/pipeline-1/i)).toBeTruthy();
     // Select item 'pipeline-2'
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <PipelinesDropdown {...props} selectedItem={{ text: 'pipeline-2' }} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByDisplayValue(/pipeline-2/i)).toBeTruthy();
     // No selected item (select item '')
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <PipelinesDropdown {...props} selectedItem="" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
   });

--- a/src/containers/Secret/Secret.test.js
+++ b/src/containers/Secret/Secret.test.js
@@ -14,8 +14,9 @@ limitations under the License.
 import React from 'react';
 import { waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import { SecretContainer } from './Secret';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -18,7 +18,8 @@ import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithRouter } from '../../utils/test';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import Secrets from '.';
 import * as API from '../../api';
 import * as PipelinesAPI from '../../api/pipelines';

--- a/src/containers/ServiceAccount/ServiceAccount.test.js
+++ b/src/containers/ServiceAccount/ServiceAccount.test.js
@@ -16,9 +16,9 @@ import { Route } from 'react-router-dom';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
 import { ServiceAccountContainer } from './ServiceAccount';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/ServiceAccounts/ServiceAccounts.test.js
+++ b/src/containers/ServiceAccounts/ServiceAccounts.test.js
@@ -18,8 +18,9 @@ import { Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import ServiceAccounts from '.';
-import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/serviceAccounts';
 
 const middleware = [thunk];

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -16,9 +16,10 @@ import { fireEvent, getNodeText } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+
 import ServiceAccountsDropdown from './ServiceAccountsDropdown';
 import * as API from '../../api/serviceAccounts';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 
 const props = {
   id: 'service-accounts-dropdown',
@@ -171,11 +172,11 @@ describe('ServiceAccountsDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={greenStore}>
         <ServiceAccountsDropdown {...props} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // View items
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
@@ -203,22 +204,22 @@ describe('ServiceAccountsDropdown', () => {
     );
     expect(queryByValue(/service-account-1/i)).toBeTruthy();
     // Select item 'service-account-2'
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <ServiceAccountsDropdown
           {...props}
           selectedItem={{ text: 'service-account-2' }}
         />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByValue(/service-account-2/i)).toBeTruthy();
     // No selected item (select item '')
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} selectedItem="" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
   });

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -17,8 +17,8 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithRouter } from '../../utils/test';
 import SideNavContainer, { SideNavWithIntl as SideNav } from './SideNav';
 
 it('SideNav renders with extensions', () => {
@@ -89,7 +89,7 @@ it('SideNav selects namespace based on URL', () => {
   });
   const namespace = 'default';
   const selectNamespace = jest.fn();
-  const { container } = renderWithRouter(
+  const { rerender } = renderWithRouter(
     <Provider store={store}>
       <SideNav
         extensions={[]}
@@ -101,6 +101,7 @@ it('SideNav selects namespace based on URL', () => {
   expect(selectNamespace).toHaveBeenCalledWith(namespace);
 
   const updatedNamespace = 'another';
+
   renderWithRouter(
     <Provider store={store}>
       <SideNav
@@ -109,9 +110,8 @@ it('SideNav selects namespace based on URL', () => {
         selectNamespace={selectNamespace}
       />
     </Provider>,
-    { container }
+    { rerender }
   );
-
   expect(selectNamespace).toHaveBeenCalledWith(updatedNamespace);
 
   renderWithRouter(
@@ -122,7 +122,7 @@ it('SideNav selects namespace based on URL', () => {
         selectNamespace={selectNamespace}
       />
     </Provider>,
-    { container }
+    { rerender }
   );
   expect(selectNamespace).toHaveBeenCalledTimes(2);
 });

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -18,8 +18,8 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/taskRuns';
 import * as selectors from '../../reducers';
 import * as store from '../../store';

--- a/src/containers/TasksDropdown/TasksDropdown.test.js
+++ b/src/containers/TasksDropdown/TasksDropdown.test.js
@@ -17,10 +17,10 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
 import TasksDropdown from './TasksDropdown';
 import * as API from '../../api/tasks';
-import { renderWithIntl, rerenderWithIntl } from '../../utils/test';
 
 const props = {
   id: 'tasks-dropdown',
@@ -171,11 +171,11 @@ describe('TasksDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={greenStore}>
         <TasksDropdown {...props} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     // View items
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
@@ -204,19 +204,19 @@ describe('TasksDropdown', () => {
     );
     expect(queryByDisplayValue(/task-1/i)).toBeTruthy();
     // Select item 'task-2'
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <TasksDropdown {...props} selectedItem={{ text: 'task-2' }} />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByDisplayValue(/task-2/i)).toBeTruthy();
     // No selected item (select item '')
-    rerenderWithIntl(
-      rerender,
+    renderWithIntl(
       <Provider store={store}>
         <TasksDropdown {...props} selectedItem="" />
-      </Provider>
+      </Provider>,
+      { rerender }
     );
     expect(queryByPlaceholderText(initialTextRegExp)).toBeTruthy();
   });

--- a/src/containers/TriggerBinding/TriggerBinding.test.js
+++ b/src/containers/TriggerBinding/TriggerBinding.test.js
@@ -16,8 +16,9 @@ import { Route } from 'react-router-dom';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import { TriggerBindingContainer } from './TriggerBinding';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/TriggerBindings/TriggerBindings.test.js
+++ b/src/containers/TriggerBindings/TriggerBindings.test.js
@@ -17,8 +17,9 @@ import { Provider } from 'react-redux';
 import { Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import TriggerBindings from '.';
-import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/triggerBindings';
 
 const middleware = [thunk];

--- a/src/containers/TriggerTemplate/TriggerTemplate.test.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.test.js
@@ -16,8 +16,9 @@ import { Route } from 'react-router-dom';
 import { fireEvent, waitForElement } from 'react-testing-library';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import { TriggerTemplateContainer } from './TriggerTemplate';
-import { renderWithRouter } from '../../utils/test';
 
 const intl = createIntl({
   locale: 'en',

--- a/src/containers/TriggerTemplates/TriggerTemplates.test.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.test.js
@@ -17,8 +17,9 @@ import { Provider } from 'react-redux';
 import { Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
+
 import TriggerTemplates from '.';
-import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/triggerTemplates';
 
 const middleware = [thunk];

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -11,62 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* istanbul ignore file */
-import React from 'react';
 import fetchMock from 'fetch-mock';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
-import { render } from 'react-testing-library';
-import { IntlProvider } from 'react-intl';
 
 import { getAPIRoot } from '../api/comms';
 
 const apiRoot = getAPIRoot();
-
-export function renderWithRouter(
-  ui,
-  {
-    route = '/',
-    history = createMemoryHistory({ initialEntries: [route] }),
-    container
-  } = {}
-) {
-  return {
-    ...render(
-      <Router history={history}>
-        <IntlProvider locale="en" defaultLocale="en">
-          {ui}
-        </IntlProvider>
-      </Router>,
-      {
-        container
-      }
-    ),
-    // adding `history` to the returned utilities to allow us
-    // to reference it in our tests (just try to avoid using
-    // this to test implementation details).
-    history
-  };
-}
-
-export function wrapWithIntl(ui) {
-  return (
-    <IntlProvider locale="en" defaultLocale="en">
-      {ui}
-    </IntlProvider>
-  );
-}
-
-export function renderWithIntl(ui) {
-  return {
-    ...render(wrapWithIntl(ui))
-  };
-}
-
-export function rerenderWithIntl(rerender, ui) {
-  return {
-    ...rerender(wrapWithIntl(ui))
-  };
-}
 
 export function mockCSRFToken() {
   fetchMock.get(`${apiRoot}/v1/token`, () => ({


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Remove the duplicate test utils from the `src/` folder, instead
using the ones from the components package.

Also update the utils to use the `react-testing-library` `wrapper`
field instead of directly wrapping the provided component as the
primary parameter to the `render` function. This is the recommended
approach and also allows us to resolve a number of warnings in the
test log output relating to modifying `<Router history>`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
