### PR TITLE
Update SideNav to hide when collapsed

### DIFF
--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -51,6 +51,11 @@ function SideNav(props) {
     selectNamespace,
     showKubernetesResources
   } = props;
+
+  if (!expanded) {
+    return null;
+  }
+
   const { namespace } = match?.params || {};
 
   useEffect(() => {
@@ -81,11 +86,10 @@ function SideNav(props) {
 
   return (
     <CarbonSideNav
-      isFixedNav={expanded}
-      isRail={!expanded}
-      expanded={expanded}
-      isChildOfHeader={false}
       aria-label="Main navigation"
+      expanded
+      isChildOfHeader={false}
+      isFixedNav
     >
       <SideNavItems>
         <SideNavMenu

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -20,6 +20,32 @@ import { renderWithRouter } from '@tektoncd/dashboard-components/src/utils/test'
 
 import SideNavContainer, { SideNavWithIntl as SideNav } from './SideNav';
 
+it('SideNav renders only when expanded', () => {
+  const namespace = 'default';
+  const selectNamespace = jest.fn();
+  const { queryByText, rerender } = renderWithRouter(
+    <SideNav
+      expanded
+      extensions={[]}
+      location={{ search: '' }}
+      match={{ params: { namespace } }}
+      selectNamespace={selectNamespace}
+    />
+  );
+  expect(queryByText(/Tekton/)).toBeTruthy();
+
+  renderWithRouter(
+    <SideNav
+      extensions={[]}
+      location={{ search: '' }}
+      match={{ params: { namespace } }}
+      selectNamespace={selectNamespace}
+    />,
+    { rerender }
+  );
+  expect(queryByText(/Tekton/)).toBeFalsy();
+});
+
 it('SideNav renders with extensions', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
@@ -54,7 +80,7 @@ it('SideNav renders with extensions', () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer location={{ search: '' }} />
+      <SideNavContainer expanded location={{ search: '' }} />
     </Provider>
   );
   expect(queryByText('Pipelines')).toBeTruthy();
@@ -76,7 +102,7 @@ it('SideNav renders with triggers', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer location={{ search: '' }} />
+      <SideNavContainer expanded location={{ search: '' }} />
     </Provider>
   );
   await waitFor(() => queryByText(/about/i));
@@ -88,50 +114,41 @@ it('SideNav renders with triggers', async () => {
 });
 
 it('SideNav selects namespace based on URL', () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-  const store = mockStore({
-    namespaces: { byName: {} },
-    properties: {}
-  });
   const namespace = 'default';
   const selectNamespace = jest.fn();
   const { rerender } = renderWithRouter(
-    <Provider store={store}>
-      <SideNav
-        extensions={[]}
-        location={{ search: '' }}
-        match={{ params: { namespace } }}
-        selectNamespace={selectNamespace}
-      />
-    </Provider>
+    <SideNav
+      expanded
+      extensions={[]}
+      location={{ search: '' }}
+      match={{ params: { namespace } }}
+      selectNamespace={selectNamespace}
+    />
   );
   expect(selectNamespace).toHaveBeenCalledWith(namespace);
 
   const updatedNamespace = 'another';
 
   renderWithRouter(
-    <Provider store={store}>
-      <SideNav
-        extensions={[]}
-        location={{ search: '' }}
-        match={{ params: { namespace: updatedNamespace } }}
-        selectNamespace={selectNamespace}
-      />
-    </Provider>,
+    <SideNav
+      expanded
+      extensions={[]}
+      location={{ search: '' }}
+      match={{ params: { namespace: updatedNamespace } }}
+      selectNamespace={selectNamespace}
+    />,
     { rerender }
   );
   expect(selectNamespace).toHaveBeenCalledWith(updatedNamespace);
 
   renderWithRouter(
-    <Provider store={store}>
-      <SideNav
-        extensions={[]}
-        location={{ search: '' }}
-        match={{ params: { namespace: updatedNamespace } }}
-        selectNamespace={selectNamespace}
-      />
-    </Provider>,
+    <SideNav
+      expanded
+      extensions={[]}
+      location={{ search: '' }}
+      match={{ params: { namespace: updatedNamespace } }}
+      selectNamespace={selectNamespace}
+    />,
     { rerender }
   );
   expect(selectNamespace).toHaveBeenCalledTimes(2);
@@ -147,7 +164,7 @@ it('SideNav renders import in the default read-write mode', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer location={{ search: '' }} />
+      <SideNavContainer expanded location={{ search: '' }} />
     </Provider>
   );
   await waitFor(() => queryByText(/Import/i));
@@ -165,7 +182,7 @@ it('SideNav does not render import in read-only mode', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer isReadOnly location={{ search: '' }} />
+      <SideNavContainer expanded isReadOnly location={{ search: '' }} />
     </Provider>
   );
   await waitFor(() => queryByText(/about/i));
@@ -182,7 +199,11 @@ it('SideNav renders kubernetes resources placeholder', async () => {
   });
   const { queryByText } = renderWithRouter(
     <Provider store={store}>
-      <SideNavContainer location={{ search: '' }} showKubernetesResources />
+      <SideNavContainer
+        expanded
+        location={{ search: '' }}
+        showKubernetesResources
+      />
     </Provider>
   );
   await waitFor(() => queryByText('placeholder'));


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Hide the SideNav when collapsed instead of displaying the rail on
the left of the window. The rail has a number of issues such as
inconsistent positioning of icons, unexpected behaviour when
NavMenus are expanded/collapsed, over-eager response to hover events,
and generally causes frustration when users are attempting to use it.

Update unit tests to account for the new behaviour while also
removing unnecessary use of the redux store in some tests.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
