### PR TITLE
Add support for overriding the default log polling cut-off

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -121,14 +121,20 @@ export class LogContainer extends Component {
   };
 
   loadLog = async () => {
-    const { fetchLogs, intl, stepStatus, pollingInterval } = this.props;
+    const {
+      fetchLogs,
+      forcePolling,
+      intl,
+      stepStatus,
+      pollingInterval
+    } = this.props;
     if (!fetchLogs) {
       return;
     }
 
     let continuePolling = false;
     try {
-      continuePolling = stepStatus && !stepStatus.terminated;
+      continuePolling = forcePolling || (stepStatus && !stepStatus.terminated);
       const logs = await fetchLogs();
       if (logs?.getReader) {
         // logs is a https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -55,6 +55,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   getLogContainer({ stepName, stepStatus, taskRun }) {
     const {
       fetchLogs,
+      forceLogPolling,
       getLogsToolbar,
       maximizedLogsContainer,
       pollingInterval,
@@ -88,6 +89,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
             })
           }
           fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
+          forcePolling={forceLogPolling}
           key={`${selectedTaskId}:${selectedStepId}`}
           pollingInterval={pollingInterval}
           stepStatus={stepStatus}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
In some cases consumers of the PipelineRun component may want to
extend the log polling beyond the default cut-off point (we currently
make 1 final request after the step is terminated).

Provide a new prop on the PipelineRun component which is passed
through to the Log component allowing consumers to override
the default behaviour and force polling to continue until some
externally determined status is met.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
