### PR TITLE
Fix header styles for RunHeader and DetailsHeader components

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.js
@@ -126,7 +126,7 @@ class DetailsHeader extends Component {
         data-status={status}
         data-reason={reason}
       >
-        <h2>
+        <h2 className="tkn--details-header--heading">
           <StatusIcon
             DefaultIcon={type === 'step' ? DefaultIcon : null}
             reason={reason}

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -13,10 +13,10 @@ limitations under the License.
 
 @import '~carbon-components/scss/globals/scss/vars';
 
-.tkn--step-details-header {
+header.tkn--step-details-header {
   padding: 1rem 1rem 0;
 
-  h2 {
+  h2.tkn--details-header--heading {
     height: 1.7rem;
     font-size: 1.3rem;
     font-weight: 400;

--- a/packages/components/src/components/RunHeader/RunHeader.js
+++ b/packages/components/src/components/RunHeader/RunHeader.js
@@ -39,7 +39,7 @@ class RunHeader extends Component {
     } = this.props;
 
     return (
-      <div
+      <header
         className="tkn--pipeline-run-header"
         data-succeeded={status}
         data-reason={reason}
@@ -56,7 +56,7 @@ class RunHeader extends Component {
           return (
             runName && (
               <>
-                <h1>
+                <h1 className="tkn--run-header--heading">
                   <div className="tkn--run-name" title={runName}>
                     {runName}
                   </div>
@@ -91,7 +91,7 @@ class RunHeader extends Component {
             )
           );
         })()}
-      </div>
+      </header>
     );
   }
 }

--- a/packages/components/src/components/RunHeader/RunHeader.scss
+++ b/packages/components/src/components/RunHeader/RunHeader.scss
@@ -13,7 +13,7 @@ limitations under the License.
 
 @import '~carbon-components/scss/globals/scss/typography';
 
-.tkn--pipeline-run-header {
+header.tkn--pipeline-run-header {
   background: white;
   margin-bottom: 2em;
   padding: .4em 0 .4em 1.5em;
@@ -24,7 +24,7 @@ limitations under the License.
     width: 15rem;
   }
 
-  h1 {
+  h1.tkn--run-header--heading {
     @include type-style('productive-heading-04');
     display: flex;
     align-items: baseline;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Increase the specifity of the selectors for the heading styles in
both the RunHeader and DetailsHeader components to ensure the
custom font styles and margin are correctly applied.

Before/After:
![image](https://user-images.githubusercontent.com/2829095/101342277-3cabf500-387a-11eb-9c10-b4b4b186dff3.png)

Change to both the main header, and also the header on the step details.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
