### PR TITLE
Add offset to min-height to prevent layout shift

### DIFF
--- a/packages/components/src/components/LabelFilter/LabelFilter.scss
+++ b/packages/components/src/components/LabelFilter/LabelFilter.scss
@@ -21,7 +21,8 @@ limitations under the License.
     flex-wrap: wrap;
     align-items: baseline;
 
-    min-height: calc(#{$spacing-08} + #{$button-border-width});
+    // NOTE: add offset to min-height to prevent layout shift.
+    min-height: calc(#{$spacing-08} + #{$button-border-width} + 2px);
     margin-bottom: calc(#{$spacing-05} - #{$button-border-width});
 
     .bx--tag {


### PR DESCRIPTION
# Changes

Label filter seems quite bigger than before. Add offset to min-height in
tkn--filters to prevent layout shift.

Closes #2050

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
