### PR TITLE
Add missing icon and styles for PipelineRunPending

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -16,6 +16,7 @@ import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { StatusIcon, Table } from '@tektoncd/dashboard-components';
 import { getStatus, urls } from '@tektoncd/dashboard-utils';
+import { Pending24 as DefaultIcon } from '@carbon/icons-react';
 
 import { FormattedDate, FormattedDuration, RunDropdown } from '..';
 
@@ -40,7 +41,9 @@ const PipelineRuns = ({
   },
   getPipelineRunStatusIcon = pipelineRun => {
     const { reason, status } = getStatus(pipelineRun);
-    return <StatusIcon reason={reason} status={status} />;
+    return (
+      <StatusIcon DefaultIcon={DefaultIcon} reason={reason} status={status} />
+    );
   },
   getPipelineRunStatusTooltip = (pipelineRun, intl) => {
     const { message } = getStatus(pipelineRun);

--- a/packages/components/src/components/RunHeader/RunHeader.scss
+++ b/packages/components/src/components/RunHeader/RunHeader.scss
@@ -94,6 +94,12 @@ header.tkn--pipeline-run-header {
     }
   }
 
+  &[data-succeeded='Unknown'][data-reason='PipelineRunPending'] {
+    .tkn--status-label {
+      color: $gray-70;
+    }
+  }
+
   &[data-succeeded='Unknown'][data-reason='Running'],
   &[data-succeeded='Unknown'][data-reason='PipelineRunStopping'] {
     .tkn--status-label {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/1944

Add missing status icon on the PipelineRuns page, and missing
styles in the RunHeader on the PipelineRun details page for
a PipelineRun with status PipelineRunPending (introduced in
Tekton Pipelines 0.21).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/master/CONTRIBUTING.md)
for more details._
