### PR TITLE
Add additional handling to prevent possible UI error selecting default Task / step

### DIFF
--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -100,7 +100,9 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     const taskRun = taskRuns.find(
       ({ metadata }) =>
         metadata.labels &&
-        (metadata.labels[labelConstants.CONDITION_CHECK] === pipelineTaskName ||
+        ((metadata.labels[labelConstants.CONDITION_CHECK] &&
+          metadata.labels[labelConstants.CONDITION_CHECK] ===
+            pipelineTaskName) ||
           // the `pipelineTask` label is present on both TaskRuns (the owning
           // TaskRun and the TaskRun created for the condition check), ensure
           // we only match on the owning TaskRun here and not another condition


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add additional handling to the PipelineRun container to ensure we
don't incorrectly select the wrong TaskRun in the case where there's
no `pipelineTaskName` selected and a TaskRun does not have a
condition check label. This would result in the comparison
`undefined == undefined`, potentially leading to the wrong TaskRun
being expanded by default, and not reflected in the URL.

This is unlikely to occur, but is easily avoided by checking that
a condition check label is present.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
