### PR TITLE
Remove link from page title

### DIFF
--- a/packages/components/src/components/Header/Header.js
+++ b/packages/components/src/components/Header/Header.js
@@ -53,9 +53,7 @@ function Header({
           onClick={onHeaderMenuButtonClick}
         />
       )}
-      <HeaderName href="/" prefix="Tekton">
-        Dashboard
-      </HeaderName>
+      <HeaderName prefix="Tekton">Dashboard</HeaderName>
       <HeaderGlobalBar>{logoutButton}</HeaderGlobalBar>
     </CarbonHeader>
   );


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The 'Tekton Dashboard' page title acts as a link to `/`, however
this is not valid when the Dashboard is exposed on a subpath rather
than at the root. Remove the `href` prop so it's no longer rendered
as an active link.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
