### PR TITLE
Add scroll buttons and auto-scroll to logs

### DIFF
--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -53,6 +53,20 @@ pre.tkn--log {
     right: 0;
   }
 
+  .bx--copy-btn.scroll-btn {
+    position: fixed;
+    width: 1.6rem;
+    right: var(--log-element-right);
+  }
+
+  .scroll-to-top-btn {
+    top: 64px;
+  }
+
+  .scroll-to-bottom-btn {
+    bottom: 64px;
+  }
+
   .bx--copy-btn {
     width: 2rem;
     height: 2rem;

--- a/packages/components/src/components/Log/utils.js
+++ b/packages/components/src/components/Log/utils.js
@@ -15,6 +15,20 @@ function hasElementPositiveScrollBottom(el) {
     return el.scrollHeight - el.clientHeight > el.scrollTop;
 }
 
+function hasElementPositiveScrollTop(el) {
+    if (!isElementScrollable(el)) {
+        return false;
+    }
+    return el.scrollTop > 0;
+}
+
+function isElementStartAboveViewTop(el) {
+    if (!el) {
+        return false;
+    }
+    return el.getBoundingClientRect().top < 0;
+}
+
 function isElementEndBelowViewBottom(el) {
     if (!el) {
         return false;
@@ -36,6 +50,8 @@ function isElementScrollable(el, includeHorizontalScroll = false) {
 
 const utils = {
     hasElementPositiveScrollBottom,
+    hasElementPositiveScrollTop,
+    isElementStartAboveViewTop,
     isElementEndBelowViewBottom,
 };
 export default utils;

--- a/packages/components/src/components/Log/utils.js
+++ b/packages/components/src/components/Log/utils.js
@@ -1,0 +1,41 @@
+const scrollRegex = /(auto|scroll)/;
+
+
+function getStyle(el, prop) {
+    if (!el) {
+        return "";
+    }
+    return window.getComputedStyle(el, null).getPropertyValue(prop);
+}
+
+function hasElementPositiveScrollBottom(el) {
+    if (!isElementScrollable(el)) {
+        return false;
+    }
+    return el.scrollHeight - el.clientHeight > el.scrollTop;
+}
+
+function isElementEndBelowViewBottom(el) {
+    if (!el) {
+        return false;
+    }
+    return el.getBoundingClientRect().bottom >
+        (window.innerHeight || document.documentElement.clientHeight);
+}
+
+function isElementScrollable(el, includeHorizontalScroll = false) {
+    if (!el) {
+        return false;
+    }
+
+    const horizontalScroll = includeHorizontalScroll ? "" : getStyle(el, "overflow-x");
+    return scrollRegex.test(
+        getStyle(el, "overflow") +
+        getStyle(el, "overflow-y") + horizontalScroll);
+}
+
+const utils = {
+    hasElementPositiveScrollBottom,
+    isElementEndBelowViewBottom,
+};
+export default utils;

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -55,6 +55,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   getLogContainer({ stepName, stepStatus, taskRun }) {
     const {
       enableLogAutoScroll,
+      enableLogScrollButtons,
       fetchLogs,
       forceLogPolling,
       getLogsToolbar,
@@ -96,6 +97,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           stepStatus={stepStatus}
           isLogsMaximized={isLogsMaximized}
           enableLogAutoScroll={enableLogAutoScroll}
+          enableLogScrollButtons={enableLogScrollButtons}
         />
       </LogsRoot>
     );

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -54,6 +54,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
   getLogContainer({ stepName, stepStatus, taskRun }) {
     const {
+      enableLogAutoScroll,
       fetchLogs,
       forceLogPolling,
       getLogsToolbar,
@@ -93,6 +94,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           key={`${selectedTaskId}:${selectedStepId}`}
           pollingInterval={pollingInterval}
           stepStatus={stepStatus}
+          isLogsMaximized={isLogsMaximized}
+          enableLogAutoScroll={enableLogAutoScroll}
         />
       </LogsRoot>
     );

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -205,6 +205,7 @@ export function App({
   }, [isFetchingConfig, tenantNamespace]);
 
   const logoutButton = <LogoutButton getLogoutURL={() => logoutURL} />;
+  const enableLogAutoScroll = true;
 
   return (
     <IntlProvider
@@ -266,7 +267,12 @@ export function App({
                   />
                   <Route
                     path={paths.pipelineRuns.byName()}
-                    component={PipelineRun}
+                    render={routeProps => (
+                      <PipelineRun
+                        {...routeProps}
+                        enableLogAutoScroll={enableLogAutoScroll}
+                      />
+                    )}
                   />
                   <Route
                     path={paths.pipelineResources.all()}
@@ -316,7 +322,12 @@ export function App({
                   <Route
                     path={paths.taskRuns.byName()}
                     exact
-                    component={TaskRun}
+                    render={routeProps => (
+                      <TaskRun
+                        {...routeProps}
+                        enableLogAutoScroll={enableLogAutoScroll}
+                      />
+                    )}
                   />
                   <Route
                     path={paths.clusterTasks.all()}

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -206,6 +206,7 @@ export function App({
 
   const logoutButton = <LogoutButton getLogoutURL={() => logoutURL} />;
   const enableLogAutoScroll = true;
+  const enableLogScrollButtons = true;
 
   return (
     <IntlProvider
@@ -271,6 +272,7 @@ export function App({
                       <PipelineRun
                         {...routeProps}
                         enableLogAutoScroll={enableLogAutoScroll}
+                        enableLogScrollButtons={enableLogScrollButtons}
                       />
                     )}
                   />
@@ -326,6 +328,7 @@ export function App({
                       <TaskRun
                         {...routeProps}
                         enableLogAutoScroll={enableLogAutoScroll}
+                        enableLogScrollButtons={enableLogScrollButtons}
                       />
                     )}
                   />

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -63,6 +63,7 @@ const { PIPELINE_TASK, RETRY, STEP, VIEW } = queryParamConstants;
 export /* istanbul ignore next */ function PipelineRunContainer(props) {
   const {
     clusterTasks,
+    enableLogAutoScroll,
     error,
     fetchClusterTasks,
     fetchPipeline,
@@ -284,6 +285,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
         />
       )}
       <PipelineRun
+        enableLogAutoScroll={enableLogAutoScroll}
         error={error}
         fetchLogs={getLogsRetriever(isLogStreamingEnabled, externalLogsURL)}
         handleTaskSelected={handleTaskSelected}

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -64,6 +64,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
   const {
     clusterTasks,
     enableLogAutoScroll,
+    enableLogScrollButtons,
     error,
     fetchClusterTasks,
     fetchPipeline,
@@ -286,6 +287,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
       )}
       <PipelineRun
         enableLogAutoScroll={enableLogAutoScroll}
+        enableLogScrollButtons={enableLogScrollButtons}
         error={error}
         fetchLogs={getLogsRetriever(isLogStreamingEnabled, externalLogsURL)}
         handleTaskSelected={handleTaskSelected}

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -90,6 +90,7 @@ function notification({ intl, kind, message }) {
 
 export function TaskRunContainer(props) {
   const {
+    enableLogAutoScroll,
     error,
     fetchTaskByType,
     fetchTaskRun,
@@ -176,6 +177,8 @@ export function TaskRunContainer(props) {
           fetchLogs={() => logsRetriever(stepName, stepStatus, run)}
           key={stepName}
           stepStatus={stepStatus}
+          isLogsMaximized={isLogsMaximized}
+          enableLogAutoScroll={enableLogAutoScroll}
         />
       </LogsRoot>
     );

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -91,6 +91,7 @@ function notification({ intl, kind, message }) {
 export function TaskRunContainer(props) {
   const {
     enableLogAutoScroll,
+    enableLogScrollButtons,
     error,
     fetchTaskByType,
     fetchTaskRun,
@@ -179,6 +180,7 @@ export function TaskRunContainer(props) {
           stepStatus={stepStatus}
           isLogsMaximized={isLogsMaximized}
           enableLogAutoScroll={enableLogAutoScroll}
+          enableLogScrollButtons={enableLogScrollButtons}
         />
       </LogsRoot>
     );


### PR DESCRIPTION
Related to https://github.com/tektoncd/dashboard/issues/327

# Changes

First commit (auto-scroll):
Logs of step runs can get very big. While the step run has not terminated, the p
age will keep scrolling down the page as needed. This behaviour can be stopped once the user scrolls up so that the bottom of the log is no longer visible. This behaviour can be resumed once the user scrolls back down to the log bottom.

This feature is activated by a boolean flag (which is turned to true in the dashboard ui) not to affect the users of the reusable component `<Log` in edge cases (the component followed by other elements in the page,component inside a non-window scrollable parent.....)

Second commit( Scroll buttons):
Step-runs with huge logs require the user to manually scroll all the way down the page. A click/press-to-scroll-to-page-top button will now appear when the top of the logs is above the viewport and a click/press-to-scroll-to-page-bottom button will now appear when the bottom of the logs is below the viewport.

The button presence is updated at each Log component update or scroll. For a logically-complete solution, we would need to use a ResizeObserver. This feature is behind a flag to not affect the users of the reusable `<Log` component with edge cases (a non-window-scrollable parent).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
