### PR TITLE
Update log trailer when forcePolling is true but step is complete

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -156,7 +156,14 @@ export class LogContainer extends Component {
   };
 
   getTrailerMessage = trailer => {
-    const { intl } = this.props;
+    const { forcePolling, intl } = this.props;
+
+    if (trailer && forcePolling) {
+      return intl.formatMessage({
+        id: 'dashboard.logs.pending',
+        defaultMessage: 'Final logs pending'
+      });
+    }
 
     switch (trailer) {
       case 'Completed':
@@ -256,7 +263,7 @@ export class LogContainer extends Component {
   };
 
   logTrailer = () => {
-    const { stepStatus } = this.props;
+    const { forcePolling, stepStatus } = this.props;
     const { reason } = (stepStatus && stepStatus.terminated) || {};
     const trailer = this.getTrailerMessage(reason);
     if (!trailer) {
@@ -264,7 +271,10 @@ export class LogContainer extends Component {
     }
 
     return (
-      <div className="tkn--log-trailer" data-status={reason}>
+      <div
+        className="tkn--log-trailer"
+        data-status={reason && (forcePolling ? 'LogsPending' : reason)}
+      >
         {trailer}
       </div>
     );

--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -75,6 +75,10 @@ pre.tkn--log {
     font-family: ibm-plex-sans, sans-serif;
     font-weight: bold;
 
+    &[data-status='LogsPending'] {
+      color: $support-03;
+    }
+
     &[data-status='Completed'] {
       color: $support-02;
     }

--- a/packages/components/src/components/Log/Log.test.js
+++ b/packages/components/src/components/Log/Log.test.js
@@ -52,6 +52,18 @@ describe('Log', () => {
     await waitFor(() => getByText(/step failed/i));
   });
 
+  it('renders pending trailer when step complete and forcePolling is true', async () => {
+    const { getByText, queryByText } = render(
+      <Log
+        fetchLogs={() => 'testing'}
+        forcePolling
+        stepStatus={{ terminated: { reason: 'Error' } }}
+      />
+    );
+    await waitFor(() => getByText(/final logs pending/i));
+    expect(queryByText(/step failed/)).toBeFalsy();
+  });
+
   it('renders virtualized list', async () => {
     const long = Array.from(
       { length: 60000 },

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "Download logs",
     "dashboard.logs.launchButtonTooltip": "Open logs in a new window",
     "dashboard.logs.maximize": "Maximize",
+    "dashboard.logs.pending": "Final logs pending",
     "dashboard.logs.restore": "Return to default",
     "dashboard.metadata.dateCreated": "Date created:",
     "dashboard.metadata.labels": "Labels:",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "ログをダウンロード",
     "dashboard.logs.launchButtonTooltip": "新しいウィンドウでログを開く",
     "dashboard.logs.maximize": "最大化",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "デフォルトに戻す",
     "dashboard.metadata.dateCreated": "作成日：",
     "dashboard.metadata.labels": "ラベル：",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "下载日志",
     "dashboard.logs.launchButtonTooltip": "在新窗口中打开日志",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "创建日期：",
     "dashboard.metadata.labels": "标签：",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -138,6 +138,7 @@
     "dashboard.logs.downloadButtonTooltip": "",
     "dashboard.logs.launchButtonTooltip": "",
     "dashboard.logs.maximize": "",
+    "dashboard.logs.pending": "",
     "dashboard.logs.restore": "",
     "dashboard.metadata.dateCreated": "",
     "dashboard.metadata.labels": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the message displayed in the log trailer when the step is complete
but the consumer of the log component has set the `forcePolling` prop. This
is to avoid confusion with the existing 'Step Completed' or 'Step Failed'
trailers as they suggest to the user that the logs are displayed in full
which may not be the case while `forcePolling` is still set.

Add a new string to make it clear that additional logs may yet be displayed
even though the step is complete.

![image](https://user-images.githubusercontent.com/2829095/126666432-e604ffcc-d81c-414b-a73c-c9891f09851b.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
