### PR TITLE
Add custom hook to refetch data when websocket reconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13094,6 +13094,20 @@
         "@testing-library/dom": "^7.28.1"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz",
+      "integrity": "sha512-jwhtDYZ5gQUIX8cmVCVdtwNvuF5EiCOWjokRlTV+o/V0GdtRZDykUllL1OXq5PS4+J33wGLNQeeWzEHcWrH7tg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "filter-console": "^0.1.1",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -13454,10 +13468,28 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-dom": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
+      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-syntax-highlighter": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -19969,6 +20001,12 @@
           }
         }
       }
+    },
+    "filter-console": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
+      "integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
+      "dev": true
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -28353,6 +28391,15 @@
           "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
           "dev": true
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz",
+      "integrity": "sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@storybook/theming": "^6.2.1",
     "@svgr/webpack": "^5.5.0",
     "@testing-library/react": "^11.2.2",
+    "@testing-library/react-hooks": "5.1.2",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-react-intl": "^8.2.18",

--- a/packages/utils/src/utils/hooks.js
+++ b/packages/utils/src/utils/hooks.js
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useEffect, useRef } from 'react';
+
+export function usePrevious(value) {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
+export function useWebSocketReconnected(callback, webSocketConnected) {
+  const prevWebSocketConnected = usePrevious(webSocketConnected);
+
+  useEffect(() => {
+    if (prevWebSocketConnected === false && webSocketConnected) {
+      callback();
+    }
+  }, [prevWebSocketConnected, webSocketConnected]);
+}

--- a/packages/utils/src/utils/hooks.test.js
+++ b/packages/utils/src/utils/hooks.test.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import { usePrevious, useWebSocketReconnected } from './hooks';
+
+describe('hooks', () => {
+  it('usePrevious', () => {
+    let initialValue = 0;
+    const { result, rerender } = renderHook(() => usePrevious(initialValue));
+
+    initialValue = 10;
+    rerender();
+    expect(result.current).toEqual(0);
+
+    initialValue = 1;
+    rerender();
+    expect(result.current).toEqual(10);
+  });
+
+  it('useWebSocketReconnected', () => {
+    const callback = jest.fn();
+    let webSocketConnected;
+
+    const { rerender } = renderHook(() =>
+      useWebSocketReconnected(callback, webSocketConnected)
+    );
+    expect(callback).not.toHaveBeenCalled();
+    webSocketConnected = true;
+    rerender();
+    expect(callback).not.toHaveBeenCalled();
+    webSocketConnected = false;
+    rerender();
+    expect(callback).not.toHaveBeenCalled();
+    // callback is only called if websocket was previously disconnected
+    // i.e. doesn't get called on initial connection
+    webSocketConnected = true;
+    rerender();
+    expect(callback).toHaveBeenCalled();
+  });
+});

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,6 +16,7 @@ import { getStatus } from './status';
 
 export { default as buildGraphData } from './buildGraphData';
 export * from './constants';
+export * from './hooks';
 export { paths, urls } from './router';
 export { getStatus } from './status';
 

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.js
@@ -15,7 +15,12 @@ import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
-import { getFilters, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  getFilters,
+  getTitle,
+  urls,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
@@ -42,9 +47,15 @@ function ClusterInterceptors(props) {
     document.title = getTitle({ page: 'ClusterInterceptors' });
   }, []);
 
-  useEffect(() => {
+  function fetchData() {
     fetchClusterInterceptors({ filters });
-  }, [JSON.stringify(filters), webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [JSON.stringify(filters)]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   function getError() {
     if (error) {

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -26,7 +26,12 @@ import {
   TrashCan16 as DeleteIcon,
   Playlist16 as RunsIcon
 } from '@carbon/icons-react';
-import { getFilters, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  getFilters,
+  getTitle,
+  urls,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 
 import { ListPageLayout } from '..';
 import { fetchClusterTasks as fetchClusterTasksActionCreator } from '../../actions/tasks';
@@ -62,9 +67,15 @@ function ClusterTasksContainer(props) {
     document.title = getTitle({ page: 'ClusterTasks' });
   }, []);
 
-  useEffect(() => {
+  function fetchData() {
     fetchClusterTasks({ filters });
-  }, [JSON.stringify(filters), webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [JSON.stringify(filters)]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   function getError() {
     if (error) {

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
-import { getTitle } from '@tektoncd/dashboard-utils';
+import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
 import {
   getClusterTriggerBinding,
   getClusterTriggerBindingsErrorMessage,
@@ -24,110 +24,94 @@ import {
   isWebSocketConnected
 } from '../../reducers';
 import { getViewChangeHandler } from '../../utils';
-import { fetchClusterTriggerBinding } from '../../actions/clusterTriggerBindings';
+import { fetchClusterTriggerBinding as fetchClusterTriggerBindingActionCreator } from '../../actions/clusterTriggerBindings';
 
 import '../../scss/Triggers.scss';
 
-export /* istanbul ignore next */ class ClusterTriggerBindingContainer extends Component {
-  componentDidMount() {
-    const { match } = this.props;
-    const { clusterTriggerBindingName: resourceName } = match.params;
+export /* istanbul ignore next */ function ClusterTriggerBindingContainer(
+  props
+) {
+  const {
+    clusterTriggerBinding,
+    error,
+    fetchClusterTriggerBinding,
+    intl,
+    loading,
+    match,
+    view,
+    webSocketConnected
+  } = props;
+  const { clusterTriggerBindingName } = match.params;
+
+  useEffect(() => {
     document.title = getTitle({
       page: 'ClusterTriggerBinding',
-      resourceName
+      resourceName: clusterTriggerBindingName
     });
-    this.fetchData();
-  }
+  }, []);
 
-  componentDidUpdate(prevProps) {
-    const { match, webSocketConnected } = this.props;
-    const { clusterTriggerBindingName } = match.params;
-    const {
-      match: prevMatch,
-      webSocketConnected: prevWebSocketConnected
-    } = prevProps;
-    const {
-      clusterTriggerBindingName: prevClusterTriggerBindingName
-    } = prevMatch.params;
-
-    if (
-      clusterTriggerBindingName !== prevClusterTriggerBindingName ||
-      (webSocketConnected && prevWebSocketConnected === false)
-    ) {
-      this.fetchData();
-    }
-  }
-
-  fetchData() {
-    const { match } = this.props;
-    const { clusterTriggerBindingName } = match.params;
-    this.props.fetchClusterTriggerBinding({
+  function fetchData() {
+    fetchClusterTriggerBinding({
       name: clusterTriggerBindingName
     });
   }
 
-  render() {
-    const {
-      clusterTriggerBinding,
-      intl,
-      error,
-      loading,
-      selectedNamespace,
-      view
-    } = this.props;
+  useEffect(() => {
+    fetchData();
+  }, [clusterTriggerBindingName]);
 
-    const headersForParameters = [
-      {
-        key: 'name',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.name',
-          defaultMessage: 'Name'
-        })
-      },
-      {
-        key: 'value',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.value',
-          defaultMessage: 'Value'
-        })
-      }
-    ];
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
-    const rowsForParameters =
-      clusterTriggerBinding?.spec.params.map(({ name, value }) => ({
-        id: name,
-        name,
-        value
-      })) || [];
+  const headersForParameters = [
+    {
+      key: 'name',
+      header: intl.formatMessage({
+        id: 'dashboard.tableHeader.name',
+        defaultMessage: 'Name'
+      })
+    },
+    {
+      key: 'value',
+      header: intl.formatMessage({
+        id: 'dashboard.tableHeader.value',
+        defaultMessage: 'Value'
+      })
+    }
+  ];
 
-    const emptyTextMessage = intl.formatMessage({
-      id: 'dashboard.clusterTriggerBinding.noParams',
-      defaultMessage: 'No parameters found for this ClusterTriggerBinding.'
-    });
+  const rowsForParameters =
+    clusterTriggerBinding?.spec.params.map(({ name, value }) => ({
+      id: name,
+      name,
+      value
+    })) || [];
 
-    return (
-      <ResourceDetails
-        error={error}
-        loading={loading}
-        onViewChange={getViewChangeHandler(this.props)}
-        resource={clusterTriggerBinding}
-        view={view}
-      >
-        <Table
-          title={intl.formatMessage({
-            id: 'dashboard.parameters.title',
-            defaultMessage: 'Parameters'
-          })}
-          headers={headersForParameters}
-          rows={rowsForParameters}
-          size="short"
-          selectedNamespace={selectedNamespace}
-          emptyTextAllNamespaces={emptyTextMessage}
-          emptyTextSelectedNamespace={emptyTextMessage}
-        />
-      </ResourceDetails>
-    );
-  }
+  const emptyTextMessage = intl.formatMessage({
+    id: 'dashboard.clusterTriggerBinding.noParams',
+    defaultMessage: 'No parameters found for this ClusterTriggerBinding.'
+  });
+
+  return (
+    <ResourceDetails
+      error={error}
+      loading={loading}
+      onViewChange={getViewChangeHandler(props)}
+      resource={clusterTriggerBinding}
+      view={view}
+    >
+      <Table
+        title={intl.formatMessage({
+          id: 'dashboard.parameters.title',
+          defaultMessage: 'Parameters'
+        })}
+        headers={headersForParameters}
+        rows={rowsForParameters}
+        size="short"
+        emptyTextAllNamespaces={emptyTextMessage}
+        emptyTextSelectedNamespace={emptyTextMessage}
+      />
+    </ResourceDetails>
+  );
 }
 
 ClusterTriggerBindingContainer.propTypes = {
@@ -159,7 +143,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 const mapDispatchToProps = {
-  fetchClusterTriggerBinding
+  fetchClusterTriggerBinding: fetchClusterTriggerBindingActionCreator
 };
 
 export default connect(

--- a/src/containers/Condition/Condition.js
+++ b/src/containers/Condition/Condition.js
@@ -15,7 +15,7 @@ import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getTitle } from '@tektoncd/dashboard-utils';
+import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import {
   getCondition,
@@ -95,9 +95,15 @@ export function ConditionContainer(props) {
     });
   }, []);
 
-  useEffect(() => {
+  function fetchData() {
     fetchCondition({ name: conditionName, namespace });
-  }, [conditionName, namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [conditionName, namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   return (
     <ResourceDetails

--- a/src/containers/Conditions/Conditions.js
+++ b/src/containers/Conditions/Conditions.js
@@ -15,7 +15,12 @@ import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
-import { getFilters, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  getFilters,
+  getTitle,
+  urls,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
@@ -43,9 +48,15 @@ function Conditions(props) {
     document.title = getTitle({ page: 'Conditions' });
   }, []);
 
-  useEffect(() => {
+  function fetchData() {
     fetchConditions({ filters, namespace });
-  }, [JSON.stringify(filters), namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [JSON.stringify(filters), namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   function getError() {
     if (error) {

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -11,16 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import isEqual from 'lodash.isequal';
 import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
-import { getFilters, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  getFilters,
+  getTitle,
+  urls,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
-import { fetchEventListeners } from '../../actions/eventListeners';
+import { fetchEventListeners as fetchEventListenersActionCreator } from '../../actions/eventListeners';
 import {
   getEventListeners,
   getEventListenersErrorMessage,
@@ -29,31 +33,34 @@ import {
   isWebSocketConnected
 } from '../../reducers';
 
-export /* istanbul ignore next */ class EventListeners extends Component {
-  componentDidMount() {
+/* istanbul ignore next */
+function EventListeners(props) {
+  const {
+    eventListeners,
+    fetchEventListeners,
+    filters,
+    intl,
+    loading,
+    selectedNamespace,
+    webSocketConnected
+  } = props;
+
+  useEffect(() => {
     document.title = getTitle({ page: 'EventListeners' });
-    this.fetchEventListeners();
+  }, []);
+
+  function fetchData() {
+    fetchEventListeners({ filters, namespace: selectedNamespace });
   }
 
-  componentDidUpdate(prevProps) {
-    const { filters, namespace, webSocketConnected } = this.props;
-    const {
-      filters: prevFilters,
-      namespace: prevNamespace,
-      webSocketConnected: prevWebSocketConnected
-    } = prevProps;
+  useEffect(() => {
+    fetchData();
+  }, [JSON.stringify(filters), selectedNamespace]);
 
-    if (
-      !isEqual(filters, prevFilters) ||
-      namespace !== prevNamespace ||
-      (webSocketConnected && prevWebSocketConnected === false)
-    ) {
-      this.fetchEventListeners();
-    }
-  }
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
-  getError() {
-    const { error } = this.props;
+  function getError() {
+    const { error } = props;
     if (error) {
       return { error };
     }
@@ -61,87 +68,69 @@ export /* istanbul ignore next */ class EventListeners extends Component {
     return null;
   }
 
-  fetchEventListeners() {
-    const { filters, namespace } = this.props;
-    this.props.fetchEventListeners({
-      filters,
-      namespace
-    });
-  }
+  const initialHeaders = [
+    {
+      key: 'name',
+      header: intl.formatMessage({
+        id: 'dashboard.tableHeader.name',
+        defaultMessage: 'Name'
+      })
+    },
+    {
+      key: 'namespace',
+      header: 'Namespace'
+    },
+    {
+      key: 'date',
+      header: intl.formatMessage({
+        id: 'dashboard.tableHeader.createdTime',
+        defaultMessage: 'Created'
+      })
+    }
+  ];
 
-  render() {
-    const { intl, loading, selectedNamespace, eventListeners } = this.props;
-
-    const initialHeaders = [
-      {
-        key: 'name',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.name',
-          defaultMessage: 'Name'
-        })
-      },
-      {
-        key: 'namespace',
-        header: 'Namespace'
-      },
-      {
-        key: 'date',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.createdTime',
-          defaultMessage: 'Created'
-        })
-      }
-    ];
-
-    const eventListenersFormatted = eventListeners.map(listener => ({
-      id: `${listener.metadata.namespace}:${listener.metadata.name}`,
-      name: (
-        <Link
-          to={urls.eventListeners.byName({
-            namespace: listener.metadata.namespace,
-            eventListenerName: listener.metadata.name
-          })}
-          title={listener.metadata.name}
-        >
-          {listener.metadata.name}
-        </Link>
-      ),
-      namespace: listener.metadata.namespace,
-      date: (
-        <FormattedDate date={listener.metadata.creationTimestamp} relative />
-      )
-    }));
-
-    return (
-      <ListPageLayout
-        {...this.props}
-        error={this.getError()}
-        title="EventListeners"
+  const eventListenersFormatted = eventListeners.map(listener => ({
+    id: `${listener.metadata.namespace}:${listener.metadata.name}`,
+    name: (
+      <Link
+        to={urls.eventListeners.byName({
+          namespace: listener.metadata.namespace,
+          eventListenerName: listener.metadata.name
+        })}
+        title={listener.metadata.name}
       >
-        <Table
-          headers={initialHeaders}
-          rows={eventListenersFormatted}
-          loading={loading && !eventListenersFormatted.length}
-          selectedNamespace={selectedNamespace}
-          emptyTextAllNamespaces={intl.formatMessage(
-            {
-              id: 'dashboard.emptyState.allNamespaces',
-              defaultMessage: 'No matching {kind} found'
-            },
-            { kind: 'EventListeners' }
-          )}
-          emptyTextSelectedNamespace={intl.formatMessage(
-            {
-              id: 'dashboard.emptyState.selectedNamespace',
-              defaultMessage:
-                'No matching {kind} found in namespace {selectedNamespace}'
-            },
-            { kind: 'EventListeners', selectedNamespace }
-          )}
-        />
-      </ListPageLayout>
-    );
-  }
+        {listener.metadata.name}
+      </Link>
+    ),
+    namespace: listener.metadata.namespace,
+    date: <FormattedDate date={listener.metadata.creationTimestamp} relative />
+  }));
+
+  return (
+    <ListPageLayout {...props} error={getError()} title="EventListeners">
+      <Table
+        headers={initialHeaders}
+        rows={eventListenersFormatted}
+        loading={loading && !eventListenersFormatted.length}
+        selectedNamespace={selectedNamespace}
+        emptyTextAllNamespaces={intl.formatMessage(
+          {
+            id: 'dashboard.emptyState.allNamespaces',
+            defaultMessage: 'No matching {kind} found'
+          },
+          { kind: 'EventListeners' }
+        )}
+        emptyTextSelectedNamespace={intl.formatMessage(
+          {
+            id: 'dashboard.emptyState.selectedNamespace',
+            defaultMessage:
+              'No matching {kind} found in namespace {selectedNamespace}'
+          },
+          { kind: 'EventListeners', selectedNamespace }
+        )}
+      />
+    </ListPageLayout>
+  );
 }
 
 function mapStateToProps(state, props) {
@@ -160,7 +149,7 @@ function mapStateToProps(state, props) {
 }
 
 const mapDispatchToProps = {
-  fetchEventListeners
+  fetchEventListeners: fetchEventListenersActionCreator
 };
 
 export default connect(

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { DataTable } from 'carbon-components-react';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
-import { getTitle } from '@tektoncd/dashboard-utils';
+import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
 
 import {
   getPipelineResource,
@@ -27,7 +27,7 @@ import {
 } from '../../reducers';
 import { getViewChangeHandler } from '../../utils';
 
-import { fetchPipelineResource } from '../../actions/pipelineResources';
+import { fetchPipelineResource as fetchPipelineResourceActionCreator } from '../../actions/pipelineResources';
 
 const {
   Table,
@@ -39,86 +39,140 @@ const {
   TableRow
 } = DataTable;
 
-export /* istanbul ignore next */ class PipelineResourceContainer extends Component {
-  componentDidMount() {
-    const { match } = this.props;
-    const { pipelineResourceName: resourceName } = match.params;
+/* istanbul ignore next */
+function PipelineResource(props) {
+  const {
+    error,
+    fetchPipelineResource,
+    intl,
+    loading,
+    match,
+    pipelineResource,
+    view,
+    webSocketConnected
+  } = props;
+  const { namespace, pipelineResourceName: resourceName } = match.params;
+
+  useEffect(() => {
     document.title = getTitle({
       page: 'PipelineResource',
       resourceName
     });
-    this.fetchData();
+  }, []);
+
+  function fetchData() {
+    fetchPipelineResource({ name: resourceName, namespace });
   }
 
-  componentDidUpdate(prevProps) {
-    const { match, webSocketConnected } = this.props;
-    const { namespace, pipelineResourceName } = match.params;
-    const {
-      match: prevMatch,
-      webSocketConnected: prevWebSocketConnected
-    } = prevProps;
-    const {
-      namespace: prevNamespace,
-      pipelineResourceName: prevPipelineResourceName
-    } = prevMatch.params;
+  useEffect(() => {
+    fetchData();
+  }, [namespace, resourceName]);
 
-    if (
-      namespace !== prevNamespace ||
-      pipelineResourceName !== prevPipelineResourceName ||
-      (webSocketConnected && prevWebSocketConnected === false)
-    ) {
-      this.fetchData();
-    }
-  }
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
-  fetchData() {
-    const { match } = this.props;
-    const { namespace, pipelineResourceName } = match.params;
-    this.props.fetchPipelineResource({ name: pipelineResourceName, namespace });
-  }
+  const { params = [], secrets, type } = pipelineResource?.spec || {};
 
-  render() {
-    const { error, intl, loading, pipelineResource, view } = this.props;
-    const { params = [], secrets, type } = pipelineResource?.spec || {};
+  return (
+    <ResourceDetails
+      additionalMetadata={
+        <p>
+          <span>
+            {intl.formatMessage({
+              id: 'dashboard.pipelineResource.type',
+              defaultMessage: 'Type:'
+            })}
+          </span>
+          {type}
+        </p>
+      }
+      error={error}
+      loading={loading}
+      onViewChange={getViewChangeHandler(props)}
+      resource={pipelineResource}
+      view={view}
+    >
+      <DataTable
+        rows={params.map(({ name, value }) => ({
+          id: name,
+          name,
+          value
+        }))}
+        headers={[
+          {
+            key: 'name',
+            header: intl.formatMessage({
+              id: 'dashboard.tableHeader.name',
+              defaultMessage: 'Name'
+            })
+          },
+          {
+            key: 'value',
+            header: intl.formatMessage({
+              id: 'dashboard.tableHeader.value',
+              defaultMessage: 'Value'
+            })
+          }
+        ]}
+        render={({
+          rows,
+          headers,
+          getHeaderProps,
+          getRowProps,
+          getTableProps
+        }) => (
+          <TableContainer title="Params" className="tkn--table">
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  {headers.map(header => (
+                    <TableHeader {...getHeaderProps({ header })}>
+                      {header.header}
+                    </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map(row => (
+                  <TableRow {...getRowProps({ row })}>
+                    {row.cells.map(cell => (
+                      <TableCell key={cell.id}>{cell.value}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      />
 
-    return (
-      <ResourceDetails
-        additionalMetadata={
-          <p>
-            <span>
-              {intl.formatMessage({
-                id: 'dashboard.pipelineResource.type',
-                defaultMessage: 'Type:'
-              })}
-            </span>
-            {type}
-          </p>
-        }
-        error={error}
-        loading={loading}
-        onViewChange={getViewChangeHandler(this.props)}
-        resource={pipelineResource}
-        view={view}
-      >
+      {secrets && (
         <DataTable
-          rows={params.map(({ name, value }) => ({
-            id: name,
-            name,
-            value
+          rows={secrets.map(({ fieldName, secretKey, secretName }) => ({
+            id: fieldName,
+            fieldName,
+            secretKey,
+            secretName
           }))}
           headers={[
             {
-              key: 'name',
+              key: 'fieldName',
               header: intl.formatMessage({
-                id: 'dashboard.tableHeader.name',
-                defaultMessage: 'Name'
+                id: 'dashboard.pipelineResource.fieldName',
+                defaultMessage: 'Field Name'
               })
             },
             {
-              key: 'value',
+              key: 'secretKey',
               header: intl.formatMessage({
-                id: 'dashboard.tableHeader.value',
-                defaultMessage: 'Value'
+                id: 'dashboard.pipelineResource.secretKey',
+                defaultMessage: 'Secret Key'
+              })
+            },
+            {
+              key: 'secretName',
+              header: intl.formatMessage({
+                id: 'dashboard.pipelineResource.secretName',
+                defaultMessage: 'Secret Name'
               })
             }
           ]}
@@ -129,7 +183,7 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
             getRowProps,
             getTableProps
           }) => (
-            <TableContainer title="Params" className="tkn--table">
+            <TableContainer title="Secrets" className="tkn--table">
               <Table {...getTableProps()}>
                 <TableHead>
                   <TableRow>
@@ -153,76 +207,12 @@ export /* istanbul ignore next */ class PipelineResourceContainer extends Compon
             </TableContainer>
           )}
         />
-
-        {secrets && (
-          <DataTable
-            rows={secrets.map(({ fieldName, secretKey, secretName }) => ({
-              id: fieldName,
-              fieldName,
-              secretKey,
-              secretName
-            }))}
-            headers={[
-              {
-                key: 'fieldName',
-                header: intl.formatMessage({
-                  id: 'dashboard.pipelineResource.fieldName',
-                  defaultMessage: 'Field Name'
-                })
-              },
-              {
-                key: 'secretKey',
-                header: intl.formatMessage({
-                  id: 'dashboard.pipelineResource.secretKey',
-                  defaultMessage: 'Secret Key'
-                })
-              },
-              {
-                key: 'secretName',
-                header: intl.formatMessage({
-                  id: 'dashboard.pipelineResource.secretName',
-                  defaultMessage: 'Secret Name'
-                })
-              }
-            ]}
-            render={({
-              rows,
-              headers,
-              getHeaderProps,
-              getRowProps,
-              getTableProps
-            }) => (
-              <TableContainer title="Secrets" className="tkn--table">
-                <Table {...getTableProps()}>
-                  <TableHead>
-                    <TableRow>
-                      {headers.map(header => (
-                        <TableHeader {...getHeaderProps({ header })}>
-                          {header.header}
-                        </TableHeader>
-                      ))}
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {rows.map(row => (
-                      <TableRow {...getRowProps({ row })}>
-                        {row.cells.map(cell => (
-                          <TableCell key={cell.id}>{cell.value}</TableCell>
-                        ))}
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            )}
-          />
-        )}
-      </ResourceDetails>
-    );
-  }
+      )}
+    </ResourceDetails>
+  );
 }
 
-PipelineResourceContainer.propTypes = {
+PipelineResource.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
       namespace: PropTypes.string.isRequired,
@@ -253,10 +243,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 const mapDispatchToProps = {
-  fetchPipelineResource
+  fetchPipelineResource: fetchPipelineResourceActionCreator
 };
 
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(injectIntl(PipelineResourceContainer));
+)(injectIntl(PipelineResource));

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
@@ -14,7 +14,10 @@ limitations under the License.
 import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import {
@@ -34,9 +37,15 @@ function PipelineResourcesDropdown({
   webSocketConnected,
   ...rest
 }) {
-  useEffect(() => {
+  function fetchData() {
     fetchPipelineResources({ namespace });
-  }, [namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   let emptyText = intl.formatMessage({
     id: 'dashboard.pipelineResourcesDropdown.empty.allNamespaces',

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -14,7 +14,10 @@ limitations under the License.
 import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import {
@@ -33,9 +36,15 @@ function PipelinesDropdown({
   webSocketConnected,
   ...rest
 }) {
-  useEffect(() => {
+  function fetchData() {
     fetchPipelines({ namespace });
-  }, [namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   const emptyText =
     namespace === ALL_NAMESPACES

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -14,7 +14,10 @@ limitations under the License.
 import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import {
@@ -33,9 +36,15 @@ function ServiceAccountsDropdown({
   webSocketConnected,
   ...rest
 }) {
-  useEffect(() => {
+  function fetchData() {
     fetchServiceAccounts({ namespace });
-  }, [namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   const emptyText =
     namespace === ALL_NAMESPACES

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { matchPath, NavLink } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
@@ -29,12 +29,12 @@ import {
 } from '@carbon/icons-react';
 import { ALL_NAMESPACES, urls } from '@tektoncd/dashboard-utils';
 
-import { selectNamespace } from '../../actions/namespaces';
+import { selectNamespace as selectNamespaceActionCreator } from '../../actions/namespaces';
 import {
   getExtensions,
   getSelectedNamespace,
-  isReadOnly,
-  isTriggersInstalled
+  isReadOnly as selectIsReadOnly,
+  isTriggersInstalled as selectIsTriggersInstalled
 } from '../../reducers';
 
 import { ReactComponent as KubernetesIcon } from '../../images/kubernetes.svg';
@@ -42,32 +42,27 @@ import { ReactComponent as TektonIcon } from '../../images/tekton-logo-20x20.svg
 
 import './SideNav.scss';
 
-class SideNav extends Component {
-  componentDidMount() {
-    const { match } = this.props;
+function SideNav(props) {
+  const {
+    expanded,
+    extensions,
+    intl,
+    isReadOnly,
+    isTriggersInstalled,
+    match,
+    selectNamespace,
+    showKubernetesResources
+  } = props;
+  const { namespace } = match?.params || {};
 
-    if (match && match.params.namespace) {
-      this.props.selectNamespace(match.params.namespace);
+  useEffect(() => {
+    if (namespace) {
+      selectNamespace(namespace);
     }
-  }
+  }, [namespace]);
 
-  componentDidUpdate(prevProps) {
-    const { match } = this.props;
-    if (!match) {
-      return;
-    }
-
-    const { namespace } = match.params;
-    const { match: prevMatch } = prevProps;
-    const prevNamespace = prevMatch && prevMatch.params.namespace;
-
-    if (namespace !== prevNamespace) {
-      this.props.selectNamespace(namespace);
-    }
-  }
-
-  getMenuItemProps(to) {
-    const { location } = this.props;
+  function getMenuItemProps(to) {
+    const { location } = props;
 
     return {
       element: NavLink,
@@ -78,8 +73,7 @@ class SideNav extends Component {
     };
   }
 
-  getPath(path, namespaced = true) {
-    const { namespace } = this.props;
+  function getPath(path, namespaced = true) {
     if (namespaced && namespace && namespace !== ALL_NAMESPACES) {
       return urls.byNamespace({ namespace, path });
     }
@@ -87,196 +81,172 @@ class SideNav extends Component {
     return path;
   }
 
-  render() {
-    const { expanded, extensions, intl, showKubernetesResources } = this.props;
+  return (
+    <CarbonSideNav
+      isFixedNav={expanded}
+      isRail={!expanded}
+      expanded={expanded}
+      isChildOfHeader={false}
+      aria-label="Main navigation"
+    >
+      <SideNavItems>
+        <SideNavMenu
+          defaultExpanded
+          renderIcon={TektonIcon}
+          title={intl.formatMessage({
+            id: 'dashboard.sideNav.tektonResources',
+            defaultMessage: 'Tekton resources'
+          })}
+        >
+          <SideNavMenuItem {...getMenuItemProps(getPath(urls.pipelines.all()))}>
+            Pipelines
+          </SideNavMenuItem>
+          <SideNavMenuItem
+            {...getMenuItemProps(getPath(urls.pipelineRuns.all()))}
+          >
+            PipelineRuns
+          </SideNavMenuItem>
+          <SideNavMenuItem
+            {...getMenuItemProps(getPath(urls.pipelineResources.all()))}
+          >
+            PipelineResources
+          </SideNavMenuItem>
+          <SideNavMenuItem {...getMenuItemProps(getPath(urls.tasks.all()))}>
+            Tasks
+          </SideNavMenuItem>
+          <SideNavMenuItem {...getMenuItemProps(urls.clusterTasks.all())}>
+            ClusterTasks
+          </SideNavMenuItem>
+          <SideNavMenuItem {...getMenuItemProps(getPath(urls.taskRuns.all()))}>
+            TaskRuns
+          </SideNavMenuItem>
+          <SideNavMenuItem
+            {...getMenuItemProps(getPath(urls.conditions.all()))}
+          >
+            Conditions
+          </SideNavMenuItem>
+          {isTriggersInstalled && (
+            <SideNavMenuItem
+              {...getMenuItemProps(getPath(urls.eventListeners.all()))}
+            >
+              EventListeners
+            </SideNavMenuItem>
+          )}
+          {isTriggersInstalled && (
+            <SideNavMenuItem
+              {...getMenuItemProps(getPath(urls.triggers.all()))}
+            >
+              Triggers
+            </SideNavMenuItem>
+          )}
+          {isTriggersInstalled && (
+            <SideNavMenuItem
+              {...getMenuItemProps(getPath(urls.triggerBindings.all()))}
+            >
+              TriggerBindings
+            </SideNavMenuItem>
+          )}
+          {isTriggersInstalled && (
+            <SideNavMenuItem
+              {...getMenuItemProps(urls.clusterTriggerBindings.all())}
+            >
+              ClusterTriggerBindings
+            </SideNavMenuItem>
+          )}
+          {isTriggersInstalled && (
+            <SideNavMenuItem
+              {...getMenuItemProps(getPath(urls.triggerTemplates.all()))}
+            >
+              TriggerTemplates
+            </SideNavMenuItem>
+          )}
+          {isTriggersInstalled && (
+            <SideNavMenuItem
+              {...getMenuItemProps(urls.clusterInterceptors.all())}
+            >
+              ClusterInterceptors
+            </SideNavMenuItem>
+          )}
+        </SideNavMenu>
 
-    return (
-      <CarbonSideNav
-        isFixedNav={expanded}
-        isRail={!expanded}
-        expanded={expanded}
-        isChildOfHeader={false}
-        aria-label="Main navigation"
-      >
-        <SideNavItems>
+        {showKubernetesResources && (
           <SideNavMenu
             defaultExpanded
-            renderIcon={TektonIcon}
+            renderIcon={KubernetesIcon}
             title={intl.formatMessage({
-              id: 'dashboard.sideNav.tektonResources',
-              defaultMessage: 'Tekton resources'
+              id: 'dashboard.sideNav.kubernetesResources',
+              defaultMessage: 'Kubernetes resources'
             })}
           >
-            <SideNavMenuItem
-              {...this.getMenuItemProps(this.getPath(urls.pipelines.all()))}
-            >
-              Pipelines
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              {...this.getMenuItemProps(this.getPath(urls.pipelineRuns.all()))}
-            >
-              PipelineRuns
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              {...this.getMenuItemProps(
-                this.getPath(urls.pipelineResources.all())
-              )}
-            >
-              PipelineResources
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              {...this.getMenuItemProps(this.getPath(urls.tasks.all()))}
-            >
-              Tasks
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              {...this.getMenuItemProps(urls.clusterTasks.all())}
-            >
-              ClusterTasks
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              {...this.getMenuItemProps(this.getPath(urls.taskRuns.all()))}
-            >
-              TaskRuns
-            </SideNavMenuItem>
-            <SideNavMenuItem
-              {...this.getMenuItemProps(this.getPath(urls.conditions.all()))}
-            >
-              Conditions
-            </SideNavMenuItem>
-            {this.props.isTriggersInstalled && (
-              <SideNavMenuItem
-                {...this.getMenuItemProps(
-                  this.getPath(urls.eventListeners.all())
-                )}
-              >
-                EventListeners
-              </SideNavMenuItem>
-            )}
-            {this.props.isTriggersInstalled && (
-              <SideNavMenuItem
-                {...this.getMenuItemProps(this.getPath(urls.triggers.all()))}
-              >
-                Triggers
-              </SideNavMenuItem>
-            )}
-            {this.props.isTriggersInstalled && (
-              <SideNavMenuItem
-                {...this.getMenuItemProps(
-                  this.getPath(urls.triggerBindings.all())
-                )}
-              >
-                TriggerBindings
-              </SideNavMenuItem>
-            )}
-            {this.props.isTriggersInstalled && (
-              <SideNavMenuItem
-                {...this.getMenuItemProps(urls.clusterTriggerBindings.all())}
-              >
-                ClusterTriggerBindings
-              </SideNavMenuItem>
-            )}
-            {this.props.isTriggersInstalled && (
-              <SideNavMenuItem
-                {...this.getMenuItemProps(
-                  this.getPath(urls.triggerTemplates.all())
-                )}
-              >
-                TriggerTemplates
-              </SideNavMenuItem>
-            )}
-            {this.props.isTriggersInstalled && (
-              <SideNavMenuItem
-                {...this.getMenuItemProps(urls.clusterInterceptors.all())}
-              >
-                ClusterInterceptors
-              </SideNavMenuItem>
+            placeholder
+          </SideNavMenu>
+        )}
+
+        {extensions.length > 0 && (
+          <SideNavMenu
+            defaultExpanded
+            renderIcon={ExtensionsIcon}
+            title={intl.formatMessage({
+              id: 'dashboard.extensions.title',
+              defaultMessage: 'Extensions'
+            })}
+          >
+            {extensions.map(
+              ({
+                apiGroup,
+                apiVersion,
+                displayName,
+                extensionType,
+                name,
+                namespaced
+              }) => {
+                const to =
+                  extensionType === 'kubernetes-resource'
+                    ? getPath(
+                        urls.kubernetesResources.all({
+                          group: apiGroup,
+                          version: apiVersion,
+                          type: name
+                        }),
+                        namespaced
+                      )
+                    : urls.extensions.byName({ name });
+                return (
+                  <SideNavMenuItem
+                    {...getMenuItemProps(to)}
+                    key={name}
+                    title={displayName}
+                  >
+                    {displayName}
+                  </SideNavMenuItem>
+                );
+              }
             )}
           </SideNavMenu>
+        )}
 
-          {showKubernetesResources && (
-            <SideNavMenu
-              defaultExpanded
-              renderIcon={KubernetesIcon}
-              title={intl.formatMessage({
-                id: 'dashboard.sideNav.kubernetesResources',
-                defaultMessage: 'Kubernetes resources'
-              })}
-            >
-              placeholder
-            </SideNavMenu>
-          )}
-
-          {extensions.length > 0 && (
-            <SideNavMenu
-              defaultExpanded
-              renderIcon={ExtensionsIcon}
-              title={intl.formatMessage({
-                id: 'dashboard.extensions.title',
-                defaultMessage: 'Extensions'
-              })}
-            >
-              {extensions.map(
-                ({
-                  apiGroup,
-                  apiVersion,
-                  displayName,
-                  extensionType,
-                  name,
-                  namespaced
-                }) => {
-                  const to =
-                    extensionType === 'kubernetes-resource'
-                      ? this.getPath(
-                          urls.kubernetesResources.all({
-                            group: apiGroup,
-                            version: apiVersion,
-                            type: name
-                          }),
-                          namespaced
-                        )
-                      : urls.extensions.byName({ name });
-                  return (
-                    <SideNavMenuItem
-                      {...this.getMenuItemProps(to)}
-                      key={name}
-                      title={displayName}
-                    >
-                      {displayName}
-                    </SideNavMenuItem>
-                  );
-                }
-              )}
-            </SideNavMenu>
-          )}
-
-          {!this.props.isReadOnly && (
-            <SideNavLink
-              element={NavLink}
-              renderIcon={ImportResourcesIcon}
-              to={urls.importResources()}
-            >
-              {intl.formatMessage({
-                id: 'dashboard.importResources.title',
-                defaultMessage: 'Import resources'
-              })}
-            </SideNavLink>
-          )}
-
+        {!isReadOnly && (
           <SideNavLink
             element={NavLink}
-            renderIcon={AboutIcon}
-            to={urls.about()}
+            renderIcon={ImportResourcesIcon}
+            to={urls.importResources()}
           >
             {intl.formatMessage({
-              id: 'dashboard.about.title',
-              defaultMessage: 'About'
+              id: 'dashboard.importResources.title',
+              defaultMessage: 'Import resources'
             })}
           </SideNavLink>
-        </SideNavItems>
-      </CarbonSideNav>
-    );
-  }
+        )}
+
+        <SideNavLink element={NavLink} renderIcon={AboutIcon} to={urls.about()}>
+          {intl.formatMessage({
+            id: 'dashboard.about.title',
+            defaultMessage: 'About'
+          })}
+        </SideNavLink>
+      </SideNavItems>
+    </CarbonSideNav>
+  );
 }
 
 SideNav.defaultProps = {
@@ -287,13 +257,13 @@ SideNav.defaultProps = {
 /* istanbul ignore next */
 const mapStateToProps = state => ({
   extensions: getExtensions(state),
-  isReadOnly: isReadOnly(state),
-  isTriggersInstalled: isTriggersInstalled(state),
+  isReadOnly: selectIsReadOnly(state),
+  isTriggersInstalled: selectIsTriggersInstalled(state),
   namespace: getSelectedNamespace(state)
 });
 
 const mapDispatchToProps = {
-  selectNamespace
+  selectNamespace: selectNamespaceActionCreator
 };
 
 export const SideNavWithIntl = injectIntl(SideNav);

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -137,7 +137,7 @@ it('SideNav selects namespace based on URL', () => {
   expect(selectNamespace).toHaveBeenCalledTimes(2);
 });
 
-it('SideNav renders import in not read-only mode', async () => {
+it('SideNav renders import in the default read-write mode', async () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
   const store = mockStore({
@@ -170,4 +170,20 @@ it('SideNav does not render import in read-only mode', async () => {
   );
   await waitFor(() => queryByText(/about/i));
   expect(queryByText(/import/i)).toBeFalsy();
+});
+
+it('SideNav renders kubernetes resources placeholder', async () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+  const store = mockStore({
+    extensions: { byName: {} },
+    namespaces: { byName: {} },
+    properties: {}
+  });
+  const { queryByText } = renderWithRouter(
+    <Provider store={store}>
+      <SideNavContainer location={{ search: '' }} showKubernetesResources />
+    </Provider>
+  );
+  await waitFor(() => queryByText('placeholder'));
 });

--- a/src/containers/TasksDropdown/TasksDropdown.js
+++ b/src/containers/TasksDropdown/TasksDropdown.js
@@ -14,7 +14,10 @@ limitations under the License.
 import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import {
@@ -33,9 +36,15 @@ function TasksDropdown({
   webSocketConnected,
   ...rest
 }) {
-  useEffect(() => {
+  function fetchData() {
     fetchTasks({ namespace });
-  }, [namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   const emptyText =
     namespace === ALL_NAMESPACES

--- a/src/containers/Trigger/Trigger.js
+++ b/src/containers/Trigger/Trigger.js
@@ -15,7 +15,7 @@ import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getTitle } from '@tektoncd/dashboard-utils';
+import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
 import {
   getSelectedNamespace,
@@ -46,9 +46,15 @@ export function TriggerContainer(props) {
     });
   }, []);
 
-  useEffect(() => {
+  function fetchData() {
     fetchTrigger({ name: triggerName, namespace });
-  }, [triggerName, namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [triggerName, namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   return (
     <ResourceDetails

--- a/src/containers/Triggers/Triggers.js
+++ b/src/containers/Triggers/Triggers.js
@@ -15,7 +15,12 @@ import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
-import { getFilters, getTitle, urls } from '@tektoncd/dashboard-utils';
+import {
+  getFilters,
+  getTitle,
+  urls,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
@@ -43,9 +48,15 @@ function Triggers(props) {
     document.title = getTitle({ page: 'Triggers' });
   }, []);
 
-  useEffect(() => {
+  function fetchData() {
     fetchTriggers({ filters, namespace });
-  }, [JSON.stringify(filters), namespace, webSocketConnected]);
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [JSON.stringify(filters), namespace]);
+
+  useWebSocketReconnected(fetchData, webSocketConnected);
 
   function getError() {
     if (error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
## NOTE: ignore whitespace for easier review

https://github.com/tektoncd/dashboard/issues/2000

Add a custom React hook that can be used to perform an action
when the websocket is reconnected (but not on initial connection).
This is useful in our containers so we can avoid refetching when
the websocket disconnects (default behaviour if we use `webSocketConnected`
as a dependency for `useEffect`).

This avoid unnecessary and unwanted requests while keeping the container
logic relatively simple. In future with `react-query` or similar libraries
we can easily change the central `useWebSocketReconnected` hook as needed
without having to update each container.

Continue refactoring containers to be functional components, using
the new hook as appropriate.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
