### PR TITLE
Add styling for active submenus on rail nav

### DIFF
--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { NavLink } from 'react-router-dom';
+import { matchPath, NavLink } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import {
   SideNav as CarbonSideNav,
@@ -76,7 +76,7 @@ class SideNav extends Component {
   }
 
   render() {
-    const { expanded, extensions, intl } = this.props;
+    const { expanded, extensions, intl, location } = this.props;
 
     return (
       <CarbonSideNav
@@ -97,70 +97,132 @@ class SideNav extends Component {
           >
             <SideNavMenuItem
               element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: this.getPath(urls.pipelines.all())
+                })
+              }
               to={this.getPath(urls.pipelines.all())}
             >
               Pipelines
             </SideNavMenuItem>
             <SideNavMenuItem
               element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: this.getPath(urls.pipelineRuns.all())
+                })
+              }
               to={this.getPath(urls.pipelineRuns.all())}
             >
               PipelineRuns
             </SideNavMenuItem>
             <SideNavMenuItem
               element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: this.getPath(urls.pipelineResources.all())
+                })
+              }
               to={this.getPath(urls.pipelineResources.all())}
             >
               PipelineResources
             </SideNavMenuItem>
             <SideNavMenuItem
               element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: this.getPath(urls.tasks.all())
+                })
+              }
               to={this.getPath(urls.tasks.all())}
             >
               Tasks
             </SideNavMenuItem>
-            <SideNavMenuItem element={NavLink} to={urls.clusterTasks.all()}>
+            <SideNavMenuItem
+              element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: urls.clusterTasks.all()
+                })
+              }
+              to={urls.clusterTasks.all()}
+            >
               ClusterTasks
             </SideNavMenuItem>
             <SideNavMenuItem
               element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: this.getPath(urls.taskRuns.all())
+                })
+              }
               to={this.getPath(urls.taskRuns.all())}
             >
               TaskRuns
             </SideNavMenuItem>
             <SideNavMenuItem
               element={NavLink}
+              isActive={
+                !!matchPath(location.pathname, {
+                  path: this.getPath(urls.conditions.all())
+                })
+              }
               to={this.getPath(urls.conditions.all())}
             >
               Conditions
             </SideNavMenuItem>
             {this.props.isTriggersInstalled && (
-              <>
-                <SideNavMenuItem
-                  element={NavLink}
-                  to={this.getPath(urls.eventListeners.all())}
-                >
-                  EventListeners
-                </SideNavMenuItem>
-                <SideNavMenuItem
-                  element={NavLink}
-                  to={this.getPath(urls.triggerBindings.all())}
-                >
-                  TriggerBindings
-                </SideNavMenuItem>
-                <SideNavMenuItem
-                  element={NavLink}
-                  to={urls.clusterTriggerBindings.all()}
-                >
-                  ClusterTriggerBindings
-                </SideNavMenuItem>
-                <SideNavMenuItem
-                  element={NavLink}
-                  to={this.getPath(urls.triggerTemplates.all())}
-                >
-                  TriggerTemplates
-                </SideNavMenuItem>
-              </>
+              <SideNavMenuItem
+                element={NavLink}
+                isActive={
+                  !!matchPath(location.pathname, {
+                    path: this.getPath(urls.eventListeners.all())
+                  })
+                }
+                to={this.getPath(urls.eventListeners.all())}
+              >
+                EventListeners
+              </SideNavMenuItem>
+            )}
+            {this.props.isTriggersInstalled && (
+              <SideNavMenuItem
+                element={NavLink}
+                isActive={
+                  !!matchPath(location.pathname, {
+                    path: this.getPath(urls.triggerBindings.all())
+                  })
+                }
+                to={this.getPath(urls.triggerBindings.all())}
+              >
+                TriggerBindings
+              </SideNavMenuItem>
+            )}
+            {this.props.isTriggersInstalled && (
+              <SideNavMenuItem
+                element={NavLink}
+                isActive={
+                  !!matchPath(location.pathname, {
+                    path: urls.clusterTriggerBindings.all()
+                  })
+                }
+                to={urls.clusterTriggerBindings.all()}
+              >
+                ClusterTriggerBindings
+              </SideNavMenuItem>
+            )}
+            {this.props.isTriggersInstalled && (
+              <SideNavMenuItem
+                element={NavLink}
+                isActive={
+                  !!matchPath(location.pathname, {
+                    path: this.getPath(urls.triggerTemplates.all())
+                  })
+                }
+                to={this.getPath(urls.triggerTemplates.all())}
+              >
+                TriggerTemplates
+              </SideNavMenuItem>
             )}
           </SideNavMenu>
 
