### PR TITLE
Update style of links in tables to match Carbon guidelines

### DIFF
--- a/packages/components/src/components/PipelineResources/PipelineResources.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,6 +15,7 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { FormattedDate, Table } from '..';
 
@@ -70,7 +71,7 @@ const PipelineResources = ({
     return {
       id: pipelineResource.metadata.uid,
       name: url ? (
-        <Link to={url} title={pipelineResourceName}>
+        <Link component={CarbonLink} to={url} title={pipelineResourceName}>
           {pipelineResourceName}
         </Link>
       ) : (

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -17,6 +17,7 @@ import { Link } from 'react-router-dom';
 import { StatusIcon, Table } from '@tektoncd/dashboard-components';
 import { getStatus, urls } from '@tektoncd/dashboard-utils';
 import { Pending24 as DefaultIcon } from '@carbon/icons-react';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { FormattedDate, FormattedDuration, RunDropdown } from '..';
 
@@ -155,7 +156,11 @@ const PipelineRuns = ({
     return {
       id: getPipelineRunId(pipelineRun),
       name: pipelineRunURL ? (
-        <Link to={pipelineRunURL} title={pipelineRunName}>
+        <Link
+          component={CarbonLink}
+          to={pipelineRunURL}
+          title={pipelineRunName}
+        >
           {pipelineRunName}
         </Link>
       ) : (
@@ -164,7 +169,11 @@ const PipelineRuns = ({
       pipeline:
         pipelineRefName &&
         (pipelineRunsByPipelineURL ? (
-          <Link to={pipelineRunsByPipelineURL} title={pipelineRefName}>
+          <Link
+            component={CarbonLink}
+            to={pipelineRunsByPipelineURL}
+            title={pipelineRefName}
+          >
             {pipelineRefName}
           </Link>
         ) : (

--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,6 +15,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getResources, urls } from '@tektoncd/dashboard-utils';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ResourceTable, ViewYAML } from '..';
 
@@ -27,6 +28,7 @@ const resourceTable = (title, namespace, resources, intl) => (
       value:
         resourceRef && resourceRef.name ? (
           <Link
+            component={CarbonLink}
             to={urls.pipelineResources.byName({
               namespace,
               pipelineResourceName: resourceRef.name

--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -178,4 +178,8 @@ limitations under the License.
       }
     }
   }
+
+  a.bx--link {
+    display: inline;
+  }
 }

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,6 +16,7 @@ import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { StatusIcon } from '@tektoncd/dashboard-components';
 import { getStatus, urls } from '@tektoncd/dashboard-utils';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { FormattedDate, FormattedDuration, RunDropdown, Table } from '..';
 
@@ -139,14 +140,14 @@ const TaskRuns = ({
     return {
       id: taskRun.metadata.uid,
       name: taskRunURL ? (
-        <Link to={taskRunURL} title={taskRunName}>
+        <Link component={CarbonLink} to={taskRunURL} title={taskRunName}>
           {taskRunName}
         </Link>
       ) : (
         taskRunName
       ),
       task: taskRefName ? (
-        <Link to={taskRunsURL} title={taskRefName}>
+        <Link component={CarbonLink} to={taskRunsURL} title={taskRefName}>
           {taskRefName}
         </Link>
       ) : (

--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -17,6 +17,7 @@ import { Link } from 'react-router-dom';
 import {
   Accordion,
   AccordionItem,
+  Link as CarbonLink,
   ListItem,
   UnorderedList
 } from 'carbon-components-react';
@@ -66,6 +67,7 @@ const Trigger = ({ intl, namespace, trigger }) => {
                   {binding.ref ? (
                     <Link
                       className="tkn--trigger-resourcelink"
+                      component={CarbonLink}
                       to={
                         binding.kind === 'ClusterTriggerBinding'
                           ? urls.clusterTriggerBindings.byName({
@@ -100,6 +102,7 @@ const Trigger = ({ intl, namespace, trigger }) => {
           ) : (
             <Link
               className="tkn--trigger-resourcelink"
+              component={CarbonLink}
               to={urls.triggerTemplates.byName({
                 namespace,
                 triggerTemplateName
@@ -317,6 +320,7 @@ const Trigger = ({ intl, namespace, trigger }) => {
                 const clusterInterceptorName = interceptor.ref.name;
                 content = (
                   <Link
+                    component={CarbonLink}
                     to={urls.clusterInterceptors.byName({
                       clusterInterceptorName
                     })}

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { fetchClusterInterceptors as fetchClusterInterceptorsActionCreator } from '../../actions/clusterInterceptors';
@@ -94,6 +95,7 @@ function ClusterInterceptors(props) {
       id: clusterInterceptor.metadata.uid,
       name: (
         <Link
+          component={CarbonLink}
           to={urls.rawCRD.cluster({
             name: clusterInterceptor.metadata.name,
             type: 'clusterinterceptors'

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -21,7 +21,7 @@ import {
   FormattedDate,
   Table
 } from '@tektoncd/dashboard-components';
-import { Button } from 'carbon-components-react';
+import { Button, Link as CarbonLink } from 'carbon-components-react';
 import {
   TrashCan16 as DeleteIcon,
   Playlist16 as RunsIcon
@@ -167,6 +167,7 @@ function ClusterTasksContainer(props) {
     id: clusterTask.metadata.uid,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.rawCRD.cluster({
           type: 'clustertasks',
           name: clusterTask.metadata.name

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { useClusterTriggerBindings } from '../../api';
@@ -71,6 +72,7 @@ function ClusterTriggerBindings(props) {
       id: `${binding.metadata.name}`,
       name: (
         <Link
+          component={CarbonLink}
           to={urls.clusterTriggerBindings.byName({
             clusterTriggerBindingName: binding.metadata.name
           })}

--- a/src/containers/Conditions/Conditions.js
+++ b/src/containers/Conditions/Conditions.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { useConditions } from '../../api';
 import { ListPageLayout } from '..';
@@ -80,6 +81,7 @@ function Conditions(props) {
     id: condition.metadata.uid,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.conditions.byName({
           namespace: condition.metadata.namespace,
           conditionName: condition.metadata.name

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { isWebSocketConnected } from '../../reducers';
 import { useEventListener } from '../../api';
@@ -110,6 +111,7 @@ export /* istanbul ignore next */ function EventListenerContainer(props) {
               <div className="tkn--trigger-resourcelinks">
                 <span>Trigger:</span>
                 <Link
+                  component={CarbonLink}
                   to={urls.triggers.byName({
                     namespace,
                     triggerName: trigger.triggerRef

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { useEventListeners } from '../../api';
@@ -74,6 +75,7 @@ function EventListeners(props) {
     id: `${listener.metadata.namespace}:${listener.metadata.name}`,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.eventListeners.byName({
           namespace: listener.metadata.namespace,
           eventListenerName: listener.metadata.name

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -15,7 +15,10 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { InlineNotification } from 'carbon-components-react';
+import {
+  Link as CarbonLink,
+  InlineNotification
+} from 'carbon-components-react';
 import { getErrorMessage, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { Table } from '@tektoncd/dashboard-components';
 
@@ -79,6 +82,7 @@ export const Extensions = /* istanbul ignore next */ ({
             id: name,
             name: (
               <Link
+                component={CarbonLink}
                 to={
                   extensionType === 'kubernetes-resource'
                     ? urls.kubernetesResources.all({

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -20,7 +20,7 @@ import {
 } from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
-import { Button } from 'carbon-components-react';
+import { Button, Link as CarbonLink } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getFilters,
@@ -177,6 +177,7 @@ export /* istanbul ignore next */ function Pipelines(props) {
     id: pipeline.metadata.uid,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.rawCRD.byNamespace({
           namespace: pipeline.metadata.namespace,
           type: 'pipelines',

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { getAPIResource, getCustomResources } from '../../api';
@@ -132,6 +133,7 @@ export function ResourceListContainer(props) {
             id: uid,
             name: (
               <Link
+                component={CarbonLink}
                 to={
                   resourceNamespace
                     ? urls.kubernetesResources.byName({

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -16,7 +16,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
-import { Button } from 'carbon-components-react';
+import { Button, Link as CarbonLink } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getFilters,
@@ -175,6 +175,7 @@ function Tasks(props) {
     id: task.metadata.uid,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.rawCRD.byNamespace({
           namespace: task.metadata.namespace,
           type: 'tasks',

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { useTriggerBindings } from '../../api';
@@ -74,6 +75,7 @@ export function TriggerBindings(props) {
     id: `${binding.metadata.namespace}:${binding.metadata.name}`,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.triggerBindings.byName({
           namespace: binding.metadata.namespace,
           triggerBindingName: binding.metadata.name

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { useTriggerTemplates } from '../../api';
@@ -74,6 +75,7 @@ function TriggerTemplates(props) {
     id: `${template.metadata.namespace}:${template.metadata.name}`,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.triggerTemplates.byName({
           namespace: template.metadata.namespace,
           triggerTemplateName: template.metadata.name

--- a/src/containers/Triggers/Triggers.js
+++ b/src/containers/Triggers/Triggers.js
@@ -22,6 +22,7 @@ import {
   useWebSocketReconnected
 } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
+import { Link as CarbonLink } from 'carbon-components-react';
 
 import { ListPageLayout } from '..';
 import { useTriggers } from '../../api';
@@ -83,6 +84,7 @@ function Triggers(props) {
     id: trigger.metadata.uid,
     name: (
       <Link
+        component={CarbonLink}
         to={urls.triggers.byName({
           namespace: trigger.metadata.namespace,
           triggerName: trigger.metadata.name


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
~~**Note:** this will need to be rebased after https://github.com/tektoncd/dashboard/pull/2093 and https://github.com/tektoncd/dashboard/pull/2095 are merged.~~ merged

Adopt the Carbon `Link` component so we correctly inherit the styles
expected for Carbon. This includes removing the default underline
from links in tables since this is reserved for inline links only.

This also brings some minor changes to the hover, focus, and active
states, mostly the text colour, and uses colour tokens so links are
still legible in dark mode.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
