### PR TITLE
Move About to the bottom of the SideNav

### DIFF
--- a/src/containers/SideNav/SideNav.scss
+++ b/src/containers/SideNav/SideNav.scss
@@ -17,6 +17,23 @@ limitations under the License.
     border-color: $gray-80;
     color: $gray-10;
 
+    .bx--side-nav__items {
+      display: flex;
+      flex-direction: column;
+
+      .bx--side-nav__item.bx--side-nav__item--icon
+        + .bx--side-nav__item:not(.bx--side-nav__item--icon) {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        justify-content: flex-end;
+      }
+
+      .bx--side-nav__item:last-child {
+        margin-bottom: 1rem;
+      }
+    }
+
     .bx--side-nav__icon {
       &:not(.bx--side-nav__submenu-chevron) {
         margin-right: 1rem;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Move About to the bottom of the SideNav. 
This was an issue proposed https://github.com/tektoncd/dashboard/issues/2115 

I used flexbox for handling the issue, Feel free to comment if there's better approach :) 

Please refer to images below according to various situations. 

- Normal
<img width="1784" alt="스크린샷 2021-07-21 오후 11 53 37" src="https://user-images.githubusercontent.com/56914200/126511202-6461f172-357c-46cc-9176-ec5f9faa0b48.png">

- Browser zoom in (200%)
<img width="1786" alt="스크린샷 2021-07-21 오후 11 52 46" src="https://user-images.githubusercontent.com/56914200/126511325-3f7f7ab3-e9e3-480e-ab6d-1214b0d100bb.png">

- Large font setting  
<img width="1786" alt="스크린샷 2021-07-21 오후 11 53 25" src="https://user-images.githubusercontent.com/56914200/126511383-7c320d90-29ce-4da8-8923-326624962b07.png">


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
