### PR TITLE
Add scroll buttons to logs of steps

### DIFF
--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -53,6 +53,32 @@ pre.tkn--log {
     right: 0;
   }
 
+  .button-container {
+    position: absolute;
+    clip-path: inset(0); // ensure the children with position:fixed are not shown outside this element.
+    top: 3.125rem; //equals the maximum between padding-top of pre.tkn--log and between the page header height
+    bottom: 0;
+    right: 0;
+    width: 1.6rem; //equals the padding-right of pre.tkn--log
+  }
+
+  #log-scroll-to-top-btn, #log-scroll-to-bottom-btn {
+    position: fixed;
+    right: var(--log-element-right);
+
+    &::before { // the tooltip is not shown because it is outside of its parent .button-container (which has clip-path inset) But fin still appears.
+      content: none; // To remove fin of truncated tooltip. To  obtain higher specificity than Carbon css, id selector is needed.
+    }
+  }
+  
+  #log-scroll-to-top-btn {
+    top: calc(var(--scroll-button-top) + 3.125rem); //3.125 rem is the maximum between padding-top of pre.tkn--log and between the page header height
+  }
+
+  #log-scroll-to-bottom-btn {
+    bottom: var(--scroll-button-bottom);
+  }
+
   .bx--copy-btn {
     width: 2rem;
     height: 2rem;

--- a/packages/components/src/components/Log/domUtils.js
+++ b/packages/components/src/components/Log/domUtils.js
@@ -31,8 +31,17 @@ export function hasElementPositiveVerticalScrollBottom(el) {
   );
 }
 
+export function hasElementPositiveVerticalScrollTop(el) {
+  return isElementVerticallyScrollable(el) && el.scrollTop > 0;
+}
+
+export function isElementStartAboveViewTop(el) {
+  return Math.round(el?.getBoundingClientRect().top) < 0;
+}
+
 export function isElementEndBelowViewBottom(el) {
   return (
-    el?.getBoundingClientRect().bottom > document.documentElement?.clientHeight
+    Math.round(el?.getBoundingClientRect().bottom) >
+    document.documentElement?.clientHeight
   );
 }

--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -55,6 +55,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
   getLogContainer({ stepName, stepStatus, taskRun }) {
     const {
       enableLogAutoScroll,
+      enableLogScrollButtons,
       fetchLogs,
       forceLogPolling,
       getLogsToolbar,
@@ -96,6 +97,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
           stepStatus={stepStatus}
           isLogsMaximized={isLogsMaximized}
           enableLogAutoScroll={enableLogAutoScroll}
+          enableLogScrollButtons={enableLogScrollButtons}
         />
       </LogsRoot>
     );

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -308,6 +308,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
       )}
       <PipelineRun
         enableLogAutoScroll
+        enableLogScrollButtons
         error={error}
         fetchLogs={getLogsRetriever(isLogStreamingEnabled, externalLogsURL)}
         handleTaskSelected={handleTaskSelected}

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -170,6 +170,7 @@ export function TaskRunContainer(props) {
           stepStatus={stepStatus}
           isLogsMaximized={isLogsMaximized}
           enableLogAutoScroll
+          enableLogScrollButtons
         />
       </LogsRoot>
     );

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "Maximize",
     "dashboard.logs.pending": "Final logs pending",
     "dashboard.logs.restore": "Return to default",
+    "dashboard.logs.scrollToBottom": "Scroll to end of logs",
+    "dashboard.logs.scrollToTop": "Scroll to start of logs",
     "dashboard.metadata.dateCreated": "Date created:",
     "dashboard.metadata.labels": "Labels:",
     "dashboard.metadata.namespace": "Namespace:",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "最大化",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "デフォルトに戻す",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "作成日：",
     "dashboard.metadata.labels": "ラベル：",
     "dashboard.metadata.namespace": "Namespace：",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "创建日期：",
     "dashboard.metadata.labels": "标签：",
     "dashboard.metadata.namespace": "Namespace：",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -140,6 +140,8 @@
     "dashboard.logs.maximize": "",
     "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
+    "dashboard.logs.scrollToBottom": "",
+    "dashboard.logs.scrollToTop": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",
     "dashboard.metadata.namespace": "",


### PR DESCRIPTION
# Changes

Related to https://github.com/tektoncd/dashboard/issues/327

A flag-activated feature to add scroll buttons when the bottom (or the top) of the logs is out of view. The buttons will appear inside the right padding of the Log component. Clicking on the scroll to bottom ( or top) button) scrolls you automatically to the bottom (or top) of the logs. This feature also accounts for presence of page headers (up to a height of 3.125 rem).

This feature is flag-activated not to to affect the behaviour of the Log pure-component users which may be using it as an element followed down the page by other elements or as a pure-component in a scrollable parent which is not the browser window.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
