### PR TITLE
add configmap which can contain dashboard info and RBAC to access this configmap

### DIFF
--- a/base/200-role.yaml
+++ b/base/200-role.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-dashboard-info
+  namespace: tekton-dashboard
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+rules:
+    # All system:authenticated users needs to have access
+    # of the dashboard-info ConfigMap even if they don't
+    # have access to the other resources present in the
+    # installed namespace.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["dashboard-info"]
+    verbs: ["get"]

--- a/base/201-rolebinding.yaml
+++ b/base/201-rolebinding.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-info
+  namespace: tekton-dashboard
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+subjects:
+    # Giving all system:authenticated users the access of the
+    # ConfigMap which contains version information.
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-dashboard-info

--- a/base/config-info.yaml
+++ b/base/config-info.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-info
+  namespace: tekton-dashboard
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+data:
+  # Contains dashboard version which can be queried by external
+  # tools such as CLI. Elevated permissions are already given to
+  # this ConfigMap such that even if we don't have access to
+  # other resources in the namespace we still can have access to
+  # this ConfigMap.
+  version: "devel"

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -79,6 +79,7 @@ spec:
           # Rewrite "devel" to params.versionTag
           sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/300-deployment.yaml
           sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/300-service.yaml
+          sed -i 's/devel/$(params.versionTag)/g' /workspace/go/src/github.com/tektoncd/dashboard/base/config-info.yaml
 
           # Publish images and create release.yamls
           which ko # Tested with 0.2.0


### PR DESCRIPTION
# Changes

As of now, we fetch the version of pipelines through labels present on the
deployments which are read by tools such as `tkn cli` and display the
version. This version may not be displayed to users if they don't have
permission to view the deployment.

In this commit, we are adding

 - A ConfigMap which contains version information.
 - RBAC which will give appropriate permissions to view the ConfigMap
irrespective of whether user is has permission to view other objects in
that namespace or not.


Similar that were done in https://github.com/tektoncd/pipeline/pull/3971 and https://github.com/tektoncd/triggers/pull/1114

This is covered as part of [TEP-0041](https://github.com/tektoncd/community/blob/main/teps/0041-tekton-component-versioning.md)

Fixes: https://github.com/tektoncd/dashboard/issues/2089

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
