### PR TITLE
Remove reference to the webhooks-extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -117,7 +117,6 @@ Well-known annotations are used to describe inner workings of the extension:
 Additionally, the Tekton Dashboard host will globally expose a few objects to let the extension's frontend code connect to these shared components (you can view the list of shared objects [here](../src/containers/Extension/globals.js)).
 
 The next section provides an example of developing a simple service based extension.
-You can also look at the [webhooks-extension](https://github.com/tektoncd/experimental/tree/main/webhooks-extension) to learn more about service based extensions.
 
 ### Example: Create a simple nodejs backend
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/experimental/issues/750

The webhooks-extension has been deprecated since August 2020 and is
now being deleted from the experimental repo.

Remove the reference to this extension from the docs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
