### PR TITLE
Replace the deprecated `waitForElement` from react testing library

### DIFF
--- a/packages/components/src/components/LabelFilter/LabelFilter.test.js
+++ b/packages/components/src/components/LabelFilter/LabelFilter.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 import LabelFilter from './LabelFilter';
 import { renderWithIntl } from '../../utils/test';
@@ -58,7 +58,7 @@ it('LabelFilter displays notification if character length is over 63 characters 
   });
   fireEvent.submit(getByText(/Input a label filter/i));
   expect(handleAddFilter).not.toHaveBeenCalled();
-  await waitForElement(() =>
+  await waitFor(() =>
     getByText(
       /Filters must be of the format labelKey:labelValue and contain less than 64 characters/i
     )
@@ -88,7 +88,7 @@ it('LabelFilter handles adding a duplicate filter', async () => {
   });
   fireEvent.submit(getByText(/Input a label filter/i));
   expect(handleAddFilter).not.toHaveBeenCalled();
-  await waitForElement(() => getByText(/no duplicate filters allowed/i));
+  await waitFor(() => getByText(/no duplicate filters allowed/i));
   fireEvent.click(getByTitle(/closes notification/i));
   expect(queryByText(/no duplicate filters allowed/i)).toBeNull();
 });

--- a/packages/components/src/components/Log/Log.test.js
+++ b/packages/components/src/components/Log/Log.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,14 +12,14 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import Log from './Log';
 import { renderWithIntl } from '../../utils/test';
 
 describe('Log', () => {
   it('renders default content', async () => {
     const { getByText } = renderWithIntl(<Log fetchLogs={() => undefined} />);
-    await waitForElement(() => getByText(/No log available/i));
+    await waitFor(() => getByText(/No log available/i));
   });
 
   it('renders the provided content', async () => {
@@ -29,7 +29,7 @@ describe('Log', () => {
         fetchLogs={() => 'testing'}
       />
     );
-    await waitForElement(() => getByText(/testing/i));
+    await waitFor(() => getByText(/testing/i));
   });
 
   it('renders trailer', async () => {
@@ -39,7 +39,7 @@ describe('Log', () => {
         fetchLogs={() => 'testing'}
       />
     );
-    await waitForElement(() => getByText(/step completed/i));
+    await waitFor(() => getByText(/step completed/i));
   });
 
   it('renders error trailer', async () => {
@@ -49,7 +49,7 @@ describe('Log', () => {
         fetchLogs={() => 'testing'}
       />
     );
-    await waitForElement(() => getByText(/step failed/i));
+    await waitFor(() => getByText(/step failed/i));
   });
 
   it('renders virtualized list', async () => {
@@ -64,7 +64,7 @@ describe('Log', () => {
       />
     );
 
-    await waitForElement(() => getByText('Line 1'));
+    await waitFor(() => getByText('Line 1'));
   });
 
   it('renders the provided content when streaming logs', async () => {
@@ -82,7 +82,7 @@ describe('Log', () => {
         }
       />
     );
-    await waitForElement(() => getByText(/testing/i));
+    await waitFor(() => getByText(/testing/i));
   });
 
   it('renders trailer when streaming logs', async () => {
@@ -100,7 +100,7 @@ describe('Log', () => {
         }
       />
     );
-    await waitForElement(() => getByText(/step completed/i));
+    await waitFor(() => getByText(/step completed/i));
   });
 
   it('renders error trailer when streaming logs', async () => {
@@ -118,6 +118,6 @@ describe('Log', () => {
         }
       />
     );
-    await waitForElement(() => getByText(/step failed/i));
+    await waitFor(() => getByText(/step failed/i));
   });
 });

--- a/packages/components/src/components/LogoutButton/LogoutButton.test.js
+++ b/packages/components/src/components/LogoutButton/LogoutButton.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../utils/test';
 import Logout from './LogoutButton';
 
@@ -22,7 +22,7 @@ it('Header renders logout button when logout url is set', async () => {
   const getLogoutURLMock = jest.fn().mockImplementation(() => mockedResponse);
   const logoutButton = <Logout getLogoutURL={getLogoutURLMock} />;
   const { queryByTitle } = renderWithRouter(logoutButton);
-  await waitForElement(() => queryByTitle(/log out/i));
+  await waitFor(() => queryByTitle(/log out/i));
 });
 
 it('Header renders logout button when logout url is not set', async () => {

--- a/packages/components/src/components/PipelineResources/PipelineResources.test.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { TrashCan32 as Delete } from '@carbon/icons-react';
 import { renderWithIntl, renderWithRouter } from '../../utils/test';
 import PipelineResources from './PipelineResources';
@@ -75,7 +75,7 @@ it('PipelineResources renders correct data', async () => {
   expect(queryByText(pipelineResourceName)).toBeTruthy();
   expect(queryByText(/default-namespace/i)).toBeTruthy();
   expect(queryByText(/git/i)).toBeTruthy();
-  fireEvent.click(await waitForElement(() => getByLabelText(/select row/i)));
-  await waitForElement(() => getByText(/Delete/i));
+  fireEvent.click(await waitFor(() => getByLabelText(/select row/i)));
+  await waitFor(() => getByText(/Delete/i));
   expect(getByText(/1 item selected/i)).toBeTruthy();
 });

--- a/packages/components/src/components/PipelineRun/PipelineRun.test.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import PipelineRun from './PipelineRun';
 import { renderWithIntl } from '../../utils/test';
 
@@ -20,12 +20,12 @@ it('PipelineRunContainer renders', async () => {
   const { getByText } = renderWithIntl(
     <PipelineRun error={null} loading={false} />
   );
-  await waitForElement(() => getByText('PipelineRun not found'));
+  await waitFor(() => getByText('PipelineRun not found'));
 });
 
 it('PipelineRunContainer handles error state', async () => {
   const { getByText } = renderWithIntl(<PipelineRun error="Error" />);
-  await waitForElement(() => getByText('Error loading PipelineRun'));
+  await waitFor(() => getByText('Error loading PipelineRun'));
 });
 
 it('PipelineRunContainer handles init step failures', async () => {
@@ -73,7 +73,7 @@ it('PipelineRunContainer handles init step failures', async () => {
       tasks={[]}
     />
   );
-  await waitForElement(() => getByText(initStepName));
+  await waitFor(() => getByText(initStepName));
 });
 
 it('PipelineRunContainer handles init step failures for retry', async () => {
@@ -162,6 +162,6 @@ it('PipelineRunContainer handles init step failures for retry', async () => {
       )}
     </TestWrapper>
   );
-  await waitForElement(() => getByText(/(retry 1)/));
-  await waitForElement(() => getByText(initStepName));
+  await waitFor(() => getByText(/(retry 1)/));
+  await waitFor(() => getByText(initStepName));
 });

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.test.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithIntl } from '../../utils/test';
 import ResourceDetails from './ResourceDetails';
 
@@ -110,7 +110,7 @@ describe('ResourceDetails', () => {
         view="yaml"
       />
     );
-    waitForElement(() => queryByText('otherContent'));
+    waitFor(() => queryByText('otherContent'));
     fireEvent.click(queryByText(/overview/i));
     expect(onViewChange).toHaveBeenCalledWith('overview');
   });

--- a/packages/components/src/components/RunDropdown/RunDropdown.test.js
+++ b/packages/components/src/components/RunDropdown/RunDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithIntl } from '../../utils/test';
 import RunDropdown from './RunDropdown';
 
@@ -35,7 +35,7 @@ describe('RunDropdown dropdown no modal', () => {
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
-    await waitForElement(() => getByText('Action'));
+    await waitFor(() => getByText('Action'));
     fireEvent.click(getByText(`Action`));
     expect(mockCallBack).toHaveBeenCalled();
   });
@@ -54,7 +54,7 @@ describe('RunDropdown dropdown missing disable default behaviour', () => {
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
-    await waitForElement(() => getByText('Action'));
+    await waitFor(() => getByText('Action'));
     fireEvent.click(getByText(`Action`));
     expect(mockCallBack).toHaveBeenCalled();
   });
@@ -74,7 +74,7 @@ describe('RunDropdown disabled field', () => {
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
-    await waitForElement(() => getByText('Action'));
+    await waitFor(() => getByText('Action'));
     fireEvent.click(getByText(`Action`));
     expect(mockCallBack).not.toHaveBeenCalled();
   });
@@ -100,9 +100,9 @@ describe('RunDropdown with modal', () => {
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
-    await waitForElement(() => getByText('Action'));
+    await waitFor(() => getByText('Action'));
     fireEvent.click(getByText(`Action`));
-    await waitForElement(() => getByText('primary'));
+    await waitFor(() => getByText('primary'));
     fireEvent.click(getByText(`primary`));
     expect(mockCallBack).toHaveBeenCalled();
   });

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import Task from './Task';
 import { renderWithIntl } from '../../utils/test';
 
@@ -49,7 +49,7 @@ describe('Task', () => {
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
     );
-    waitForElement(() =>
+    waitFor(() =>
       queryByText(
         (content, element) =>
           content === 'a step' &&
@@ -66,7 +66,7 @@ describe('Task', () => {
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
     );
-    waitForElement(() =>
+    waitFor(() =>
       queryByText(
         (content, element) =>
           content === 'a step two' &&
@@ -83,7 +83,7 @@ describe('Task', () => {
     const { queryByText } = renderWithIntl(
       <Task {...props} expanded steps={steps} />
     );
-    waitForElement(() =>
+    waitFor(() =>
       queryByText(
         (content, element) =>
           content === 'a step two' &&

--- a/src/containers/App/App.test.js
+++ b/src/containers/App/App.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, waitForElement } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
@@ -57,7 +57,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
 
     expect(queryByText('Namespace')).toBeTruthy();
     expect(queryByText('Pipelines')).toBeTruthy();
@@ -89,7 +89,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
 
     expect(queryByText('Namespaces')).toBeFalsy();
     expect(queryByText('Pipelines')).toBeTruthy();
@@ -122,7 +122,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
     expect(selectNamespace).toHaveBeenCalledWith('fake');
   });
 
@@ -157,7 +157,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
     expect(selectNamespace).toHaveBeenCalledWith('fake');
     expect(fetchNamespaces).not.toHaveBeenCalled();
   });
@@ -188,7 +188,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
     expect(selectNamespace).not.toHaveBeenCalled();
     expect(fetchNamespaces).toHaveBeenCalled();
   });
@@ -223,7 +223,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
     expect(selectNamespace).toHaveBeenCalledWith('fake');
     expect(fetchExtensions).toHaveBeenCalledWith({ namespace: 'fake' });
   });
@@ -253,7 +253,7 @@ describe('App', () => {
       </Provider>
     );
 
-    await waitForElement(() => queryByText('Tekton resources'));
+    await waitFor(() => queryByText('Tekton resources'));
     expect(fetchExtensions).toHaveBeenCalledWith({ namespace: ALL_NAMESPACES });
     expect(fetchNamespaces).toHaveBeenCalled();
   });

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.test.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
@@ -79,7 +79,7 @@ it('ClusterTriggerBindingContainer renders', async () => {
       loading={false}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('ClusterTriggerBindingContainer handles error state', async () => {
@@ -97,7 +97,7 @@ it('ClusterTriggerBindingContainer handles error state', async () => {
       fetchClusterTriggerBinding={() => Promise.resolve()}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('ClusterTriggerBindingContainer renders overview', async () => {
@@ -119,12 +119,12 @@ it('ClusterTriggerBindingContainer renders overview', async () => {
     />
   );
 
-  await waitForElement(() => getByText('cluster-trigger-binding-simple'));
-  await waitForElement(() => getByText(/param1/i));
-  await waitForElement(() => getByText(/param2/i));
-  await waitForElement(() => getByText('$(body.head_commit.id)'));
-  await waitForElement(() => getByText('$(body.repository.clone_url)'));
-  await waitForElement(() => getByText('None'));
+  await waitFor(() => getByText('cluster-trigger-binding-simple'));
+  await waitFor(() => getByText(/param1/i));
+  await waitFor(() => getByText(/param2/i));
+  await waitFor(() => getByText('$(body.head_commit.id)'));
+  await waitFor(() => getByText('$(body.repository.clone_url)'));
+  await waitFor(() => getByText('None'));
 });
 
 it('ClusterTriggerBindingContainer renders YAML', async () => {
@@ -152,14 +152,14 @@ it('ClusterTriggerBindingContainer renders YAML', async () => {
     }
   );
 
-  await waitForElement(() => getByText(clusterTriggerBindingName));
+  await waitFor(() => getByText(clusterTriggerBindingName));
   const yamlTab = getByText('YAML');
   fireEvent.click(yamlTab);
-  await waitForElement(() => getByText(/creationTimestamp/i));
-  await waitForElement(() => getByText(/spec/i));
-  await waitForElement(() => getByText(/params/i));
-  await waitForElement(() => getByText(/metadata/i));
-  await waitForElement(() => getByText(/ClusterTriggerBinding/i));
+  await waitFor(() => getByText(/creationTimestamp/i));
+  await waitFor(() => getByText(/spec/i));
+  await waitFor(() => getByText(/params/i));
+  await waitFor(() => getByText(/metadata/i));
+  await waitFor(() => getByText(/ClusterTriggerBinding/i));
 });
 
 it('ClusterTriggerBindingContainer does not render label section if they are not present', async () => {
@@ -181,8 +181,8 @@ it('ClusterTriggerBindingContainer does not render label section if they are not
     />
   );
 
-  await waitForElement(() => getByText('cluster-trigger-binding-simple'));
-  await waitForElement(() => getByText('None'));
+  await waitFor(() => getByText('cluster-trigger-binding-simple'));
+  await waitFor(() => getByText('None'));
 });
 
 it('ClusterTriggerBindingContainer renders labels section if they are present', async () => {
@@ -204,8 +204,8 @@ it('ClusterTriggerBindingContainer renders labels section if they are present', 
     />
   );
 
-  await waitForElement(() => getByText('cluster-trigger-binding-labels'));
-  await waitForElement(() => getByText('Labels:'));
-  await waitForElement(() => getByText(/mylabel: foo/i));
-  await waitForElement(() => getByText(/myotherlabel: bar/i));
+  await waitFor(() => getByText('cluster-trigger-binding-labels'));
+  await waitFor(() => getByText('Labels:'));
+  await waitFor(() => getByText(/mylabel: foo/i));
+  await waitFor(() => getByText(/myotherlabel: bar/i));
 });

--- a/src/containers/Condition/Condition.test.js
+++ b/src/containers/Condition/Condition.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -40,7 +40,7 @@ describe('ConditionContainer', () => {
         error={null}
       />
     );
-    await waitForElement(() => getByText('Error loading resource'));
+    await waitFor(() => getByText('Error loading resource'));
   });
 
   it('handles error state', async () => {
@@ -60,7 +60,7 @@ describe('ConditionContainer', () => {
         fetchCondition={() => Promise.resolve()}
       />
     );
-    await waitForElement(() => getByText('Error loading resource'));
+    await waitFor(() => getByText('Error loading resource'));
     expect(getByText(errorMessage)).toBeTruthy();
   });
 
@@ -82,7 +82,7 @@ describe('ConditionContainer', () => {
         fetchCondition={fetchConditionSpy}
       />
     );
-    await waitForElement(() => getByText('Error loading resource'));
+    await waitFor(() => getByText('Error loading resource'));
     expect(fetchConditionSpy).toHaveBeenCalledTimes(1);
 
     renderWithIntl(

--- a/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -83,7 +83,7 @@ it('CreatePipelineResource error notification appears', async () => {
     target: { value: 'test-pipeline-resource' }
   });
   fireEvent.click(getByPlaceholderText(/select namespace/i));
-  await waitForElement(() => getByText(/default/i));
+  await waitFor(() => getByText(/default/i));
   fireEvent.click(getByText(/default/i));
 
   fireEvent.change(getByPlaceholderText(/pipeline-resource-url/i), {
@@ -94,6 +94,6 @@ it('CreatePipelineResource error notification appears', async () => {
   });
   fireEvent.click(queryByText('Create'));
 
-  await waitForElement(() => getByText('Error:'));
+  await waitFor(() => getByText('Error:'));
   expect(getByText('error code 404'));
 });

--- a/src/containers/CreateSecret/CreateSecret.test.js
+++ b/src/containers/CreateSecret/CreateSecret.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -447,6 +447,6 @@ it('Can clear the selected namespace', async () => {
   fireEvent.click(getByPlaceholderText(/select namespace/i));
   fireEvent.click(getByText('default'));
   fireEvent.click(getByTitle(/Clear selected item/i));
-  await waitForElement(() => queryByText(/namespace required/i));
+  await waitFor(() => queryByText(/namespace required/i));
   expect(queryByDisplayValue('default')).toBeFalsy();
 });

--- a/src/containers/CreateSecret/Form/Annotations.test.js
+++ b/src/containers/CreateSecret/Form/Annotations.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -67,11 +67,11 @@ it('Annotations respond correctly to add/remove actions', async () => {
   expect(queryByPlaceholderText(gitServerPlaceholder)).toBeTruthy();
 
   // Change value and placeholder to dockerhub
-  fireEvent.click(await waitForElement(() => getByText(/Git Server/i)));
-  fireEvent.click(await waitForElement(() => getByText(/Docker Registry/i)));
+  fireEvent.click(await waitFor(() => getByText(/Git Server/i)));
+  fireEvent.click(await waitFor(() => getByText(/Docker Registry/i)));
 
   // Add a second annotation to the list
-  fireEvent.click(await waitForElement(() => getByText(/add/i)));
+  fireEvent.click(await waitFor(() => getByText(/add/i)));
 
   props.annotations.push({
     access: 'git',
@@ -90,7 +90,7 @@ it('Annotations respond correctly to add/remove actions', async () => {
   expect(queryAllByDisplayValue(gitServerPlaceholder).length).toEqual(2);
   expect(queryAllByPlaceholderText(gitServerPlaceholder).length).toEqual(2);
 
-  fireEvent.click(await waitForElement(() => getAllByTestId(/removeIcon/i)[0]));
+  fireEvent.click(await waitFor(() => getAllByTestId(/removeIcon/i)[0]));
   expect(handleRemove).toHaveBeenCalledTimes(1);
 
   props.annotations.pop();
@@ -103,8 +103,8 @@ it('Annotations respond correctly to add/remove actions', async () => {
   );
 
   // Change value and placeholder back to github (both annotations should update)
-  fireEvent.click(await waitForElement(() => getByText(/Docker Registry/i)));
-  fireEvent.click(await waitForElement(() => getByText(/Git Server/i)));
+  fireEvent.click(await waitFor(() => getByText(/Docker Registry/i)));
+  fireEvent.click(await waitFor(() => getByText(/Git Server/i)));
   expect(queryAllByDisplayValue(gitServerPlaceholder).length).toEqual(1);
   expect(queryAllByPlaceholderText(gitServerPlaceholder).length).toEqual(1);
 });

--- a/src/containers/EventListener/EventListener.test.js
+++ b/src/containers/EventListener/EventListener.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -138,7 +138,7 @@ it('EventListener displays with formatted labels', async () => {
     />
   );
 
-  await waitForElement(() => getByText(eventListenerName));
+  await waitFor(() => getByText(eventListenerName));
   expect(queryByText(/Namespace/i)).toBeTruthy();
   expect(queryByText(/tekton-pipelines/i)).toBeTruthy();
   expect(queryByText(/Labels/i)).toBeTruthy();
@@ -180,7 +180,7 @@ it('EventListener handles no serviceAccountName', async () => {
     />
   );
 
-  await waitForElement(() => getByText(eventListenerName));
+  await waitFor(() => getByText(eventListenerName));
   expect(queryByText('ServiceAccount:')).toBeFalsy();
 });
 
@@ -202,7 +202,7 @@ it('EventListener handles no service type', async () => {
     />
   );
 
-  await waitForElement(() => getByText(eventListenerName));
+  await waitFor(() => getByText(eventListenerName));
   expect(queryByText(/Service Type/i)).toBeFalsy();
 });
 
@@ -224,6 +224,6 @@ it('EventListener handles no triggers', async () => {
     />
   );
 
-  await waitForElement(() => getByText(eventListenerName));
+  await waitFor(() => getByText(eventListenerName));
   expect(queryByText(/Trigger/i)).toBeFalsy();
 });

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -65,8 +65,8 @@ describe('ImportResources component', () => {
     );
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please enter a valid Git URL/i));
-    await waitForElement(() => getByText(/Please select a namespace/i));
+    await waitFor(() => getByText(/Please enter a valid Git URL/i));
+    await waitFor(() => getByText(/Please select a namespace/i));
   });
 
   it('Displays an error when Repository URL is empty', async () => {
@@ -81,7 +81,7 @@ describe('ImportResources component', () => {
     fireEvent.click(getByText(namespace));
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please enter a valid Git URL/i));
+    await waitFor(() => getByText(/Please enter a valid Git URL/i));
   });
 
   it('Displays an error when Namespace is empty', async () => {
@@ -97,7 +97,7 @@ describe('ImportResources component', () => {
     });
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please select a namespace/i));
+    await waitFor(() => getByText(/Please select a namespace/i));
   });
 
   it('Valid data submit displays success notification ', async () => {
@@ -155,7 +155,7 @@ describe('ImportResources component', () => {
     fireEvent.click(getByText(namespace));
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() =>
+    await waitFor(() =>
       getByText(/Triggered PipelineRun to import Tekton resources/i)
     );
 
@@ -194,7 +194,7 @@ describe('ImportResources component', () => {
     fireEvent.click(getByText('namespace1'));
 
     fireEvent.click(getByText('Import and Apply'));
-    await waitForElement(() => getByText(/Please enter a valid Git URL/i));
+    await waitFor(() => getByText(/Please enter a valid Git URL/i));
   });
 
   it('URL TextInput handles onChange event', async () => {
@@ -208,7 +208,7 @@ describe('ImportResources component', () => {
       target: { value: 'Invalid URL here' }
     });
 
-    await waitForElement(() => queryByDisplayValue(/Invalid URL here/i));
+    await waitFor(() => queryByDisplayValue(/Invalid URL here/i));
   });
 
   it('Can clear the selected namespace', async () => {
@@ -226,7 +226,7 @@ describe('ImportResources component', () => {
     fireEvent.click(getAllByPlaceholderText(/select namespace/i)[0]);
     fireEvent.click(getByText('default'));
     fireEvent.click(getAllByTitle(/Clear selected item/i)[0]);
-    await waitForElement(() => queryByText(/please select a namespace/i));
+    await waitFor(() => queryByText(/please select a namespace/i));
     expect(queryByDisplayValue('default')).toBeFalsy();
   });
 });

--- a/src/containers/PipelineRun/PipelineRun.test.js
+++ b/src/containers/PipelineRun/PipelineRun.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -44,7 +44,7 @@ it('PipelineRunContainer renders', async () => {
       loading={false}
     />
   );
-  await waitForElement(() => getByText(`PipelineRun not found`));
+  await waitFor(() => getByText(`PipelineRun not found`));
 });
 
 it('PipelineRunContainer handles error state', async () => {
@@ -66,5 +66,5 @@ it('PipelineRunContainer handles error state', async () => {
       fetchClusterTasks={() => Promise.resolve()}
     />
   );
-  await waitForElement(() => getByText('Error loading PipelineRun'));
+  await waitFor(() => getByText('Error loading PipelineRun'));
 });

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -293,7 +293,7 @@ describe('PipelineRuns container', () => {
     expect(queryByText('pipelineRunWithTwoLabels')).toBeTruthy();
 
     fireEvent.click(getByText(filterValue));
-    await waitForElement(() => getByText('pipelineRunWithSingleLabel'));
+    await waitFor(() => getByText('pipelineRunWithSingleLabel'));
     expect(queryByText(filterValue)).toBeFalsy();
 
     expect(queryByText('pipelineRunWithSingleLabel')).toBeTruthy();
@@ -408,7 +408,7 @@ describe('PipelineRuns container', () => {
     );
 
     // Let the page finish rendering so we know if we're in read-only mode or not
-    await waitForElement(() => getByText('pipelineRunWithTwoLabels'));
+    await waitFor(() => getByText('pipelineRunWithTwoLabels'));
     expect(queryAllByText('Create')[0]).toBeTruthy(); // So we don't match on "Created" which is a table header
     expect(getAllByTitle(/actions/i)[0]).toBeTruthy();
   });
@@ -442,7 +442,7 @@ describe('PipelineRuns container', () => {
       { route: '/pipelineruns' }
     );
     // Let the page finish rendering so we know if we're in read-only mode or not
-    await waitForElement(() => getByText('pipelineRunWithTwoLabels'));
+    await waitFor(() => getByText('pipelineRunWithTwoLabels'));
     expect(queryAllByText('Create')[0]).toBeFalsy();
     expect(queryAllByTitle(/actions/i)[0]).toBeFalsy();
   });
@@ -468,11 +468,9 @@ describe('PipelineRuns container', () => {
       </Provider>,
       { route: urls.pipelineRuns.all() }
     );
-    await waitForElement(() => getByText(/pipelineRunWithTwoLabels/i));
-    fireEvent.click(
-      await waitForElement(() => getAllByTestId('overflowmenu')[0])
-    );
-    await waitForElement(() => getByText(/Rerun/i));
+    await waitFor(() => getByText(/pipelineRunWithTwoLabels/i));
+    fireEvent.click(await waitFor(() => getAllByTestId('overflowmenu')[0]));
+    await waitFor(() => getByText(/Rerun/i));
     fireEvent.click(getByText('Rerun'));
     expect(PipelineRunsAPI.rerunPipelineRun).toHaveBeenCalledTimes(1);
     expect(PipelineRunsAPI.rerunPipelineRun).toHaveBeenCalledWith(

--- a/src/containers/Secret/Secret.test.js
+++ b/src/containers/Secret/Secret.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -65,7 +65,7 @@ it('SecretContainer renders', async () => {
       loading={false}
     />
   );
-  await waitForElement(() => getByText(`Secret bar not found`));
+  await waitFor(() => getByText(`Secret bar not found`));
 });
 
 it('SecretContainer renders service accounts', async () => {
@@ -88,8 +88,8 @@ it('SecretContainer renders service accounts', async () => {
     />
   );
 
-  await waitForElement(() => getByText('secret-simple'));
-  await waitForElement(() => getByText('tekton-pipelines'));
-  await waitForElement(() => getByText('None'));
-  await waitForElement(() => getByText('serviceAccount1'));
+  await waitFor(() => getByText('secret-simple'));
+  await waitFor(() => getByText('tekton-pipelines'));
+  await waitFor(() => getByText('None'));
+  await waitFor(() => getByText('serviceAccount1'));
 });

--- a/src/containers/Secrets/Secrets.test.js
+++ b/src/containers/Secrets/Secrets.test.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
@@ -283,7 +283,7 @@ describe('Secrets', () => {
       </Provider>,
       { route: urls.secrets.all() }
     );
-    await waitForElement(() => queryByText(/github-repo-access-secret/i));
+    await waitFor(() => queryByText(/github-repo-access-secret/i));
     expect(queryByText('Create')).toBeFalsy();
   });
 
@@ -299,7 +299,7 @@ describe('Secrets', () => {
       </Provider>,
       { route: urls.secrets.all() }
     );
-    await waitForElement(() => queryByText(/github-repo-access-secret/i));
+    await waitFor(() => queryByText(/github-repo-access-secret/i));
     expect(queryByText('Create')).toBeTruthy();
   });
 });

--- a/src/containers/ServiceAccount/ServiceAccount.test.js
+++ b/src/containers/ServiceAccount/ServiceAccount.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
@@ -83,7 +83,7 @@ it('ServiceAccountContainer renders', async () => {
       loading={false}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('ServiceAccountContainer handles error state', async () => {
@@ -102,7 +102,7 @@ it('ServiceAccountContainer handles error state', async () => {
       fetchSecrets={() => Promise.resolve()}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('ServiceAccountContainer renders YAML', async () => {
@@ -128,13 +128,13 @@ it('ServiceAccountContainer renders YAML', async () => {
     }
   );
 
-  await waitForElement(() => getByText(serviceAccountName));
+  await waitFor(() => getByText(serviceAccountName));
   const yamlTab = getByText(/yaml/i);
   fireEvent.click(yamlTab);
-  await waitForElement(() => getByText(/creationTimestamp/i));
-  await waitForElement(() => getByText(/metadata/i));
-  await waitForElement(() => getByText(/ServiceAccount/i));
-  await waitForElement(() => getByText(/namespace/i));
+  await waitFor(() => getByText(/creationTimestamp/i));
+  await waitFor(() => getByText(/metadata/i));
+  await waitFor(() => getByText(/ServiceAccount/i));
+  await waitFor(() => getByText(/namespace/i));
 });
 
 it('ServiceAccountContainer does not render label section if they are not present', async () => {
@@ -155,8 +155,8 @@ it('ServiceAccountContainer does not render label section if they are not presen
     />
   );
 
-  await waitForElement(() => getByText(serviceAccountName));
-  await waitForElement(() => getByText('None'));
+  await waitFor(() => getByText(serviceAccountName));
+  await waitFor(() => getByText('None'));
 });
 
 it('ServiceAccountContainer renders labels section if they are present', async () => {
@@ -177,10 +177,10 @@ it('ServiceAccountContainer renders labels section if they are present', async (
     />
   );
 
-  await waitForElement(() => getByText('service-account-labels'));
-  await waitForElement(() => getByText('Labels:'));
-  await waitForElement(() => getByText(/mylabel: foo/i));
-  await waitForElement(() => getByText(/myotherlabel: bar/i));
+  await waitFor(() => getByText('service-account-labels'));
+  await waitFor(() => getByText('Labels:'));
+  await waitFor(() => getByText(/mylabel: foo/i));
+  await waitFor(() => getByText(/myotherlabel: bar/i));
 });
 
 it('ServiceAccountContainer renders overview with no secret nor imagePullSecrets ', async () => {
@@ -201,13 +201,11 @@ it('ServiceAccountContainer renders overview with no secret nor imagePullSecrets
     />
   );
 
-  await waitForElement(() => getByText(serviceAccountName));
-  await waitForElement(() => getByText(namespace));
-  await waitForElement(() => getByText('None')); // Label
-  await waitForElement(() =>
-    getByText('No Secrets found for this ServiceAccount.')
-  );
-  await waitForElement(() =>
+  await waitFor(() => getByText(serviceAccountName));
+  await waitFor(() => getByText(namespace));
+  await waitFor(() => getByText('None')); // Label
+  await waitFor(() => getByText('No Secrets found for this ServiceAccount.'));
+  await waitFor(() =>
     getByText('No imagePullSecrets found for this ServiceAccount.')
   );
 });
@@ -234,11 +232,11 @@ it('ServiceAccountContainer renders secrets', async () => {
     />
   );
 
-  await waitForElement(() => getByText(serviceAccountName));
-  await waitForElement(() => getByText(namespace));
-  await waitForElement(() => getByText('None'));
-  await waitForElement(() => getByText('secret1'));
-  await waitForElement(() =>
+  await waitFor(() => getByText(serviceAccountName));
+  await waitFor(() => getByText(namespace));
+  await waitFor(() => getByText('None'));
+  await waitFor(() => getByText('secret1'));
+  await waitFor(() =>
     getByText('No imagePullSecrets found for this ServiceAccount.')
   );
 });
@@ -264,10 +262,8 @@ it('ServiceAccountContainer renders imagePullSecrets', async () => {
     />
   );
 
-  await waitForElement(() => getByText('service-account-labels'));
-  await waitForElement(() => getByText(namespace));
-  await waitForElement(() => getByText('imagePull1'));
-  await waitForElement(() =>
-    getByText('No Secrets found for this ServiceAccount.')
-  );
+  await waitFor(() => getByText('service-account-labels'));
+  await waitFor(() => getByText(namespace));
+  await waitFor(() => getByText('imagePull1'));
+  await waitFor(() => getByText('No Secrets found for this ServiceAccount.'));
 });

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { waitForElement } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
 
 import SideNavContainer, { SideNavWithIntl as SideNav } from './SideNav';
@@ -79,10 +79,10 @@ it('SideNav renders with triggers', async () => {
       <SideNavContainer location={{ search: '' }} />
     </Provider>
   );
-  await waitForElement(() => queryByText(/about/i));
+  await waitFor(() => queryByText(/about/i));
   expect(queryByText('Pipelines')).toBeTruthy();
   expect(queryByText('Tasks')).toBeTruthy();
-  await waitForElement(() => queryByText('EventListeners'));
+  await waitFor(() => queryByText('EventListeners'));
   expect(queryByText('TriggerTemplates')).toBeTruthy();
   expect(queryByText('TriggerBindings')).toBeTruthy();
 });
@@ -150,7 +150,7 @@ it('SideNav renders import in not read-only mode', async () => {
       <SideNavContainer location={{ search: '' }} />
     </Provider>
   );
-  await waitForElement(() => queryByText(/Import/i));
+  await waitFor(() => queryByText(/Import/i));
 });
 
 it('SideNav does not render import in read-only mode', async () => {
@@ -168,6 +168,6 @@ it('SideNav does not render import in read-only mode', async () => {
       <SideNavContainer isReadOnly location={{ search: '' }} />
     </Provider>
   );
-  await waitForElement(() => queryByText(/about/i));
+  await waitFor(() => queryByText(/about/i));
   expect(queryByText(/import/i)).toBeFalsy();
 });

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -267,7 +267,7 @@ describe('TaskRuns container', () => {
     expect(queryByText('taskRunWithTwoLabels')).toBeTruthy();
 
     fireEvent.click(getByText(filterValue));
-    await waitForElement(() => getByText('taskRunWithSingleLabel'));
+    await waitFor(() => getByText('taskRunWithSingleLabel'));
     expect(queryByText(filterValue)).toBeFalsy();
 
     expect(queryByText('taskRunWithSingleLabel')).toBeTruthy();
@@ -378,7 +378,7 @@ describe('TaskRuns container', () => {
       { route: urls.taskRuns.all() }
     );
 
-    await waitForElement(() => getByText('taskRunWithTwoLabels'));
+    await waitFor(() => getByText('taskRunWithTwoLabels'));
     expect(getAllByTitle(/actions/i)[0]).toBeTruthy();
   });
 
@@ -410,7 +410,7 @@ describe('TaskRuns container', () => {
       { route: urls.taskRuns.all() }
     );
 
-    await waitForElement(() => getByText('taskRunWithTwoLabels'));
+    await waitFor(() => getByText('taskRunWithTwoLabels'));
     expect(queryAllByTitle(/actions/i)[0]).toBeFalsy();
   });
 
@@ -433,11 +433,9 @@ describe('TaskRuns container', () => {
       </Provider>,
       { route: urls.taskRuns.all() }
     );
-    await waitForElement(() => getByText(/taskRunWithTwoLabels/i));
-    fireEvent.click(
-      await waitForElement(() => getAllByTestId('overflowmenu')[0])
-    );
-    await waitForElement(() => getByText(/Rerun/i));
+    await waitFor(() => getByText(/taskRunWithTwoLabels/i));
+    fireEvent.click(await waitFor(() => getAllByTestId('overflowmenu')[0]));
+    await waitFor(() => getByText(/Rerun/i));
     fireEvent.click(getByText('Rerun'));
     expect(API.rerunTaskRun).toHaveBeenCalledTimes(1);
     expect(API.rerunTaskRun).toHaveBeenCalledWith(

--- a/src/containers/TriggerBinding/TriggerBinding.test.js
+++ b/src/containers/TriggerBinding/TriggerBinding.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
@@ -83,7 +83,7 @@ it('TriggerBindingContainer renders', async () => {
       loading={false}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('TriggerBindingContainer handles error state', async () => {
@@ -101,7 +101,7 @@ it('TriggerBindingContainer handles error state', async () => {
       fetchTriggerBinding={() => Promise.resolve()}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('TriggerBindingContainer renders details', async () => {
@@ -121,13 +121,13 @@ it('TriggerBindingContainer renders details', async () => {
     />
   );
 
-  await waitForElement(() => getByText('trigger-binding-simple'));
-  await waitForElement(() => getByText(/param1/i));
-  await waitForElement(() => getByText(/param2/i));
-  await waitForElement(() => getByText('$(body.head_commit.id)'));
-  await waitForElement(() => getByText('$(body.repository.clone_url)'));
-  await waitForElement(() => getByText(namespace));
-  await waitForElement(() => getByText('None'));
+  await waitFor(() => getByText('trigger-binding-simple'));
+  await waitFor(() => getByText(/param1/i));
+  await waitFor(() => getByText(/param2/i));
+  await waitFor(() => getByText('$(body.head_commit.id)'));
+  await waitFor(() => getByText('$(body.repository.clone_url)'));
+  await waitFor(() => getByText(namespace));
+  await waitFor(() => getByText('None'));
 });
 
 it('TriggerBindingContainer renders YAML', async () => {
@@ -154,15 +154,15 @@ it('TriggerBindingContainer renders YAML', async () => {
     }
   );
 
-  await waitForElement(() => getByText(triggerBindingName));
+  await waitFor(() => getByText(triggerBindingName));
   const yamlTab = getByText('YAML');
   fireEvent.click(yamlTab);
-  await waitForElement(() => getByText(/creationTimestamp/i));
-  await waitForElement(() => getByText(/spec/i));
-  await waitForElement(() => getByText(/params/i));
-  await waitForElement(() => getByText(/metadata/i));
-  await waitForElement(() => getByText(/TriggerBinding/i));
-  await waitForElement(() => getByText(/namespace/i));
+  await waitFor(() => getByText(/creationTimestamp/i));
+  await waitFor(() => getByText(/spec/i));
+  await waitFor(() => getByText(/params/i));
+  await waitFor(() => getByText(/metadata/i));
+  await waitFor(() => getByText(/TriggerBinding/i));
+  await waitFor(() => getByText(/namespace/i));
 });
 
 it('TriggerBindingContainer does not render label section if they are not present', async () => {
@@ -182,8 +182,8 @@ it('TriggerBindingContainer does not render label section if they are not presen
     />
   );
 
-  await waitForElement(() => getByText('trigger-binding-simple'));
-  await waitForElement(() => getByText('None'));
+  await waitFor(() => getByText('trigger-binding-simple'));
+  await waitFor(() => getByText('None'));
 });
 
 it('TriggerBindingContainer renders labels section if they are present', async () => {
@@ -203,8 +203,8 @@ it('TriggerBindingContainer renders labels section if they are present', async (
     />
   );
 
-  await waitForElement(() => getByText('trigger-binding-labels'));
-  await waitForElement(() => getByText('Labels:'));
-  await waitForElement(() => getByText(/mylabel: foo/i));
-  await waitForElement(() => getByText(/myotherlabel: bar/i));
+  await waitFor(() => getByText('trigger-binding-labels'));
+  await waitFor(() => getByText('Labels:'));
+  await waitFor(() => getByText(/mylabel: foo/i));
+  await waitFor(() => getByText(/myotherlabel: bar/i));
 });

--- a/src/containers/TriggerTemplate/TriggerTemplate.test.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { fireEvent, waitForElement } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import { paths, urls } from '@tektoncd/dashboard-utils';
 import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test';
@@ -197,7 +197,7 @@ it('TriggerTemplateContainer renders', async () => {
       loading={false}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('TriggerTemplateContainer handles error state', async () => {
@@ -215,7 +215,7 @@ it('TriggerTemplateContainer handles error state', async () => {
       fetchTriggerTemplate={() => Promise.resolve()}
     />
   );
-  await waitForElement(() => getByText('Error loading resource'));
+  await waitFor(() => getByText('Error loading resource'));
 });
 
 it('TriggerTemplateContainer renders basic information', async () => {
@@ -234,7 +234,7 @@ it('TriggerTemplateContainer renders basic information', async () => {
       triggerTemplate={fakeTriggerTemplate}
     />
   );
-  await waitForElement(() => getByText('pipeline-template'));
+  await waitFor(() => getByText('pipeline-template'));
 });
 
 it('TriggerTemplateContainer renders parameters', async () => {
@@ -254,17 +254,17 @@ it('TriggerTemplateContainer renders parameters', async () => {
     />
   );
 
-  await waitForElement(() => getByText(/pipeline-template/i));
-  await waitForElement(() => getByText('Default'));
-  await waitForElement(() => getByText(/description/i));
-  await waitForElement(() => getByText(/gitrevision/i));
-  await waitForElement(() => getByText(/gitrepositoryurl/i));
-  await waitForElement(() => getAllByText(/message/i)[0]);
-  await waitForElement(() => getByText(/contenttype/i));
-  await waitForElement(() => getByText(/the git revision/i));
-  await waitForElement(() => getByText(/the git repository url/i));
-  await waitForElement(() => getByText(/the message to print/i));
-  await waitForElement(() => getByText(/the Content-Type of the event/i));
+  await waitFor(() => getByText(/pipeline-template/i));
+  await waitFor(() => getByText('Default'));
+  await waitFor(() => getByText(/description/i));
+  await waitFor(() => getByText(/gitrevision/i));
+  await waitFor(() => getByText(/gitrepositoryurl/i));
+  await waitFor(() => getAllByText(/message/i)[0]);
+  await waitFor(() => getByText(/contenttype/i));
+  await waitFor(() => getByText(/the git revision/i));
+  await waitFor(() => getByText(/the git repository url/i));
+  await waitFor(() => getByText(/the message to print/i));
+  await waitFor(() => getByText(/the Content-Type of the event/i));
 });
 
 it('TriggerTemplateContainer renders resource templates', async () => {
@@ -284,7 +284,7 @@ it('TriggerTemplateContainer renders resource templates', async () => {
     />
   );
 
-  await waitForElement(() => getByText('pipeline-template'));
+  await waitFor(() => getByText('pipeline-template'));
   expect(getByText(resourceTemplate1NameInfo)).toBeTruthy();
   expect(getByText(resourceTemplate2NameInfo)).toBeTruthy();
 });
@@ -307,14 +307,14 @@ it('TriggerTemplateContainer renders full resource template information', async 
   );
 
   const compareToName = resourceTemplate1Details.metadata.name;
-  await waitForElement(() => getByText(compareToName));
-  await waitForElement(() => getAllByText(/revision/i)[0]);
-  await waitForElement(() => getAllByText(/url/i)[0]);
-  await waitForElement(() => getByText(/gitrevision/i));
-  await waitForElement(() => getByText(/gitrepositoryurl/i));
-  await waitForElement(() => getByText(/simple-pipeline-run/i));
-  await waitForElement(() => getAllByText(/message/i)[0]);
-  await waitForElement(() => getByText(/contenttype/i));
+  await waitFor(() => getByText(compareToName));
+  await waitFor(() => getAllByText(/revision/i)[0]);
+  await waitFor(() => getAllByText(/url/i)[0]);
+  await waitFor(() => getByText(/gitrevision/i));
+  await waitFor(() => getByText(/gitrepositoryurl/i));
+  await waitFor(() => getByText(/simple-pipeline-run/i));
+  await waitFor(() => getAllByText(/message/i)[0]);
+  await waitFor(() => getByText(/contenttype/i));
 });
 
 it('TriggerTemplateContainer contains overview tab with accurate information', async () => {
@@ -333,11 +333,11 @@ it('TriggerTemplateContainer contains overview tab with accurate information', a
       triggerTemplate={fakeTriggerTemplate}
     />
   );
-  await waitForElement(() => getByText('pipeline-template'));
+  await waitFor(() => getByText('pipeline-template'));
   const overviewTab = getByText(/overview/i);
   fireEvent.click(overviewTab);
-  await waitForElement(() => getByText(/Date created/i));
-  await waitForElement(() => getByText(/tekton-pipelines/i));
+  await waitFor(() => getByText(/Date created/i));
+  await waitFor(() => getByText(/tekton-pipelines/i));
 });
 
 it('TriggerTemplateContainer contains YAML tab with accurate information', async () => {
@@ -362,19 +362,19 @@ it('TriggerTemplateContainer contains YAML tab with accurate information', async
     }
   );
 
-  await waitForElement(() => getByText('pipeline-template'));
+  await waitFor(() => getByText('pipeline-template'));
   const yamlTab = getByText('YAML');
   fireEvent.click(yamlTab);
-  await waitForElement(() => getByText(/creationtimestamp/i));
-  await waitForElement(() => getByText(/selflink/i));
-  await waitForElement(() => getByText(/pipelineref/i));
-  await waitForElement(() => getByText(/resourceref/i));
-  await waitForElement(() => getByText(/generation/i));
-  await waitForElement(() => getByText(/resourceversion/i));
-  await waitForElement(() => getByText(/git-source/i));
-  await waitForElement(() => getByText(/params.message/i));
-  await waitForElement(() => getByText(/type: git/i));
-  await waitForElement(() => getAllByText(/revision/i)[0]);
+  await waitFor(() => getByText(/creationtimestamp/i));
+  await waitFor(() => getByText(/selflink/i));
+  await waitFor(() => getByText(/pipelineref/i));
+  await waitFor(() => getByText(/resourceref/i));
+  await waitFor(() => getByText(/generation/i));
+  await waitFor(() => getByText(/resourceversion/i));
+  await waitFor(() => getByText(/git-source/i));
+  await waitFor(() => getByText(/params.message/i));
+  await waitFor(() => getByText(/type: git/i));
+  await waitFor(() => getAllByText(/revision/i)[0]);
 });
 
 it('TriggerTemplateContainer does not render label section if they are not present', async () => {
@@ -394,7 +394,7 @@ it('TriggerTemplateContainer does not render label section if they are not prese
     />
   );
 
-  await waitForElement(() => getByText('pipeline-template'));
+  await waitFor(() => getByText('pipeline-template'));
   expect(queryByText('Labels')).toBeFalsy();
 });
 
@@ -417,14 +417,14 @@ it('TriggerTemplateContainer renders labels section if they are present', async 
     />
   );
 
-  await waitForElement(() => getByText(triggerTemplateName));
+  await waitFor(() => getByText(triggerTemplateName));
   const overviewTab = getByText(/overview/i);
   fireEvent.click(overviewTab);
-  await waitForElement(() => getByText(/labels/i));
-  await waitForElement(() => getByText(/mylabel/i));
-  await waitForElement(() => getByText(/foo/i));
-  await waitForElement(() => getByText(/myotherlabel/i));
-  await waitForElement(() => getByText(/bar/i));
+  await waitFor(() => getByText(/labels/i));
+  await waitFor(() => getByText(/mylabel/i));
+  await waitFor(() => getByText(/foo/i));
+  await waitFor(() => getByText(/myotherlabel/i));
+  await waitFor(() => getByText(/bar/i));
 });
 
 it('TriggerTemplateContainer contains formatted labels', async () => {
@@ -446,10 +446,10 @@ it('TriggerTemplateContainer contains formatted labels', async () => {
     />
   );
 
-  await waitForElement(() => getByText(triggerTemplateName));
+  await waitFor(() => getByText(triggerTemplateName));
   const overviewTab = getByText(/overview/i);
   fireEvent.click(overviewTab);
-  await waitForElement(() => getByText('Labels:'));
-  await waitForElement(() => getByText(/mylabel: foo/i));
-  await waitForElement(() => getByText(/myotherlabel: bar/i));
+  await waitFor(() => getByText('Labels:'));
+  await waitFor(() => getByText(/mylabel: foo/i));
+  await waitFor(() => getByText(/myotherlabel: bar/i));
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1793

`waitForElement` is deprecated, replace all usage with `waitFor` to
ensure this will continue working in future versions and to reduce
the number of warnings appearing in the test logs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
