### PR TITLE
Fix runtime error after delete cluster task

### DIFF
--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -128,7 +128,7 @@ function ClusterTasksContainer(props) {
     const resourcesById = keyBy(clusterTasks, 'metadata.uid');
     setShowDeleteModal(true);
     setToBeDeleted(selectedRows.map(({ id }) => resourcesById[id]));
-    setCancelSelection(handleCancelSelection);
+    setCancelSelection(() => handleCancelSelection);
   }
 
   const batchActionButtons = isReadOnly


### PR DESCRIPTION
# Changes

The error happens when the user clicks the delete button in confirm delete modal.
The reason is when opening the modal it set the callback directly to
`cancelSelection` via `setCancelSelection` but `React.useState` treat
that it must be return a new state value when passing a function to it.
To fix this issue, passing a function that returns a callback that wants
to set instead.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
