### PR TITLE
Fix dependent queries on Create PipelineRun and Create TaskRun pages

### DIFF
--- a/src/api/clusterTasks.js
+++ b/src/api/clusterTasks.js
@@ -39,6 +39,6 @@ export function useClusterTasks(params) {
   return useCollection('ClusterTask', getClusterTasks, params);
 }
 
-export function useClusterTask(params) {
-  return useResource('ClusterTask', getClusterTask, params);
+export function useClusterTask(params, queryConfig) {
+  return useResource('ClusterTask', getClusterTask, params, queryConfig);
 }

--- a/src/api/clusterTasks.test.js
+++ b/src/api/clusterTasks.test.js
@@ -66,6 +66,16 @@ it('useClusterTask', () => {
   expect(utils.useResource).toHaveBeenCalledWith(
     'ClusterTask',
     API.getClusterTask,
-    params
+    params,
+    undefined
+  );
+
+  const queryConfig = { fake: 'queryConfig' };
+  API.useClusterTask(params, queryConfig);
+  expect(utils.useResource).toHaveBeenCalledWith(
+    'ClusterTask',
+    API.getClusterTask,
+    params,
+    queryConfig
   );
 });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -58,11 +58,11 @@ export function useCustomResource(params) {
   return useResource('customResource', getCustomResource, params);
 }
 
-export function useTaskByKind({ kind, ...rest }) {
+export function useTaskByKind({ kind, ...rest }, queryConfig) {
   if (kind === 'ClusterTask') {
-    return useClusterTask({ ...rest });
+    return useClusterTask({ ...rest }, queryConfig);
   }
-  return useTask({ ...rest });
+  return useTask({ ...rest }, queryConfig);
 }
 
 export async function getInstallProperties() {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -78,10 +78,12 @@ it('useTaskByKind', () => {
 
   let returnValue = API.useTaskByKind({ ...params, kind: 'ClusterTask' });
   expect(ClusterTasksAPI.useClusterTask).toHaveBeenCalledWith(
-    expect.objectContaining(params)
+    expect.objectContaining(params),
+    undefined
   );
   expect(ClusterTasksAPI.useClusterTask).not.toHaveBeenCalledWith(
-    expect.objectContaining({ kind: expect.any(String) })
+    expect.objectContaining({ kind: expect.any(String) }),
+    undefined
   );
   expect(TasksAPI.useTask).not.toHaveBeenCalled();
   expect(returnValue).toEqual(clusterTaskQuery);
@@ -90,10 +92,12 @@ it('useTaskByKind', () => {
   returnValue = API.useTaskByKind({ ...params, kind: 'Task' });
   expect(ClusterTasksAPI.useClusterTask).not.toHaveBeenCalled();
   expect(TasksAPI.useTask).toHaveBeenCalledWith(
-    expect.objectContaining(params)
+    expect.objectContaining(params),
+    undefined
   );
   expect(TasksAPI.useTask).not.toHaveBeenCalledWith(
-    expect.objectContaining({ kind: expect.any(String) })
+    expect.objectContaining({ kind: expect.any(String) }),
+    undefined
   );
   expect(returnValue).toEqual(taskQuery);
 });

--- a/src/api/pipelines.js
+++ b/src/api/pipelines.js
@@ -39,6 +39,6 @@ export function usePipelines(params) {
   return useCollection('Pipeline', getPipelines, params);
 }
 
-export function usePipeline(params) {
-  return useResource('Pipeline', getPipeline, params);
+export function usePipeline(params, queryConfig) {
+  return useResource('Pipeline', getPipeline, params, queryConfig);
 }

--- a/src/api/pipelines.test.js
+++ b/src/api/pipelines.test.js
@@ -66,6 +66,16 @@ it('usePipeline', () => {
   expect(utils.useResource).toHaveBeenCalledWith(
     'Pipeline',
     API.getPipeline,
-    params
+    params,
+    undefined
+  );
+
+  const queryConfig = { fake: 'queryConfig' };
+  API.usePipeline(params, queryConfig);
+  expect(utils.useResource).toHaveBeenCalledWith(
+    'Pipeline',
+    API.getPipeline,
+    params,
+    queryConfig
   );
 });

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -39,6 +39,6 @@ export function useTasks(params) {
   return useCollection('Task', getTasks, params);
 }
 
-export function useTask(params) {
-  return useResource('Task', getTask, params);
+export function useTask(params, queryConfig) {
+  return useResource('Task', getTask, params, queryConfig);
 }

--- a/src/api/tasks.test.js
+++ b/src/api/tasks.test.js
@@ -63,5 +63,19 @@ it('useTask', () => {
   const params = { fake: 'params' };
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useTask(params)).toEqual(query);
-  expect(utils.useResource).toHaveBeenCalledWith('Task', API.getTask, params);
+  expect(utils.useResource).toHaveBeenCalledWith(
+    'Task',
+    API.getTask,
+    params,
+    undefined
+  );
+
+  const queryConfig = { fake: 'queryConfig' };
+  API.useTask(params, queryConfig);
+  expect(utils.useResource).toHaveBeenCalledWith(
+    'Task',
+    API.getTask,
+    params,
+    queryConfig
+  );
 });

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -186,14 +186,14 @@ export function useWebSocket({ kind: _ }) {
   }, [queryClient, webSocket]);
 }
 
-export function useCollection(kind, api, params) {
-  const query = useQuery([kind, params], () => api(params));
+export function useCollection(kind, api, params, queryConfig) {
+  const query = useQuery([kind, params], () => api(params), queryConfig);
   useWebSocket({ kind });
   return query;
 }
 
-export function useResource(kind, api, params) {
-  const query = useQuery([kind, params], () => api(params));
+export function useResource(kind, api, params, queryConfig) {
+  const query = useQuery([kind, params], () => api(params), queryConfig);
   useWebSocket({ kind });
   return query;
 }

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -118,7 +118,7 @@ function CreatePipelineRun(props) {
 
   const { data: pipeline, error: pipelineError } = usePipeline(
     { name: pipelineRef, namespace },
-    { enabled: pipelineRef }
+    { enabled: !!pipelineRef }
   );
 
   let paramSpecs;

--- a/src/containers/CreateTaskRun/CreateTaskRun.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.js
@@ -146,7 +146,7 @@ function CreateTaskRun(props) {
 
   const { data: task, error: taskError } = useTaskByKind(
     { kind, name: taskRef, namespace },
-    { enabled: taskRef }
+    { enabled: !!taskRef }
   );
 
   const paramSpecs = task?.spec?.params;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the `useResource` hook to correctly pass the query config to
react-query so we can set queries to idle pending some condition.

This eliminates unnecessary requests on the Create pages until we
have the correct data available to filter the queries.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
