### PR TITLE
Fix for logs on some Kubernetes versions

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -96,7 +96,7 @@ export function getPodLogURL({ container, name, namespace, follow }) {
 
 export function getPodLog({ container, name, namespace, stream }) {
   const uri = getPodLogURL({ container, name, namespace, follow: stream });
-  return get(uri, { Accept: 'text/plain' }, { stream });
+  return get(uri, { Accept: 'text/plain,*/*' }, { stream });
 }
 
 /* istanbul ignore next */


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Depending on Kubernetes version / platform the logs endpoint
may not support `text/plain` as the value of the `Accept` request
header, even though the response is returned as `Content-Type: text/plain`.

Update the value of the `Accept` header to provide a wildcard fallback
for these cases rather than setting the misleading `application/json` value.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
