### PR TITLE
Prevent side nav menus from overlapping in short windows

### DIFF
--- a/src/containers/SideNav/SideNav.scss
+++ b/src/containers/SideNav/SideNav.scss
@@ -21,6 +21,10 @@ limitations under the License.
       display: flex;
       flex-direction: column;
 
+      .bx--side-nav__item {
+        flex-shrink: 0;
+      }
+
       .bx--side-nav__item.bx--side-nav__item--icon
         + .bx--side-nav__item:not(.bx--side-nav__item--icon) {
         display: flex;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Closes https://github.com/tektoncd/dashboard/issues/2115

Prevent side nav flex items from shrinking in shorter windows / when
zoomed / using large font. Side nav will scroll instead if items
are off the viewport edge.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
