### PR TITLE
Add autoscroll to logs of running steps

### DIFF
--- a/packages/components/src/components/Log/domUtils.js
+++ b/packages/components/src/components/Log/domUtils.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2019-2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const scrollRegex = /(auto|scroll)/;
+
+function getStyle(el, prop) {
+  return el && window.getComputedStyle(el, null).getPropertyValue(prop);
+}
+
+function isElementVerticallyScrollable(el) {
+  return (
+    el &&
+    scrollRegex.test(getStyle(el, 'overflow') + getStyle(el, 'overflow-y'))
+  );
+}
+
+export function hasElementPositiveVerticalScrollBottom(el) {
+  return (
+    isElementVerticallyScrollable(el) &&
+    el.scrollHeight - el.clientHeight > el.scrollTop
+  );
+}
+
+export function isElementEndBelowViewBottom(el) {
+  return (
+    el?.getBoundingClientRect().bottom > document.documentElement?.clientHeight
+  );
+}

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -54,6 +54,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
 
   getLogContainer({ stepName, stepStatus, taskRun }) {
     const {
+      enableLogAutoScroll,
       fetchLogs,
       forceLogPolling,
       getLogsToolbar,
@@ -93,6 +94,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           key={`${selectedTaskId}:${selectedStepId}`}
           pollingInterval={pollingInterval}
           stepStatus={stepStatus}
+          isLogsMaximized={isLogsMaximized}
+          enableLogAutoScroll={enableLogAutoScroll}
         />
       </LogsRoot>
     );

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -304,6 +304,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
         />
       )}
       <PipelineRun
+        enableLogAutoScroll
         error={error}
         fetchLogs={getLogsRetriever(isLogStreamingEnabled, externalLogsURL)}
         handleTaskSelected={handleTaskSelected}

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -176,6 +176,8 @@ export function TaskRunContainer(props) {
           fetchLogs={() => logsRetriever(stepName, stepStatus, run)}
           key={stepName}
           stepStatus={stepStatus}
+          isLogsMaximized={isLogsMaximized}
+          enableLogAutoScroll
         />
       </LogsRoot>
     );


### PR DESCRIPTION
# Changes

A flag-activated feature to autoscroll the logs of a running step (running = was running at any point after the component mounting). The logs will auto-scroll down when there is new text added and the bottom of the "old" logs was already seen. This behaviour can be stopped at any time if the user scrolls up so that the bottom of the logs is out of view. This behaviour can be resumed if the user scrolls down so that the bottom of the logs is in view.

This feature is flag-activated not to to affect the behaviour of the Log pure-component users which may be using it as an element followed down the page by other elements or as a pure-component in a scrollable parent which is not the browser window.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
