### PR TITLE
Fix colour token for PipelineRunPending status label

### DIFF
--- a/packages/components/src/components/RunHeader/RunHeader.scss
+++ b/packages/components/src/components/RunHeader/RunHeader.scss
@@ -96,7 +96,7 @@ header.tkn--pipeline-run-header {
 
   &[data-succeeded='Unknown'][data-reason='PipelineRunPending'] {
     .tkn--status-label {
-      color: $gray-70;
+      color: $text-02;
     }
   }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
We were using a hardcoded colour token `$gray-70` which appeared
very low contrast when viewed in dark mode. Switch to the semantic
token `$text-02` so that it's updated correctly in the switch to
dark mode, replacing `$gray-70` with `$gray-30` as expected.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
