### PR TITLE
Update websocket payload format

### DIFF
--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -18,67 +18,18 @@ import (
 	"sync"
 )
 
-type MessageType string
+type Operation string
 
-// Reference outside of package
 const (
-	Log                          MessageType = "Log"
-	NamespaceCreated             MessageType = "NamespaceCreated"
-	NamespaceUpdated             MessageType = "NamespaceUpdated"
-	NamespaceDeleted             MessageType = "NamespaceDeleted"
-	PipelineCreated              MessageType = "PipelineCreated"
-	PipelineDeleted              MessageType = "PipelineDeleted"
-	PipelineUpdated              MessageType = "PipelineUpdated"
-	ClusterTaskCreated           MessageType = "ClusterTaskCreated"
-	ClusterTaskDeleted           MessageType = "ClusterTaskDeleted"
-	ClusterTaskUpdated           MessageType = "ClusterTaskUpdated"
-	TaskCreated                  MessageType = "TaskCreated"
-	TaskDeleted                  MessageType = "TaskDeleted"
-	TaskUpdated                  MessageType = "TaskUpdated"
-	PipelineResourceCreated      MessageType = "PipelineResourceCreated"
-	PipelineResourceDeleted      MessageType = "PipelineResourceDeleted"
-	PipelineResourceUpdated      MessageType = "PipelineResourceUpdated"
-	PipelineRunCreated           MessageType = "PipelineRunCreated"
-	PipelineRunDeleted           MessageType = "PipelineRunDeleted"
-	PipelineRunUpdated           MessageType = "PipelineRunUpdated"
-	TaskRunCreated               MessageType = "TaskRunCreated"
-	TaskRunDeleted               MessageType = "TaskRunDeleted"
-	TaskRunUpdated               MessageType = "TaskRunUpdated"
-	ConditionCreated             MessageType = "ConditionCreated"
-	ConditionDeleted             MessageType = "ConditionDeleted"
-	ConditionUpdated             MessageType = "ConditionUpdated"
-	ResourceExtensionCreated     MessageType = "ResourceExtensionCreated"
-	ResourceExtensionUpdated     MessageType = "ResourceExtensionUpdated"
-	ResourceExtensionDeleted     MessageType = "ResourceExtensionDeleted"
-	ServiceExtensionCreated      MessageType = "ServiceExtensionCreated"
-	ServiceExtensionUpdated      MessageType = "ServiceExtensionUpdated"
-	ServiceExtensionDeleted      MessageType = "ServiceExtensionDeleted"
-	ServiceAccountCreated        MessageType = "ServiceAccountCreated"
-	ServiceAccountDeleted        MessageType = "ServiceAccountDeleted"
-	ServiceAccountUpdated        MessageType = "ServiceAccountUpdated"
-	TriggerCreated               MessageType = "TriggerCreated"
-	TriggerDeleted               MessageType = "TriggerDeleted"
-	TriggerUpdated               MessageType = "TriggerUpdated"
-	TriggerBindingCreated        MessageType = "TriggerBindingCreated"
-	TriggerBindingDeleted        MessageType = "TriggerBindingDeleted"
-	TriggerBindingUpdated        MessageType = "TriggerBindingUpdated"
-	ClusterInterceptorCreated    MessageType = "ClusterInterceptorCreated"
-	ClusterInterceptorDeleted    MessageType = "ClusterInterceptorDeleted"
-	ClusterInterceptorUpdated    MessageType = "ClusterInterceptorUpdated"
-	ClusterTriggerBindingCreated MessageType = "ClusterTriggerBindingCreated"
-	ClusterTriggerBindingDeleted MessageType = "ClusterTriggerBindingDeleted"
-	ClusterTriggerBindingUpdated MessageType = "ClusterTriggerBindingUpdated"
-	TriggerTemplateCreated       MessageType = "TriggerTemplateCreated"
-	TriggerTemplateDeleted       MessageType = "TriggerTemplateDeleted"
-	TriggerTemplateUpdated       MessageType = "TriggerTemplateUpdated"
-	EventListenerCreated         MessageType = "EventListenerCreated"
-	EventListenerDeleted         MessageType = "EventListenerDeleted"
-	EventListenerUpdated         MessageType = "EventListenerUpdated"
+	Created Operation = "Created"
+	Deleted Operation = "Deleted"
+	Updated Operation = "Updated"
 )
 
 type SocketData struct {
-	MessageType MessageType
-	Payload     interface{}
+	Kind      string      `json:"kind"`
+	Operation Operation   `json:"operation"`
+	Payload   interface{} `json:"payload"`
 }
 
 // Only a pointer to the struct should be used

