### PR TITLE
Add option to maximize logs container

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -180,7 +180,7 @@ export class LogContainer extends Component {
   };
 
   render() {
-    const { downloadButton } = this.props;
+    const { toolbar } = this.props;
     const { loading } = this.state;
     return (
       <pre className="tkn--log">
@@ -188,7 +188,7 @@ export class LogContainer extends Component {
           <SkeletonText paragraph width="60%" />
         ) : (
           <>
-            {downloadButton}
+            {toolbar}
             <div className="tkn--log-container">{this.getLogList()}</div>
             {this.logTrailer()}
           </>

--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -56,6 +56,8 @@ pre.tkn--log {
   }
 
   .bx--copy-btn {
+    width: 2rem;
+    height: 2rem;
     background-color: $gray-90; // TODO: $inverse-02 - see above
 
     &:hover {

--- a/packages/components/src/components/Log/Log.stories.js
+++ b/packages/components/src/components/Log/Log.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 
 import Log from './Log';
-import { LogDownloadButton } from '..';
+import { LogsToolbar } from '..';
 
 const ansiLog =
   '\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-git-source-skaffold-git-ml8j4 ===\n{"level":"info","ts":1553865693.943092,"logger":"fallback-logger","caller":"git-init/main.go:100","msg":"Successfully cloned https://github.com/GoogleContainerTools/skaffold @ \\"master\\" in path \\"/workspace\\""}\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-build-and-push ===\n\u001b[36mINFO\u001b[0m[0000] Downloading base image golang:1.10.1-alpine3.7\n2019/03/29 13:21:34 No matching credentials were found, falling back on anonymous\n\u001b[36mINFO\u001b[0m[0001] Executing 0 build triggers\n\u001b[36mINFO\u001b[0m[0001] Unpacking rootfs as cmd RUN go build -o /app . requires it.\n\u001b[36mINFO\u001b[0m[0010] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0015] Using files from context: [/workspace/examples/microservices/leeroy-app/app.go]\n\u001b[36mINFO\u001b[0m[0015] COPY app.go .\n\u001b[36mINFO\u001b[0m[0015] Taking snapshot of files...\n\u001b[36mINFO\u001b[0m[0015] RUN go build -o /app .\n\u001b[36mINFO\u001b[0m[0015] cmd: /bin/sh\n\u001b[36mINFO\u001b[0m[0015] args: [-c go build -o /app .]\n\u001b[36mINFO\u001b[0m[0016] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0036] CMD ["./app"]\n\u001b[36mINFO\u001b[0m[0036] COPY --from=builder /app .\n\u001b[36mINFO\u001b[0m[0036] Taking snapshot of files...\nerror pushing image: failed to push to destination gcr.io/christiewilson-catfactory/leeroy-app:latest: Get https://gcr.io/v2/token?scope=repository%3Achristiewilson-catfactory%2Fleeroy-app%3Apush%2Cpull\u0026scope=repository%3Alibrary%2Falpine%3Apull\u0026service=gcr.io exit status 1\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: nop ===\nBuild successful\n\r\r\n';
@@ -74,14 +74,14 @@ export const Performance = () => (
 );
 Performance.storyName = 'performance test (<20,000 lines with ANSI)';
 
-export const DownloadButton = () => {
+export const Toolbar = () => {
   const name = 'step_log_filename.txt';
   const url = '/step/log/url';
   return (
     <Log
-      downloadButton={<LogDownloadButton name={name} url={url} />}
-      stepStatus={{ terminated: { reason: 'Completed' } }}
       fetchLogs={() => 'A log message'}
+      stepStatus={{ terminated: { reason: 'Completed' } }}
+      toolbar={<LogsToolbar name={name} url={url} />}
     />
   );
 };

--- a/packages/components/src/components/LogsToolbar/LogsToolbar.js
+++ b/packages/components/src/components/LogsToolbar/LogsToolbar.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,11 +13,43 @@ limitations under the License.
 /* istanbul ignore file */
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { Download16, Launch16 } from '@carbon/icons-react';
+import {
+  Download16,
+  Launch16,
+  Maximize16,
+  Minimize16
+} from '@carbon/icons-react';
 
-const LogDownloadButton = ({ intl, name, url }) => (
+const LogsToolbar = ({ intl, isMaximized, name, toggleMaximized, url }) => (
   <>
     <div className="bx--btn-set">
+      {toggleMaximized ? (
+        <button
+          className="bx--copy-btn"
+          onClick={toggleMaximized}
+          type="button"
+        >
+          {isMaximized ? (
+            <Minimize16>
+              <title>
+                {intl.formatMessage({
+                  id: 'dashboard.logs.restore',
+                  defaultMessage: 'Return to embedded logs'
+                })}
+              </title>
+            </Minimize16>
+          ) : (
+            <Maximize16>
+              <title>
+                {intl.formatMessage({
+                  id: 'dashboard.logs.maximize',
+                  defaultMessage: 'Maximize logs'
+                })}
+              </title>
+            </Maximize16>
+          )}
+        </button>
+      ) : null}
       <a
         className="bx--copy-btn"
         href={url}
@@ -47,4 +79,4 @@ const LogDownloadButton = ({ intl, name, url }) => (
   </>
 );
 
-export default injectIntl(LogDownloadButton);
+export default injectIntl(LogsToolbar);

--- a/packages/components/src/components/LogsToolbar/LogsToolbar.stories.js
+++ b/packages/components/src/components/LogsToolbar/LogsToolbar.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,13 +13,13 @@ limitations under the License.
 
 import React from 'react';
 
-import LogDownloadButton from './LogDownloadButton';
+import LogsToolbar from './LogsToolbar';
 
 export default {
-  component: LogDownloadButton,
-  title: 'Components/LogDownloadButton'
+  component: LogsToolbar,
+  title: 'Components/LogsToolbar'
 };
 
 export const Base = () => (
-  <LogDownloadButton name="some_filename.txt" url="/some/logs/url" />
+  <LogsToolbar name="some_filename.txt" url="/some/logs/url" />
 );

--- a/packages/components/src/components/LogsToolbar/index.js
+++ b/packages/components/src/components/LogsToolbar/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,4 +11,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* istanbul ignore file */
-export { default } from './LogDownloadButton';
+export { default } from './LogsToolbar';

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -23,11 +23,22 @@ import {
   labels as labelConstants
 } from '@tektoncd/dashboard-utils';
 
-import { Log, RunHeader, StepDetails, TaskRunDetails, TaskTree } from '..';
+import {
+  Log,
+  Portal,
+  RunHeader,
+  StepDetails,
+  TaskRunDetails,
+  TaskTree
+} from '..';
 
 import '../../scss/Run.scss';
 
 export /* istanbul ignore next */ class PipelineRunContainer extends Component {
+  state = {
+    isLogsMaximized: false
+  };
+
   getPipelineRunError = () => {
     const { pipelineRun } = this.props;
 
@@ -46,30 +57,52 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   getLogContainer({ stepName, stepStatus, taskRun }) {
     const {
       fetchLogs,
-      getLogDownloadButton,
+      getLogsToolbar,
+      maximizedLogsContainer,
       pollingInterval,
       selectedStepId,
       selectedTaskId
     } = this.props;
 
+    const { isLogsMaximized } = this.state;
+
     if (!selectedStepId || !stepStatus) {
       return null;
     }
 
+    const LogsRoot =
+      isLogsMaximized && maximizedLogsContainer ? Portal : React.Fragment;
+
     return (
-      <Log
-        downloadButton={
-          getLogDownloadButton &&
-          stepStatus &&
-          getLogDownloadButton({ stepName, stepStatus, taskRun })
-        }
-        fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
-        key={`${selectedTaskId}:${selectedStepId}`}
-        pollingInterval={pollingInterval}
-        stepStatus={stepStatus}
-      />
+      <LogsRoot
+        {...(isLogsMaximized ? { container: maximizedLogsContainer } : null)}
+      >
+        <Log
+          toolbar={
+            getLogsToolbar &&
+            stepStatus &&
+            getLogsToolbar({
+              isMaximized: isLogsMaximized,
+              stepStatus,
+              taskRun,
+              toggleMaximized:
+                !!maximizedLogsContainer && this.toggleLogsMaximized
+            })
+          }
+          fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
+          key={`${selectedTaskId}:${selectedStepId}`}
+          pollingInterval={pollingInterval}
+          stepStatus={stepStatus}
+        />
+      </LogsRoot>
     );
   }
+
+  toggleLogsMaximized = () => {
+    this.setState(({ isLogsMaximized }) => ({
+      isLogsMaximized: !isLogsMaximized
+    }));
+  };
 
   loadTaskRuns = () => {
     const { intl, pipelineRun } = this.props;

--- a/packages/components/src/components/Portal/index.js
+++ b/packages/components/src/components/Portal/index.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+import { createPortal } from 'react-dom';
+
+const Portal = ({ children, container }) => createPortal(children, container);
+
+export default Portal;

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -24,8 +24,8 @@ export { default as KeyValueList } from './KeyValueList';
 export { default as LabelFilter } from './LabelFilter';
 export { default as LoadingShell } from './LoadingShell';
 export { default as Log } from './Log';
-export { default as LogDownloadButton } from './LogDownloadButton';
 export { default as LogoutButton } from './LogoutButton';
+export { default as LogsToolbar } from './LogsToolbar';
 export { default as Modal } from './Modal';
 export { default as PageErrorBoundary } from './PageErrorBoundary';
 export { default as Param } from './Param';
@@ -33,6 +33,7 @@ export { default as PipelineGraph } from './Graph/PipelineGraph';
 export { default as PipelineResources } from './PipelineResources';
 export { default as PipelineRun } from './PipelineRun';
 export { default as PipelineRuns } from './PipelineRuns';
+export { default as Portal } from './Portal';
 export { default as Rerun } from './Rerun';
 export { default as ResourceDetails } from './ResourceDetails';
 export { default as ResourceTable } from './ResourceTable';

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -47,8 +47,8 @@ import { fetchTaskRuns } from '../../actions/taskRuns';
 import { rerunPipelineRun } from '../../api';
 
 import {
-  getLogDownloadButton,
   getLogsRetriever,
+  getLogsToolbar,
   getViewChangeHandler
 } from '../../utils';
 
@@ -63,6 +63,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       loading: true,
       showRerunNotification: null
     };
+
+    this.maximizedLogsContainer = React.createRef();
   }
 
   componentDidMount() {
@@ -270,6 +272,10 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
     return (
       <>
+        <div
+          id="tkn--maximized-logs-container"
+          ref={this.maximizedLogsContainer}
+        />
         {showRerunNotification && (
           <InlineNotification
             lowContrast
@@ -301,7 +307,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           )}
           handleTaskSelected={this.handleTaskSelected}
           loading={loading}
-          getLogDownloadButton={getLogDownloadButton}
+          getLogsToolbar={getLogsToolbar}
+          maximizedLogsContainer={this.maximizedLogsContainer.current}
           onViewChange={getViewChangeHandler(this.props)}
           pipelineRun={pipelineRun}
           rerun={rerun}

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "Meow",
     "dashboard.logs.downloadButtonTooltip": "Download logs",
     "dashboard.logs.launchButtonTooltip": "Open logs in a new window",
+    "dashboard.logs.maximize": "Maximize logs",
+    "dashboard.logs.restore": "Return to embedded logs",
     "dashboard.metadata.dateCreated": "Date Created:",
     "dashboard.metadata.labels": "Labels:",
     "dashboard.metadata.namespace": "Namespace:",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "ニャー",
     "dashboard.logs.downloadButtonTooltip": "ログをダウンロード",
     "dashboard.logs.launchButtonTooltip": "新しいウィンドウでログを開く",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "作成日：",
     "dashboard.metadata.labels": "ラベル：",
     "dashboard.metadata.namespace": "Namespace：",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "Meow",
     "dashboard.logs.downloadButtonTooltip": "下载日志",
     "dashboard.logs.launchButtonTooltip": "在新窗口中打开日志",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "创建日期：",
     "dashboard.metadata.labels": "标签：",
     "dashboard.metadata.namespace": "Namespace：",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -134,6 +134,8 @@
     "dashboard.logo.tooltip": "",
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
+    "dashboard.logs.maximize": "",
+    "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -19,6 +19,7 @@ limitations under the License.
 
 .bx--header ~ {
   .bx--content {
+    position: relative;
     background-color: $ui-background;
     transform: none;
     padding-top: $layout-02;
@@ -58,4 +59,21 @@ limitations under the License.
 
 .bx--list--unordered {
   margin-top: 1rem;
+}
+
+#tkn--maximized-logs-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  z-index: -1;
+
+  &:not(:empty) {
+    z-index: 9999;
+  }
+
+  .tkn--log {
+    height: 100%;
+  }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import snakeCase from 'lodash.snakecase';
-import { LogDownloadButton } from '@tektoncd/dashboard-components';
+import { LogsToolbar } from '@tektoncd/dashboard-components';
 
 import { getPodLog, getPodLogURL } from '../api';
 import { get } from '../api/comms';
@@ -136,7 +136,12 @@ export function getViewChangeHandler({ history, location, match }) {
   };
 }
 
-export function getLogDownloadButton({ stepStatus, taskRun }) {
+export function getLogsToolbar({
+  isMaximized,
+  stepStatus,
+  taskRun,
+  toggleMaximized
+}) {
   const { container } = stepStatus;
   const { namespace } = taskRun.metadata;
   const { podName } = taskRun.status;
@@ -148,8 +153,10 @@ export function getLogDownloadButton({ stepStatus, taskRun }) {
   });
 
   return (
-    <LogDownloadButton
+    <LogsToolbar
+      isMaximized={isMaximized}
       name={`${podName}__${container}__log.txt`}
+      toggleMaximized={toggleMaximized}
       url={logURL}
     />
   );

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -18,7 +18,7 @@ import {
   fetchLogs,
   fetchLogsFallback,
   followLogs,
-  getLogDownloadButton,
+  getLogsToolbar,
   getViewChangeHandler,
   isStale,
   sortRunsByStartTime,
@@ -208,7 +208,7 @@ it('getViewChangeHandler', () => {
   );
 });
 
-it('getLogDownloadButton', () => {
+it('getLogsToolbar', () => {
   const container = 'fake_container';
   const namespace = 'fake_namespace';
   const podName = 'fake_podname';
@@ -216,12 +216,12 @@ it('getLogDownloadButton', () => {
   const taskRun = { metadata: { namespace }, status: { podName } };
   jest.spyOn(API, 'getPodLogURL');
 
-  const logDownloadButton = getLogDownloadButton({ stepStatus, taskRun });
+  const logsToolbar = getLogsToolbar({ stepStatus, taskRun });
 
   expect(API.getPodLogURL).toHaveBeenCalledWith({
     container,
     name: podName,
     namespace
   });
-  expect(logDownloadButton).toBeTruthy();
+  expect(logsToolbar).toBeTruthy();
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add an option to the logs toolbar allowing the user to maximize
the space used to view the logs. This will hide the run header,
task tree, and other elements, leaving only the main page header,
side nav (which can be collapsed), and the logs.

![image](https://user-images.githubusercontent.com/2829095/108757615-fba2b300-7541-11eb-9215-84268c460056.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
