### PR TITLE
Remove status label string on step display

### DIFF
--- a/packages/components/src/components/Spinner/Spinner.js
+++ b/packages/components/src/components/Spinner/Spinner.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -17,6 +17,10 @@ import { Renew20 as SpinnerIcon } from '@carbon/icons-react';
 
 import './Spinner.scss';
 
-export default function Spinner({ className }) {
-  return <SpinnerIcon className={`tkn--spinner ${className}`} />;
+export default function Spinner({ children, className }) {
+  return (
+    <SpinnerIcon className={`tkn--spinner ${className}`}>
+      {children}
+    </SpinnerIcon>
+  );
 }

--- a/packages/components/src/components/Spinner/index.js
+++ b/packages/components/src/components/Spinner/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,5 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 export { default } from './Spinner';

--- a/packages/components/src/components/StatusIcon/StatusIcon.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.js
@@ -10,7 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* istanbul ignore file */
 
 import './StatusIcon.scss';
 
@@ -48,7 +47,8 @@ export default function StatusIcon({
   DefaultIcon,
   type = 'normal',
   reason,
-  status
+  status,
+  title
 }) {
   let statusClass;
   if (
@@ -84,6 +84,8 @@ export default function StatusIcon({
       className={classNames('tkn--status-icon', {
         [`tkn--status-icon--${statusClass}`]: statusClass
       })}
-    />
+    >
+      {title && <title>{title}</title>}
+    </Icon>
   ) : null;
 }

--- a/packages/components/src/components/StatusIcon/StatusIcon.test.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.test.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import StatusIcon from './StatusIcon';
+
+describe('StatusIcon', () => {
+  it('renders title', () => {
+    const title = 'fake_title';
+    const { queryByText } = render(<StatusIcon title={title} />);
+
+    expect(queryByText(title)).toBeTruthy();
+  });
+
+  it('renders PipelineRunCancelled state', () => {
+    render(<StatusIcon reason="PipelineRunCancelled" status="False" />);
+  });
+
+  it('renders TaskRunCancelled state', () => {
+    render(<StatusIcon reason="TaskRunCancelled" status="False" />);
+  });
+
+  it('renders PipelineRunCouldntCancel state', () => {
+    render(<StatusIcon reason="PipelineRunCouldntCancel" status="Unknown" />);
+  });
+
+  it('gracefully handles unsupported state', () => {
+    render(<StatusIcon reason="???" status="???" />);
+  });
+});

--- a/packages/components/src/components/Step/Step.js
+++ b/packages/components/src/components/Step/Step.js
@@ -60,13 +60,14 @@ class Step extends Component {
         defaultMessage: 'Failed'
       });
     }
+
     if (status === 'waiting') {
       return intl.formatMessage({
         id: 'dashboard.taskRun.status.waiting',
         defaultMessage: 'Waiting'
       });
     }
-    // task is done, step did not run
+
     return intl.formatMessage({
       id: 'dashboard.taskRun.status.notRun',
       defaultMessage: 'Not run'
@@ -95,11 +96,11 @@ class Step extends Component {
             type="inverse"
             reason={reason}
             status={status}
+            title={statusLabel}
           />
           <span className="tkn--step-name" title={stepName}>
             {stepName}
           </span>
-          <span className="tkn--status-label">{statusLabel}</span>
         </a>
       </li>
     );

--- a/packages/components/src/components/Step/Step.scss
+++ b/packages/components/src/components/Step/Step.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -55,47 +55,5 @@ limitations under the License.
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .tkn--status-label {
-    flex-shrink: 0;
-    margin-left: 0.75rem;
-    font-size: 0.7rem;
-    letter-spacing: 0.01rem;
-  }
-
-  &[data-status='running'] > a.tkn--step-link {
-    opacity: 1;
-    .tkn--status-label {
-      color: $support-04;
-      font-weight: bold;
-      font-size: 0.69rem;
-    }
-  }
-  &[data-status='terminated'][data-reason='Completed'] > a.tkn--step-link {
-    opacity: 1;
-    .tkn--status-label {
-      color: $support-02;
-      font-size: 0.66rem;
-      font-weight: bold;
-    }
-  }
-  &[data-status='terminated'][data-reason='Error'] > a.tkn--step-link {
-    opacity: 1;
-    .tkn--status-label {
-      color: $support-01;
-      font-weight: bold;
-    }
-  }
-  &[data-status='cancelled'],
-  &[data-status='terminated'][data-reason='TaskRunCancelled'],
-  &[data-status='terminated'][data-reason='TaskRunTimeout'] {
-    > a.tkn--step-link {
-      opacity: 1;
-      .tkn--status-label {
-        color: $support-01;
-        font-weight: bold;
-      }
-    }
   }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Move the status label string to a tooltip on the status icon to
free up more space for displaying the step name.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
