### PR TITLE
Add experimental support for dark mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* istanbul ignore file */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
@@ -31,6 +32,11 @@ function closeSocket() {
 const store = configureStore({ webSocket });
 
 store.dispatch(setLocale(navigator.language));
+
+const theme = localStorage.getItem('tkn-theme');
+if (['dark', 'system'].includes(theme)) {
+  document.body.classList.add(`tkn--theme-${theme}`);
+}
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/scss/_carbon.scss
+++ b/src/scss/_carbon.scss
@@ -24,13 +24,29 @@ $feature-flags: (
 );
 
 @import '~@carbon/themes/scss/themes';
+@import '~carbon-components/scss/globals/scss/component-tokens';
+@import '~carbon-components/scss/components/notification/tokens';
+@import '~carbon-components/scss/components/tag/tokens';
 
-:root {
+:root, .tkn--theme-light {
   @include carbon--theme($carbon--theme--g10, true);
 }
 
-body.tkn--dark-theme {
-  @include carbon--theme($carbon--theme--g90, true);
+@mixin tkn--theme-dark {
+  @include carbon--theme($carbon--theme--g90, true) {
+    @include emit-component-tokens($notification-colors);
+    @include emit-component-tokens($tag-colors);
+  };
+}
+
+.tkn--theme-dark {
+  @include tkn--theme-dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tkn--theme-system {
+    @include tkn--theme-dark;
+  }
 }
 
 @import '~carbon-components/scss/globals/scss/vars';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1713

Add experimental support for enabling dark mode display of the
Dashboard UI. This doesn't affect the header/nav which are already
using a dark presentation, but updates the rest of the UI to adopt
a dark look and feel using Carbon's gray 90 theme.

For this initial version, dark mode can be enabled by setting a flag
in local storage, e.g. `localStorage.setItem('tkn-theme', 'dark')`

Supported values are:
- `light` which is the default and current theme
- `dark` which enables the dark theme
- `system` which enables/disables dark theme according to the user's
  OS settings (uses the `prefers-color-scheme: dark` media query)

Preview:
![image](https://user-images.githubusercontent.com/2829095/117040965-5b67c800-ad02-11eb-84d5-c8857aef9efc.png)

There's some remaining work to test contrast etc. for accessibility before promoting this from experimental,
as well as deciding how (or if?) this should be configured by the user in the UI.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
