### PR TITLE
Set HOME env var for release pipeline publish task

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -27,6 +27,10 @@ spec:
         type: storage
       - name: builtDashboardImage
         type: image
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
   steps:
     - name: link-input-bucket-to-output
       image: busybox


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Set the HOME env var for the publish task so the final step
to upload resources to GCS via the Storage PipelineResource
will work. This is required now that the default value for
the `disable-home-env-overwrite` feature flag has been switched
to true since Pipelines v0.24.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
