### PR TITLE
Fix compilation error in EventListenerContainer section in Storybook

### DIFF
--- a/src/containers/EventListener/EventListener.stories.js
+++ b/src/containers/EventListener/EventListener.stories.js
@@ -120,6 +120,7 @@ const eventListener = {
 };
 const match = {
   params: {
+    namespace: 'foo',
     eventListenerName: 'my-eventlistener'
   }
 };


### PR DESCRIPTION
# Changes

It's compile error because `EventListener` container component requires
namespace in `match.params`. Fixes by adding namespace `foo` into
`match.params` in story file.

Closes #2057

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
