### PR TITLE
Update editorconfig to avoid unwanted trailing newlines in JSON files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 8
 
+[*.json]
+insert_final_newline = false
+
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/pull/1924#discussion_r566396754

Add a stanza to the editorconfig for JSON files to disable the
trailing newline. This is important for the message bundles to
avoid unexpected PR build failures when checking for diffs after
running the string extraction test.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
