### PR TITLE
Add hook to keep page title in sync with displayed resource(s)

### DIFF
--- a/packages/utils/src/utils/hooks.js
+++ b/packages/utils/src/utils/hooks.js
@@ -23,6 +23,13 @@ export function usePrevious(value) {
   return ref.current;
 }
 
+export function useTitleSync({ page, resourceName }) {
+  useEffect(() => {
+    const pageTitle = page + (resourceName ? ` - ${resourceName}` : '');
+    document.title = `Tekton Dashboard | ${pageTitle}`;
+  }, [resourceName]);
+}
+
 export function useWebSocketReconnected(callback, webSocketConnected) {
   const prevWebSocketConnected = usePrevious(webSocketConnected);
 

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -45,11 +45,6 @@ export function getErrorMessage(error) {
   );
 }
 
-export function getTitle({ page, resourceName }) {
-  const pageTitle = page + (resourceName ? ` - ${resourceName}` : '');
-  return `Tekton Dashboard | ${pageTitle}`;
-}
-
 export function getStepDefinition({ selectedStepId, task, taskRun }) {
   if (!selectedStepId) {
     return null;

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -32,7 +32,6 @@ import {
   getStepStatusReason,
   getTaskRunsWithPlaceholders,
   getTaskSpecFromTaskRef,
-  getTitle,
   isRunning,
   updateUnexecutedSteps
 } from '.';
@@ -301,14 +300,6 @@ describe('getResources', () => {
     expect(inputResources).toEqual(fakeInputResources);
     expect(outputResources).toEqual(fakeOutputResources);
   });
-});
-
-it('getTitle', () => {
-  let title = getTitle({ page: 'SomePage' });
-  expect(title).toEqual('Tekton Dashboard | SomePage');
-
-  title = getTitle({ page: 'SomePage', resourceName: 'someResource' });
-  expect(title).toEqual('Tekton Dashboard | SomePage - someResource');
 });
 
 describe('getStepDefinition', () => {

--- a/src/containers/About/About.js
+++ b/src/containers/About/About.js
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { InlineNotification } from 'carbon-components-react';
 import { Table } from '@tektoncd/dashboard-components';
-import { getErrorMessage, getTitle } from '@tektoncd/dashboard-utils';
+import { getErrorMessage, useTitleSync } from '@tektoncd/dashboard-utils';
 
 import tektonLogo from '../../images/tekton-dashboard-color.svg';
 
@@ -45,14 +45,12 @@ export function About({
   triggersNamespace,
   triggersVersion
 }) {
-  useEffect(() => {
-    document.title = getTitle({
-      page: intl.formatMessage({
-        id: 'dashboard.about.title',
-        defaultMessage: 'About'
-      })
-    });
-  }, []);
+  useTitleSync({
+    page: intl.formatMessage({
+      id: 'dashboard.about.title',
+      defaultMessage: 'About'
+    })
+  });
 
   const getDisplayValue = value => {
     switch (value) {

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.js
@@ -17,8 +17,8 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -43,9 +43,7 @@ function ClusterInterceptors(props) {
     webSocketConnected
   } = props;
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'ClusterInterceptors' });
-  }, []);
+  useTitleSync({ page: 'ClusterInterceptors' });
 
   function fetchData() {
     fetchClusterInterceptors({ filters });

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -28,8 +28,8 @@ import {
 } from '@carbon/icons-react';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 
@@ -61,9 +61,7 @@ function ClusterTasksContainer(props) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [toBeDeleted, setToBeDeleted] = useState([]);
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'ClusterTasks' });
-  }, []);
+  useTitleSync({ page: 'ClusterTasks' });
 
   function fetchData() {
     fetchClusterTasks({ filters });

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -16,7 +16,10 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import {
   getClusterTriggerBinding,
   getClusterTriggerBindingsErrorMessage,
@@ -41,12 +44,10 @@ export /* istanbul ignore next */ function ClusterTriggerBindingContainer(
   } = props;
   const { clusterTriggerBindingName } = match.params;
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'ClusterTriggerBinding',
-      resourceName: clusterTriggerBindingName
-    });
-  }, []);
+  useTitleSync({
+    page: 'ClusterTriggerBinding',
+    resourceName: clusterTriggerBindingName
+  });
 
   function fetchData() {
     fetchClusterTriggerBinding({

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
@@ -17,8 +17,8 @@ import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -43,9 +43,7 @@ function ClusterTriggerBindings(props) {
     webSocketConnected
   } = props;
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'ClusterTriggerBindings' });
-  }, []);
+  useTitleSync({ page: 'ClusterTriggerBindings' });
 
   function fetchData() {
     fetchClusterTriggerBindings({ filters });

--- a/src/containers/Condition/Condition.js
+++ b/src/containers/Condition/Condition.js
@@ -15,7 +15,10 @@ import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import {
   getCondition,
@@ -88,12 +91,10 @@ export function ConditionContainer(props) {
   } = props;
   const { conditionName, namespace } = match.params;
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'Condition',
-      resourceName: conditionName
-    });
-  }, []);
+  useTitleSync({
+    page: 'Condition',
+    resourceName: conditionName
+  });
 
   function fetchData() {
     fetchCondition({ name: conditionName, namespace });

--- a/src/containers/Conditions/Conditions.js
+++ b/src/containers/Conditions/Conditions.js
@@ -17,8 +17,8 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -44,9 +44,7 @@ function Conditions(props) {
     namespace,
     webSocketConnected
   } = props;
-  useEffect(() => {
-    document.title = getTitle({ page: 'Conditions' });
-  }, []);
+  useTitleSync({ page: 'Conditions' });
 
   function fetchData() {
     fetchConditions({ filters, namespace });

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.js
@@ -11,15 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { Button, InlineNotification } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getErrorMessage,
-  getTitle,
-  urls
+  urls,
+  useTitleSync
 } from '@tektoncd/dashboard-utils';
 
 import GitResourceFields from './GitResourceFields';
@@ -66,14 +66,12 @@ export /* istanbul ignore next */ function CreatePipelineResource(props) {
   const [type, setType] = useState('Git');
   const [url, setURL] = useState('');
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: intl.formatMessage({
-        id: 'dashboard.createPipelineResource.title',
-        defaultMessage: 'Create PipelineResource'
-      })
-    });
-  }, []);
+  useTitleSync({
+    page: intl.formatMessage({
+      id: 'dashboard.createPipelineResource.title',
+      defaultMessage: 'Create PipelineResource'
+    })
+  });
 
   function handleClose() {
     history.push(urls.pipelineResources.all());

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import keyBy from 'lodash.keyby';
 import {
@@ -24,8 +24,8 @@ import {
 import {
   ALL_NAMESPACES,
   generateId,
-  getTitle,
-  urls
+  urls,
+  useTitleSync
 } from '@tektoncd/dashboard-utils';
 import { KeyValueList } from '@tektoncd/dashboard-components';
 import { injectIntl } from 'react-intl';
@@ -154,14 +154,12 @@ function CreatePipelineRun(props) {
     setState
   ] = useState(getInitialState());
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: intl.formatMessage({
-        id: 'dashboard.createPipelineRun.title',
-        defaultMessage: 'Create PipelineRun'
-      })
-    });
-  }, []);
+  useTitleSync({
+    page: intl.formatMessage({
+      id: 'dashboard.createPipelineRun.title',
+      defaultMessage: 'Create PipelineRun'
+    })
+  });
 
   function checkFormValidation() {
     // Namespace, PipelineRef, Resources, and Params must all have values

--- a/src/containers/CreateTaskRun/CreateTaskRun.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import keyBy from 'lodash.keyby';
 import {
@@ -25,9 +25,9 @@ import {
 import {
   ALL_NAMESPACES,
   generateId,
-  getTitle,
   getTranslateWithId,
-  urls
+  urls,
+  useTitleSync
 } from '@tektoncd/dashboard-utils';
 import { KeyValueList } from '@tektoncd/dashboard-components';
 import { injectIntl } from 'react-intl';
@@ -170,14 +170,12 @@ function CreateTaskRun(props) {
     setState
   ] = useState(getInitialState());
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: intl.formatMessage({
-        id: 'dashboard.createTaskRun.title',
-        defaultMessage: 'Create TaskRun'
-      })
-    });
-  }, []);
+  useTitleSync({
+    page: intl.formatMessage({
+      id: 'dashboard.createTaskRun.title',
+      defaultMessage: 'Create TaskRun'
+    })
+  });
 
   function checkFormValidation() {
     // Namespace, PipelineRef, Resources, and Params must all have values

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -14,7 +14,10 @@ limitations under the License.
 import React, { useEffect, useState } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
 
 import { fetchClusterInterceptor as fetchClusterInterceptorActionCreator } from '../../actions/clusterInterceptors';
@@ -55,12 +58,10 @@ function CustomResourceDefinition(props) {
   const [loading, setLoading] = useState(true);
   const [customResource, setCustomResource] = useState(null);
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: type,
-      resourceName: name
-    });
-  }, []);
+  useTitleSync({
+    page: type,
+    resourceName: name
+  });
 
   function fetch() {
     switch (type) {

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -17,8 +17,8 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import {
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
@@ -49,12 +49,10 @@ export /* istanbul ignore next */ function EventListenerContainer(props) {
     fetchEventListener({ name: eventListenerName, namespace });
   }
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'EventListener',
-      resourceName: eventListenerName
-    });
-  }, []);
+  useTitleSync({
+    page: 'EventListener',
+    resourceName: eventListenerName
+  });
 
   useEffect(() => {
     fetchData();

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -17,8 +17,8 @@ import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -45,9 +45,7 @@ function EventListeners(props) {
     webSocketConnected
   } = props;
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'EventListeners' });
-  }, []);
+  useTitleSync({ page: 'EventListeners' });
 
   function fetchData() {
     fetchEventListeners({ filters, namespace: selectedNamespace });

--- a/src/containers/Extension/Extension.js
+++ b/src/containers/Extension/Extension.js
@@ -11,65 +11,51 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Component, Suspense } from 'react';
+import React, { Suspense, useState } from 'react';
 import { injectIntl } from 'react-intl';
 import { ErrorBoundary } from '@tektoncd/dashboard-components';
