### PR TITLE
Replace Carbon layout tokens with spacing

### DIFF
--- a/packages/components/src/components/LoadingShell/LoadingShell.scss
+++ b/packages/components/src/components/LoadingShell/LoadingShell.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -20,7 +20,7 @@ limitations under the License.
     .bx--content {
       background-color: $ui-background;
       transform: none;
-      padding-top: $layout-02;
+      padding-top: $spacing-06;
     }
   }
 

--- a/src/containers/EventListener/EventListener.scss
+++ b/src/containers/EventListener/EventListener.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,5 +14,5 @@ limitations under the License.
 @import '../../scss/Triggers.scss';
 
 .tkn--eventlistener--triggers {
-  margin-top: $layout-02;
+  margin-top: $spacing-06;
 }

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -22,11 +22,11 @@ limitations under the License.
     position: relative;
     background-color: $ui-background;
     transform: none;
-    padding-top: $layout-02;
+    padding-top: $spacing-06;
 
     h1 {
       @include type-style('productive-heading-04');
-      margin-bottom: $layout-02;
+      margin-bottom: $spacing-06;
     }
 
     h2 {
@@ -46,11 +46,11 @@ limitations under the License.
 }
 
 .bx--modal-content {
-  margin-bottom: $carbon--spacing-07
+  margin-bottom: $spacing-07
 }
 
 .bx--data-table-container {
-  margin-top: $carbon--spacing-07;
+  margin-top: $spacing-07;
 }
 
 .bx--table-header-label {

--- a/src/scss/Create.scss
+++ b/src/scss/Create.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -49,7 +49,7 @@ limitations under the License.
 
   .bx--list-box__wrapper,
   .bx--form-item {
-    margin-bottom: $carbon--spacing-06;
+    margin-bottom: $spacing-06;
     max-width: 40rem;
   }
 }

--- a/src/scss/Triggers.scss
+++ b/src/scss/Triggers.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -47,8 +47,8 @@ limitations under the License.
 }
 
 .tkn--resourcedetails-metadata {
-  margin-bottom: $layout-01;
-  padding: $layout-01;
+  margin-bottom: $spacing-05;
+  padding: $spacing-05;
   background-color: $ui-01;
 
   .bx--tag {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Carbon v10.32 combines the layout and spacing tokens into a single
set of spacing tokens. Update all use of `$layout-*` to use the
corresponding `$spacing-*` in preparation for this update.

There is no visual impact from this change as the values are the same.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
