### PR TITLE
Remove unnecessary tags for LogFormat component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 stats.json
+.vscode/
 
 # System Files
 .DS_Store

--- a/packages/components/src/components/LogFormat/LogFormat.js
+++ b/packages/components/src/components/LogFormat/LogFormat.js
@@ -36,6 +36,18 @@ const getXtermColor = commandStack => {
   return null;
 };
 
+const createFormattedString = (str, styleObj, className) => {
+  const hasStyles = styleObj.color || styleObj.backgroundColor || className;
+  if (hasStyles) {
+    return (
+      <span style={styleObj} className={className}>
+        {str}
+      </span>
+    );
+  }
+  return str;
+};
+
 const linkify = (str, styleObj, classNameString) => {
   const className = classNameString || undefined;
   if (!str) {
@@ -43,22 +55,14 @@ const linkify = (str, styleObj, classNameString) => {
   }
   const matches = linkifyIt.match(str);
   if (!matches) {
-    return (
-      <span style={styleObj} className={className}>
-        {str}
-      </span>
-    );
+    return createFormattedString(str, styleObj, className);
   }
   const elements = [];
   let offset = 0;
   matches.forEach(match => {
     if (match.index > offset) {
       const string = str.substring(offset, match.index);
-      elements.push(
-        <span style={styleObj} className={className}>
-          {string}
-        </span>
-      );
+      elements.push(createFormattedString(string, styleObj, className));
     }
     elements.push(
       <a
@@ -76,11 +80,7 @@ const linkify = (str, styleObj, classNameString) => {
 
   if (str.length > offset) {
     const string = str.substring(offset, str.length);
-    elements.push(
-      <span style={styleObj} className={className}>
-        {string}
-      </span>
-    );
+    elements.push(createFormattedString(string, styleObj, className));
   }
   return elements;
 };

--- a/packages/components/src/components/LogFormat/LogFormat.test.js
+++ b/packages/components/src/components/LogFormat/LogFormat.test.js
@@ -95,11 +95,10 @@ describe('LogFormat', () => {
   });
 
   it('resets colors after red text on blue background', () => {
-    const element = getElement('\u001b[31;44mHello\u001b[0m world', 'Hello');
-    expect(element.outerHTML).toBe(
-      `<span class="${fgColorClassPrefix}-red ${bgColorClassPrefix}-blue">Hello</span>`
+    const element = getElement('\u001b[31;44mHello\u001b[0m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${fgColorClassPrefix}-red ${bgColorClassPrefix}-blue">Hello</span> world`
     );
-    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
   });
 
   it('performs a color change from red/blue to yellow/blue', () => {
@@ -127,7 +126,7 @@ describe('LogFormat', () => {
 
   it('ignores unsupported codes', () => {
     const element = getElement('\u001b[51mHello\u001b[0m', 'Hello');
-    expect(element.outerHTML).toBe('<span>Hello</span>');
+    expect(element.innerHTML).toBe('Hello');
   });
 
   it('displays bright red text', () => {
@@ -166,13 +165,17 @@ describe('LogFormat', () => {
   });
 
   it('can reset bold text (bold off)', () => {
-    const element = getElement('\u001b[1mHello\u001b[21m world', 'Hello');
-    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
+    const element = getElement('\u001b[1mHello\u001b[21m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${textClassPrefix}-bold">Hello</span> world`
+    );
   });
 
   it('can reset bold text (normal color / intensity)', () => {
-    const element2 = getElement('\u001b[1mHello\u001b[22m world', 'Hello');
-    expect(element2.nextElementSibling.outerHTML).toBe('<span> world</span>');
+    const element = getElement('\u001b[1mHello\u001b[22m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${textClassPrefix}-bold">Hello</span> world`
+    );
   });
 
   it('displays italic text', () => {
@@ -183,11 +186,10 @@ describe('LogFormat', () => {
   });
 
   it('can reset italic text', () => {
-    const element = getElement('\u001b[3mHello\u001b[23m world', 'Hello');
-    expect(element.outerHTML).toBe(
-      `<span class="${textClassPrefix}-italic">Hello</span>`
+    const element = getElement('\u001b[3mHello\u001b[23m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${textClassPrefix}-italic">Hello</span> world`
     );
-    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
   });
 
   it('displays underline text', () => {
@@ -198,11 +200,10 @@ describe('LogFormat', () => {
   });
 
   it('can resets underline text', () => {
-    const element = getElement('\u001b[4mHello\u001b[24m world', 'Hello');
-    expect(element.outerHTML).toBe(
-      `<span class="${textClassPrefix}-underline">Hello</span>`
+    const element = getElement('\u001b[4mHello\u001b[24m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${textClassPrefix}-underline">Hello</span> world`
     );
-    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
   });
 
   it('displays concealed text', () => {
@@ -213,11 +214,10 @@ describe('LogFormat', () => {
   });
 
   it('can resets concealed text', () => {
-    const element = getElement('\u001b[8mHello\u001b[28m world', 'Hello');
-    expect(element.outerHTML).toBe(
-      `<span class="${textClassPrefix}-conceal">Hello</span>`
+    const element = getElement('\u001b[8mHello\u001b[28m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${textClassPrefix}-conceal">Hello</span> world`
     );
-    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
   });
 
   it('displays crossed text', () => {
@@ -228,19 +228,18 @@ describe('LogFormat', () => {
   });
 
   it('can reset crossed-out text', () => {
-    const element = getElement('\u001b[9mHello\u001b[29m world', 'Hello');
-    expect(element.outerHTML).toBe(
-      `<span class="${textClassPrefix}-cross">Hello</span>`
+    const element = getElement('\u001b[9mHello\u001b[29m world', 'world');
+    expect(element.innerHTML).toBe(
+      `<span class="${textClassPrefix}-cross">Hello</span> world`
     );
-    expect(element.nextElementSibling.outerHTML).toBe('<span> world</span>');
   });
 
   it('displays links', () => {
     const element = getElement(
       'A dashboard for Tekton! https://github.com/tektoncd/dashboard',
-      'A dashboard for Tekton!'
+      'https://github.com/tektoncd/dashboard'
     );
-    expect(element.nextElementSibling.outerHTML).toBe(
+    expect(element.outerHTML).toBe(
       '<a href="https://github.com/tektoncd/dashboard" target="_blank" rel="noopener noreferrer">https://github.com/tektoncd/dashboard</a>'
     );
   });
@@ -248,9 +247,9 @@ describe('LogFormat', () => {
   it('displays links with styles', () => {
     const element = getElement(
       'A dashboard for Tekton!\u001b[9m\u001b[48;5;194mhttps://github.com/tektoncd/dashboard',
-      'A dashboard for Tekton!'
+      'https://github.com/tektoncd/dashboard'
     );
-    expect(element.nextElementSibling.outerHTML).toBe(
+    expect(element.outerHTML).toBe(
       `<a href="https://github.com/tektoncd/dashboard" style="background-color: rgb(215, 255, 215);" class="${textClassPrefix}-cross" target="_blank" rel="noopener noreferrer">https://github.com/tektoncd/dashboard</a>`
     );
   });
@@ -259,7 +258,7 @@ describe('LogFormat', () => {
     const text = 'Hello\n\nWorld';
     const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
     expect(container.childNodes[0].innerHTML).toBe(
-      '<div><span>Hello</span></div><br><div><span>World</span></div>'
+      '<div>Hello</div><br><div>World</div>'
     );
   });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Goal is to reduce the size of the DOM tree to hopefully improve the rendering time of large logs.  

If text isn't formatted, we return the string instead of wrapping the string in a <span> tag. 

**Example:** 
```
<div>
  <span class="tkn--ansi--color-fg--cyan">INFO</span>
  <span>[0015] Taking snapshot of files...</span>
</div>
```
_becomes_
```
<div>
  <span class="tkn--ansi--color-fg--cyan">INFO</span>
  [0015] Taking snapshot of files...
</div>
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
