### PR TITLE
Fix styling of inline table actions in read only mode

### DIFF
--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -94,6 +94,7 @@ limitations under the License.
   &.tkn--table--inline-actions {
     .bx--data-table td {
       &.cell-actions {
+        text-align: right;
         width: 6rem;
       }
     }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

When in read only mode there's currently only a single inline action
on table rows. Align the inline actions to the right so that they're
always at the end of the row instead of being positioned at the left
of their containing column.

Before:
![image](https://user-images.githubusercontent.com/2829095/103902485-7e86c000-50f2-11eb-9f2d-60d0d4e95051.png)

After:
![image](https://user-images.githubusercontent.com/2829095/103902510-88102800-50f2-11eb-8d12-d70f9982fecc.png)

There should be no visual difference when multiple inline actions are present:
![image](https://user-images.githubusercontent.com/2829095/103902583-a544f680-50f2-11eb-9a58-cb09d74dd398.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
