### PR TITLE
Remove unneccessary requests for TaskRuns

### DIFF
--- a/src/api/pipelineRuns.js
+++ b/src/api/pipelineRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,10 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-  getGenerateNamePrefixForRerun,
-  labels as labelConstants
-} from '@tektoncd/dashboard-utils';
+import { getGenerateNamePrefixForRerun } from '@tektoncd/dashboard-utils';
 import deepClone from 'lodash.clonedeep';
 
 import { deleteRequest, get, patch, post, put } from './comms';
@@ -64,11 +61,7 @@ export function createPipelineRun({
     kind: 'PipelineRun',
     metadata: {
       name: `${pipelineName}-run-${Date.now()}`,
-      labels: {
-        ...labels,
-        [labelConstants.PIPELINE]: pipelineName,
-        app: 'tekton-app'
-      }
+      labels
     },
     spec: {
       pipelineRef: {

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import fetchMock from 'fetch-mock';
-import { labels } from '@tektoncd/dashboard-utils';
 
 import * as API from './pipelineRuns';
 
@@ -54,11 +53,7 @@ it('createPipelineRun', () => {
     apiVersion: 'tekton.dev/v1beta1',
     kind: 'PipelineRun',
     metadata: {
-      name: `${pipelineName}-run-${Date.now()}`,
-      labels: {
-        [labels.PIPELINE]: pipelineName,
-        app: 'tekton-app'
-      }
+      name: `${pipelineName}-run-${Date.now()}`
     },
     spec: {
       pipelineRef: {
@@ -110,11 +105,7 @@ it('createPipelineRun with nodeSelector', () => {
     apiVersion: 'tekton.dev/v1beta1',
     kind: 'PipelineRun',
     metadata: {
-      name: `${pipelineName}-run-${Date.now()}`,
-      labels: {
-        [labels.PIPELINE]: pipelineName,
-        app: 'tekton-app'
-      }
+      name: `${pipelineName}-run-${Date.now()}`
     },
     spec: {
       pipelineRef: {

--- a/src/api/taskRuns.js
+++ b/src/api/taskRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,10 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-  getGenerateNamePrefixForRerun,
-  labels as labelConstants
-} from '@tektoncd/dashboard-utils';
+import { getGenerateNamePrefixForRerun } from '@tektoncd/dashboard-utils';
 import deepClone from 'lodash.clonedeep';
 
 import { deleteRequest, get, post, put } from './comms';
@@ -60,10 +57,7 @@ export function createTaskRun({
     metadata: {
       name: `${taskName}-run-${Date.now()}`,
       namespace,
-      labels: {
-        [labelConstants.TASK]: taskName,
-        ...labels
-      }
+      labels
     },
     spec: {
       params: [],

--- a/src/api/taskRuns.test.js
+++ b/src/api/taskRuns.test.js
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import fetchMock from 'fetch-mock';
-import { labels as labelConstants } from '@tektoncd/dashboard-utils';
 
 import * as API from './taskRuns';
 
@@ -62,7 +61,6 @@ it('createTaskRun has correct metadata', () => {
     expect(sentMetadata.name).toMatch('fake-timestamp'); // include timestamp
     expect(sentMetadata).toHaveProperty('namespace', namespace);
     expect(sentMetadata.labels).toHaveProperty('app', 'fake-app');
-    expect(sentMetadata.labels).toHaveProperty([labelConstants.TASK], taskName);
     fetchMock.restore();
     mockDateNow.mockRestore();
   });

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -84,16 +84,6 @@ function TaskRuns(props) {
   useTitleSync({ page: 'TaskRuns' });
 
   function fetchData() {
-    if (kind === 'ClusterTask') {
-      // TaskRuns from ClusterTask should have label 'tekton.dev/clusterTask=',
-      // (and that is the filter on the page), but some taskruns might still
-      // only have the old label 'tekton.dev/task='
-      // So, for ClusterTasks, also fetch with the old filter:
-      fetchTaskRuns({
-        filters: [`${TASK}=${taskName}`]
-      });
-    }
-
     fetchTaskRuns({ filters, namespace });
   }
 
@@ -356,19 +346,7 @@ function mapStateToProps(state, props) {
       ? clusterTaskFilter.replace(`${CLUSTER_TASK}=`, '')
       : taskFilter.replace(`${TASK}=`, '');
 
-  let taskRuns = getTaskRuns(state, { filters, namespace });
-  if (kind === 'ClusterTask') {
-    // TaskRuns from ClusterTask should have label 'tekton.dev/clusterTask=',
-    // (and that is the filter on the page), but some taskruns might still
-    // only have the old label 'tekton.dev/task='
-    // So, for ClusterTasks, also fetch with the old filter:
-    const clusterTaskRuns = getTaskRuns(state, {
-      filters: [`${TASK}=${taskName}`]
-    });
-
-    // Then merge the arrays, using a Set to prevent duplicates
-    taskRuns = [...new Set([...taskRuns, ...clusterTaskRuns])];
-  }
+  const taskRuns = getTaskRuns(state, { filters, namespace });
 
   return {
     error: getTaskRunsErrorMessage(state),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Prior to Pipelines v0.12, TaskRuns for ClusterTasks had the label
`tekton.dev/task` applied, rather than `tekton.dev/clusterTask`.

In Pipelines v0.12 this was fixed and the old 'task' label was
deprecated. It was later removed in Pipelines v0.22, leaving just
the expected 'clusterTask' label.

The last Dashboard release to support Pipelines v0.12 was v0.14 so
the extra code to handle this is no longer required and we can just
request TaskRuns using the correct 'clusterTask' label.

Also stop adding `tekton.dev/*` labels in Create TaskRun / PipelineRun
as these will be added automatically by Tekton Pipelines.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
