### PR TITLE
Display placeholders for pipeline tasks that haven't begun executing yet

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -74,33 +74,6 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     );
   }
 
-  sortTaskRuns = taskRuns => {
-    const toReturn = taskRuns.sort((taskRunA, taskRunB) => {
-      if (!taskRunA || !taskRunB) {
-        return 0;
-      }
-
-      const firstStepA = taskRunA.status?.steps?.[0];
-      const firstStepB = taskRunB.status?.steps?.[0];
-
-      if (!firstStepA || !firstStepB) {
-        return 0;
-      }
-
-      const { startedAt: startedAtA } =
-        firstStepA.terminated || firstStepA.running || {};
-      const { startedAt: startedAtB } =
-        firstStepB.terminated || firstStepB.running || {};
-
-      if (!startedAtA || !startedAtB) {
-        return 0;
-      }
-
-      return new Date(startedAtA).getTime() - new Date(startedAtB).getTime();
-    });
-    return toReturn;
-  };
-
   loadTaskRuns = () => {
     const { intl, pipelineRun } = this.props;
     if (!pipelineRun?.status?.taskRuns) {
@@ -186,7 +159,6 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       selectedStepId,
       selectedTaskId,
       showIO,
-      sortTaskRuns,
       triggerHeader,
       view
     } = this.props;
@@ -275,11 +247,6 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     }
 
     const taskRuns = this.loadTaskRuns();
-
-    if (sortTaskRuns) {
-      this.sortTaskRuns(taskRuns);
-    }
-
     const taskRun =
       taskRuns.find(run => run.metadata.uid === selectedTaskId) || {};
 
@@ -360,7 +327,6 @@ PipelineRunContainer.propTypes = {
   onViewChange: PropTypes.func,
   selectedStepId: PropTypes.string,
   selectedTaskId: PropTypes.string,
-  sortTaskRuns: PropTypes.bool,
   view: PropTypes.string
 };
 
@@ -369,7 +335,6 @@ PipelineRunContainer.defaultProps = {
   onViewChange: /* istanbul ignore next */ () => {},
   selectedStepId: null,
   selectedTaskId: null,
-  sortTaskRuns: false,
   view: null
 };
 

--- a/packages/utils/src/utils/constants.js
+++ b/packages/utils/src/utils/constants.js
@@ -14,6 +14,7 @@ limitations under the License.
 export const labels = {
   CLUSTER_TASK: 'tekton.dev/clusterTask',
   CONDITION_CHECK: 'tekton.dev/conditionCheck',
+  CONDITION_NAME: 'tekton.dev/conditionName',
   DASHBOARD_IMPORT: 'dashboard.tekton.dev/import',
   DASHBOARD_RETRY_NAME: 'dashboard.tekton.dev/retryName',
   PIPELINE: 'tekton.dev/pipeline',


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/1263
Resolves https://github.com/tektoncd/dashboard/issues/932

On the PipelineRun details page, display placeholders for pipeline tasks
that don't yet have a corresponding TaskRun. Fill in spec details where
available so the user can still view the definition.

Once the pipeline task begins executing the placeholder will be replaced
with the real TaskRun and corresponding details.

In the case of Conditions, we make a best effort to display placeholders
for the TaskRuns generated to evaluate them. Once they execute we will
display the correct TaskRun details, however before this is available
the placeholder may be incomplete and may become unselected as the
PipelineRun updates. This is due to a lack of required runtime information
to produce a consistent link between the resources. Since Conditions are
deprecated, we're not planning to invest further effort in improving this.

This update also changes the ordering of TaskRun in the TaskTree component.
Instead of sorting by start time of the first step in each TaskRun, they're
now sorted in order of definition in the Pipeline.

A nice (subj.) side effect of this is that retries for a given TaskRun
will be displayed immediately following the corresponding TaskRun rather
than interspersed among other TaskRuns in an often unpredictable order.
Future changes to the display of retries will further improve this grouping.

Before:
![image](https://user-images.githubusercontent.com/2829095/102107975-40b3b600-3e2a-11eb-9fa5-cac0b9aca715.png)

After:
![image](https://user-images.githubusercontent.com/2829095/102108334-b28bff80-3e2a-11eb-8c04-4632975225bb.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
