### PR TITLE
Fix display of EventListeners with null triggers field

### DIFF
--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -68,7 +68,11 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
       return null;
     }
 
-    const { serviceAccountName, serviceType } = eventListener.spec;
+    const {
+      namespaceSelector,
+      serviceAccountName,
+      serviceType
+    } = eventListener.spec;
     return (
       <>
         {serviceAccountName && (
@@ -93,6 +97,17 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
             {serviceType}
           </p>
         )}
+        {namespaceSelector?.matchNames?.length ? (
+          <p>
+            <span>
+              {intl.formatMessage({
+                id: 'dashboard.eventListener.namespaceSelector',
+                defaultMessage: 'Namespace Selector:'
+              })}
+            </span>
+            {namespaceSelector.matchNames.join(', ')}
+          </p>
+        ) : null}
       </>
     );
   }
@@ -100,7 +115,7 @@ export /* istanbul ignore next */ class EventListenerContainer extends Component
   getTriggersContent() {
     const { eventListener } = this.props;
 
-    if (!eventListener) {
+    if (!eventListener?.spec?.triggers) {
       return null;
     }
 

--- a/src/containers/EventListener/index.js
+++ b/src/containers/EventListener/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,5 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 export { default } from './EventListener';

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "Error:",
     "dashboard.errorBoundary.defaultError": "Something went wrong",
     "dashboard.errorBoundary.pageError": "Error loading page",
+    "dashboard.eventListener.namespaceSelector": "Namespace Selector:",
     "dashboard.eventListener.serviceAccount": "ServiceAccount:",
     "dashboard.eventListener.serviceType": "Service Type:",
     "dashboard.extension.error": "Error loading extension",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "エラー：",
     "dashboard.errorBoundary.defaultError": "問題が発生しています",
     "dashboard.errorBoundary.pageError": "ページのロード中にエラーが発生しました",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "ServiceAccount：",
     "dashboard.eventListener.serviceType": "Service Type：",
     "dashboard.extension.error": "拡張機能のロード中にエラーが発生しました",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "错误：",
     "dashboard.errorBoundary.defaultError": "出了点问题",
     "dashboard.errorBoundary.pageError": "加载页面时发生错误",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "ServiceAccount：",
     "dashboard.eventListener.serviceType": "Service 类型：",
     "dashboard.extension.error": "加载扩展时发生错误",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -86,6 +86,7 @@
     "dashboard.error.title": "",
     "dashboard.errorBoundary.defaultError": "",
     "dashboard.errorBoundary.pageError": "",
+    "dashboard.eventListener.namespaceSelector": "",
     "dashboard.eventListener.serviceAccount": "",
     "dashboard.eventListener.serviceType": "",
     "dashboard.extension.error": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Handle missing triggers field in EventListener spec

Display NamespaceSelector if specified

Before:
![image](https://user-images.githubusercontent.com/2829095/109992021-c432c400-7d02-11eb-94a7-b39e3e408154.png)

After:
local dev frontend connected to dogfooding cluster, so it's the same resource
![image](https://user-images.githubusercontent.com/2829095/109992046-c9900e80-7d02-11eb-9d2b-26539290c288.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
