### PR TITLE
Fix for SideNav not collapsing when toggling the menu button

### DIFF
--- a/packages/components/src/components/LabelFilter/LabelFilter.js
+++ b/packages/components/src/components/LabelFilter/LabelFilter.js
@@ -151,7 +151,7 @@ class LabelFilter extends Component {
         )}
         <Form onSubmit={this.handleAddFilter} autoComplete="on">
           <Search
-            placeHolderText={searchDescription}
+            placeholder={searchDescription}
             labelText={searchDescription}
             onChange={this.handleChange}
             value={currentFilterValue}

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -218,9 +218,9 @@ export function App({
               isSideNavExpanded={isSideNavExpanded}
               logoutButton={logoutButton}
               onHeaderMenuButtonClick={() => {
-                setIsSideNavExpanded(prevIsSideNavExpanded => ({
-                  isSideNavExpanded: !prevIsSideNavExpanded
-                }));
+                setIsSideNavExpanded(
+                  prevIsSideNavExpanded => !prevIsSideNavExpanded
+                );
               }}
             />
             <Route path={paths.byNamespace({ path: '/*' })}>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The `expanded` prop of the `SideNav` component was incorrectly set
as an object instead of a boolean, preventing the nav from being
collapsed. Fix the state update so it's providing a boolean as
expected.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
