### PR TITLE
Ensure installer script removes all Dashboard-related resource on uninstall

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -462,6 +462,7 @@ uninstall() {
     "clusterrolebindings.rbac.authorization.k8s.io"
     "clusterroles.rbac.authorization.k8s.io"
     "rolebindings.rbac.authorization.k8s.io"
+    "roles.rbac.authorization.k8s.io"
   )
   for resourceKind in "${resourceKinds[@]}";do
     echo "Deleting ${resourceKind}"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

A new ConfigMap was added for v0.18 containing the Dashboard version
and may be used for other install / config data in future. As part of
that change, a new Role and RoleBinding were added granting `get` permissions
on this ConfigMap to all authenticated users.

Add Roles to the list of resource types that get cleaned up on uninstall.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
