### PR TITLE
Update installer script to build multi-arch image only on release action

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -92,7 +92,7 @@ compile() {
   if [ "$OPENSHIFT" == "true" ] && [ "$IMAGE_STREAM" == "true" ]; then
     kustomize build --load_restrictor none "$overlay" > "$TMP_FILE"
   else
-    kustomize build --load_restrictor none "$overlay" | ko resolve --platform=all $KO_RESOLVE_OPTIONS -f - > "$TMP_FILE"
+    kustomize build --load_restrictor none "$overlay" | ko resolve $KO_RESOLVE_OPTIONS -f - > "$TMP_FILE"
   fi
 }
 
@@ -523,7 +523,7 @@ case $1 in
     shift
     ;;
   'release'|r)
-    KO_RESOLVE_OPTIONS="--preserve-import-paths"
+    KO_RESOLVE_OPTIONS="--preserve-import-paths --platform=all"
     ACTION="build"
     shift
     ;;

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -220,13 +220,13 @@ test_dashboard() {
 
 header "Validating that we can build the release manifests"
 echo "Building manifests for k8s"
-$tekton_repo_dir/scripts/installer build                          || fail_test "Failed to build manifests for k8s"
+$tekton_repo_dir/scripts/installer release                          || fail_test "Failed to build manifests for k8s"
 echo "Building manifests for k8s --read-only"
-$tekton_repo_dir/scripts/installer build --read-only              || fail_test "Failed to build manifests for k8s --read-only"
+$tekton_repo_dir/scripts/installer release --read-only              || fail_test "Failed to build manifests for k8s --read-only"
 echo "Building manifests for openshift"
-$tekton_repo_dir/scripts/installer build --openshift              || fail_test "Failed to build manifests for openshift"
+$tekton_repo_dir/scripts/installer release --openshift              || fail_test "Failed to build manifests for openshift"
 echo "Building manifests for openshift --read-only"
-$tekton_repo_dir/scripts/installer build --openshift --read-only  || fail_test "Failed to build manifests for openshift --read-only"
+$tekton_repo_dir/scripts/installer release --openshift --read-only  || fail_test "Failed to build manifests for openshift --read-only"
 
 if [ -z "$PIPELINES_VERSION" ]; then
   export PIPELINES_VERSION=v0.19.0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When a user is installing the Dashboard in a dev environment using the
installer script there's no need to build for other architectures.

Update the script to pass the `--platform=all` arg to `ko` only for
the release action and update the e2e test script to ensure we're
actually exercising the release action and not just the build.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
