### PR TITLE
Update installer script to allow overriding target platform

### DIFF
--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -17,6 +17,8 @@ It covers the following topics:
   - [Install ingress](#install-ingress)
 - [Uninstall command](#uninstall-command)
 - [Build command](#build-command)
+- [Release command](#release-command)
+- [Platform support](#platform-support)
 
 ## Before you begin
 
@@ -78,6 +80,7 @@ Accepted options:
         [--stream-logs]                         Will enable log streaming instead of polling
         [--external-logs <logs-provider-url>]   External url to fetch logs from when not available in the cluster
         [--output <file>]                       Will output built manifests in the file instead of in the console
+        [--platform <platform>]                 Override the platform to build for
 ```
 
 ## Install command
@@ -231,6 +234,28 @@ The `build` command is useful when you want to ensure everything builds correctl
 This command is essentially the same as the [build command](#build-command) but adds the `--preserve-import-paths` option when invoking `ko`.
 
 This is needed to generate the correct docker image name in the manifests when cutting a release.
+
+## Platform support
+
+Official Dashboard releases since v0.12.0 provide multi-platform images supporting the following:
+- `linux/amd64`
+- `linux/arm`
+- `linux/arm64`
+- `linux/ppc64le`
+- `linux/s390x`
+
+The `installer` script's `build` and `install` commands will build an image for `linux/amd64` by default.
+To override the platform in cases where the target cluster is running on a different architecture, add `--platform <platform>` where `<platform>` is a value from the list of supported values, for example:
+```bash
+./scripts/installer install --platform linux/arm
+```
+or build a multi-platform image by specifying `all` or a comma-separated list of supported platforms:
+```bash
+./scripts/installer install --platform all
+```
+
+This behaviour can also be controlled using the `GOOS` and `GOARCH` environment variables. 
+See the [`ko` documentation](https://github.com/google/ko#multi-platform-images) for further details.
 
 ---
 

--- a/scripts/installer
+++ b/scripts/installer
@@ -488,6 +488,7 @@ help () {
   echo -e "\t[--stream-logs]\t\t\t\tWill enable log streaming instead of polling"
   echo -e "\t[--external-logs <logs-provider-url>]\tExternal url to fetch logs from when not available in the cluster"
   echo -e "\t[--output <file>]\t\t\tWill output built manifests in the file instead of in the console"
+  echo -e "\t[--platform <platform>]\t\t\tOverride the platform to build for"
 }
 
 # cleanup temporary files
@@ -603,6 +604,10 @@ while [[ $# -gt 0 ]]; do
     '--output')
       shift
       export OUTPUT_FILE="${1}"
+      ;;
+    '--platform')
+      shift
+      KO_RESOLVE_OPTIONS="$KO_RESOLVE_OPTIONS --platform=${1}"
       ;;
     *)
       echo "ERROR: Unknown option $1"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Allow the user of the installer script's `build` and `install` commands
to override the default target platform by specifying one or more of
the supported platforms.

This is useful for example when developing on a linux/amd64 system
but deploying to a linux/arm or linux/s390x cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
