### PR TITLE
2065_add spacing between spinner and text

### DIFF
--- a/packages/components/src/components/LoadingShell/LoadingShell.scss
+++ b/packages/components/src/components/LoadingShell/LoadingShell.scss
@@ -38,6 +38,7 @@ limitations under the License.
 
     .bx--loading {
       margin-top: -3rem;
+      margin-bottom: $spacing-05;
     }
 
     .tkn--config-loading-text {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
https://github.com/tektoncd/dashboard/issues/2065
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
update the space between the spinner animation and the 'loading' text
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
