### PR TITLE
Fix UI bug for TaskRuns in read-only mode

### DIFF
--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -399,7 +399,12 @@ describe('PipelineRuns container', () => {
       url: '/pipelineruns'
     };
 
-    const { getByText, queryAllByText, queryAllByTitle } = renderWithRouter(
+    const {
+      getByText,
+      queryAllByLabelText,
+      queryAllByText,
+      queryAllByTitle
+    } = renderWithRouter(
       <Provider store={mockTestStore}>
         <Route
           path="/pipelineruns"
@@ -422,6 +427,7 @@ describe('PipelineRuns container', () => {
     await waitFor(() => getByText('pipelineRunWithTwoLabels'));
     expect(queryAllByText('Create')[0]).toBeFalsy();
     expect(queryAllByTitle(/actions/i)[0]).toBeFalsy();
+    expect(queryAllByLabelText('Select row').length).toBe(0);
   });
 
   it('handles rerun event in PipelineRuns page', async () => {

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -276,7 +276,7 @@ function TaskRuns(props) {
         }
       ];
 
-  const batchActionButtons = props.isReadOnly
+  const batchActionButtons = isReadOnly
     ? []
     : [
         {

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -369,7 +369,11 @@ describe('TaskRuns container', () => {
       url: urls.taskRuns.all()
     };
 
-    const { getByText, queryAllByTitle } = renderWithRouter(
+    const {
+      getByText,
+      queryAllByLabelText,
+      queryAllByTitle
+    } = renderWithRouter(
       <Provider store={store.getStore()}>
         <Route
           path={urls.taskRuns.all()}
@@ -391,6 +395,7 @@ describe('TaskRuns container', () => {
 
     await waitFor(() => getByText('taskRunWithTwoLabels'));
     expect(queryAllByTitle(/actions/i)[0]).toBeFalsy();
+    expect(queryAllByLabelText('Select row').length).toBe(0);
   });
 
   it('handles rerun event in TaskRuns page', async () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/2128

Batch actions should not be enabled in read-only mode. A bug introduced
during recent refactoring meant that the read-only flag wasn't being read
correctly in this case causing the checkboxes to appear on the TaskRuns
table. This gave the impression that TaskRuns could be deleted, however
the action is still blocked in environments where RBAC is enforced as
the Dashboard ServiceAccount does not have permissions to delete these
resources when deployed in read-only mode.

Update the test to prevent a similar regression in future, as well as
updating the equivalent test for PipelineRuns in the same manner.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
