### PR TITLE
Update Ingress resources to stable version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -138,7 +138,7 @@ Assuming you have an [ingress controller](https://kubernetes.io/docs/concepts/se
 # the hostname should be setup to point to your ingress controller
 DASHBOARD_URL=dashboard.domain.tld
 kubectl apply -n tekton-pipelines -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tekton-dashboard
@@ -148,9 +148,12 @@ spec:
   - host: $DASHBOARD_URL
     http:
       paths:
-      - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
 EOF
 ```
 

--- a/docs/walkthrough/walkthrough-kind.md
+++ b/docs/walkthrough/walkthrough-kind.md
@@ -156,7 +156,7 @@ Assuming the following url `http://tekton-dashboard.127.0.0.1.nip.io`, run the f
 
 ```bash
 kubectl apply -n tekton-pipelines -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tekton-dashboard
@@ -165,9 +165,12 @@ spec:
   - host: tekton-dashboard.127.0.0.1.nip.io
     http:
       paths:
-      - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
 EOF
 ```
 

--- a/docs/walkthrough/walkthrough-logs.md
+++ b/docs/walkthrough/walkthrough-logs.md
@@ -306,7 +306,7 @@ spec:
   selector:
     app: logs-server
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tekton-logs
@@ -315,9 +315,12 @@ spec:
   - host: logs.127.0.0.1.nip.io
     http:
       paths:
-      - backend:
-          serviceName: logs-server
-          servicePort: 3000
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: logs-server
+            port:
+              number: 3000
 EOF
 ```
 

--- a/docs/walkthrough/walkthrough-oauth2-proxy.md
+++ b/docs/walkthrough/walkthrough-oauth2-proxy.md
@@ -122,7 +122,7 @@ To apply the ingress annotations run the command below:
 
 ```bash
 kubectl apply -n tekton-pipelines -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tekton-dashboard
@@ -134,9 +134,12 @@ spec:
   - host: tekton-dashboard.127.0.0.1.nip.io
     http:
       paths:
-      - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
 EOF
 ```
 

--- a/scripts/installer
+++ b/scripts/installer
@@ -328,7 +328,7 @@ ingress() {
 if [ ! -z "$INGRESS_URL" ] && [ ! -z "$INGRESS_SECRET" ]; then
 cat <<EOF >> $TMP_FILE
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tekton-dashboard
@@ -342,14 +342,17 @@ spec:
   - host: $INGRESS_URL
     http:
       paths:
-      - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
 EOF
 elif [ ! -z "$INGRESS_URL" ]; then
 cat <<EOF >> $TMP_FILE
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tekton-dashboard
@@ -359,9 +362,12 @@ spec:
   - host: $INGRESS_URL
     http:
       paths:
-      - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
 EOF
 fi
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Ingress has moved from `extensions/v1beta1` to `networking.k8s.io/v1`.
The old version is deprecated since kubernetes 1.14 and will be
unavailable in kubernetes 1.22 and later.

Update our docs and installer to use the new version.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
