### PR TITLE
Reduce duplication in the SideNav component

### DIFF
--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -66,6 +66,18 @@ class SideNav extends Component {
     }
   }
 
+  getMenuItemProps(to) {
+    const { location } = this.props;
+
+    return {
+      element: NavLink,
+      isActive: !!matchPath(location.pathname, {
+        path: to
+      }),
+      to
+    };
+  }
+
   getPath(path, namespaced = true) {
     const { namespace } = this.props;
     if (namespaced && namespace && namespace !== ALL_NAMESPACES) {
@@ -76,7 +88,7 @@ class SideNav extends Component {
   }
 
   render() {
-    const { expanded, extensions, intl, location } = this.props;
+    const { expanded, extensions, intl } = this.props;
 
     return (
       <CarbonSideNav
@@ -96,130 +108,72 @@ class SideNav extends Component {
             })}
           >
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: this.getPath(urls.pipelines.all())
-                })
-              }
-              to={this.getPath(urls.pipelines.all())}
+              {...this.getMenuItemProps(this.getPath(urls.pipelines.all()))}
             >
               Pipelines
             </SideNavMenuItem>
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: this.getPath(urls.pipelineRuns.all())
-                })
-              }
-              to={this.getPath(urls.pipelineRuns.all())}
+              {...this.getMenuItemProps(this.getPath(urls.pipelineRuns.all()))}
             >
               PipelineRuns
             </SideNavMenuItem>
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: this.getPath(urls.pipelineResources.all())
-                })
-              }
-              to={this.getPath(urls.pipelineResources.all())}
+              {...this.getMenuItemProps(
+                this.getPath(urls.pipelineResources.all())
+              )}
             >
               PipelineResources
             </SideNavMenuItem>
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: this.getPath(urls.tasks.all())
-                })
-              }
-              to={this.getPath(urls.tasks.all())}
+              {...this.getMenuItemProps(this.getPath(urls.tasks.all()))}
             >
               Tasks
             </SideNavMenuItem>
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: urls.clusterTasks.all()
-                })
-              }
-              to={urls.clusterTasks.all()}
+              {...this.getMenuItemProps(urls.clusterTasks.all())}
             >
               ClusterTasks
             </SideNavMenuItem>
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: this.getPath(urls.taskRuns.all())
-                })
-              }
-              to={this.getPath(urls.taskRuns.all())}
+              {...this.getMenuItemProps(this.getPath(urls.taskRuns.all()))}
             >
               TaskRuns
             </SideNavMenuItem>
             <SideNavMenuItem
-              element={NavLink}
-              isActive={
-                !!matchPath(location.pathname, {
-                  path: this.getPath(urls.conditions.all())
-                })
-              }
-              to={this.getPath(urls.conditions.all())}
+              {...this.getMenuItemProps(this.getPath(urls.conditions.all()))}
             >
               Conditions
             </SideNavMenuItem>
             {this.props.isTriggersInstalled && (
               <SideNavMenuItem
-                element={NavLink}
-                isActive={
-                  !!matchPath(location.pathname, {
-                    path: this.getPath(urls.eventListeners.all())
-                  })
-                }
-                to={this.getPath(urls.eventListeners.all())}
+                {...this.getMenuItemProps(
+                  this.getPath(urls.eventListeners.all())
+                )}
               >
                 EventListeners
               </SideNavMenuItem>
             )}
             {this.props.isTriggersInstalled && (
               <SideNavMenuItem
-                element={NavLink}
-                isActive={
-                  !!matchPath(location.pathname, {
-                    path: this.getPath(urls.triggerBindings.all())
-                  })
-                }
-                to={this.getPath(urls.triggerBindings.all())}
+                {...this.getMenuItemProps(
+                  this.getPath(urls.triggerBindings.all())
+                )}
               >
                 TriggerBindings
               </SideNavMenuItem>
             )}
             {this.props.isTriggersInstalled && (
               <SideNavMenuItem
-                element={NavLink}
-                isActive={
-                  !!matchPath(location.pathname, {
-                    path: urls.clusterTriggerBindings.all()
-                  })
-                }
-                to={urls.clusterTriggerBindings.all()}
+                {...this.getMenuItemProps(urls.clusterTriggerBindings.all())}
               >
                 ClusterTriggerBindings
               </SideNavMenuItem>
             )}
             {this.props.isTriggersInstalled && (
               <SideNavMenuItem
-                element={NavLink}
-                isActive={
-                  !!matchPath(location.pathname, {
-                    path: this.getPath(urls.triggerTemplates.all())
-                  })
-                }
-                to={this.getPath(urls.triggerTemplates.all())}
+                {...this.getMenuItemProps(
+                  this.getPath(urls.triggerTemplates.all())
+                )}
               >
                 TriggerTemplates
               </SideNavMenuItem>
@@ -236,24 +190,14 @@ class SideNav extends Component {
               })}
             >
               <SideNavMenuItem
-                element={NavLink}
-                isActive={
-                  !!matchPath(location.pathname, {
-                    path: this.getPath(urls.secrets.all())
-                  })
-                }
-                to={this.getPath(urls.secrets.all())}
+                {...this.getMenuItemProps(this.getPath(urls.secrets.all()))}
               >
                 Secrets
               </SideNavMenuItem>
               <SideNavMenuItem
-                element={NavLink}
-                isActive={
-                  !!matchPath(location.pathname, {
-                    path: this.getPath(urls.serviceAccounts.all())
-                  })
-                }
-                to={this.getPath(urls.serviceAccounts.all())}
+                {...this.getMenuItemProps(
+                  this.getPath(urls.serviceAccounts.all())
+                )}
               >
                 ServiceAccounts
               </SideNavMenuItem>
@@ -291,13 +235,7 @@ class SideNav extends Component {
                       : urls.extensions.byName({ name });
                   return (
                     <SideNavMenuItem
-                      element={NavLink}
-                      isActive={
-                        !!matchPath(location.pathname, {
-                          path: to
-                        })
-                      }
-                      to={to}
+                      {...this.getMenuItemProps(to)}
                       key={name}
                       title={displayName}
                     >


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Reduce duplicate code for setting the props (particularly `isActive`)
of the `SideNavMenuItem` components by adding a function to set them.

The only value that changes between menu items is the path, so pass
that as a param and also return the other common props.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
