### PR TITLE
Handle properties fallback when running in client mode

### DIFF
--- a/src/actions/properties.js
+++ b/src/actions/properties.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,6 +21,11 @@ export function fetchInstallProperties() {
       dispatch({ type: 'INSTALL_PROPERTIES_SUCCESS', data });
     } catch (error) {
       dispatch({ type: 'INSTALL_PROPERTIES_FAILURE', error });
+      if (error?.response?.status === 404) {
+        dispatch({
+          type: 'CLIENT_PROPERTIES_SUCCESS'
+        });
+      }
     }
     return data;
   };

--- a/src/actions/properties.test.js
+++ b/src/actions/properties.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -41,6 +41,26 @@ it('fetchInstallProperties error', async () => {
   const store = mockStore({});
 
   const expectedActions = [{ type: 'INSTALL_PROPERTIES_FAILURE', error }];
+
+  await store.dispatch(fetchInstallProperties());
+  expect(API.getInstallProperties).toHaveBeenCalled();
+  expect(store.getActions()).toEqual(expectedActions);
+});
+
+it('fetchInstallProperties kubectl client', async () => {
+  const error = new Error();
+  error.response = { status: 404 };
+  jest.spyOn(API, 'getInstallProperties').mockImplementation(() => {
+    throw error;
+  });
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({});
+
+  const expectedActions = [
+    { type: 'INSTALL_PROPERTIES_FAILURE', error },
+    { type: 'CLIENT_PROPERTIES_SUCCESS' }
+  ];
 
   await store.dispatch(fetchInstallProperties());
   expect(API.getInstallProperties).toHaveBeenCalled();

--- a/src/reducers/properties.js
+++ b/src/reducers/properties.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,10 +12,23 @@ limitations under the License.
 */
 
 const defaultState = { ReadOnly: true };
+
+const clientDefaultState = {
+  DashboardNamespace: 'N/A',
+  DashboardVersion: 'kubectl-proxy-client',
+  PipelineNamespace: 'Unknown',
+  PipelineVersion: 'Unknown',
+  TriggersNamespace: 'Unknown',
+  TriggersVersion: 'Unknown',
+  ReadOnly: false
+};
+
 function properties(state = defaultState, action) {
   switch (action.type) {
     case 'INSTALL_PROPERTIES_SUCCESS':
       return action.data;
+    case 'CLIENT_PROPERTIES_SUCCESS':
+      return clientDefaultState;
     default:
       return state;
   }

--- a/src/reducers/properties.test.js
+++ b/src/reducers/properties.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -20,18 +20,21 @@ it('handles init or unknown actions', () => {
 });
 
 it('INSTALL_PROPERTIES_SUCCESS', () => {
+  const ExternalLogsURL = 'fake_logs_url';
   const installProperties = {
     fake: 'installProperties',
-    ReadOnly: false,
+    ExternalLogsURL,
     IsOpenShift: false,
     LogoutURL: '/logout',
     DashboardNamespace: 'ns-dashboard',
     DashboardVersion: 'version-dashboard',
     PipelineNamespace: 'ns-pipeline',
     PipelineVersion: 'version-pipeline',
+    ReadOnly: false,
+    StreamLogs: true,
+    TenantNamespace: 'ns-tenant',
     TriggersNamespace: 'ns-triggers',
-    TriggersVersion: 'version-triggers',
-    TenantNamespace: 'ns-tenant'
+    TriggersVersion: 'version-triggers'
   };
 
   const action = {
@@ -40,15 +43,31 @@ it('INSTALL_PROPERTIES_SUCCESS', () => {
   };
 
   const state = propertiesReducer({}, action);
-  expect(selectors.isReadOnly(state)).toBe(false);
-  expect(selectors.isOpenShift(state)).toBe(false);
-  expect(selectors.isTriggersInstalled(state)).toBe(true);
-  expect(selectors.getLogoutURL(state)).toBe('/logout');
-  expect(selectors.getDashboardNamespace(state)).toBe('ns-dashboard');
-  expect(selectors.getDashboardVersion(state)).toBe('version-dashboard');
-  expect(selectors.getPipelineNamespace(state)).toBe('ns-pipeline');
-  expect(selectors.getPipelineVersion(state)).toBe('version-pipeline');
-  expect(selectors.getTriggersNamespace(state)).toBe('ns-triggers');
-  expect(selectors.getTriggersVersion(state)).toBe('version-triggers');
-  expect(selectors.getTenantNamespace(state)).toBe('ns-tenant');
+  expect(selectors.isReadOnly(state)).toEqual(false);
+  expect(selectors.isOpenShift(state)).toEqual(false);
+  expect(selectors.isTriggersInstalled(state)).toEqual(true);
+  expect(selectors.isLogStreamingEnabled(state)).toEqual(true);
+  expect(selectors.getExternalLogsURL(state)).toEqual(ExternalLogsURL);
+  expect(selectors.getLogoutURL(state)).toEqual('/logout');
+  expect(selectors.getDashboardNamespace(state)).toEqual('ns-dashboard');
+  expect(selectors.getDashboardVersion(state)).toEqual('version-dashboard');
+  expect(selectors.getPipelineNamespace(state)).toEqual('ns-pipeline');
+  expect(selectors.getPipelineVersion(state)).toEqual('version-pipeline');
+  expect(selectors.getTriggersNamespace(state)).toEqual('ns-triggers');
+  expect(selectors.getTriggersVersion(state)).toEqual('version-triggers');
+  expect(selectors.getTenantNamespace(state)).toEqual('ns-tenant');
+});
+
+it('CLIENT_PROPERTIES_SUCCESS', () => {
+  const action = { type: 'CLIENT_PROPERTIES_SUCCESS' };
+
+  const state = propertiesReducer({}, action);
+  expect(selectors.isReadOnly(state)).toEqual(false);
+  expect(selectors.isTriggersInstalled(state)).toEqual(true);
+  expect(selectors.getDashboardNamespace(state)).toEqual('N/A');
+  expect(selectors.getDashboardVersion(state)).toEqual('kubectl-proxy-client');
+  expect(selectors.getPipelineNamespace(state)).toEqual('Unknown');
+  expect(selectors.getPipelineVersion(state)).toEqual('Unknown');
+  expect(selectors.getTriggersNamespace(state)).toEqual('Unknown');
+  expect(selectors.getTriggersVersion(state)).toEqual('Unknown');
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1388

When the Dashboard frontend is running in client mode (i.e.
`kubectl proxy --www...`), set the fallback values for the
install properties (e.g. ReadOnly, IsTriggersInstalled) so
the Dashboard is more useful in this case.

Future updates will add more fine-grained access checks so
we only display options that are actually available depending
on the user's permissions.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