@@ -175,12 +237,22 @@ class SideNav extends Component {
             >
               <SideNavMenuItem
                 element={NavLink}
+                isActive={
+                  !!matchPath(location.pathname, {
+                    path: this.getPath(urls.secrets.all())
+                  })
+                }
                 to={this.getPath(urls.secrets.all())}
               >
                 Secrets
               </SideNavMenuItem>
               <SideNavMenuItem
                 element={NavLink}
+                isActive={
+                  !!matchPath(location.pathname, {
+                    path: this.getPath(urls.serviceAccounts.all())
+                  })
+                }
                 to={this.getPath(urls.serviceAccounts.all())}
               >
                 ServiceAccounts
@@ -205,27 +277,34 @@ class SideNav extends Component {
                   extensionType,
                   name,
                   namespaced
-                }) => (
-                  <SideNavMenuItem
-                    element={NavLink}
-                    to={
-                      extensionType === 'kubernetes-resource'
-                        ? this.getPath(
-                            urls.kubernetesResources.all({
-                              group: apiGroup,
-                              version: apiVersion,
-                              type: name
-                            }),
-                            namespaced
-                          )
-                        : urls.extensions.byName({ name })
-                    }
-                    key={name}
-                    title={displayName}
-                  >
-                    {displayName}
-                  </SideNavMenuItem>
-                )
+                }) => {
+                  const to =
+                    extensionType === 'kubernetes-resource'
+                      ? this.getPath(
+                          urls.kubernetesResources.all({
+                            group: apiGroup,
+                            version: apiVersion,
+                            type: name
+                          }),
+                          namespaced
+                        )
+                      : urls.extensions.byName({ name });
+                  return (
+                    <SideNavMenuItem
+                      element={NavLink}
+                      isActive={
+                        !!matchPath(location.pathname, {
+                          path: to
+                        })
+                      }
+                      to={to}
+                      key={name}
+                      title={displayName}
+                    >
+                      {displayName}
+                    </SideNavMenuItem>
+                  );
+                }
               )}
             </SideNavMenu>
           )}

--- a/src/containers/SideNav/SideNav.scss
+++ b/src/containers/SideNav/SideNav.scss
@@ -78,6 +78,15 @@ limitations under the License.
       }
     }
 
+    .bx--side-nav__item--active {
+      .bx--side-nav__submenu[aria-expanded=false] {
+        background-color: $gray-80;
+      }
+      .bx--side-nav__submenu-title {
+        color: $gray-10;
+      }
+    }
+
     .bx--side-nav__menu a.bx--side-nav__link--current,
     .bx--side-nav__menu a.bx--side-nav__link[aria-current=page] {
       background-color: $gray-80;

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -54,7 +54,7 @@ it('SideNav renders with extensions', () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer />
+      <SideNavContainer location={{ search: '' }} />
     </Provider>
   );
   expect(queryByText(/pipelines/i)).toBeTruthy();
@@ -76,7 +76,7 @@ it('SideNav renders with triggers', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer />
+      <SideNavContainer location={{ search: '' }} />
     </Provider>
   );
   await waitForElement(() => queryByText(/about/i));
@@ -100,6 +100,7 @@ it('SideNav selects namespace based on URL', () => {
     <Provider store={store}>
       <SideNav
         extensions={[]}
+        location={{ search: '' }}
         match={{ params: { namespace } }}
         selectNamespace={selectNamespace}
       />
@@ -113,6 +114,7 @@ it('SideNav selects namespace based on URL', () => {
     <Provider store={store}>
       <SideNav
         extensions={[]}
+        location={{ search: '' }}
         match={{ params: { namespace: updatedNamespace } }}
         selectNamespace={selectNamespace}
       />
@@ -125,6 +127,7 @@ it('SideNav selects namespace based on URL', () => {
     <Provider store={store}>
       <SideNav
         extensions={[]}
+        location={{ search: '' }}
         match={{ params: { namespace: updatedNamespace } }}
         selectNamespace={selectNamespace}
       />
@@ -144,7 +147,7 @@ it('SideNav renders import in not read-only mode', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer />
+      <SideNavContainer location={{ search: '' }} />
     </Provider>
   );
   await waitForElement(() => queryByText(/Import/i));
@@ -162,7 +165,7 @@ it('SideNav does not render import in read-only mode', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer isReadOnly />
+      <SideNavContainer isReadOnly location={{ search: '' }} />
     </Provider>
   );
   await waitForElement(() => queryByText(/about/i));


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/803

When the main nav is collapsed to its rail presentation,
ensure we mark any link / menu with an active nav item
as active. This is to help orient users and help guide
them to the relevant section in the expanded nav.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
