### PR TITLE
enable Dashboard iframe loading with flag

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,12 +4,12 @@
 
 approvers:
 - alangreene
+- briangleeson
 - skaegi
 - steveodonovan
 
 reviewers:
 - ziheng
-- briangleeson
 - LyndseyBu
 
 # Alumni ❤️

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -47,7 +47,7 @@ var (
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
 	streamLogs         = flag.Bool("stream-logs", false, "Enable log streaming instead of polling")
 	externalLogs       = flag.String("external-logs", "", "External logs provider url")
-	enableXframe       = flag.Bool("enable-xframe", false, "Whether or not a browser should be allowed to render a page in a <frame>, <iframe>, <embed> or <object>")
+	xFrameOptions      = flag.String("xframe-options", "DENY", "Whether or not a browser should be allowed to render a page in a <frame>, <iframe>, <embed> or <object>")
 )
 
 func main() {
@@ -110,7 +110,7 @@ func main() {
 		LogoutURL:          *logoutURL,
 		StreamLogs:         *streamLogs,
 		ExternalLogsURL:    *externalLogs,
-		EnableXframe:       *enableXframe,
+		XFrameOptions:      *xFrameOptions,
 	}
 
 	resource := endpoints.Resource{

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -47,6 +47,7 @@ var (
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
 	streamLogs         = flag.Bool("stream-logs", false, "Enable log streaming instead of polling")
 	externalLogs       = flag.String("external-logs", "", "External logs provider url")
+	enableXframe       = flag.Bool("enable-xframe", false, "Whether or not a browser should be allowed to render a page in a <frame>, <iframe>, <embed> or <object>")
 )
 
 func main() {
@@ -109,6 +110,7 @@ func main() {
 		LogoutURL:          *logoutURL,
 		StreamLogs:         *streamLogs,
 		ExternalLogsURL:    *externalLogs,
+		EnableXframe:       *enableXframe,
 	}
 
 	resource := endpoints.Resource{

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -32,7 +32,7 @@ type Options struct {
 	LogoutURL          string
 	StreamLogs         bool
 	ExternalLogsURL    string
-	EnableXframe       bool
+	XFrameOptions      string
 }
 
 // GetPipelinesNamespace returns the PipelinesNamespace property if set

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -32,6 +32,7 @@ type Options struct {
 	LogoutURL          string
 	StreamLogs         bool
 	ExternalLogsURL    string
+	EnableXframe       bool
 }
 
 // GetPipelinesNamespace returns the PipelinesNamespace property if set

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -221,8 +221,13 @@ func registerWeb(resource endpoints.Resource, container *restful.Container) {
 			// Static resources are immutable and have a content hash in their URL
 			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		}
-		if !resource.Options.EnableXframe {
-			w.Header().Set("X-Frame-Options", "deny")
+
+		switch resource.Options.XFrameOptions {
+		case "": //DO nothing, no X-Frame-Options header
+		case "SAMEORIGIN":
+			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		default:
+			w.Header().Set("X-Frame-Options", "DENY")
 		}
 		fs.ServeHTTP(w, r)
 	}))

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -67,7 +67,7 @@ func Register(resource endpoints.Resource) *Handler {
 		uidExtensionMap: make(map[string]*Extension),
 	}
 
-	registerWeb(h.Container)
+	registerWeb(resource, h.Container)
 	registerPropertiesEndpoint(resource, h.Container)
 	registerWebsocket(resource, h.Container)
 	registerHealthProbe(resource, h.Container)
@@ -212,7 +212,7 @@ func registerKubeAPIProxy(r endpoints.Resource, container *restful.Container) {
 	container.Add(proxy)
 }
 
-func registerWeb(container *restful.Container) {
+func registerWeb(resource endpoints.Resource, container *restful.Container) {
 	logging.Log.Info("Adding Web API")
 
 	fs := http.FileServer(http.Dir(webResourcesDir))
@@ -221,7 +221,9 @@ func registerWeb(container *restful.Container) {
 			// Static resources are immutable and have a content hash in their URL
 			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		}
-		w.Header().Set("X-Frame-Options", "deny")
+		if !resource.Options.EnableXframe {
+			w.Header().Set("X-Frame-Options", "deny")
+		}
 		fs.ServeHTTP(w, r)
 	}))
 }

--- a/pkg/router/routes_test.go
+++ b/pkg/router/routes_test.go
@@ -312,16 +312,20 @@ func TestXframeOptions(t *testing.T) {
 		expected []string
 	}{
 		{
-			options:  endpoints.Options{},
-			expected: []string{"deny"},
+			options:  endpoints.Options{XFrameOptions: "DENY"},
+			expected: []string{"DENY"},
 		},
 		{
-			options:  endpoints.Options{EnableXframe: false},
-			expected: []string{"deny"},
+			options:  endpoints.Options{XFrameOptions: "SAMEORIGIN"},
+			expected: []string{"SAMEORIGIN"},
 		},
 		{
-			options:  endpoints.Options{EnableXframe: true},
+			options:  endpoints.Options{XFrameOptions: ""},
 			expected: nil,
+		},
+		{
+			options:  endpoints.Options{XFrameOptions: "FOO"},
+			expected: []string{"DENY"},
 		},
 	}
 


### PR DESCRIPTION
The value of the response header "X-Frame-Options" is "deny" by default in http requests because of security concerns. 
However in some use cases people want to load the dashboard in their internal web applications via iframe.  


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Add an additional boolean flag to disable the header "X-Frame-Options".


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
