### PR TITLE
Limit width of theme tile group

### DIFF
--- a/src/containers/Settings/Settings.scss
+++ b/src/containers/Settings/Settings.scss
@@ -13,6 +13,10 @@ limitations under the License.
 
 .tkn--settings {
   .tkn--settings--content {
+    .bx--tile-group {
+      max-width: 400px;
+    }
+
     .bx--tile {
       display: flex;
       align-items: center;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Restrict the width of the tile group on the settings page to a more
reasonable size so it doesn't flow to the full page width.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
