### PR TITLE
Expand ViewYAML to the full width of container

### DIFF
--- a/packages/components/src/components/ViewYAML/ViewYAML.scss
+++ b/packages/components/src/components/ViewYAML/ViewYAML.scss
@@ -20,6 +20,8 @@ limitations under the License.
 // https://github.com/carbon-design-system/carbon-website/issues/965 for more
 // details.
 .bx--snippet--multi {
+  max-width: none;
+
   .token.string {
     color: rgb(0, 187, 0);
   }


### PR DESCRIPTION
# Changes

Override `max-width` in `.bx--snippet--multi` in ViewYAML component to
make the component expand the content inside container.

Closes #2083

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
