### PR TITLE
Fix the koparse URL in the publish job

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -130,7 +130,7 @@ spec:
           set -e
           set -x
 
-          curl https://raw.githubusercontent.com/tektoncd/pipeline/master/tekton/koparse/koparse.py --output /usr/bin/koparse.py
+          curl https://raw.githubusercontent.com/tektoncd/plumbing/main/tekton/images/koparse/koparse/koparse.py --output /usr/bin/koparse.py
           chmod +x /usr/bin/koparse.py
 
           REGIONS=(us eu asia)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The koparse script was moved to the plumbing repo, so fix the link
in the publish task.

Next up a larger fix to start using the new koparse image, along
with crane instead of gcloud client.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._

/kind misc