### PR TITLE
Rename renderWithIntl to render

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 
 import DetailsHeader from './DetailsHeader';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 const props = {
   displayName: 'test name'
@@ -22,47 +22,47 @@ const props = {
 
 describe('DetailsHeader', () => {
   it('renders the provided content', () => {
-    const { queryByText } = renderWithIntl(<DetailsHeader {...props} />);
+    const { queryByText } = render(<DetailsHeader {...props} />);
     expect(queryByText(/test name/i)).toBeTruthy();
   });
 
   it('renders the running state', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} status="running" />
     );
     expect(queryByText(/running/i)).toBeTruthy();
   });
 
   it('renders the completed state', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} status="terminated" reason="Completed" />
     );
     expect(queryByText(/completed/i)).toBeTruthy();
   });
 
   it('renders the cancelled state', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} status="cancelled" />
     );
     expect(queryByText(/Cancelled/i)).toBeTruthy();
   });
 
   it('renders the cancelled state for TaskRunCancelled', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} status="terminated" reason="TaskRunCancelled" />
     );
     expect(queryByText(/Cancelled/i)).toBeTruthy();
   });
 
   it('renders the cancelled state for TaskRunTimeout', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} status="terminated" reason="TaskRunTimeout" />
     );
     expect(queryByText(/Cancelled/i)).toBeTruthy();
   });
 
   it('renders the failed state', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} status="terminated" />
     );
     expect(queryByText(/failed/i)).toBeTruthy();
@@ -81,7 +81,7 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} taskRun={taskRun} />
     );
     expect(queryByText(/waiting/i)).toBeTruthy();
@@ -100,7 +100,7 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} taskRun={taskRun} type="taskRun" />
     );
     expect(queryByText(/pending/i)).toBeTruthy();
@@ -113,7 +113,7 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} stepStatus={stepStatus} />
     );
     expect(queryByText(/duration/i)).toBeFalsy();
@@ -128,7 +128,7 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} stepStatus={stepStatus} />
     );
     expect(queryByText(/duration/i)).toBeTruthy();
@@ -140,7 +140,7 @@ describe('DetailsHeader', () => {
       waiting: {}
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} stepStatus={stepStatus} />
     );
     expect(queryByText(/duration/i)).toBeFalsy();
@@ -162,7 +162,7 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <DetailsHeader {...props} taskRun={taskRun} type="taskRun" />
     );
     expect(queryByText(/duration/i)).toBeTruthy();

