### PR TITLE
Remove src/components folder and move contents to more suitable locations

### DIFF
--- a/.storybook/Container.scss
+++ b/.storybook/Container.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,4 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '../src/components/App/App';
+@import '../src/scss/App';

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -88,7 +88,7 @@ import {
 } from '../../reducers';
 import messages from '../../nls/messages_en.json';
 
-import '../../components/App/App.scss';
+import '../../scss/App.scss';
 
 /* istanbul ignore next */
 if (process.env.I18N_PSEUDO) {

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -45,7 +45,7 @@ import {
   isWebSocketConnected
 } from '../../reducers';
 
-import '../../components/Definitions/Definitions.scss';
+import '../../scss/Definitions.scss';
 
 export /* istanbul ignore next */ class ClusterTasksContainer extends Component {
   state = {

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import {
   urls
 } from '@tektoncd/dashboard-utils';
 
-import GitResourceFields from '../../components/CreatePipelineResource/GitResourceFields';
-import UniversalFields from '../../components/CreatePipelineResource/UniversalFields';
+import GitResourceFields from './GitResourceFields';
+import UniversalFields from './UniversalFields';
 import { createPipelineResource } from '../../api';
 import { getSelectedNamespace } from '../../reducers';
 

--- a/src/containers/CreatePipelineResource/GitResourceFields.js
+++ b/src/containers/CreatePipelineResource/GitResourceFields.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreatePipelineResource/UniversalFields.js
+++ b/src/containers/CreatePipelineResource/UniversalFields.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { Dropdown, TextInput } from 'carbon-components-react';
 import { injectIntl } from 'react-intl';
 import { getTranslateWithId } from '@tektoncd/dashboard-utils';
 
-import NamespacesDropdown from '../../containers/NamespacesDropdown';
+import NamespacesDropdown from '../NamespacesDropdown';
 
 const itemToString = item => (item ? item.text : '');
 

--- a/src/containers/CreateSecret/CreateSecret.js
+++ b/src/containers/CreateSecret/CreateSecret.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,8 +21,8 @@ import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
-import Form from '../../components/CreateSecret/Form';
-import ServiceAccountSelector from '../../components/CreateSecret/ServiceAccountSelector';
+import Form from './Form';
+import ServiceAccountSelector from './ServiceAccountSelector';
 import {
   getCreateSecretsSuccessMessage,
   getPatchSecretsErrorMessage,
@@ -42,7 +42,8 @@ import {
 } from '../../actions/secrets';
 import { fetchServiceAccounts } from '../../actions/serviceAccounts';
 import { selectNamespace } from '../../actions/namespaces';
-import '../../components/CreateSecret/CreateSecret.scss';
+
+import './CreateSecret.scss';
 
 const defaultGithubServerURL = 'https://github.com';
 const defaultDockerServerURL = 'https://index.docker.io/v1/';

--- a/src/containers/CreateSecret/CreateSecret.scss
+++ b/src/containers/CreateSecret/CreateSecret.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/AccessTokenType.js
+++ b/src/containers/CreateSecret/Form/AccessTokenType.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/AccessTokenType.test.js
+++ b/src/containers/CreateSecret/Form/AccessTokenType.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/Annotations.js
+++ b/src/containers/CreateSecret/Form/Annotations.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/Annotations.test.js
+++ b/src/containers/CreateSecret/Form/Annotations.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/PasswordType.js
+++ b/src/containers/CreateSecret/Form/PasswordType.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/PasswordType.test.js
+++ b/src/containers/CreateSecret/Form/PasswordType.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/UniversalFields.js
+++ b/src/containers/CreateSecret/Form/UniversalFields.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import {
   TextInput,
   Tooltip
 } from 'carbon-components-react';
-import NamespacesDropdown from '../../../containers/NamespacesDropdown';
+import NamespacesDropdown from '../../NamespacesDropdown';
 
 const UniversalFields = props => {
   const {

--- a/src/containers/CreateSecret/Form/UniversalFields.test.js
+++ b/src/containers/CreateSecret/Form/UniversalFields.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/index.js
+++ b/src/containers/CreateSecret/Form/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/Form/index.test.js
+++ b/src/containers/CreateSecret/Form/index.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/ServiceAccountSelector.js
+++ b/src/containers/CreateSecret/ServiceAccountSelector.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/CreateSecret/ServiceAccountSelector.test.js
+++ b/src/containers/CreateSecret/ServiceAccountSelector.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -25,7 +25,7 @@ import {
   isFetchingExtensions
 } from '../../reducers';
 
-import '../../components/Definitions/Definitions.scss';
+import '../../scss/Definitions.scss';
 
 export const Extensions = /* istanbul ignore next */ ({
   error,

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -47,7 +47,7 @@ import {
   isWebSocketConnected
 } from '../../reducers';
 
-import '../../components/Definitions/Definitions.scss';
+import '../../scss/Definitions.scss';
 
 export /* istanbul ignore next */ class Pipelines extends Component {
   state = {

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -47,7 +47,7 @@ import {
   isWebSocketConnected
 } from '../../reducers';
 
-import '../../components/Definitions/Definitions.scss';
+import '../../scss/Definitions.scss';
 
 export /* istanbul ignore next */ class Tasks extends Component {
   state = {

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/scss/Definitions.scss
+++ b/src/scss/Definitions.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/scss/_carbon.scss
+++ b/src/scss/_carbon.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/708

- Move SCSS files under `src/components` to `src/scss`
- Move files under CreateSecret to `src/containers/CreateSecret`
- Move files under CreatePipelineResource to `src/containers/CreatePipelineResource`

The reason for moving these and deleting the `src/components` folder is to
help clarify where pure UI components should live (i.e. `packages/components`)
and avoid confusion for contributors.

We may go further in a future change and extract pure UI components from
CreateSecret and/or CreatePipelineResource but that's out of scope for this change.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
