### PR TITLE
Add syntax highlight to ViewYAML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12661,6 +12661,7 @@
         "linkify-it": "^3.0.2",
         "prop-types": "^15.7.2",
         "react-intl-formatted-duration": "^4.0.0",
+        "react-syntax-highlighter": "^15.4.3",
         "react-window": "^1.8.6",
         "tlds": "^1.208.0"
       },
@@ -12793,6 +12794,18 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "optional": true
+        },
+        "react-syntax-highlighter": {
+          "version": "15.4.3",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz",
+          "integrity": "sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "^10.4.1",
+            "lowlight": "^1.17.0",
+            "prismjs": "^1.22.0",
+            "refractor": "^3.2.0"
+          }
         },
         "react-window": {
           "version": "1.8.6",
@@ -13193,7 +13206,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
       "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
-      "dev": true,
       "requires": {
         "@types/unist": "*"
       }
@@ -13496,8 +13508,7 @@
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-      "dev": true
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/webpack": {
       "version": "4.41.25",
@@ -15787,20 +15798,17 @@
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -16006,7 +16014,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
       "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
@@ -16236,8 +16243,7 @@
     "comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "dev": true
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "command-line-usage": {
       "version": "6.1.1",
@@ -17745,7 +17751,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
       "optional": true
     },
     "delegates": {
@@ -19469,7 +19474,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
       "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "dev": true,
       "requires": {
         "format": "^0.2.0"
       }
@@ -19870,8 +19874,7 @@
     "format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
-      "dev": true
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -20642,7 +20645,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
       "optional": true,
       "requires": {
         "delegate": "^3.1.2"
@@ -20896,8 +20898,7 @@
     "hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "dev": true
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
     },
     "hast-util-raw": {
       "version": "6.0.1",
@@ -20934,7 +20935,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
       "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -20952,8 +20952,7 @@
     "highlight.js": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.1.tgz",
-      "integrity": "sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA==",
-      "dev": true
+      "integrity": "sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA=="
     },
     "history": {
       "version": "4.10.1",
@@ -21766,14 +21765,12 @@
     "is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
     },
     "is-alphanumerical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -21870,8 +21867,7 @@
     "is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -21960,8 +21956,7 @@
     "is-hexadecimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-ip": {
       "version": "3.1.0",
@@ -24506,7 +24501,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
       "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
-      "dev": true,
       "requires": {
         "fault": "^1.0.0",
         "highlight.js": "~10.7.0"
@@ -24878,7 +24872,8 @@
           "dependencies": {
             "hosted-git-info": {
               "version": "2.8.8",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+              "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
               "dev": true
             },
             "normalize-package-data": {
@@ -26479,7 +26474,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -27110,7 +27104,6 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "dev": true,
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -27328,7 +27321,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "dev": true,
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -28436,7 +28428,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.1.tgz",
       "integrity": "sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==",
-      "dev": true,
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
@@ -29270,7 +29261,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
       "optional": true
     },
     "select-hose": {
@@ -29871,8 +29861,7 @@
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "dev": true
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -31543,7 +31532,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
       "optional": true
     },
     "tiny-invariant": {
@@ -33680,8 +33668,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,7 +4,12 @@
   "author": {
     "name": "The Tekton Authors"
   },
-  "keywords": ["tekton", "tektoncd", "components", "react"],
+  "keywords": [
+    "tekton",
+    "tektoncd",
+    "components",
+    "react"
+  ],
   "license": "Apache-2.0",
   "private": false,
   "main": "./dist/components/index.js",
@@ -25,6 +30,7 @@
     "linkify-it": "^3.0.2",
     "prop-types": "^15.7.2",
     "react-intl-formatted-duration": "^4.0.0",
+    "react-syntax-highlighter": "^15.4.3",
     "react-window": "^1.8.6",
     "tlds": "^1.208.0"
   },

--- a/packages/components/src/components/ViewYAML/ViewYAML.js
+++ b/packages/components/src/components/ViewYAML/ViewYAML.js
@@ -15,20 +15,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import jsYaml from 'js-yaml';
 import classNames from 'classnames';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 const ViewYAML = props => {
   const { className, dark, resource } = props;
 
   return (
-    <div
+    <SyntaxHighlighter
       className={classNames('bx--snippet--multi', className, {
         'tkn--view-yaml--dark': dark
       })}
+      codeTagProps={{}}
+      language="yaml"
+      useInlineStyles={false}
     >
-      <code>
-        <pre>{jsYaml.dump(resource)}</pre>
-      </code>
-    </div>
+      {jsYaml.dump(resource).trim()}
+    </SyntaxHighlighter>
   );
 };
 

--- a/packages/components/src/components/ViewYAML/ViewYAML.scss
+++ b/packages/components/src/components/ViewYAML/ViewYAML.scss
@@ -11,7 +11,116 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+$colors: (
+  "black": rgb(0, 0, 0),
+  "red": rgb(187, 0, 0),
+  "green": rgb(0, 187, 0),
+  "yellow": rgb(187, 187, 0),
+  "blue": rgb(85, 85, 255),
+  "magenta": rgb(187, 0, 187),
+  "cyan": rgb(0, 187, 187),
+  "white": rgb(187, 187, 187),
+
+  "bright-black": rgb(85, 85, 85),
+  "bright-red": rgb(255, 85, 85),
+  "bright-green": rgb(0, 255, 0),
+  "bright-yellow": rgb(255, 255, 85),
+  "bright-blue": rgb(136, 136, 255),
+  "bright-magenta": rgb(255, 85, 255),
+  "bright-cyan": rgb(85, 255, 255),
+  "bright-white": rgb(255, 255, 255)
+);
+
+// Light theme.
+.bx--snippet--multi {
+  .token.comment {
+    color: hsl(30, 20%, 50%);
+  }
+
+  .token.property,
+  .token.tag,
+  .token.boolean,
+  .token.number,
+  .token.constant,
+  .token.symbol {
+    color: hsl(350, 40%, 70%);
+  }
+
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.builtin,
+  .token.inserted {
+    // color: hsl(75, 70%, 60%);
+    color: rgb(0, 187, 0)
+  }
+
+  .token.operator,
+  .token.entity,
+  .token.url,
+  .language-css .token.string,
+  .style .token.string,
+  .token.variable {
+    color: hsl(40, 90%, 60%);
+  }
+
+  // .token.atrule,
+  // .token.attr-value,
+  // .token.keyword {
+  //   color: hsl(350, 40%, 70%);
+  // }
+
+  // .token.regex,
+  // .token.important {
+  //   color: #e90;
+  // }
+}
+
 .bx--snippet--multi.tkn--view-yaml--dark {
-  background-color: $gray-90; // TODO: $inverse-02 - see Log.scss
-  color: $gray-10;            //       $inverse-01
+  background-color: $inverse-02;
+  color: $inverse-01;
+
+  .token.comment {
+    color: hsl(30, 20%, 50%);
+  }
+
+  .token.property,
+  .token.tag,
+  .token.boolean,
+  .token.number,
+  .token.constant,
+  .token.symbol {
+    color: hsl(350, 40%, 70%);
+  }
+
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.builtin,
+  .token.inserted {
+    // color: hsl(75, 70%, 60%);
+    color: rgb(0, 187, 0)
+  }
+
+  .token.operator,
+  .token.entity,
+  .token.url,
+  .language-css .token.string,
+  .style .token.string,
+  .token.variable {
+    color: hsl(40, 90%, 60%);
+  }
+
+  // .token.atrule,
+  // .token.attr-value,
+  // .token.keyword {
+  //   color: hsl(350, 40%, 70%);
+  // }
+
+  // .token.regex,
+  // .token.important {
+  //   color: #e90;
+  // }
 }


### PR DESCRIPTION
# Changes

Replacing the current code tag with SyntaxHighlight from
react-syntax-highlight package. The SyntaxHighlight needs to set
codeTagProps to empty object to prevent SyntaxHighlight add inline
style. And add style in ViewYAML.scss to handle light & dark theme.

The code is still need to cleanup. Just open to see visibility and tweaking
color style.

Closes #1972

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
