### PR TITLE
Restrict X-Frame-Options header with new flag

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -47,6 +47,7 @@ var (
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
 	streamLogs         = flag.Bool("stream-logs", false, "Enable log streaming instead of polling")
 	externalLogs       = flag.String("external-logs", "", "External logs provider url")
+	xFrameOptions      = flag.String("x-frame-options", "DENY", "Value for the X-Frame-Options response header, set '' to omit it")
 )
 
 func main() {
@@ -109,6 +110,7 @@ func main() {
 		LogoutURL:          *logoutURL,
 		StreamLogs:         *streamLogs,
 		ExternalLogsURL:    *externalLogs,
+		XFrameOptions:      *xFrameOptions,
 	}
 
 	resource := endpoints.Resource{

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -32,6 +32,7 @@ type Options struct {
 	LogoutURL          string
 	StreamLogs         bool
 	ExternalLogsURL    string
+	XFrameOptions      string
 }
 
 // GetPipelinesNamespace returns the PipelinesNamespace property if set

--- a/pkg/router/routes_test.go
+++ b/pkg/router/routes_test.go
@@ -305,3 +305,48 @@ func TestGetAllExtensions(t *testing.T) {
 		}
 	}
 }
+
+func TestXframeOptions(t *testing.T) {
+	tests := []struct {
+		options  endpoints.Options
+		expected []string
+	}{
+		{
+			options:  endpoints.Options{XFrameOptions: "DENY"},
+			expected: []string{"DENY"},
+		},
+		{
+			options:  endpoints.Options{XFrameOptions: "SAMEORIGIN"},
+			expected: []string{"SAMEORIGIN"},
+		},
+		{
+			options:  endpoints.Options{XFrameOptions: ""},
+			expected: nil,
+		},
+		{
+			options:  endpoints.Options{XFrameOptions: "FOO"},
+			expected: []string{"DENY"},
+		},
+	}
+
+	server, _, _ := testutils.DummyServer()
+	defer server.Close()
+
+	for _, tt := range tests {
+		r := testutils.DummyResource()
+		r.Options = tt.options
+		h := router.Register(*r)
+		server.Config.Handler = h
+		httpReq := testutils.DummyHTTPRequest("GET", server.URL, nil)
+		response, err := http.DefaultClient.Do(httpReq)
+		if err != nil {
+			t.Fatalf("Error getting server response: %s", err.Error())
+		}
+		if tt.expected == nil && response.Header["X-Frame-Options"] != nil {
+			t.Fatalf("response xframe header: %v, expected: %v ", response.Header["X-Frame-Options"], tt.expected)
+		}
+		if tt.expected != nil && !reflect.DeepEqual(response.Header["X-Frame-Options"], tt.expected) {
+			t.Fatalf("response xframe header: %v, expected: %v ", response.Header["X-Frame-Options"], tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
The value of the response header "X-Frame-Options" is "deny" by default in http requests because of security concerns.
However in some use cases people want to load the dashboard in their internal web applications via iframe.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Add a string flag xframe-options to restrict the header "X-Frame-Options".

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