--- a/pkg/controllers/dashboard/extension.go
+++ b/pkg/controllers/dashboard/extension.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,23 +14,17 @@ limitations under the License.
 package dashboard
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	dashboardinformer "github.com/tektoncd/dashboard/pkg/client/informers/externalversions"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/logging"
 )
 
-// NewNamespaceController registers the K8s shared informer that reacts to
-// create and delete events for namespaces
 func NewExtensionController(sharedDashboardInformerFactory dashboardinformer.SharedInformerFactory) {
 	logging.Log.Debug("In NewExtensionController")
 
 	utils.NewController(
-		"Extension",
+		"ResourceExtension",
 		sharedDashboardInformerFactory.Dashboard().V1alpha1().Extensions().Informer(),
-		broadcaster.ResourceExtensionCreated,
-		broadcaster.ResourceExtensionUpdated,
-		broadcaster.ResourceExtensionDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/kubernetes/extension.go
+++ b/pkg/controllers/kubernetes/extension.go
@@ -1,3 +1,15 @@
+/*
+Copyright 2019-2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package kubernetes
 
 import (
@@ -40,8 +52,9 @@ func (e extensionHandler) serviceCreated(obj interface{}) {
 		logging.Log.Debugf("Extension Controller detected extension '%s' created", service.Name)
 		ext := e.RegisterExtension(service)
 		data := broadcaster.SocketData{
-			MessageType: broadcaster.ServiceExtensionCreated,
-			Payload:     ext,
+			Kind:      "ServiceExtension",
+			Operation: broadcaster.Created,
+			Payload:   ext,
 		}
 		endpoints.ResourcesChannel <- data
 	}
@@ -72,20 +85,23 @@ func (e extensionHandler) serviceUpdated(oldObj, newObj interface{}) {
 		switch event {
 		case "delete": // Service has removed the extension label
 			data := broadcaster.SocketData{
-				MessageType: broadcaster.ServiceExtensionDeleted,
-				Payload:     ext,
+				Kind:      "ServiceExtension",
+				Operation: broadcaster.Deleted,
+				Payload:   ext,
 			}
 			endpoints.ResourcesChannel <- data
 		case "create": // Service has added the extension label
 			data := broadcaster.SocketData{
-				MessageType: broadcaster.ServiceExtensionCreated,
-				Payload:     ext,
+				Kind:      "ServiceExtension",
+				Operation: broadcaster.Created,
+				Payload:   ext,
 			}
 			endpoints.ResourcesChannel <- data
 		case "update": // Extension service was modified
 			data := broadcaster.SocketData{
-				MessageType: broadcaster.ServiceExtensionUpdated,
-				Payload:     ext,
+				Kind:      "ServiceExtension",
+				Operation: broadcaster.Updated,
+				Payload:   ext,
 			}
 			endpoints.ResourcesChannel <- data
 		}
@@ -99,8 +115,9 @@ func (e extensionHandler) serviceDeleted(obj interface{}) {
 		if serviceMeta.GetUID() != "" {
 			ext := e.UnregisterExtensionByMeta(serviceMeta)
 			data := broadcaster.SocketData{
-				MessageType: broadcaster.ServiceExtensionDeleted,
-				Payload:     ext,
+				Kind:      "ServiceExtension",
+				Operation: broadcaster.Deleted,
+				Payload:   ext,
 			}
 			endpoints.ResourcesChannel <- data
 		}

--- a/pkg/controllers/kubernetes/namespaces.go
+++ b/pkg/controllers/kubernetes/namespaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/logging"
 	k8sinformer "k8s.io/client-go/informers"
@@ -28,9 +27,6 @@ func NewNamespaceController(sharedK8sInformerFactory k8sinformer.SharedInformerF
 	utils.NewController(
 		"Namespace",
 		sharedK8sInformerFactory.Core().V1().Namespaces().Informer(),
-		broadcaster.NamespaceCreated,
-		broadcaster.NamespaceUpdated,
-		broadcaster.NamespaceDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/kubernetes/serviceAccount.go
+++ b/pkg/controllers/kubernetes/serviceAccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	"github.com/tektoncd/dashboard/pkg/logging"
 	k8sinformer "k8s.io/client-go/informers"
@@ -28,9 +27,6 @@ func NewServiceAccountController(sharedK8sInformerFactory k8sinformer.SharedInfo
 	utils.NewController(
 		"ServiceAccount",
 		sharedK8sInformerFactory.Core().V1().ServiceAccounts().Informer(),
-		broadcaster.ServiceAccountCreated,
-		broadcaster.ServiceAccountUpdated,
-		broadcaster.ServiceAccountDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/clustertask.go
+++ b/pkg/controllers/tekton/clustertask.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewClusterTaskController(sharedInformerFactory dynamicinformer.DynamicShare
 	utils.NewController(
 		"ClusterTask",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.ClusterTaskCreated,
-		broadcaster.ClusterTaskUpdated,
-		broadcaster.ClusterTaskDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/condition.go
+++ b/pkg/controllers/tekton/condition.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewConditionController(sharedInformerFactory dynamicinformer.DynamicSharedI
 	utils.NewController(
 		"Condition",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.ConditionCreated,
-		broadcaster.ConditionUpdated,
-		broadcaster.ConditionDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/pipeline.go
+++ b/pkg/controllers/tekton/pipeline.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewPipelineController(sharedInformerFactory dynamicinformer.DynamicSharedIn
 	utils.NewController(
 		"Pipeline",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.PipelineCreated,
-		broadcaster.PipelineUpdated,
-		broadcaster.PipelineDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/pipelineresource.go
+++ b/pkg/controllers/tekton/pipelineresource.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewPipelineResourceController(sharedInformerFactory dynamicinformer.Dynamic
 	utils.NewController(
 		"PipelineResource",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.PipelineResourceCreated,
-		broadcaster.PipelineResourceUpdated,
-		broadcaster.PipelineResourceDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/pipelinerun.go
+++ b/pkg/controllers/tekton/pipelinerun.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewPipelineRunController(sharedInformerFactory dynamicinformer.DynamicShare
 	utils.NewController(
 		"PipelineRun",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.PipelineRunCreated,
-		broadcaster.PipelineRunUpdated,
-		broadcaster.PipelineRunDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/task.go
+++ b/pkg/controllers/tekton/task.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewTaskController(sharedInformerFactory dynamicinformer.DynamicSharedInform
 	utils.NewController(
 		"Task",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.TaskCreated,
-		broadcaster.TaskUpdated,
-		broadcaster.TaskDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/tekton/taskrun.go
+++ b/pkg/controllers/tekton/taskrun.go
@@ -14,7 +14,6 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewTaskRunController(sharedInformerFactory dynamicinformer.DynamicSharedInf
 	utils.NewController(
 		"TaskRun",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.TaskRunCreated,
-		broadcaster.TaskRunUpdated,
-		broadcaster.TaskRunDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/triggers/clusterInterceptor.go
+++ b/pkg/controllers/triggers/clusterInterceptor.go
@@ -14,7 +14,6 @@ limitations under the License.
 package triggers
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewClusterInterceptorController(sharedInformerFactory dynamicinformer.Dynam
 	utils.NewController(
 		"ClusterInterceptor",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.ClusterInterceptorCreated,
-		broadcaster.ClusterInterceptorUpdated,
-		broadcaster.ClusterInterceptorDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/triggers/clusterTriggerBinding.go
+++ b/pkg/controllers/triggers/clusterTriggerBinding.go
@@ -14,7 +14,6 @@ limitations under the License.
 package triggers
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewClusterTriggerBindingController(sharedInformerFactory dynamicinformer.Dy
 	utils.NewController(
 		"ClusterTriggerBinding",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.ClusterTriggerBindingCreated,
-		broadcaster.ClusterTriggerBindingUpdated,
-		broadcaster.ClusterTriggerBindingDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/triggers/eventListener.go
+++ b/pkg/controllers/triggers/eventListener.go
@@ -14,7 +14,6 @@ limitations under the License.
 package triggers
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewEventListenerController(sharedInformerFactory dynamicinformer.DynamicSha
 	utils.NewController(
 		"EventListener",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.EventListenerCreated,
-		broadcaster.EventListenerUpdated,
-		broadcaster.EventListenerDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/triggers/trigger.go
+++ b/pkg/controllers/triggers/trigger.go
@@ -14,7 +14,6 @@ limitations under the License.
 package triggers
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewTriggerController(sharedInformerFactory dynamicinformer.DynamicSharedInf
 	utils.NewController(
 		"Trigger",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.TriggerCreated,
-		broadcaster.TriggerUpdated,
-		broadcaster.TriggerDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/triggers/triggerBinding.go
+++ b/pkg/controllers/triggers/triggerBinding.go
@@ -14,7 +14,6 @@ limitations under the License.
 package triggers
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewTriggerBindingController(sharedInformerFactory dynamicinformer.DynamicSh
 	utils.NewController(
 		"TriggerBinding",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.TriggerBindingCreated,
-		broadcaster.TriggerBindingUpdated,
-		broadcaster.TriggerBindingDeleted,
 		nil,
 	)
 }

--- a/pkg/controllers/triggers/triggerTemplate.go
+++ b/pkg/controllers/triggers/triggerTemplate.go
@@ -14,7 +14,6 @@ limitations under the License.
 package triggers
 
 import (
-	"github.com/tektoncd/dashboard/pkg/broadcaster"
 	"github.com/tektoncd/dashboard/pkg/controllers/utils"
 	logging "github.com/tektoncd/dashboard/pkg/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,9 +32,6 @@ func NewTriggerTemplateController(sharedInformerFactory dynamicinformer.DynamicS
 	utils.NewController(
 		"TriggerTemplate",
 		sharedInformerFactory.ForResource(gvr).Informer(),
-		broadcaster.TriggerTemplateCreated,
-		broadcaster.TriggerTemplateUpdated,
-		broadcaster.TriggerTemplateDeleted,
 		nil,
 	)
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -93,7 +93,7 @@ func DummyServer() (*httptest.Server, *endpoints.Resource, string) {
 		case <-timeout:
 			logging.Log.Fatalf("Namespace informer did not detect installNamespace by deadline")
 		case event := <-subscriber.SubChan():
-			if event.MessageType == broadcaster.NamespaceCreated {
+			if event.Kind == "Namespace" && event.Operation == broadcaster.Created {
 				goto NamespaceDetected
 			}
 		}

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -26,8 +26,8 @@ export function createWebSocketMiddleware(socket) {
       if (event.type !== 'message') {
         return;
       }
-      const message = JSON.parse(event.data);
-      dispatch({ type: message.MessageType, payload: message.Payload });
+      const { kind, operation, payload } = JSON.parse(event.data);
+      dispatch({ type: kind + operation, payload });
     });
     return next => action => next(action);
   };


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
More preparation for https://github.com/tektoncd/dashboard/issues/1842

Split the `MessageType` field into two separate fields:
- Kind: the resource kind
- Operation: one of 'Created', 'Deleted', or 'Updated'

This will make it much easier to handle websocket events
more locally at a page level, especially when dealing
with the react-query cache.

In future we may split the websocket stream so pages
can subscribe to updates for specific resources / kinds
instead of receiving all events for all supported kinds.
split websocket MessageType field

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
