### PR TITLE
Fix table layout for TaskRun parameters and results

### DIFF
--- a/packages/components/src/components/StepDetails/StepDetails.scss
+++ b/packages/components/src/components/StepDetails/StepDetails.scss
@@ -21,10 +21,4 @@ limitations under the License.
   .bx--tab-content {
     padding-left: 0;
   }
-
-  .bx--tab-content .tkn--table .bx--data-table.bx--data-table--short {
-    td.cell-value {
-      max-width: unset;
-    }
-  }
 }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
@@ -17,10 +17,4 @@ limitations under the License.
   flex-wrap: nowrap;
   align-items: stretch;
   overflow: hidden;
-
-  .bx--tab-content .tkn--table .bx--data-table.bx--data-table--short {
-    td.cell-value {
-      max-width: unset;
-    }
-  }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Remove the width override on the value column to allow for normal
browser layout to kick in. This prevents the description being
unnecessarily squashed or pushed off the right edge.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
