### PR TITLE
Use small Tag variant on ResourceDetails labels

### DIFF
--- a/packages/components/src/components/ResourceDetails/ResourceDetails.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.js
@@ -108,7 +108,7 @@ const ResourceDetails = ({
                       defaultMessage: 'None'
                     })
                   : formattedLabelsToRender.map(label => (
-                      <Tag type="blue" key={label}>
+                      <Tag key={label} size="sm" type="blue">
                         {label}
                       </Tag>
                     ))}

--- a/src/scss/Triggers.scss
+++ b/src/scss/Triggers.scss
@@ -50,4 +50,8 @@ limitations under the License.
   margin-bottom: $layout-01;
   padding: $layout-01;
   background-color: $ui-01;
+
+  .bx--tag {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Use the new small variant of the Tag component introduced in
Carbon 10.28 to fit more in line with other content in the
ResourceDetails metadata section.

Depends on https://github.com/tektoncd/dashboard/pull/1991

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
