### PR TITLE
Remove ReadableStream polyfill

### DIFF
--- a/config_frontend/setupTests.js
+++ b/config_frontend/setupTests.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,6 @@ limitations under the License.
 import fetch from 'node-fetch';
 import fetchMock from 'fetch-mock';
 import { TextDecoder, TextEncoder } from 'util';
-import { ReadableStream } from 'web-streams-polyfill/es6';
 
 if (!global.fetch) {
   global.fetch = fetch;
@@ -27,4 +26,3 @@ fetchMock.config.warnOnFallback = false;
 window.HTMLElement.prototype.scrollIntoView = function scrollIntoViewTestStub() {};
 window.TextDecoder = TextDecoder;
 window.TextEncoder = TextEncoder;
-window.ReadableStream = ReadableStream;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27009,12 +27009,6 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
     },
-    "web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==",
-      "dev": true
-    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "stylelint": "^13.8.0",
     "stylelint-plugin-carbon-tokens": "^0.7.0",
     "watch": "^1.0.2",
-    "web-streams-polyfill": "^2.1.1",
     "webpack": "^5.10.0",
     "webpack-cli": "^4.2.0",
     "webpack-dev-server": "^4.0.0-beta.0",

--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -38,7 +38,7 @@ export class LogContainer extends Component {
 
   componentWillUnmount() {
     clearInterval(this.timer);
-    this.canceled = true;
+    this.cancelled = true;
   }
 
   getLogList = () => {
@@ -94,7 +94,7 @@ export class LogContainer extends Component {
   };
 
   readChunks = ({ done, value }, decoder, text = '') => {
-    if (this.canceled) {
+    if (this.cancelled) {
       this.reader.cancel();
       return undefined;
     }
@@ -106,10 +106,9 @@ export class LogContainer extends Component {
         logs: logs.split('\n')
       });
     } else {
-      this.setState(prevState => ({
-        loading: false,
-        logs: prevState.logs
-      }));
+      this.setState({
+        loading: false
+      });
     }
     if (done) {
       return undefined;
@@ -128,7 +127,8 @@ export class LogContainer extends Component {
     if (fetchLogs) {
       try {
         const logs = await fetchLogs();
-        if (logs instanceof ReadableStream) {
+        if (logs?.getReader) {
+          // logs is a https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
           const decoder = new TextDecoder();
           this.reader = logs.getReader();
           await this.reader

--- a/packages/components/src/components/Log/Log.test.js
+++ b/packages/components/src/components/Log/Log.test.js
@@ -72,13 +72,18 @@ describe('Log', () => {
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() =>
-          Promise.resolve(
-            new ReadableStream({
-              start(controller) {
-                controller.enqueue(new TextEncoder().encode('testing'));
-              }
-            })
-          )
+          Promise.resolve({
+            getReader() {
+              return {
+                read() {
+                  return Promise.resolve({
+                    done: true,
+                    value: new TextEncoder().encode('testing')
+                  });
+                }
+              };
+            }
+          })
         }
       />
     );
@@ -90,13 +95,18 @@ describe('Log', () => {
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() =>
-          Promise.resolve(
-            new ReadableStream({
-              start(controller) {
-                controller.enqueue(new TextEncoder().encode('testing'));
-              }
-            })
-          )
+          Promise.resolve({
+            getReader() {
+              return {
+                read() {
+                  return Promise.resolve({
+                    done: true,
+                    value: new TextEncoder().encode('testing')
+                  });
+                }
+              };
+            }
+          })
         }
       />
     );
@@ -108,13 +118,18 @@ describe('Log', () => {
       <Log
         stepStatus={{ terminated: { reason: 'Error' } }}
         fetchLogs={() =>
-          Promise.resolve(
-            new ReadableStream({
-              start(controller) {
-                controller.enqueue(new TextEncoder().encode('testing'));
-              }
-            })
-          )
+          Promise.resolve({
+            getReader() {
+              return {
+                read() {
+                  return Promise.resolve({
+                    done: true,
+                    value: new TextEncoder().encode('testing')
+                  });
+                }
+              };
+            }
+          })
         }
       />
     );

--- a/packages/components/src/components/Log/index.js
+++ b/packages/components/src/components/Log/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,5 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 export { default } from './Log';

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -156,11 +156,18 @@ describe('followLogs', () => {
       status: { podName }
     };
 
-    const logs = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('fake logs'));
+    const logs = {
+      getReader() {
+        return {
+          read() {
+            return Promise.resolve({
+              done: true,
+              value: new TextEncoder().encode('fake logs')
+            });
+          }
+        };
       }
-    });
+    };
     jest.spyOn(API, 'getPodLog').mockImplementation(() => logs);
 
     const returnedLogs = followLogs(stepName, stepStatus, taskRun);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
ReadableStream is available natively in all supported browsers and
the polyfill was only required for testing. Stub out the specific
subfeature we're using in the tests and remove the need for the polyfill.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
