### PR TITLE
display language according to the language setting

### DIFF
--- a/config_frontend/config.json
+++ b/config_frontend/config.json
@@ -3,7 +3,7 @@
   "PORT": "8000",
   "locales": {
     "default": "en",
-    "supported": ["en"],
+    "supported": ["en", "ja"],
     "build": ["de", "en", "es", "fr", "it", "ja", "ko", "pt", "zh-Hans", "zh-Hant"]
   }
 }


### PR DESCRIPTION
related to #1727, #1808, #1813 (especially regarding [this comment](https://github.com/tektoncd/dashboard/pull/1808#discussion_r514165025))

We changed the language displayed on the screen according to the language setting of the browser.
Valid languages ​​are defined in locales.supported of config_frontend / config.json.
If not supported, the default language (English) will be displayed.

We have added Japanese to the locales.supported parameter in config_frontend / config.json.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