-import { getTitle, paths, urls } from '@tektoncd/dashboard-utils';
+import { paths, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 
 import * as actions from './actions';
 import * as selectors from '../../reducers';
 import './globals';
 
-/* istanbul ignore next */ class Extension extends Component {
-  constructor(props) {
-    super(props);
+/* istanbul ignore next */
+function Extension({ displayName: resourceName, intl, source }) {
+  const [ExtensionComponent] = useState(() =>
+    React.lazy(() => import(/* webpackIgnore: true */ source))
+  );
 
-    const { source } = props;
-    const ExtensionComponent = React.lazy(() =>
-      import(/* webpackIgnore: true */ source)
-    );
+  useTitleSync({
+    page: 'Extension',
+    resourceName
+  });
 
-    this.state = { ExtensionComponent };
-  }
-
-  componentDidMount() {
-    const { displayName: resourceName } = this.props;
-    document.title = getTitle({
-      page: 'Extension',
-      resourceName
-    });
-  }
-
-  render() {
-    const { intl } = this.props;
-    const { ExtensionComponent } = this.state;
-
-    return (
-      <ErrorBoundary
-        message={intl.formatMessage({
-          id: 'dashboard.extension.error',
-          defaultMessage: 'Error loading extension'
-        })}
+  return (
+    <ErrorBoundary
+      message={intl.formatMessage({
+        id: 'dashboard.extension.error',
+        defaultMessage: 'Error loading extension'
+      })}
+    >
+      <Suspense
+        fallback={
+          <div>
+            {intl.formatMessage({
+              id: 'dashboard.loading',
+              defaultMessage: 'Loading…'
+            })}
+          </div>
+        }
       >
-        <Suspense
-          fallback={
-            <div>
-              {intl.formatMessage({
-                id: 'dashboard.loading',
-                defaultMessage: 'Loading…'
-              })}
-            </div>
-          }
-        >
-          <ExtensionComponent
-            actions={actions}
-            selectors={selectors}
-            utils={{ paths, urls }}
-          />
-        </Suspense>
-      </ErrorBoundary>
-    );
-  }
+        <ExtensionComponent
+          actions={actions}
+          selectors={selectors}
+          utils={{ paths, urls }}
+        />
+      </Suspense>
+    </ErrorBoundary>
+  );
 }
 
 export default injectIntl(Extension);

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { InlineNotification } from 'carbon-components-react';
-import { getErrorMessage, getTitle, urls } from '@tektoncd/dashboard-utils';
+import { getErrorMessage, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { Table } from '@tektoncd/dashboard-components';
 
 import {
@@ -31,14 +31,12 @@ export const Extensions = /* istanbul ignore next */ ({
   loading,
   extensions
 }) => {
-  useEffect(() => {
-    document.title = getTitle({
-      page: intl.formatMessage({
-        id: 'dashboard.extensions.title',
-        defaultMessage: 'Extensions'
-      })
-    });
-  }, []);
+  useTitleSync({
+    page: intl.formatMessage({
+      id: 'dashboard.extensions.title',
+      defaultMessage: 'Extensions'
+    })
+  });
 
   const emptyText = intl.formatMessage({
     id: 'dashboard.extensions.emptyState',

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { injectIntl } from 'react-intl';
 import {
   Accordion,
@@ -30,9 +30,9 @@ import { Link } from 'react-router-dom';
 import {
   ALL_NAMESPACES,
   getErrorMessage,
-  getTitle,
   getTranslateWithId,
-  urls
+  urls,
+  useTitleSync
 } from '@tektoncd/dashboard-utils';
 import parseGitURL from 'git-url-parse';
 import { importResources } from '../../api';
@@ -80,14 +80,12 @@ export function ImportResources(props) {
   const [submitError, setSubmitError] = useState('');
   const [submitSuccess, setSubmitSuccess] = useState(false);
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: intl.formatMessage({
-        id: 'dashboard.importResources.title',
-        defaultMessage: 'Import resources'
-      })
-    });
-  }, []);
+  useTitleSync({
+    page: intl.formatMessage({
+      id: 'dashboard.importResources.title',
+      defaultMessage: 'Import resources'
+    })
+  });
 
   function resetError() {
     setSubmitError('');

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -17,7 +17,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { DataTable } from 'carbon-components-react';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 
 import {
   getPipelineResource,
@@ -53,12 +56,10 @@ function PipelineResource(props) {
   } = props;
   const { namespace, pipelineResourceName: resourceName } = match.params;
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'PipelineResource',
-      resourceName
-    });
-  }, []);
+  useTitleSync({
+    page: 'PipelineResource',
+    resourceName
+  });
 
   function fetchData() {
     fetchPipelineResource({ name: resourceName, namespace });

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -18,8 +18,8 @@ import keyBy from 'lodash.keyby';
 import {
   ALL_NAMESPACES,
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import {
@@ -59,9 +59,7 @@ export /* istanbul ignore next */ function PipelineResources(props) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [toBeDeleted, setToBeDeleted] = useState([]);
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'PipelineResources' });
-  }, []);
+  useTitleSync({ page: 'PipelineResources' });
 
   function fetchData() {
     fetchPipelineResources({ filters, namespace });

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -17,10 +17,10 @@ import { connect } from 'react-redux';
 import { PipelineRun, Rerun } from '@tektoncd/dashboard-components';
 import {
   getTaskRunsWithPlaceholders,
-  getTitle,
   labels as labelConstants,
   queryParams as queryParamConstants,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { InlineNotification } from 'carbon-components-react';
@@ -87,12 +87,10 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
   const [loading, setLoading] = useState(true);
   const [showRerunNotification, setShowRerunNotification] = useState(null);
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'PipelineRun',
-      resourceName: pipelineRunName
-    });
-  }, []);
+  useTitleSync({
+    page: 'PipelineRun',
+    resourceName: pipelineRunName
+  });
 
   async function fetchResources() {
     const [run] = await Promise.all([

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -27,11 +27,11 @@ import {
   getStatus,
   getStatusFilter,
   getStatusFilterHandler,
-  getTitle,
   isRunning,
   labels,
   runMatchesStatusFilter,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { Add16 as Add, TrashCan32 as Delete } from '@carbon/icons-react';
@@ -76,9 +76,7 @@ export /* istanbul ignore next */ function PipelineRuns(props) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [toBeDeleted, setToBeDeleted] = useState([]);
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'PipelineRuns' });
-  }, []);
+  useTitleSync({ page: 'PipelineRuns' });
 
   function reset() {
     setDeleteError(null);

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -24,8 +24,8 @@ import { Button } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import {
@@ -64,9 +64,7 @@ export /* istanbul ignore next */ function Pipelines(props) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [toBeDeleted, setToBeDeleted] = useState([]);
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'Pipelines' });
-  }, []);
+  useTitleSync({ page: 'Pipelines' });
 
   function fetchData() {
     fetchPipelines({ filters, namespace });

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -17,8 +17,8 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -36,11 +36,7 @@ export function ResourceListContainer(props) {
   const [isNamespaced, setIsNamespaced] = useState(true);
   const [resources, setResources] = useState([]);
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: `${group}/${version}/${type}`
-    });
-  }, []);
+  useTitleSync({ page: `${group}/${version}/${type}` });
 
   function fetchResources() {
     return getAPIResource({ group, version, type })

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -30,9 +30,9 @@ import {
   getStatus,
   getStepDefinition,
   getStepStatus,
-  getTitle,
   queryParams as queryParamConstants,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 
@@ -113,12 +113,10 @@ export /* istanbul ignore next */ function TaskRunContainer(props) {
   const [loading, setLoading] = useState(true);
   const [rerunNotification, setRerunNotification] = useState(null);
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'TaskRun',
-      resourceName: taskRunName
-    });
-  }, []);
+  useTitleSync({
+    page: 'TaskRun',
+    resourceName: taskRunName
+  });
 
   function fetchTaskAndRuns() {
     fetchTaskRun({ name: taskRunName, namespace }).then(run => {

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -27,11 +27,11 @@ import {
   getStatus,
   getStatusFilter,
   getStatusFilterHandler,
-  getTitle,
   isRunning,
   labels,
   runMatchesStatusFilter,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { Add16 as Add, TrashCan32 as Delete } from '@carbon/icons-react';
@@ -76,9 +76,7 @@ function TaskRuns(props) {
   const [toBeDeleted, setToBeDeleted] = useState([]);
   const [cancelSelection, setCancelSelection] = useState(null);
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'TaskRuns' });
-  }, []);
+  useTitleSync({ page: 'TaskRuns' });
 
   function fetchData() {
     if (kind === 'ClusterTask') {

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -20,8 +20,8 @@ import { Button } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import {
@@ -90,9 +90,7 @@ function Tasks(props) {
     return null;
   }
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'Tasks' });
-  }, []);
+  useTitleSync({ page: 'Tasks' });
 
   useEffect(() => {
     fetchData();

--- a/src/containers/Trigger/Trigger.js
+++ b/src/containers/Trigger/Trigger.js
@@ -15,7 +15,10 @@ import React, { useEffect } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
 import {
   getSelectedNamespace,
@@ -39,12 +42,10 @@ export function TriggerContainer(props) {
   } = props;
   const { triggerName, namespace } = match.params;
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'Trigger',
-      resourceName: triggerName
-    });
-  }, []);
+  useTitleSync({
+    page: 'Trigger',
+    resourceName: triggerName
+  });
 
   function fetchData() {
     fetchTrigger({ name: triggerName, namespace });

--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -16,7 +16,10 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import {
   getSelectedNamespace,
   getTriggerBinding,
@@ -42,12 +45,10 @@ export /* istanbul ignore next */ function TriggerBindingContainer(props) {
   } = props;
   const { namespace, triggerBindingName: resourceName } = match.params;
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'TriggerBinding',
-      resourceName
-    });
-  }, []);
+  useTitleSync({
+    page: 'TriggerBinding',
+    resourceName
+  });
 
   function fetchData() {
     fetchTriggerBinding({ name: resourceName, namespace });

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -17,8 +17,8 @@ import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -44,9 +44,7 @@ export /* istanbul ignore next */ function TriggerBindings(props) {
     webSocketConnected
   } = props;
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'TriggerBindings' });
-  }, []);
+  useTitleSync({ page: 'TriggerBindings' });
 
   function fetchData() {
     fetchTriggerBindings({ filters, namespace: selectedNamespace });

--- a/src/containers/TriggerTemplate/TriggerTemplate.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.js
@@ -21,7 +21,10 @@ import {
   ResourceDetails,
   ViewYAML
 } from '@tektoncd/dashboard-components';
-import { getTitle, useWebSocketReconnected } from '@tektoncd/dashboard-utils';
+import {
+  useTitleSync,
+  useWebSocketReconnected
+} from '@tektoncd/dashboard-utils';
 import {
   getSelectedNamespace,
   getTriggerTemplate,
@@ -60,12 +63,10 @@ export /* istanbul ignore next */ function TriggerTemplateContainer(props) {
   } = props;
   const { namespace, triggerTemplateName: resourceName } = match.params;
 
-  useEffect(() => {
-    document.title = getTitle({
-      page: 'TriggerTemplate',
-      resourceName
-    });
-  }, []);
+  useTitleSync({
+    page: 'TriggerTemplate',
+    resourceName
+  });
 
   function fetchData() {
     fetchTriggerTemplate({ name: resourceName, namespace });

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -17,8 +17,8 @@ import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -45,9 +45,7 @@ function TriggerTemplates(props) {
     webSocketConnected
   } = props;
 
-  useEffect(() => {
-    document.title = getTitle({ page: 'TriggerTemplates' });
-  }, []);
+  useTitleSync({ page: 'TriggerTemplates' });
 
   function fetchData() {
     fetchTriggerTemplates({ filters, namespace: selectedNamespace });

--- a/src/containers/Triggers/Triggers.js
+++ b/src/containers/Triggers/Triggers.js
@@ -17,8 +17,8 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import {
   getFilters,
-  getTitle,
   urls,
+  useTitleSync,
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -44,9 +44,7 @@ function Triggers(props) {
     triggers,
     webSocketConnected
   } = props;
-  useEffect(() => {
-    document.title = getTitle({ page: 'Triggers' });
-  }, []);
+  useTitleSync({ page: 'Triggers' });
 
   function fetchData() {
     fetchTriggers({ filters, namespace });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add a custom hook which will keep the `document.title` in sync
with the display resource(s) as the user navigates through the
application. On a given resource details page, respond to changes
in the resource name. Responding to changes caused by navigation
to another resource kind is already handled via the router as a
new page container will be mounted and its `useTitleSync` hook
will take over.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