--- a/packages/components/src/components/ErrorBoundary/ErrorBoundary.test.js
+++ b/packages/components/src/components/ErrorBoundary/ErrorBoundary.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,12 +12,12 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 import ErrorBoundary from './ErrorBoundary';
 
 it('ErrorBoundary renders children', () => {
-  const { queryByText } = renderWithIntl(
+  const { queryByText } = render(
     <ErrorBoundary>
       <span>hello</span>
     </ErrorBoundary>
@@ -30,7 +30,7 @@ it('ErrorBoundary renders the error message', () => {
     throw new Error();
   }
   jest.spyOn(console, 'error').mockImplementation(() => {}); // suppress error log from test output
-  const { queryByText } = renderWithIntl(
+  const { queryByText } = render(
     <ErrorBoundary>
       <Bomb />
     </ErrorBoundary>

--- a/packages/components/src/components/FormattedDate/FormattedDate.test.js
+++ b/packages/components/src/components/FormattedDate/FormattedDate.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,17 +12,17 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import FormattedDate from './FormattedDate';
 
 describe('FormattedDate', () => {
   it('handles missing props', () => {
-    const { container } = renderWithIntl(<FormattedDate />);
+    const { container } = render(<FormattedDate />);
     expect(container.firstChild).toBeNull();
   });
 
   it('handles absolute date formatting', () => {
-    const { queryByText } = renderWithIntl(<FormattedDate date="2019/12/01" />);
+    const { queryByText } = render(<FormattedDate date="2019/12/01" />);
     expect(queryByText(/December 1, 2019/i)).toBeTruthy();
   });
 
@@ -30,7 +30,7 @@ describe('FormattedDate', () => {
     if (!Intl.RelativeTimeFormat) {
       Intl.RelativeTimeFormat = {};
     }
-    const { container, queryByText } = renderWithIntl(
+    const { container, queryByText } = render(
       <FormattedDate date="2019/12/01" relative />
     );
     expect(container.firstChild).not.toBeNull();

--- a/packages/components/src/components/FormattedDuration/FormattedDuration.test.js
+++ b/packages/components/src/components/FormattedDuration/FormattedDuration.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,18 +12,18 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import FormattedDuration from './FormattedDuration';
 
 describe('FormattedDuration', () => {
   it('renders the duration and handles updates', () => {
-    const { getByText, getByTitle, rerender } = renderWithIntl(
+    const { getByText, getByTitle, rerender } = render(
       <FormattedDuration milliseconds={1000} />
     );
     expect(getByText(/1 second/i)).toBeTruthy();
     expect(getByTitle(/1 second/i)).toBeTruthy();
 
-    renderWithIntl(<FormattedDuration milliseconds={2000} />, { rerender });
+    render(<FormattedDuration milliseconds={2000} />, { rerender });
     expect(getByText(/2 seconds/i)).toBeTruthy();
     expect(getByTitle(/2 seconds/i)).toBeTruthy();
   });

--- a/packages/components/src/components/KeyValueList/KeyValueList.test.js
+++ b/packages/components/src/components/KeyValueList/KeyValueList.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import KeyValueList from './KeyValueList';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 it('KeyValueList shows blank fields', () => {
   const props = {
@@ -29,7 +29,7 @@ it('KeyValueList shows blank fields', () => {
     onAdd() {},
     onRemove() {}
   };
-  const { getAllByDisplayValue, getByText } = renderWithIntl(
+  const { getAllByDisplayValue, getByText } = render(
     <KeyValueList {...props} />
   );
 
@@ -56,7 +56,7 @@ it('KeyValueList incorrect fields', () => {
     onAdd() {},
     onRemove() {}
   };
-  const { getByDisplayValue } = renderWithIntl(<KeyValueList {...props} />);
+  const { getByDisplayValue } = render(<KeyValueList {...props} />);
 
   const annotationKey0 = getByDisplayValue(props.keyValues[0].key);
   const annotationKey1 = getByDisplayValue(props.keyValues[1].key);
@@ -85,7 +85,7 @@ it('KeyValueList change key', () => {
     onAdd() {},
     onRemove() {}
   };
-  const { getByDisplayValue } = renderWithIntl(<KeyValueList {...props} />);
+  const { getByDisplayValue } = render(<KeyValueList {...props} />);
 
   fireEvent.change(getByDisplayValue(/foo0/i), {
     target: { value: 'new key 0' }
@@ -107,7 +107,7 @@ it('KeyValueList change value', () => {
     onAdd() {},
     onRemove() {}
   };
-  const { getByDisplayValue } = renderWithIntl(<KeyValueList {...props} />);
+  const { getByDisplayValue } = render(<KeyValueList {...props} />);
 
   fireEvent.change(getByDisplayValue(/bar0/i), {
     target: { value: 'new value 0' }
@@ -134,9 +134,7 @@ it('KeyValueList add and remove buttons work', () => {
     onAdd: jest.fn(),
     onRemove: jest.fn()
   };
-  const { getByText, getAllByText } = renderWithIntl(
-    <KeyValueList {...props} />
-  );
+  const { getByText, getAllByText } = render(<KeyValueList {...props} />);
 
   const addButton = getByText(/Add/i);
 

--- a/packages/components/src/components/LabelFilter/LabelFilter.test.js
+++ b/packages/components/src/components/LabelFilter/LabelFilter.test.js
@@ -15,17 +15,17 @@ import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 
 import LabelFilter from './LabelFilter';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 it('LabelFilter renders', () => {
   const filter = 'tekton.dev/pipeline=demo-pipeline';
-  const { queryByText } = renderWithIntl(<LabelFilter filters={[filter]} />);
+  const { queryByText } = render(<LabelFilter filters={[filter]} />);
   expect(queryByText(/Input a label filter/i)).not.toBeNull();
   expect(queryByText(filter.replace('=', ':'))).not.toBeNull();
 });
 
 it('LabelFilter renders error on empty filter', () => {
-  const { getByText, queryByText } = renderWithIntl(<LabelFilter />);
+  const { getByText, queryByText } = render(<LabelFilter />);
   fireEvent.submit(getByText(/Input a label filter/i));
   expect(queryByText(/filters must be/i)).not.toBeNull();
 });
@@ -33,7 +33,7 @@ it('LabelFilter renders error on empty filter', () => {
 it('LabelFilter handles adding a filter', () => {
   const filter = 'app:test';
   const handleAddFilter = jest.fn();
-  const { getByPlaceholderText, getByText } = renderWithIntl(
+  const { getByPlaceholderText, getByText } = render(
     <LabelFilter handleAddFilter={handleAddFilter} />
   );
   fireEvent.change(getByPlaceholderText(/input a label filter/i), {
@@ -47,12 +47,9 @@ it('LabelFilter displays notification if character length is over 63 characters 
   const filter =
     'app:1234567890123456789012345678901234567890123456789012345678901234';
   const handleAddFilter = jest.fn();
-  const {
-    getByPlaceholderText,
-    getByText,
-    getByTitle,
-    queryByText
-  } = renderWithIntl(<LabelFilter handleAddFilter={handleAddFilter} />);
+  const { getByPlaceholderText, getByText, getByTitle, queryByText } = render(
+    <LabelFilter handleAddFilter={handleAddFilter} />
+  );
   fireEvent.change(getByPlaceholderText(/input a label filter/i), {
     target: { value: filter }
   });
@@ -75,12 +72,7 @@ it('LabelFilter handles adding a duplicate filter', async () => {
   const filter = 'app=test';
   const filterDisplayValue = 'app:test';
   const handleAddFilter = jest.fn();
-  const {
-    getByPlaceholderText,
-    getByText,
-    getByTitle,
-    queryByText
-  } = renderWithIntl(
+  const { getByPlaceholderText, getByText, getByTitle, queryByText } = render(
     <LabelFilter filters={[filter]} handleAddFilter={handleAddFilter} />
   );
   fireEvent.change(getByPlaceholderText(/input a label filter/i), {
@@ -96,7 +88,7 @@ it('LabelFilter handles adding a duplicate filter', async () => {
 it('LabelFilter handles deleting a filter', () => {
   const filter = 'tekton.dev/pipeline=demo-pipeline';
   const handleDeleteFilter = jest.fn();
-  const { getByText } = renderWithIntl(
+  const { getByText } = render(
     <LabelFilter filters={[filter]} handleDeleteFilter={handleDeleteFilter} />
   );
   fireEvent.click(getByText(filter.replace('=', ':')));
@@ -106,7 +98,7 @@ it('LabelFilter handles deleting a filter', () => {
 it('LabelFilter handles clearing all filters', () => {
   const filter = 'tekton.dev/pipeline=demo-pipeline';
   const handleClearFilters = jest.fn();
-  const { getByText } = renderWithIntl(
+  const { getByText } = render(
     <LabelFilter filters={[filter]} handleClearFilters={handleClearFilters} />
   );
   fireEvent.click(getByText(/clear all/i));

--- a/packages/components/src/components/Log/Log.test.js
+++ b/packages/components/src/components/Log/Log.test.js
@@ -14,16 +14,16 @@ limitations under the License.
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import Log from './Log';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 describe('Log', () => {
   it('renders default content', async () => {
-    const { getByText } = renderWithIntl(<Log fetchLogs={() => undefined} />);
+    const { getByText } = render(<Log fetchLogs={() => undefined} />);
     await waitFor(() => getByText(/No log available/i));
   });
 
   it('renders the provided content', async () => {
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() => 'testing'}
@@ -33,7 +33,7 @@ describe('Log', () => {
   });
 
   it('renders trailer', async () => {
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() => 'testing'}
@@ -43,7 +43,7 @@ describe('Log', () => {
   });
 
   it('renders error trailer', async () => {
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Error' } }}
         fetchLogs={() => 'testing'}
@@ -57,7 +57,7 @@ describe('Log', () => {
       { length: 60000 },
       (v, i) => `Line ${i + 1}\n`
     ).join('');
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() => long}
@@ -68,7 +68,7 @@ describe('Log', () => {
   });
 
   it('renders the provided content when streaming logs', async () => {
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() =>
@@ -91,7 +91,7 @@ describe('Log', () => {
   });
 
   it('renders trailer when streaming logs', async () => {
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Completed' } }}
         fetchLogs={() =>
@@ -114,7 +114,7 @@ describe('Log', () => {
   });
 
   it('renders error trailer when streaming logs', async () => {
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Log
         stepStatus={{ terminated: { reason: 'Error' } }}
         fetchLogs={() =>

--- a/packages/components/src/components/LogFormat/LogFormat.test.js
+++ b/packages/components/src/components/LogFormat/LogFormat.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,11 +12,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import LogFormat from './LogFormat';
 
 const getElement = (text, query) => {
-  const { queryByText } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+  const { queryByText } = render(<LogFormat>{text}</LogFormat>);
   const queryRegex = new RegExp(query, 'i');
   return queryByText(queryRegex);
 };
@@ -256,7 +256,7 @@ describe('LogFormat', () => {
 
   it('converts new lines as line breaks', () => {
     const text = 'Hello\n\nWorld';
-    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    const { container } = render(<LogFormat>{text}</LogFormat>);
     expect(container.childNodes[0].innerHTML).toBe(
       '<div>Hello</div><br><div>World</div>'
     );
@@ -265,19 +265,19 @@ describe('LogFormat', () => {
   it('separates text by new lines', () => {
     const text =
       'Hello World\nA dashboard for Tekton! https://github.com/tektoncd/dashboard\nTekon is cool!';
-    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    const { container } = render(<LogFormat>{text}</LogFormat>);
     expect(container.childNodes[0].childNodes).toHaveLength(3);
   });
 
   it('separates text by new lines and carriage returns', () => {
     const text = '\r \n \r \n\r \n';
-    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    const { container } = render(<LogFormat>{text}</LogFormat>);
     expect(container.childNodes[0].childNodes).toHaveLength(4);
   });
 
   it('handles consecutive carriage returns without error', () => {
     const text = '\r\r';
-    const { container } = renderWithIntl(<LogFormat>{text}</LogFormat>);
+    const { container } = render(<LogFormat>{text}</LogFormat>);
     expect(container.childNodes[0].childNodes).toHaveLength(1);
   });
 });

--- a/packages/components/src/components/PipelineResources/PipelineResources.test.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.test.js
@@ -14,21 +14,17 @@ limitations under the License.
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { TrashCan32 as Delete } from '@carbon/icons-react';
-import { renderWithIntl, renderWithRouter } from '../../utils/test';
+import { render, renderWithRouter } from '../../utils/test';
 import PipelineResources from './PipelineResources';
 
 it('PipelineResources renders empty state', () => {
-  const { queryByText } = renderWithIntl(
-    <PipelineResources pipelineResources={[]} />
-  );
+  const { queryByText } = render(<PipelineResources pipelineResources={[]} />);
   expect(queryByText(/no matching pipelineresources/i)).toBeTruthy();
   expect(queryByText('Namespace')).toBeTruthy();
 });
 
 it('PipelineResources renders headers state', () => {
-  const { queryByText } = renderWithIntl(
-    <PipelineResources pipelineResources={[]} />
-  );
+  const { queryByText } = render(<PipelineResources pipelineResources={[]} />);
   expect(queryByText(/pipelineresources/i)).toBeTruthy();
   expect(queryByText('Namespace')).toBeTruthy();
   expect(queryByText(/type/i)).toBeTruthy();

--- a/packages/components/src/components/PipelineRun/PipelineRun.test.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.js
@@ -14,17 +14,15 @@ limitations under the License.
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import PipelineRun from './PipelineRun';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 it('PipelineRunContainer renders', async () => {
-  const { getByText } = renderWithIntl(
-    <PipelineRun error={null} loading={false} />
-  );
+  const { getByText } = render(<PipelineRun error={null} loading={false} />);
   await waitFor(() => getByText('PipelineRun not found'));
 });
 
 it('PipelineRunContainer handles error state', async () => {
-  const { getByText } = renderWithIntl(<PipelineRun error="Error" />);
+  const { getByText } = render(<PipelineRun error="Error" />);
   await waitFor(() => getByText('Error loading PipelineRun'));
 });
 
@@ -66,7 +64,7 @@ it('PipelineRunContainer handles init step failures', async () => {
     }
   };
 
-  const { getByText } = renderWithIntl(
+  const { getByText } = render(
     <PipelineRun
       handleTaskSelected={() => {}}
       pipelineRun={pipelineRun}
@@ -158,7 +156,7 @@ it('PipelineRunContainer handles init step failures for retry', async () => {
     }
   }
 
-  const { getByText } = renderWithIntl(
+  const { getByText } = render(
     <TestWrapper>
       {({ handleTaskSelected, selectedStepId, selectedTaskId }) => (
         <PipelineRun

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
@@ -13,18 +13,18 @@ limitations under the License.
 
 import React from 'react';
 
-import { renderWithIntl, renderWithRouter } from '../../utils/test';
+import { render, renderWithRouter } from '../../utils/test';
 import PipelineRuns from './PipelineRuns';
 
 describe('PipelineRuns', () => {
   it('renders empty state', () => {
-    const { queryByText } = renderWithIntl(<PipelineRuns pipelineRuns={[]} />);
+    const { queryByText } = render(<PipelineRuns pipelineRuns={[]} />);
     expect(queryByText(/no matching pipelineruns/i)).toBeTruthy();
     expect(queryByText('Namespace')).toBeTruthy();
   });
 
   it('hides namespace when omitted from the list of columns', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <PipelineRuns
         columns={['status', 'name', 'pipeline']}
         pipelineRuns={[]}
@@ -37,7 +37,7 @@ describe('PipelineRuns', () => {
   });
 
   it('renders custom columns', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <PipelineRuns
         columns={['aCustomColumn']}
         customColumns={{
@@ -67,7 +67,7 @@ describe('PipelineRuns', () => {
   });
 
   it('renders custom column headers', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <PipelineRuns
         columns={['status']}
         customColumns={{
@@ -93,7 +93,7 @@ describe('PipelineRuns', () => {
   });
 
   it('renders custom column values', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <PipelineRuns
         columns={['status']}
         customColumns={{

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.test.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.test.js
@@ -13,20 +13,18 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import ResourceDetails from './ResourceDetails';
 
 describe('ResourceDetails', () => {
   it('renders the loading state', () => {
-    const { queryByText } = renderWithIntl(<ResourceDetails loading />);
+    const { queryByText } = render(<ResourceDetails loading />);
     expect(queryByText(/overview/i)).toBeFalsy();
   });
 
   it('renders the error state', () => {
     const errorMessage = 'an error message';
-    const { queryByText } = renderWithIntl(
-      <ResourceDetails error={errorMessage} />
-    );
+    const { queryByText } = render(<ResourceDetails error={errorMessage} />);
     expect(queryByText(/labels/i)).toBeFalsy();
     expect(queryByText(errorMessage)).toBeTruthy();
   });
@@ -44,9 +42,7 @@ describe('ResourceDetails', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
-      <ResourceDetails resource={resource} />
-    );
+    const { queryByText } = render(<ResourceDetails resource={resource} />);
     expect(queryByText(/labels/i)).toBeTruthy();
     expect(queryByText(/description/i)).toBeTruthy();
     expect(queryByText(name)).toBeTruthy();
@@ -71,7 +67,7 @@ describe('ResourceDetails', () => {
     const additionalMetadata = 'fake_additionalMetadata';
     const children = 'fake_children';
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <ResourceDetails
         resource={resource}
         additionalMetadata={additionalMetadata}
@@ -103,7 +99,7 @@ describe('ResourceDetails', () => {
 
     const onViewChange = jest.fn();
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <ResourceDetails
         onViewChange={onViewChange}
         resource={resource}

--- a/packages/components/src/components/RunDropdown/RunDropdown.test.js
+++ b/packages/components/src/components/RunDropdown/RunDropdown.test.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import RunDropdown from './RunDropdown';
 
 const resource = {
@@ -31,7 +31,7 @@ describe('RunDropdown dropdown no modal', () => {
         action: () => mockCallBack()
       }
     ];
-    const { getByText, getAllByTitle } = renderWithIntl(
+    const { getByText, getAllByTitle } = render(
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
@@ -50,7 +50,7 @@ describe('RunDropdown dropdown missing disable default behaviour', () => {
         action: () => mockCallBack()
       }
     ];
-    const { getByText, getAllByTitle } = renderWithIntl(
+    const { getByText, getAllByTitle } = render(
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
@@ -70,7 +70,7 @@ describe('RunDropdown disabled field', () => {
         action: () => mockCallBack()
       }
     ];
-    const { getByText, getAllByTitle } = renderWithIntl(
+    const { getByText, getAllByTitle } = render(
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);
@@ -96,7 +96,7 @@ describe('RunDropdown with modal', () => {
         }
       }
     ];
-    const { getByText, getAllByTitle } = renderWithIntl(
+    const { getByText, getAllByTitle } = render(
       <RunDropdown items={items} resource={resource} />
     );
     fireEvent.click(getAllByTitle('Actions')[0]);

--- a/packages/components/src/components/Step/Step.test.js
+++ b/packages/components/src/components/Step/Step.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,72 +14,68 @@ limitations under the License.
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import Step from './Step';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 it('Step renders default content', () => {
-  const { queryByText } = renderWithIntl(<Step />);
+  const { queryByText } = render(<Step />);
 
   expect(queryByText(/Unknown/i)).toBeTruthy();
 });
 
 it('Step renders the provided content', () => {
   const stepName = 'build';
-  const { queryByText } = renderWithIntl(<Step stepName={stepName} />);
+  const { queryByText } = render(<Step stepName={stepName} />);
   expect(queryByText(/build/i)).toBeTruthy();
 });
 
 it('Step renders selected state', () => {
-  renderWithIntl(<Step selected />);
+  render(<Step selected />);
 });
 
 it('Step renders waiting state', () => {
-  const { queryByText } = renderWithIntl(<Step status="waiting" />);
+  const { queryByText } = render(<Step status="waiting" />);
   expect(queryByText(/waiting/i)).toBeTruthy();
 });
 
 it('Step renders running state', () => {
-  const { queryByText } = renderWithIntl(<Step status="running" />);
+  const { queryByText } = render(<Step status="running" />);
   expect(queryByText(/running/i)).toBeTruthy();
 });
 
 it('Step renders cancelled state', () => {
-  const { queryByText } = renderWithIntl(<Step status="cancelled" />);
+  const { queryByText } = render(<Step status="cancelled" />);
   expect(queryByText(/Cancelled/i)).toBeTruthy();
 });
 
 it('Step renders cancelled state for TaskRunCancelled', () => {
-  const { queryByText } = renderWithIntl(
+  const { queryByText } = render(
     <Step status="terminated" reason="TaskRunCancelled" />
   );
   expect(queryByText(/Cancelled/i)).toBeTruthy();
 });
 
 it('Step renders cancelled state for TaskRunTimeout', () => {
-  const { queryByText } = renderWithIntl(
+  const { queryByText } = render(
     <Step status="terminated" reason="TaskRunTimeout" />
   );
   expect(queryByText(/Cancelled/i)).toBeTruthy();
 });
 
 it('Step renders completed state', () => {
-  const { queryByText } = renderWithIntl(
+  const { queryByText } = render(
     <Step status="terminated" reason="Completed" />
   );
   expect(queryByText(/Completed/i)).toBeTruthy();
 });
 
 it('Step renders error state', () => {
-  const { queryByText } = renderWithIntl(
-    <Step status="terminated" reason="Error" />
-  );
+  const { queryByText } = render(<Step status="terminated" reason="Error" />);
   expect(queryByText(/Failed/i)).toBeTruthy();
 });
 
 it('Step handles click event', () => {
   const onSelect = jest.fn();
-  const { getByText } = renderWithIntl(
-    <Step stepName="build" onSelect={onSelect} />
-  );
+  const { getByText } = render(<Step stepName="build" onSelect={onSelect} />);
   fireEvent.click(getByText(/build/i));
   expect(onSelect).toHaveBeenCalledTimes(1);
 });

--- a/packages/components/src/components/StepDefinition/StepDefinition.test.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.test.js
@@ -12,11 +12,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import { renderWithIntl, renderWithRouter } from '../../utils/test';
+import { render, renderWithRouter } from '../../utils/test';
 import StepDefinition from './StepDefinition';
 
 it('StepDefinition renders default content', () => {
-  const { queryByText } = renderWithIntl(<StepDefinition taskRun={{}} />);
+  const { queryByText } = render(<StepDefinition taskRun={{}} />);
   expect(queryByText(/Step definition not available/i)).toBeTruthy();
 });
 
@@ -26,7 +26,7 @@ it('StepDefinition renders the provided content', () => {
     command: ['docker'],
     name: 'test name'
   };
-  const { queryByText } = renderWithIntl(
+  const { queryByText } = render(
     <StepDefinition definition={definition} taskRun={{}} />
   );
 

--- a/packages/components/src/components/StepStatus/StepStatus.test.js
+++ b/packages/components/src/components/StepStatus/StepStatus.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,11 +13,11 @@ limitations under the License.
 
 import React from 'react';
 import StepStatus from './StepStatus';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 describe('StepStatus', () => {
   it('renders default content', () => {
-    const { queryByText } = renderWithIntl(<StepStatus />);
+    const { queryByText } = render(<StepStatus />);
     expect(queryByText(/Status not available/i)).toBeTruthy();
   });
 
@@ -27,7 +27,7 @@ describe('StepStatus', () => {
     const name = 'fake_name';
     const terminated = 'fake_terminated';
     const status = { container, imageID, name, terminated };
-    const { queryByText } = renderWithIntl(<StepStatus status={status} />);
+    const { queryByText } = render(<StepStatus status={status} />);
 
     expect(queryByText(new RegExp(container, 'i'))).toBeTruthy();
     expect(queryByText(new RegExp(imageID, 'i'))).toBeTruthy();
@@ -43,7 +43,7 @@ describe('StepStatus', () => {
     const running = 'fake_running';
     const waiting = 'fake_waiting';
     const status = { container, imageID, name, running, waiting };
-    const { queryByText } = renderWithIntl(<StepStatus status={status} />);
+    const { queryByText } = render(<StepStatus status={status} />);
 
     expect(queryByText(new RegExp(container, 'i'))).toBeTruthy();
     expect(queryByText(new RegExp(imageID, 'i'))).toBeTruthy();

--- a/packages/components/src/components/Table/Table.test.js
+++ b/packages/components/src/components/Table/Table.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import Table from './Table';
 
 const rows = [
@@ -63,9 +63,7 @@ describe('Table', () => {
       emptyTextAllNamespaces,
       emptyTextSelectedNamespace
     };
-    const { queryByLabelText, queryByText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByLabelText, queryByText } = render(<Table {...props} />);
 
     expect(queryByText(title)).toBeFalsy();
     expect(
@@ -96,9 +94,7 @@ describe('Table', () => {
       title,
       toolbarButtons: toolbarButtons.slice(0, 1)
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(queryByText('Resource')).toBeTruthy();
     expect(
@@ -120,9 +116,7 @@ describe('Table', () => {
       headers,
       selectedNamespace: ALL_NAMESPACES
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(queryByText(title)).toBeNull();
     expect(
@@ -147,7 +141,7 @@ describe('Table', () => {
       selectedNamespace: ALL_NAMESPACES,
       isSortable: true
     };
-    const { queryByText } = renderWithIntl(<Table {...props} />);
+    const { queryByText } = render(<Table {...props} />);
 
     expect(
       queryByText('Name').parentNode.className.includes('sort')
@@ -163,7 +157,7 @@ describe('Table', () => {
       rows: rows.slice(0, 1),
       selectedNamespace: ALL_NAMESPACES
     };
-    const { queryByText } = renderWithIntl(<Table {...props} />);
+    const { queryByText } = render(<Table {...props} />);
 
     expect(queryByText(filters)).toBeTruthy();
   });
@@ -176,9 +170,7 @@ describe('Table', () => {
       selectedNamespace: ALL_NAMESPACES,
       toolbarButtons: toolbarButtons.slice(0, 1)
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(
       queryByText('Name').parentNode.className.includes('sort')
@@ -198,9 +190,7 @@ describe('Table', () => {
       selectedNamespace: ALL_NAMESPACES,
       toolbarButtons
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(
       queryByText('Name').parentNode.className.includes('sort')
@@ -220,9 +210,7 @@ describe('Table', () => {
       headers,
       selectedNamespace: ALL_NAMESPACES
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(
       queryByText('Name').parentNode.className.includes('sort')
@@ -242,9 +230,7 @@ describe('Table', () => {
       headers,
       selectedNamespace: ALL_NAMESPACES
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(
       queryByText('Name').parentNode.className.includes('sort')
@@ -267,11 +253,9 @@ describe('Table', () => {
       toolbarButtons,
       isSortable: true
     };
-    const {
-      queryAllByLabelText,
-      queryByText,
-      queryByLabelText
-    } = renderWithIntl(<Table {...props} />);
+    const { queryAllByLabelText, queryByText, queryByLabelText } = render(
+      <Table {...props} />
+    );
 
     expect(
       queryByText('Name').parentNode.className.includes('sort')
@@ -292,7 +276,7 @@ describe('Table', () => {
       selectedNamespace: ALL_NAMESPACES,
       toolbarButtons: toolbarButtons.slice(0, 1)
     };
-    const { queryByText } = renderWithIntl(<Table {...props} />);
+    const { queryByText } = render(<Table {...props} />);
 
     expect(queryByText(/Add/i).disabled).toBeTruthy();
   });
@@ -304,9 +288,7 @@ describe('Table', () => {
       headers,
       selectedNamespace: ALL_NAMESPACES
     };
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(queryByText(/Resources/i)).toBeNull();
     expect(queryByText('Name')).toBeTruthy();
@@ -329,9 +311,7 @@ describe('Table', () => {
       selectedNamespace: ALL_NAMESPACES
     };
     props.batchActionButtons[0].onClick = handleDelete;
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(queryByText(/Delete/i)).toBeTruthy();
     expect(queryByText(/Add/i)).toBeNull();
@@ -359,9 +339,7 @@ describe('Table', () => {
       selectedNamespace: ALL_NAMESPACES
     };
     props.batchActionButtons[0].onClick = handleDelete;
-    const { queryByText, queryByLabelText } = renderWithIntl(
-      <Table {...props} />
-    );
+    const { queryByText, queryByLabelText } = render(<Table {...props} />);
 
     expect(queryByText(/Delete/i)).toBeTruthy();
     expect(queryByText(/Add/i)).toBeNull();
@@ -389,7 +367,7 @@ describe('Table', () => {
       toolbarButtons: toolbarButtons.slice(0, 1)
     };
     props.toolbarButtons[0].onClick = handleAdd;
-    const { queryByText } = renderWithIntl(<Table {...props} />);
+    const { queryByText } = render(<Table {...props} />);
 
     expect(queryByText(/Delete/i)).toBeNull();
     expect(queryByText(/Add/i)).toBeTruthy();

--- a/packages/components/src/components/Task/Task.test.js
+++ b/packages/components/src/components/Task/Task.test.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import Task from './Task';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 const props = {
   onSelect: () => {},
@@ -23,21 +23,19 @@ const props = {
 
 describe('Task', () => {
   it('renders default content', () => {
-    const { queryByText } = renderWithIntl(<Task {...props} />);
+    const { queryByText } = render(<Task {...props} />);
     expect(queryByText(/a task/i)).toBeTruthy();
   });
 
   it('does not render steps in collapsed state', () => {
     const steps = [{ name: 'a step' }];
-    const { queryByText } = renderWithIntl(<Task {...props} steps={steps} />);
+    const { queryByText } = render(<Task {...props} steps={steps} />);
     expect(queryByText(/a step/i)).toBeFalsy();
   });
 
   it('renders steps in expanded state', () => {
     const steps = [{ name: 'a step' }];
-    const { queryByText } = renderWithIntl(
-      <Task {...props} expanded steps={steps} />
-    );
+    const { queryByText } = render(<Task {...props} expanded steps={steps} />);
     expect(queryByText(/a step/i)).toBeTruthy();
   });
 
@@ -46,9 +44,7 @@ describe('Task', () => {
       { name: 'a step', terminated: { reason: 'Completed' } },
       { name: 'a step two', terminated: { reason: 'Completed' } }
     ];
-    const { queryByText } = renderWithIntl(
-      <Task {...props} expanded steps={steps} />
-    );
+    const { queryByText } = render(<Task {...props} expanded steps={steps} />);
     waitFor(() =>
       queryByText(
         (content, element) =>
@@ -63,9 +59,7 @@ describe('Task', () => {
       { name: 'a step', terminated: { reason: 'Completed' } },
       { name: 'a step two', terminated: { reason: 'Error' } }
     ];
-    const { queryByText } = renderWithIntl(
-      <Task {...props} expanded steps={steps} />
-    );
+    const { queryByText } = render(<Task {...props} expanded steps={steps} />);
     waitFor(() =>
       queryByText(
         (content, element) =>
@@ -80,9 +74,7 @@ describe('Task', () => {
       { name: 'a step', terminated: { reason: 'Completed' } },
       { name: 'a step two', terminated: { reason: undefined } }
     ];
-    const { queryByText } = renderWithIntl(
-      <Task {...props} expanded steps={steps} />
-    );
+    const { queryByText } = render(<Task {...props} expanded steps={steps} />);
     waitFor(() =>
       queryByText(
         (content, element) =>
@@ -98,36 +90,34 @@ describe('Task', () => {
       { name: 'step 2', terminated: { reason: 'Error' } },
       { name: 'step 3', terminated: { reason: 'Completed' } }
     ];
-    const { queryByText } = renderWithIntl(
-      <Task {...props} expanded steps={steps} />
-    );
+    const { queryByText } = render(<Task {...props} expanded steps={steps} />);
     expect(queryByText(/step 1/i)).toBeTruthy();
     expect(queryByText(/step 2/i)).toBeTruthy();
     expect(queryByText(/step 3/i)).toBeTruthy();
   });
 
   it('renders success state', () => {
-    renderWithIntl(<Task {...props} succeeded="True" />);
+    render(<Task {...props} succeeded="True" />);
   });
 
   it('renders failure state', () => {
-    renderWithIntl(<Task {...props} succeeded="False" />);
+    render(<Task {...props} succeeded="False" />);
   });
 
   it('renders unknown state', () => {
-    renderWithIntl(<Task {...props} succeeded="Unknown" />);
+    render(<Task {...props} succeeded="Unknown" />);
   });
 
   it('renders pending state', () => {
-    renderWithIntl(<Task {...props} succeeded="Unknown" reason="Pending" />);
+    render(<Task {...props} succeeded="Unknown" reason="Pending" />);
   });
 
   it('renders running state', () => {
-    renderWithIntl(<Task {...props} succeeded="Unknown" reason="Running" />);
+    render(<Task {...props} succeeded="Unknown" reason="Running" />);
   });
 
   it('renders cancelled state', () => {
-    renderWithIntl(
+    render(
       <Task
         {...props}
         expanded
@@ -140,14 +130,14 @@ describe('Task', () => {
 
   it('renders selected step state', () => {
     const steps = [{ name: 'a step' }];
-    renderWithIntl(
+    render(
       <Task {...props} expanded selectedStepId="some-step" steps={steps} />
     );
   });
 
   it('handles click event', () => {
     const onSelect = jest.fn();
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Task displayName="build" onSelect={onSelect} />
     );
     fireEvent.click(getByText(/build/i));
@@ -157,7 +147,7 @@ describe('Task', () => {
   it('handles click event on Step', () => {
     const onSelect = jest.fn();
     const steps = [{ name: 'build' }];
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Task displayName="A Task" expanded onSelect={onSelect} steps={steps} />
     );
     expect(onSelect).not.toHaveBeenCalled();

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -14,14 +14,14 @@ limitations under the License.
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import TaskRunDetails from './TaskRunDetails';
 
 describe('TaskRunDetails', () => {
   it('renders task name and error state', () => {
     const taskRunName = 'task-run-name';
     const status = 'error';
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <TaskRunDetails
         taskRun={{ metadata: { name: taskRunName }, spec: {}, status }}
       />
@@ -38,7 +38,7 @@ describe('TaskRunDetails', () => {
     const paramValue = 'v';
     const params = [{ name: paramKey, value: paramValue }];
     const description = 'param_description';
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <TaskRunDetails
         task={{
           metadata: 'task',
@@ -61,7 +61,7 @@ describe('TaskRunDetails', () => {
     const paramValue = 'v';
     const params = [{ name: paramKey, value: paramValue }];
     const description = 'param_description';
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <TaskRunDetails
         taskRun={{
           metadata: { name: taskRunName },
@@ -85,9 +85,7 @@ describe('TaskRunDetails', () => {
       spec: {},
       status: {}
     };
-    const { queryByText } = renderWithIntl(
-      <TaskRunDetails taskRun={taskRun} />
-    );
+    const { queryByText } = render(<TaskRunDetails taskRun={taskRun} />);
     expect(queryByText(/parameters/i)).toBeFalsy();
     expect(queryByText(/results/i)).toBeFalsy();
     expect(queryByText(/status/i)).toBeTruthy();
@@ -98,7 +96,7 @@ describe('TaskRunDetails', () => {
       metadata: { name: 'task-run-name' },
       spec: { params: [{ name: 'fake_name', value: 'fake_value' }] }
     };
-    const { queryByText, queryAllByText } = renderWithIntl(
+    const { queryByText, queryAllByText } = render(
       <TaskRunDetails taskRun={taskRun} view="status" />
     );
     expect(queryByText(/status/i)).toBeTruthy();
@@ -116,7 +114,7 @@ describe('TaskRunDetails', () => {
       spec: {},
       status: { taskResults: [{ name: resultName, value: 'hello' }] }
     };
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <TaskRunDetails
         task={{
           metadata: 'task',
@@ -142,7 +140,7 @@ describe('TaskRunDetails', () => {
       },
       status: { taskResults: [{ name: resultName, value: 'hello' }] }
     };
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <TaskRunDetails taskRun={taskRun} view="results" />
     );
     expect(queryByText(description)).toBeTruthy();

--- a/packages/components/src/components/TaskRuns/TaskRuns.test.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,16 +13,16 @@ limitations under the License.
 
 import React from 'react';
 
-import { renderWithIntl, renderWithRouter } from '../../utils/test';
+import { render, renderWithRouter } from '../../utils/test';
 import TaskRuns from './TaskRuns';
 
 it('TaskRuns renders empty state', () => {
-  const { queryByText } = renderWithIntl(<TaskRuns taskRuns={[]} />);
+  const { queryByText } = render(<TaskRuns taskRuns={[]} />);
   expect(queryByText(/no matching taskruns/i)).toBeTruthy();
 });
 
 it('TaskRuns renders headers state', () => {
-  const { queryByText } = renderWithIntl(<TaskRuns taskRuns={[]} />);
+  const { queryByText } = render(<TaskRuns taskRuns={[]} />);
   expect(queryByText(/taskrun/i)).toBeTruthy();
   expect(queryByText('Task')).toBeTruthy();
   expect(queryByText('Namespace')).toBeTruthy();

--- a/packages/components/src/components/TaskTree/TaskTree.test.js
+++ b/packages/components/src/components/TaskTree/TaskTree.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import TaskTree from './TaskTree';
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 
 const getProps = () => ({
   onSelect: () => {},
@@ -74,19 +74,19 @@ const getProps = () => ({
 });
 
 it('TaskTree renders', () => {
-  renderWithIntl(<TaskTree {...getProps()} />);
+  render(<TaskTree {...getProps()} />);
 });
 
 it('TaskTree renders when taskRuns is falsy', () => {
-  renderWithIntl(<TaskTree {...getProps()} taskRuns={null} />);
+  render(<TaskTree {...getProps()} taskRuns={null} />);
 });
 
 it('TaskTree renders when taskRuns contains a falsy run', () => {
-  renderWithIntl(<TaskTree {...getProps()} taskRuns={[null]} />);
+  render(<TaskTree {...getProps()} taskRuns={[null]} />);
 });
 
 it('TaskTree renders and expands first Task in TaskRun with no error', () => {
-  const { queryByText } = renderWithIntl(<TaskTree {...getProps()} />);
+  const { queryByText } = render(<TaskTree {...getProps()} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
   expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
@@ -104,7 +104,7 @@ it('TaskTree renders and expands error Task in TaskRun', () => {
   const props = getProps();
   props.taskRuns[1].status.conditions[0].status = 'False';
 
-  const { queryByText } = renderWithIntl(<TaskTree {...props} />);
+  const { queryByText } = render(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
   expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
@@ -123,7 +123,7 @@ it('TaskTree renders and expands first error Task in TaskRun', () => {
   props.taskRuns[1].status.conditions[0].status = 'False';
   props.taskRuns[2].status.conditions[0].status = 'False';
 
-  const { queryByText } = renderWithIntl(<TaskTree {...props} />);
+  const { queryByText } = render(<TaskTree {...props} />);
   // Selected Task should have two child elements. The anchor and ordered list
   // of steps in expanded task
   expect(queryByText('A Task').parentNode.parentNode.childNodes).toHaveLength(
@@ -139,7 +139,7 @@ it('TaskTree renders and expands first error Task in TaskRun', () => {
 
 it('TaskTree handles click event on Task', () => {
   const onSelect = jest.fn();
-  const { getByText } = renderWithIntl(
+  const { getByText } = render(
     <TaskTree {...getProps()} onSelect={onSelect} />
   );
   expect(onSelect).toHaveBeenCalledTimes(1);
@@ -150,7 +150,7 @@ it('TaskTree handles click event on Task', () => {
 
 it('TaskTree handles click event on Step', () => {
   const onSelect = jest.fn();
-  const { getByText } = renderWithIntl(
+  const { getByText } = render(
     <TaskTree {...getProps()} selectedTaskId="task" onSelect={onSelect} />
   );
   onSelect.mockClear();

--- a/packages/components/src/components/TooltipDropdown/TooltipDropdown.test.js
+++ b/packages/components/src/components/TooltipDropdown/TooltipDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
-import { renderWithIntl } from '../../utils/test';
+import { render } from '../../utils/test';
 import TooltipDropdown from './TooltipDropdown';
 
 const props = {
@@ -33,7 +33,7 @@ it('TooltipDropdown renders', () => {
     getByPlaceholderText,
     queryByText,
     queryByDisplayValue
-  } = renderWithIntl(<TooltipDropdown {...props} />);
+  } = render(<TooltipDropdown {...props} />);
   fireEvent.click(getByPlaceholderText(initialTextRegExp));
   props.items.forEach(item => {
     expect(queryByText(item.text || item)).toBeTruthy();
@@ -43,14 +43,14 @@ it('TooltipDropdown renders', () => {
 });
 
 it('TooltipDropdown renders selected item', () => {
-  const { queryByDisplayValue } = renderWithIntl(
+  const { queryByDisplayValue } = render(
     <TooltipDropdown {...props} selectedItem={{ text: 'item 1' }} />
   );
   expect(queryByDisplayValue('item 1')).toBeTruthy();
 });
 
 it('TooltipDropdown renders empty', () => {
-  const { queryByPlaceholderText } = renderWithIntl(
+  const { queryByPlaceholderText } = render(
     <TooltipDropdown {...props} items={[]} />
   );
   expect(queryByPlaceholderText(/no items found/i)).toBeTruthy();
@@ -58,7 +58,7 @@ it('TooltipDropdown renders empty', () => {
 });
 
 it('TooltipDropdown renders loading skeleton', () => {
-  const { queryByPlaceholderText } = renderWithIntl(
+  const { queryByPlaceholderText } = render(
     <TooltipDropdown {...props} loading />
   );
   expect(queryByPlaceholderText(initialTextRegExp)).toBeFalsy();
@@ -66,7 +66,7 @@ it('TooltipDropdown renders loading skeleton', () => {
 
 it('TooltipDropdown handles onChange event', () => {
   const onChange = jest.fn();
-  const { getByPlaceholderText, getByText } = renderWithIntl(
+  const { getByPlaceholderText, getByText } = render(
     <TooltipDropdown {...props} onChange={onChange} />
   );
   fireEvent.click(getByPlaceholderText(initialTextRegExp));

--- a/packages/components/src/utils/test.js
+++ b/packages/components/src/utils/test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { render } from '@testing-library/react';
+import { render as baseRender } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
 function RouterWrapper({ children }) {
@@ -32,7 +32,7 @@ export function renderWithRouter(
 ) {
   window.history.pushState({}, 'Test page', route);
 
-  return (rerender || render)(ui, {
+  return (rerender || baseRender)(ui, {
     route,
     wrapper: RouterWrapper,
     ...otherOptions
@@ -47,6 +47,6 @@ function IntlWrapper({ children }) {
   );
 }
 
-export function renderWithIntl(ui, { rerender } = {}) {
-  return (rerender || render)(ui, { wrapper: IntlWrapper });
+export function render(ui, { rerender } = {}) {
+  return (rerender || baseRender)(ui, { wrapper: IntlWrapper });
 }

--- a/src/containers/About/About.test.js
+++ b/src/containers/About/About.test.js
@@ -15,7 +15,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import About from '.';
 
@@ -39,7 +39,7 @@ describe('About', () => {
       }
     });
 
-    const { queryByText, queryAllByText } = renderWithIntl(
+    const { queryByText, queryAllByText } = render(
       <Provider store={store}>
         <About />)
       </Provider>
@@ -80,7 +80,7 @@ describe('About', () => {
       }
     });
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <Provider store={store}>
         <About />)
       </Provider>
@@ -111,7 +111,7 @@ describe('About', () => {
       }
     });
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <Provider store={store}>
         <About />)
       </Provider>
@@ -146,7 +146,7 @@ describe('About', () => {
       }
     });
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <Provider store={store}>
         <About />)
       </Provider>

--- a/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.test.js
+++ b/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.test.js
@@ -16,7 +16,7 @@ import { fireEvent, getNodeText } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import ClusterTasksDropdown from './ClusterTasksDropdown';
 import * as API from '../../api/clusterTasks';
@@ -90,7 +90,7 @@ describe('ClusterTasksDropdown', () => {
       ...clusterTasksStoreDefault,
       notifications: {}
     });
-    const { getByPlaceholderText, getAllByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getAllByText, queryByText } = render(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} />
       </Provider>
@@ -110,11 +110,7 @@ describe('ClusterTasksDropdown', () => {
       notifications: {}
     });
     // Select item 'clustertask-1'
-    const {
-      queryByDisplayValue,
-      queryByPlaceholderText,
-      rerender
-    } = renderWithIntl(
+    const { queryByDisplayValue, queryByPlaceholderText, rerender } = render(
       <Provider store={store}>
         <ClusterTasksDropdown
           {...props}
@@ -124,7 +120,7 @@ describe('ClusterTasksDropdown', () => {
     );
     expect(queryByDisplayValue(/clustertask-1/i)).toBeTruthy();
     // Select item 'clustertask-2'
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <ClusterTasksDropdown
           {...props}
@@ -135,7 +131,7 @@ describe('ClusterTasksDropdown', () => {
     );
     expect(queryByDisplayValue(/clustertask-2/i)).toBeTruthy();
     // No selected item (select item '')
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} selectedItem="" />
       </Provider>,
@@ -152,7 +148,7 @@ describe('ClusterTasksDropdown', () => {
       },
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} />
       </Provider>
@@ -166,7 +162,7 @@ describe('ClusterTasksDropdown', () => {
       ...clusterTasksStoreFetching,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} />
       </Provider>
@@ -180,7 +176,7 @@ describe('ClusterTasksDropdown', () => {
       notifications: {}
     });
     const onChange = jest.fn();
-    const { getByPlaceholderText, getByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} onChange={onChange} />
       </Provider>
@@ -200,7 +196,7 @@ describe('ClusterTasksDropdown', () => {
       ...clusterTasksStoreDefault,
       notifications: {}
     });
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <ClusterTasksDropdown {...props} />
       </Provider>

--- a/src/containers/Condition/Condition.test.js
+++ b/src/containers/Condition/Condition.test.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import { ConditionContainer } from './Condition';
 
@@ -33,7 +33,7 @@ describe('ConditionContainer', () => {
 
     const errorMessage = 'fake_errorMessage';
 
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <ConditionContainer
         error={errorMessage}
         fetchCondition={() => Promise.resolve()}
@@ -56,7 +56,7 @@ describe('ConditionContainer', () => {
       }
     };
 
-    const { getByText, rerender } = renderWithIntl(
+    const { getByText, rerender } = render(
       <ConditionContainer
         fetchCondition={fetchConditionSpy}
         intl={intl}
@@ -66,7 +66,7 @@ describe('ConditionContainer', () => {
     await waitFor(() => getByText('Error loading resource'));
     expect(fetchConditionSpy).toHaveBeenCalledTimes(1);
 
-    renderWithIntl(
+    render(
       <ConditionContainer
         fetchCondition={fetchConditionSpy}
         intl={intl}
@@ -83,7 +83,7 @@ describe('ConditionContainer', () => {
         namespace: 'updated_namespace'
       }
     };
-    renderWithIntl(
+    render(
       <ConditionContainer
         fetchCondition={fetchConditionSpy}
         intl={intl}
@@ -99,7 +99,7 @@ describe('ConditionContainer', () => {
         conditionName: 'updated_conditionName'
       }
     };
-    renderWithIntl(
+    render(
       <ConditionContainer
         fetchCondition={fetchConditionSpy}
         intl={intl}
@@ -110,7 +110,7 @@ describe('ConditionContainer', () => {
     );
     expect(fetchConditionSpy).toHaveBeenCalledTimes(3);
 
-    renderWithIntl(
+    render(
       <ConditionContainer
         fetchCondition={fetchConditionSpy}
         intl={intl}
@@ -142,7 +142,7 @@ describe('ConditionContainer', () => {
       }
     };
 
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <ConditionContainer
         condition={condition}
         fetchCondition={fetchConditionSpy}
@@ -172,7 +172,7 @@ describe('ConditionContainer', () => {
       }
     };
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <ConditionContainer
         condition={condition}
         fetchCondition={fetchConditionSpy}

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
@@ -19,7 +19,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 import {
-  renderWithIntl,
+  render,
   renderWithRouter
 } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -63,7 +63,7 @@ describe('CreatePipelineResource', () => {
   it('renders blank', () => {
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
 
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -100,7 +100,7 @@ describe('CreatePipelineResource', () => {
   const revisionValidationErrorRegExp = /Revision required/i;
 
   it('validates all empty inputs', () => {
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -113,7 +113,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('errors when name starts with a "-"', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -129,7 +129,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('errors when name ends with a "-"', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -145,7 +145,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('errors when name contains "."', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -161,7 +161,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('errors when name contains spaces', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -177,7 +177,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('errors when name contains capital letters', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -193,7 +193,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('doesn\'t error when contains "-" in the middle of the name', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -209,7 +209,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it("doesn't error when name contains number", () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -225,7 +225,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('errors when name contains 64 characters', () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -244,7 +244,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it("doesn't error when name contains 63 characters", () => {
-    const { queryByText, getByPlaceholderText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -262,7 +262,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it("doesn't error when contains a valid namespace", () => {
-    const { queryByText, getByPlaceholderText, getByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -280,7 +280,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it("doesn't error when a url is entered", () => {
-    const { queryByText, getByPlaceholderText, getByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -303,7 +303,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it("doesn't error when a revision is entered", () => {
-    const { queryByText, getByPlaceholderText, getByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>
@@ -326,7 +326,7 @@ describe('CreatePipelineResource', () => {
   });
 
   it('handles type change', () => {
-    const { queryByText, getByPlaceholderText, getByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <CreatePipelineResource />
       </Provider>

--- a/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
@@ -15,7 +15,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import CreatePipelineResource from '.';
 import * as API from '../../api';
@@ -73,7 +73,7 @@ it('CreatePipelineResource error notification appears', async () => {
     notifications: {}
   });
 
-  const { getByPlaceholderText, getByText, queryByText } = renderWithIntl(
+  const { getByPlaceholderText, getByText, queryByText } = render(
     <Provider store={store}>
       <CreatePipelineResource />
     </Provider>

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -18,7 +18,7 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import CreatePipelineRun from './CreatePipelineRun';
 import * as PipelineResourcesAPI from '../../api/pipelineResources';
@@ -267,7 +267,7 @@ describe('CreatePipelineRun', () => {
       getByTitle,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -304,7 +304,7 @@ describe('CreatePipelineRun', () => {
       getByText,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -337,7 +337,7 @@ describe('CreatePipelineRun', () => {
       queryByText,
       queryAllByText,
       queryByPlaceholderText
-    } = renderWithIntl(
+    } = render(
       <Provider
         store={mockStore({
           ...testStore,
@@ -387,7 +387,7 @@ describe('CreatePipelineRun', () => {
       getByText,
       queryByDisplayValue,
       queryByText
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -424,7 +424,7 @@ describe('CreatePipelineRun', () => {
       queryAllByLabelText,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun
           {...props}
@@ -445,7 +445,7 @@ describe('CreatePipelineRun', () => {
       getByText,
       getByPlaceholderText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockStore(testStore)}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -467,11 +467,7 @@ describe('CreatePipelineRun', () => {
   it('resets Pipeline and ServiceAccount when namespace changes', async () => {
     const mockTestStore = mockStore(testStore);
     jest.spyOn(store, 'getStore').mockImplementation(() => mockTestStore);
-    const {
-      getByPlaceholderText,
-      getByText,
-      getByDisplayValue
-    } = renderWithIntl(
+    const { getByPlaceholderText, getByText, getByDisplayValue } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -506,7 +502,7 @@ describe('CreatePipelineRun', () => {
       getByText,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -563,7 +559,7 @@ describe('CreatePipelineRun', () => {
 
   it('handles onClose event', () => {
     jest.spyOn(props.history, 'push');
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Provider store={mockStore(testStore)}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -585,7 +581,7 @@ describe('CreatePipelineRun', () => {
       getByText,
       queryAllByText,
       queryByText
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -654,7 +650,7 @@ describe('CreatePipelineRun', () => {
     const mockTestStore = mockStore(testStore);
     jest.spyOn(store, 'getStore').mockImplementation(() => mockTestStore);
     jest.spyOn(reducers, 'getPipeline').mockImplementation(() => null);
-    const { getByPlaceholderText, getByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText, queryByText } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -667,7 +663,7 @@ describe('CreatePipelineRun', () => {
     const mockTestStore = mockStore(testStore);
     jest.spyOn(store, 'getStore').mockImplementation(() => mockTestStore);
     const badPipelineName = 'pipeline-thisDoesNotExist';
-    const { getByPlaceholderText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, queryByText } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun
           {...props}
@@ -690,7 +686,7 @@ describe('CreatePipelineRun', () => {
       queryAllByTitle,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>
@@ -709,7 +705,7 @@ describe('CreatePipelineRun', () => {
   it('handles close', () => {
     jest.spyOn(props.history, 'push');
     const mockTestStore = mockStore(testStore);
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Provider store={mockTestStore}>
         <CreatePipelineRun {...props} />
       </Provider>

--- a/src/containers/CreateTaskRun/CreateTaskRun.test.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.js
@@ -18,7 +18,7 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import CreateTaskRun from './CreateTaskRun';
 import * as PipelineResourcesAPI from '../../api/pipelineResources';
@@ -305,7 +305,7 @@ describe('CreateTaskRun', () => {
       getByTitle,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -340,7 +340,7 @@ describe('CreateTaskRun', () => {
       getByText,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -373,7 +373,7 @@ describe('CreateTaskRun', () => {
       queryByText,
       queryAllByText,
       queryByPlaceholderText
-    } = renderWithIntl(
+    } = render(
       <Provider
         store={mockStore({
           ...testStore,
@@ -419,7 +419,7 @@ describe('CreateTaskRun', () => {
       getByText,
       queryByDisplayValue,
       queryByText
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -454,7 +454,7 @@ describe('CreateTaskRun', () => {
       queryAllByLabelText,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} location={{ search: '?taskName=task-1' }} />
       </Provider>
@@ -472,7 +472,7 @@ describe('CreateTaskRun', () => {
       getByText,
       getByPlaceholderText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -492,11 +492,7 @@ describe('CreateTaskRun', () => {
   });
 
   it('resets Task and ServiceAccount when namespace changes', async () => {
-    const {
-      getByPlaceholderText,
-      getByText,
-      getByDisplayValue
-    } = renderWithIntl(
+    const { getByPlaceholderText, getByText, getByDisplayValue } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -529,7 +525,7 @@ describe('CreateTaskRun', () => {
       getByText,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -592,7 +588,7 @@ describe('CreateTaskRun', () => {
 
   it('handles onClose event', () => {
     jest.spyOn(props.history, 'push');
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -609,7 +605,7 @@ describe('CreateTaskRun', () => {
       getByText,
       queryAllByText,
       queryByText
-    } = renderWithIntl(
+    } = render(
       <Provider
         store={mockStore({
           ...testStore,
@@ -681,7 +677,7 @@ describe('CreateTaskRun', () => {
 
   it('handles error getting task', async () => {
     jest.spyOn(reducers, 'getTask').mockImplementation(() => null);
-    const { getByPlaceholderText, getByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText, queryByText } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>
@@ -692,7 +688,7 @@ describe('CreateTaskRun', () => {
 
   it('handles error getting task controlled', () => {
     const badTaskRef = 'task-thisDoesNotExist';
-    const { getByPlaceholderText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, queryByText } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun
           {...props}
@@ -713,7 +709,7 @@ describe('CreateTaskRun', () => {
       queryAllByTitle,
       queryByText,
       queryByDisplayValue
-    } = renderWithIntl(
+    } = render(
       <Provider store={store.getStore()}>
         <CreateTaskRun {...props} />
       </Provider>

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -18,7 +18,7 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { ALL_NAMESPACES, urls } from '@tektoncd/dashboard-utils';
 import {
-  renderWithIntl,
+  render,
   renderWithRouter
 } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -58,7 +58,7 @@ describe('ImportResources component', () => {
   });
 
   it('Displays errors when Repository URL and Namespace is empty', async () => {
-    const { getByText } = await renderWithIntl(
+    const { getByText } = await render(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -70,7 +70,7 @@ describe('ImportResources component', () => {
   });
 
   it('Displays an error when Repository URL is empty', async () => {
-    const { getAllByPlaceholderText, getByText } = await renderWithIntl(
+    const { getAllByPlaceholderText, getByText } = await render(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -85,7 +85,7 @@ describe('ImportResources component', () => {
   });
 
   it('Displays an error when Namespace is empty', async () => {
-    const { getByPlaceholderText, getByText } = await renderWithIntl(
+    const { getByPlaceholderText, getByText } = await render(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -191,7 +191,7 @@ describe('ImportResources component', () => {
       getAllByPlaceholderText,
       getByPlaceholderText,
       getByText
-    } = await renderWithIntl(
+    } = await render(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -208,7 +208,7 @@ describe('ImportResources component', () => {
   });
 
   it('URL TextInput handles onChange event', async () => {
-    const { getByPlaceholderText, queryByDisplayValue } = await renderWithIntl(
+    const { getByPlaceholderText, queryByDisplayValue } = await render(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>
@@ -228,7 +228,7 @@ describe('ImportResources component', () => {
       getAllByTitle,
       queryByText,
       queryByDisplayValue
-    } = await renderWithIntl(
+    } = await render(
       <Provider store={store}>
         <ImportResourcesContainer />
       </Provider>

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { fireEvent, getNodeText } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import NamespacesDropdown from './NamespacesDropdown';
 
@@ -44,7 +44,7 @@ it('NamespacesDropdown renders items based on Redux state', () => {
     },
     properties: {}
   });
-  const { getAllByText, getByPlaceholderText, queryByText } = renderWithIntl(
+  const { getAllByText, getByPlaceholderText, queryByText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>
@@ -67,18 +67,14 @@ it('NamespacesDropdown renders controlled selection', () => {
     properties: {}
   });
   // Select item 'namespace-1'
-  const {
-    queryByPlaceholderText,
-    queryByDisplayValue,
-    rerender
-  } = renderWithIntl(
+  const { queryByPlaceholderText, queryByDisplayValue, rerender } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} selectedItem={{ text: 'namespace-1' }} />
     </Provider>
   );
   expect(queryByDisplayValue(/namespace-1/i)).toBeTruthy();
   // Select item 'namespace-2'
-  renderWithIntl(
+  render(
     <Provider store={store}>
       <NamespacesDropdown {...props} selectedItem={{ text: 'namespace-2' }} />
     </Provider>,
@@ -86,7 +82,7 @@ it('NamespacesDropdown renders controlled selection', () => {
   );
   expect(queryByDisplayValue(/namespace-2/i)).toBeTruthy();
   // No selected item (select item '')
-  renderWithIntl(
+  render(
     <Provider store={store}>
       <NamespacesDropdown {...props} selectedItem="" />
     </Provider>,
@@ -104,7 +100,7 @@ it('NamespacesDropdown renders empty', () => {
     properties: {}
   });
 
-  const { queryByPlaceholderText } = renderWithIntl(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>
@@ -121,7 +117,7 @@ it('NamespacesDropdown renders loading skeleton based on Redux state', () => {
     properties: {}
   });
 
-  const { queryByPlaceholderText } = renderWithIntl(
+  const { queryByPlaceholderText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>
@@ -138,7 +134,7 @@ it('NamespacesDropdown handles onChange event', () => {
     properties: {}
   });
   const onChange = jest.fn();
-  const { getByPlaceholderText, getByText } = renderWithIntl(
+  const { getByPlaceholderText, getByText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} onChange={onChange} />
     </Provider>
@@ -157,7 +153,7 @@ it('NamespacesDropdown renders tenant namespace in single namespace mode', () =>
       TenantNamespace: 'fake'
     }
   });
-  const { getByPlaceholderText, getByText } = renderWithIntl(
+  const { getByPlaceholderText, getByText } = render(
     <Provider store={store}>
       <NamespacesDropdown {...props} />
     </Provider>

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { fireEvent, getNodeText } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import PipelineResourcesDropdown from './PipelineResourcesDropdown';
 import * as API from '../../api/pipelineResources';
@@ -137,7 +137,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { getByPlaceholderText, getAllByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getAllByText, queryByText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} />
       </Provider>
@@ -157,7 +157,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { getByPlaceholderText, queryByText, rerender } = renderWithIntl(
+    const { getByPlaceholderText, queryByText, rerender } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} type="type-1" />
       </Provider>
@@ -167,7 +167,7 @@ describe('PipelineResourcesDropdown', () => {
     expect(queryByText(/pipeline-resource-1/i)).toBeTruthy();
     expect(queryByText(/pipeline-resource-2/i)).toBeFalsy();
     fireEvent.click(getByPlaceholderText(initialTextRegExp));
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} type="type-2" />
       </Provider>,
@@ -190,7 +190,7 @@ describe('PipelineResourcesDropdown', () => {
       getAllByText,
       queryByText,
       rerender
-    } = renderWithIntl(
+    } = render(
       <Provider store={blueStore}>
         <PipelineResourcesDropdown {...props} />
       </Provider>
@@ -210,7 +210,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    renderWithIntl(
+    render(
       <Provider store={greenStore}>
         <PipelineResourcesDropdown {...props} />
       </Provider>,
@@ -232,11 +232,7 @@ describe('PipelineResourcesDropdown', () => {
       notifications: {}
     });
     // Select item 'pipeline-resource-1'
-    const {
-      queryByPlaceholderText,
-      queryByDisplayValue,
-      rerender
-    } = renderWithIntl(
+    const { queryByPlaceholderText, queryByDisplayValue, rerender } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown
           {...props}
@@ -246,7 +242,7 @@ describe('PipelineResourcesDropdown', () => {
     );
     expect(queryByDisplayValue(/pipeline-resource-1/i)).toBeTruthy();
     // Select item 'pipeline-resource-2'
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <PipelineResourcesDropdown
           {...props}
@@ -257,7 +253,7 @@ describe('PipelineResourcesDropdown', () => {
     );
     expect(queryByDisplayValue(/pipeline-resource-2/i)).toBeTruthy();
     // No selected item (select item '')
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} selectedItem="" />
       </Provider>,
@@ -273,7 +269,7 @@ describe('PipelineResourcesDropdown', () => {
       notifications: {}
     });
     // Select namespace 'green'
-    const { queryByText, getByPlaceholderText, getAllByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getAllByText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} namespace="green" />
       </Provider>
@@ -296,7 +292,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} />
       </Provider>
@@ -319,7 +315,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreAll,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} />
       </Provider>
@@ -338,7 +334,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} type="bogus" />
       </Provider>
@@ -361,7 +357,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreAll,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} type="bogus" />
       </Provider>
@@ -378,7 +374,7 @@ describe('PipelineResourcesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} />
       </Provider>
@@ -393,7 +389,7 @@ describe('PipelineResourcesDropdown', () => {
       notifications: {}
     });
     const onChange = jest.fn();
-    const { getByPlaceholderText, getByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <PipelineResourcesDropdown {...props} onChange={onChange} />
       </Provider>

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import PipelinesDropdown from './PipelinesDropdown';
 import * as API from '../../api/pipelines';
@@ -126,7 +126,7 @@ describe('PipelinesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { getByPlaceholderText, getAllByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getAllByText, queryByText } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} />
       </Provider>
@@ -151,7 +151,7 @@ describe('PipelinesDropdown', () => {
       getAllByText,
       queryByText,
       rerender
-    } = renderWithIntl(
+    } = render(
       <Provider store={blueStore}>
         <PipelinesDropdown {...props} />
       </Provider>
@@ -171,7 +171,7 @@ describe('PipelinesDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    renderWithIntl(
+    render(
       <Provider store={greenStore}>
         <PipelinesDropdown {...props} />
       </Provider>,
@@ -193,18 +193,14 @@ describe('PipelinesDropdown', () => {
       notifications: {}
     });
     // Select item 'pipeline-1'
-    const {
-      queryByDisplayValue,
-      queryByPlaceholderText,
-      rerender
-    } = renderWithIntl(
+    const { queryByDisplayValue, queryByPlaceholderText, rerender } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} selectedItem={{ text: 'pipeline-1' }} />
       </Provider>
     );
     expect(queryByDisplayValue(/pipeline-1/i)).toBeTruthy();
     // Select item 'pipeline-2'
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <PipelinesDropdown {...props} selectedItem={{ text: 'pipeline-2' }} />
       </Provider>,
@@ -212,7 +208,7 @@ describe('PipelinesDropdown', () => {
     );
     expect(queryByDisplayValue(/pipeline-2/i)).toBeTruthy();
     // No selected item (select item '')
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <PipelinesDropdown {...props} selectedItem="" />
       </Provider>,
@@ -228,7 +224,7 @@ describe('PipelinesDropdown', () => {
       notifications: {}
     });
     // Select namespace 'green'
-    const { queryByText, getByPlaceholderText, getAllByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getAllByText } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} namespace="green" />
       </Provider>
@@ -251,7 +247,7 @@ describe('PipelinesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} />
       </Provider>
@@ -272,7 +268,7 @@ describe('PipelinesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} namespace={ALL_NAMESPACES} />
       </Provider>
@@ -287,7 +283,7 @@ describe('PipelinesDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} />
       </Provider>
@@ -302,7 +298,7 @@ describe('PipelinesDropdown', () => {
       notifications: {}
     });
     const onChange = jest.fn();
-    const { getByPlaceholderText, getByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <PipelinesDropdown {...props} onChange={onChange} />
       </Provider>

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { fireEvent, getNodeText } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import ServiceAccountsDropdown from './ServiceAccountsDropdown';
 import * as API from '../../api/serviceAccounts';
@@ -127,7 +127,7 @@ describe('ServiceAccountsDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { getByPlaceholderText, getAllByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getAllByText, queryByText } = render(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} />
       </Provider>
@@ -152,7 +152,7 @@ describe('ServiceAccountsDropdown', () => {
       getAllByText,
       queryByText,
       rerender
-    } = renderWithIntl(
+    } = render(
       <Provider store={blueStore}>
         <ServiceAccountsDropdown {...props} />
       </Provider>
@@ -172,7 +172,7 @@ describe('ServiceAccountsDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    renderWithIntl(
+    render(
       <Provider store={greenStore}>
         <ServiceAccountsDropdown {...props} />
       </Provider>,
@@ -194,11 +194,7 @@ describe('ServiceAccountsDropdown', () => {
       notifications: {}
     });
     // Select item 'service-account-1'
-    const {
-      queryByPlaceholderText,
-      queryByDisplayValue,
-      rerender
-    } = renderWithIntl(
+    const { queryByPlaceholderText, queryByDisplayValue, rerender } = render(
       <Provider store={store}>
         <ServiceAccountsDropdown
           {...props}
@@ -208,7 +204,7 @@ describe('ServiceAccountsDropdown', () => {
     );
     expect(queryByDisplayValue(/service-account-1/i)).toBeTruthy();
     // Select item 'service-account-2'
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <ServiceAccountsDropdown
           {...props}
@@ -219,7 +215,7 @@ describe('ServiceAccountsDropdown', () => {
     );
     expect(queryByDisplayValue(/service-account-2/i)).toBeTruthy();
     // No selected item (select item '')
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} selectedItem="" />
       </Provider>,
@@ -235,7 +231,7 @@ describe('ServiceAccountsDropdown', () => {
       notifications: {}
     });
     // Select namespace 'green'
-    const { queryByText, getByPlaceholderText, getAllByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getAllByText } = render(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} namespace="green" />
       </Provider>
@@ -259,7 +255,7 @@ describe('ServiceAccountsDropdown', () => {
       notifications: {}
     });
     // Select item 'service-account-1'
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} />
       </Provider>
@@ -278,7 +274,7 @@ describe('ServiceAccountsDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByText } = renderWithIntl(
+    const { queryByText } = render(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} />
       </Provider>
@@ -293,7 +289,7 @@ describe('ServiceAccountsDropdown', () => {
       notifications: {}
     });
     const onChange = jest.fn();
-    const { getByPlaceholderText, getByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <ServiceAccountsDropdown {...props} onChange={onChange} />
       </Provider>

--- a/src/containers/TasksDropdown/TasksDropdown.test.js
+++ b/src/containers/TasksDropdown/TasksDropdown.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
-import { renderWithIntl } from '@tektoncd/dashboard-components/src/utils/test';
+import { render } from '@tektoncd/dashboard-components/src/utils/test';
 
 import TasksDropdown from './TasksDropdown';
 import * as API from '../../api/tasks';
@@ -126,7 +126,7 @@ describe('TasksDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { getByPlaceholderText, getAllByText, queryByText } = renderWithIntl(
+    const { getByPlaceholderText, getAllByText, queryByText } = render(
       <Provider store={store}>
         <TasksDropdown {...props} />
       </Provider>
@@ -151,7 +151,7 @@ describe('TasksDropdown', () => {
       getAllByText,
       queryByText,
       rerender
-    } = renderWithIntl(
+    } = render(
       <Provider store={blueStore}>
         <TasksDropdown {...props} />
       </Provider>
@@ -171,7 +171,7 @@ describe('TasksDropdown', () => {
       ...namespacesStoreGreen,
       notifications: {}
     });
-    renderWithIntl(
+    render(
       <Provider store={greenStore}>
         <TasksDropdown {...props} />
       </Provider>,
@@ -193,18 +193,14 @@ describe('TasksDropdown', () => {
       notifications: {}
     });
     // Select item 'task-1'
-    const {
-      queryByDisplayValue,
-      queryByPlaceholderText,
-      rerender
-    } = renderWithIntl(
+    const { queryByDisplayValue, queryByPlaceholderText, rerender } = render(
       <Provider store={store}>
         <TasksDropdown {...props} selectedItem={{ text: 'task-1' }} />
       </Provider>
     );
     expect(queryByDisplayValue(/task-1/i)).toBeTruthy();
     // Select item 'task-2'
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <TasksDropdown {...props} selectedItem={{ text: 'task-2' }} />
       </Provider>,
@@ -212,7 +208,7 @@ describe('TasksDropdown', () => {
     );
     expect(queryByDisplayValue(/task-2/i)).toBeTruthy();
     // No selected item (select item '')
-    renderWithIntl(
+    render(
       <Provider store={store}>
         <TasksDropdown {...props} selectedItem="" />
       </Provider>,
@@ -228,7 +224,7 @@ describe('TasksDropdown', () => {
       notifications: {}
     });
     // Select namespace 'green'
-    const { queryByText, getByPlaceholderText, getAllByText } = renderWithIntl(
+    const { queryByText, getByPlaceholderText, getAllByText } = render(
       <Provider store={store}>
         <TasksDropdown {...props} namespace="green" />
       </Provider>
@@ -251,7 +247,7 @@ describe('TasksDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <TasksDropdown {...props} />
       </Provider>
@@ -272,7 +268,7 @@ describe('TasksDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <TasksDropdown {...props} namespace={ALL_NAMESPACES} />
       </Provider>
@@ -287,7 +283,7 @@ describe('TasksDropdown', () => {
       ...namespacesStoreBlue,
       notifications: {}
     });
-    const { queryByPlaceholderText } = renderWithIntl(
+    const { queryByPlaceholderText } = render(
       <Provider store={store}>
         <TasksDropdown {...props} />
       </Provider>
@@ -302,7 +298,7 @@ describe('TasksDropdown', () => {
       notifications: {}
     });
     const onChange = jest.fn();
-    const { getByPlaceholderText, getByText } = renderWithIntl(
+    const { getByPlaceholderText, getByText } = render(
       <Provider store={store}>
         <TasksDropdown {...props} onChange={onChange} />
       </Provider>

--- a/src/containers/Trigger/Trigger.test.js
+++ b/src/containers/Trigger/Trigger.test.js
@@ -15,7 +15,7 @@ import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 import {
-  renderWithIntl,
+  render,
   renderWithRouter
 } from '@tektoncd/dashboard-components/src/utils/test';
 
@@ -36,7 +36,7 @@ describe('TriggerContainer', () => {
 
     const errorMessage = 'fake_errorMessage';
 
-    const { getByText } = renderWithIntl(
+    const { getByText } = render(
       <TriggerContainer
         error={errorMessage}
         fetchTrigger={() => Promise.resolve()}
@@ -59,7 +59,7 @@ describe('TriggerContainer', () => {
       }
     };
 
-    const { getByText, rerender } = renderWithIntl(
+    const { getByText, rerender } = render(
       <TriggerContainer
         fetchTrigger={fetchTriggerSpy}
         intl={intl}
@@ -69,7 +69,7 @@ describe('TriggerContainer', () => {
     await waitFor(() => getByText('Error loading resource'));
     expect(fetchTriggerSpy).toHaveBeenCalledTimes(1);
 
-    renderWithIntl(
+    render(
       <TriggerContainer
         fetchTrigger={fetchTriggerSpy}
         intl={intl}
@@ -86,7 +86,7 @@ describe('TriggerContainer', () => {
         namespace: 'updated_namespace'
       }
     };
-    renderWithIntl(
+    render(
       <TriggerContainer
         fetchTrigger={fetchTriggerSpy}
         intl={intl}
@@ -102,7 +102,7 @@ describe('TriggerContainer', () => {
         triggerName: 'updated_triggerName'
       }
     };
-    renderWithIntl(
+    render(
       <TriggerContainer
         fetchTrigger={fetchTriggerSpy}
         intl={intl}
@@ -113,7 +113,7 @@ describe('TriggerContainer', () => {
     );
     expect(fetchTriggerSpy).toHaveBeenCalledTimes(3);
 
-    renderWithIntl(
+    render(
       <TriggerContainer
         fetchTrigger={fetchTriggerSpy}
         intl={intl}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
More preparation for https://github.com/tektoncd/dashboard/issues/1842

`renderWithIntl` is our main test render function which just
happens to wrap a `react-intl` provider. Rename it since we'll
be adding other providers to this, e.g. the `react-query` client
provider, in the very near future.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
