### PR TITLE
Remove noisy log on websocket error

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -34,9 +34,7 @@ const proxyOptions = {
     console.warn('webpack-dev-server proxy error:', err); // eslint-disable-line no-console
   },
   onProxyReqWs(proxyReq, req, socket, _options, _head) {
-    socket.on('error', function handleProxyWSError(err) {
-      console.warn('webpack-dev-server websocket proxy error:', err); // eslint-disable-line no-console
-    });
+    socket.on('error', function handleProxyWSError(_err) {});
   },
   secure: false,
   target: process.env.API_DOMAIN || API_DOMAIN,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Follow up to https://github.com/tektoncd/dashboard/pull/2014

websocket connection errors are being logged frequently, even in
the course of normal termination / reconnection flow, resulting
in unwanted noise in the dev server logs.

Disable the websocket error log but leave the handler so we catch
any otherwise fatal errors and prevent the dev server from crashing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
