### PR TITLE
Fix references to robocat cluster

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -124,8 +124,8 @@ Make sure that the backend service running in the cluster is proxied using `kube
 
 **Note:** If you've exposed the backend by some other means than port-forwarding port 9097 as described above, set the `API_DOMAIN` environment variable to provide the correct details.
 
-e.g. to connect your local dev frontend to the Dashboard deployed on the robotcat cluster:
-`API_DOMAIN=https://dashboard.robotcat.tekton.dev/ npm start`
+e.g. to connect your local dev frontend to the Dashboard deployed on the robocat cluster:
+`API_DOMAIN=https://dashboard.robocat.tekton.dev/ npm start`
 
 **Note:** If modifying any of the sub-packages (e.g. components or utils in https://github.com/tektoncd/dashboard/tree/main/packages), you'll need to run `npm run bootstrap` to ensure those packages are correctly built and linked before starting the dev server or running a build. This is done automatically by `npm ci` or `npm install` so you may not have to run it directly depending on your workflow.
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
DNS records have been updated to match the cluster name which was
already `robocat`, so the subdomain now matches and is `robocat`
instead of `robotcat`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
