### PR TITLE
Fix error handling in logs fallback

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,6 +16,7 @@ import snakeCase from 'lodash.snakecase';
 import { LogDownloadButton } from '@tektoncd/dashboard-components';
 
 import { getPodLog, getPodLogURL } from '../api';
+import { get } from '../api/comms';
 
 export function sortRunsByStartTime(runs) {
   runs.sort((a, b) => {
@@ -69,7 +70,7 @@ export async function fetchLogs(stepName, stepStatus, taskRun) {
   return logs;
 }
 
-function fetchLogsFallback(externalLogsURL) {
+export function fetchLogsFallback(externalLogsURL) {
   if (!externalLogsURL) {
     return undefined;
   }
@@ -78,9 +79,9 @@ function fetchLogsFallback(externalLogsURL) {
     const { namespace } = taskRun.metadata;
     const { podName } = taskRun.status || {};
     const { container } = stepStatus;
-    return fetch(
-      `${externalLogsURL}/${namespace}/${podName}/${container}`
-    ).then(response => response.text());
+    return get(`${externalLogsURL}/${namespace}/${podName}/${container}`, {
+      Accept: 'text/plain'
+    });
   };
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/1918

The logs fallback for external log providers was not correctly
handling errors / timeouts on the requests to the external provider.

Update to use the common `get` util which has this error handling
built in for consistency with the rest of the application.

Add tests for the main scenarios.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
