### PR TITLE
Remove duplicate requests for Extensions

### DIFF
--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -18,10 +18,15 @@ import {
   Link as CarbonLink,
   InlineNotification
 } from 'carbon-components-react';
-import { getErrorMessage, urls, useTitleSync } from '@tektoncd/dashboard-utils';
+import {
+  ALL_NAMESPACES,
+  getErrorMessage,
+  urls,
+  useTitleSync
+} from '@tektoncd/dashboard-utils';
 import { Table } from '@tektoncd/dashboard-components';
 
-import { useExtensions } from '../../api';
+import { useExtensions, useTenantNamespace } from '../../api';
 
 function Extensions(props) {
   const { intl } = props;
@@ -33,7 +38,10 @@ function Extensions(props) {
     })
   });
 
-  const { data: extensions = [], error, isFetching } = useExtensions();
+  const tenantNamespace = useTenantNamespace();
+  const { data: extensions = [], error, isFetching } = useExtensions({
+    namespace: tenantNamespace || ALL_NAMESPACES
+  });
 
   const emptyText = intl.formatMessage({
     id: 'dashboard.extensions.emptyState',

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -34,7 +34,8 @@ import { getSelectedNamespace } from '../../reducers';
 import {
   useExtensions,
   useIsReadOnly,
-  useIsTriggersInstalled
+  useIsTriggersInstalled,
+  useTenantNamespace
 } from '../../api';
 
 import { ReactComponent as KubernetesIcon } from '../../images/kubernetes.svg';
@@ -55,7 +56,10 @@ function SideNav(props) {
 
   const { namespace } = match?.params || {};
 
-  const { data: extensions = [] } = useExtensions();
+  const tenantNamespace = useTenantNamespace();
+  const { data: extensions = [] } = useExtensions({
+    namespace: tenantNamespace || ALL_NAMESPACES
+  });
 
   useEffect(() => {
     if (namespace) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Ensure all calls to `useExtensions` are using a consistent query key
by passing the correct value for `namespace` in the params.

Without this change the keys are as follows:
- `['Extensions', null]`
- `['Extensions', { namespace: 'some_namespace' }]`

meaning we have 2 separate requests for Extensions being made.

Setting the namespace param eliminates the additional request with
`null` in the key and ensure that if the tenant namespace is changed
we will invalidate the cache and refetch with the correct namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
