### PR TITLE
Add initial react-query utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15121,6 +15121,11 @@
         "open": "^7.0.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -15343,6 +15348,35 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.6.0.tgz",
+      "integrity": "sha512-0x87tKJULniTOfECZP/LCsqWyMEbz0Oa+4yJ4i5dosOMxWUjx6mZ6nt9QmD2ox0r3MaCPojHrTQ2dj4ASZupeA==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
+      },
+      "dependencies": {
+        "detect-node": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+          "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
           }
         }
       }
@@ -17790,8 +17824,7 @@
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
-      "dev": true
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -23827,6 +23860,11 @@
         }
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -24629,6 +24667,15 @@
       "integrity": "sha512-O8DMCl32V34RrD+ZHxcAPc2+kYytuDIoQYjY36RVdsLK7uHjgNVvFec4yv0X6LgB4YEZgSvK5QtFi5YVqEpoMA==",
       "dev": true
     },
+    "match-sorter": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -24993,6 +25040,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -25384,6 +25436,14 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.1.20",
@@ -28077,6 +28137,16 @@
         "react-popper": "^2.2.4"
       }
     },
+    "react-query": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.16.1.tgz",
+      "integrity": "sha512-dof8XXSZ7HprfzvpbJE+YZrhUXcQYxy1j+NU8ZPYpKKDF79wlZAke+GyYhQ0b6SuOFp8ZpVXSpdD4AL3lxmeXQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-redux": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
@@ -28784,6 +28854,11 @@
       "requires": {
         "mdast-util-to-markdown": "^0.5.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -32007,6 +32082,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",
     "react-intl": "^5.10.2",
+    "react-query": "3.16.1",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "reconnecting-websocket": "^4.4.0",

--- a/packages/components/src/utils/test.js
+++ b/packages/components/src/utils/test.js
@@ -47,6 +47,15 @@ function IntlWrapper({ children }) {
   );
 }
 
-export function render(ui, { rerender } = {}) {
-  return (rerender || baseRender)(ui, { wrapper: IntlWrapper });
+export function render(
+  ui,
+  { rerender, wrapper: Wrapper = React.Fragment } = {}
+) {
+  return (rerender || baseRender)(ui, {
+    wrapper: ({ children }) => (
+      <Wrapper>
+        <IntlWrapper>{children}</IntlWrapper>
+      </Wrapper>
+    )
+  });
 }

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React, { useContext, useEffect } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { getAPIRoot } from './comms';
@@ -99,4 +101,57 @@ export function getTektonAPI(
     { group, version, type, name, namespace },
     queryParams
   );
+}
+
+export const WebSocketContext = React.createContext();
+
+function getResourceVersion(resource) {
+  return parseInt(resource.metadata.resourceVersion, 10);
+}
+
+export function useWebSocket(resourceType) {
+  const webSocket = useContext(WebSocketContext);
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    const eventListener = event => {
+      if (event.type !== 'message') {
+        return;
+      }
+      const { operation, payload } = JSON.parse(event.data);
+      queryClient.setQueriesData(resourceType, data => {
+        switch (operation) {
+          case 'Created':
+            const existingResource = data.find(
+              resource => resource.metadata.uid === payload.metadata.uid
+            );
+            if (existingResource) {
+              return data; // payload is stale, ignore it
+            }
+            return [...data, payload];
+          case 'Deleted':
+            return data.filter(
+              resource => resource.metadata.uid !== payload.metadata.uid
+            );
+          case 'Updated':
+            return data.map(resource => {
+              return resource.metadata.uid === payload.metadata.uid &&
+                // only apply the update if it's newer than the version we already have
+                getResourceVersion(payload) > getResourceVersion(resource)
+                ? payload
+                : resource;
+            });
+          default:
+            return data;
+        }
+      });
+    };
+    webSocket.addEventListener('message', eventListener);
+    return () => webSocket.removeEventListener('message', eventListener);
+  }, [queryClient, webSocket]);
+}
+
+export function useNamespacedCollection(resourceType, api, params) {
+  const query = useQuery([resourceType, params], () => api(params));
+  useWebSocket(resourceType);
+  return query;
 }

--- a/src/api/utils.test.js
+++ b/src/api/utils.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { act, renderHook } from '@testing-library/react-hooks';
+
 import * as utils from './utils';
+import { useNamespacedCollection, useWebSocket } from './utils';
+import { getAPIWrapper, getQueryClient, getWebSocket } from '../utils/test';
 
 describe('getAPI', () => {
   it('returns a URI containing the given type', () => {
@@ -141,5 +145,199 @@ describe('checkData', () => {
 
   it('throws an error if items is not present', () => {
     expect(() => utils.checkData({})).toThrow();
+  });
+});
+
+describe('useWebSocket', () => {
+  const kind = 'TaskRun';
+  it('should handle Created events', () => {
+    const queryClient = getQueryClient();
+    const webSocket = getWebSocket();
+
+    const existingResource = { metadata: { uid: 'existing-id' } };
+    const newResource = { metadata: { uid: 'new-uid' } };
+
+    queryClient.setQueryData(kind, () => [existingResource]);
+
+    renderHook(() => useWebSocket(kind), {
+      wrapper: getAPIWrapper({ queryClient, webSocket })
+    });
+
+    // should ignore non-message websocket events
+    jest.spyOn(queryClient, 'setQueriesData');
+    act(() => {
+      webSocket.fireEvent({
+        type: 'foo'
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([existingResource]);
+    expect(queryClient.setQueriesData).not.toHaveBeenCalled();
+
+    // should ignore Create events for resources we already have in the cache
+    act(() => {
+      webSocket.fireEvent({
+        type: 'message',
+        data: JSON.stringify({
+          kind,
+          operation: 'Created',
+          payload: existingResource
+        })
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([existingResource]);
+
+    // should add new resources to the cache
+    act(() => {
+      webSocket.fireEvent({
+        type: 'message',
+        data: JSON.stringify({
+          kind,
+          operation: 'Created',
+          payload: newResource
+        })
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([
+      existingResource,
+      newResource
+    ]);
+  });
+
+  it('should handle Deleted events', () => {
+    const queryClient = getQueryClient();
+    const webSocket = getWebSocket();
+
+    const resource1 = { metadata: { uid: 'existing-id-1' } };
+    const resource2 = { metadata: { uid: 'existing-id-2' } };
+    const resource3 = { metadata: { uid: 'existing-id-3' } };
+
+    queryClient.setQueryData(kind, () => [resource1, resource2, resource3]);
+
+    renderHook(() => useWebSocket(kind), {
+      wrapper: getAPIWrapper({ queryClient, webSocket })
+    });
+
+    act(() => {
+      webSocket.fireEvent({
+        type: 'message',
+        data: JSON.stringify({
+          kind,
+          operation: 'Deleted',
+          payload: resource2
+        })
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([resource1, resource3]);
+  });
+
+  it('should handle Updated events', () => {
+    const queryClient = getQueryClient();
+    const webSocket = getWebSocket();
+
+    const existingResource = {
+      metadata: { uid: 'existing-id', resourceVersion: '10' }
+    };
+    const staleResource = {
+      metadata: { ...existingResource.metadata, resourceVersion: '9' }
+    };
+    const updatedResource = {
+      metadata: { ...existingResource.metadata, resourceVersion: '11' }
+    };
+
+    queryClient.setQueryData(kind, () => [existingResource]);
+
+    renderHook(() => useWebSocket(kind), {
+      wrapper: getAPIWrapper({ queryClient, webSocket })
+    });
+
+    // should ignore stale update events
+    act(() => {
+      webSocket.fireEvent({
+        type: 'message',
+        data: JSON.stringify({
+          kind,
+          operation: 'Updated',
+          payload: staleResource
+        })
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([existingResource]);
+
+    // should update cache when a fresh update is received
+    act(() => {
+      webSocket.fireEvent({
+        type: 'message',
+        data: JSON.stringify({
+          kind,
+          operation: 'Updated',
+          payload: updatedResource
+        })
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([updatedResource]);
+  });
+
+  it('should handle unsupported events', () => {
+    const queryClient = getQueryClient();
+    const webSocket = getWebSocket();
+
+    const existingResource = {
+      metadata: { uid: 'existing-id' }
+    };
+
+    queryClient.setQueryData(kind, () => [existingResource]);
+
+    renderHook(() => useWebSocket(kind), {
+      wrapper: getAPIWrapper({ queryClient, webSocket })
+    });
+
+    // should ignore stale update events
+    act(() => {
+      webSocket.fireEvent({
+        type: 'message',
+        data: JSON.stringify({
+          kind,
+          operation: 'SomeUnsupportedOperation'
+        })
+      });
+    });
+    expect(queryClient.getQueryData(kind)).toEqual([existingResource]);
+  });
+});
+
+describe('useNamespacedCollection', () => {
+  const kind = 'TaskRun';
+  it('should return a valid query response', async () => {
+    const queryClient = getQueryClient();
+    const webSocket = getWebSocket();
+
+    const existingResource = {
+      metadata: { uid: 'existing-id', resourceVersion: '10' }
+    };
+    const updatedResource = {
+      metadata: { ...existingResource.metadata, resourceVersion: '11' }
+    };
+
+    const api = () => [existingResource];
+    const { result, waitFor, waitForNextUpdate } = renderHook(
+      () => useNamespacedCollection(kind, api),
+      {
+        wrapper: getAPIWrapper({ queryClient, webSocket })
+      }
+    );
+
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data).toEqual([existingResource]);
+
+    webSocket.fireEvent({
+      type: 'message',
+      data: JSON.stringify({
+        kind,
+        operation: 'Updated',
+        payload: updatedResource
+      })
+    });
+    await waitForNextUpdate();
+    expect(result.current.data).toEqual([updatedResource]);
   });
 });

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { render as baseRender } from '@tektoncd/dashboard-components/src/utils/test';
+
+import { WebSocketContext } from '../api/utils';
+
+export function getQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        cacheTime: 1000 * 60 * 5, // 5 minutes
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: Infinity
+      }
+    }
+  });
+}
+
+export function getWebSocket() {
+  return {
+    listener: null,
+    addEventListener(type, listener) {
+      this.listener = listener;
+    },
+    removeEventListener() {},
+    fireEvent(event) {
+      this.listener(event);
+    }
+  };
+}
+
+export function getAPIWrapper({
+  queryClient = getQueryClient(),
+  webSocket = getWebSocket()
+} = {}) {
+  return function apiWrapper({ children }) {
+    return (
+      <WebSocketContext.Provider value={webSocket}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </WebSocketContext.Provider>
+    );
+  };
+}
+
+export function render(ui, { queryClient, rerender, webSocket } = {}) {
+  return (rerender || baseRender)(ui, {
+    wrapper: getAPIWrapper({ queryClient, webSocket })
+  });
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
~~Depends on https://github.com/tektoncd/dashboard/pull/2084 due to dependency updates.~~ merged

https://github.com/tektoncd/dashboard/issues/1842

Add a custom hook for fetching a list of namespaced resources
similar to our existing `fetchNamespacedCollection` action creator.
The difference with this is that we won't need action creators,
selectors, or the reducer backing it, all of the caching functionality
is handled internally by react-query while giving us control over
config (e.g. cache time, stale time, retries) if desired.

Add a custom hook to handle websocket events, updating the react-query
cache directly for any matching queries. This is a replacement for
the existing websocket middleware and events handlers we've added with
redux.

These are not yet wired into the application, this will be handled
in another PR.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
