### PR TITLE
Store namespace resources for consistency with other resource types

### DIFF
--- a/packages/components/src/components/StepDetails/StepDetails.test.js
+++ b/packages/components/src/components/StepDetails/StepDetails.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,8 +12,6 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
 import { fireEvent } from '@testing-library/react';
 import { renderWithRouter } from '../../utils/test';
 
@@ -21,59 +19,37 @@ import StepDetails from './StepDetails';
 
 describe('StepDetails', () => {
   it('renders', () => {
-    const mockStore = configureStore();
-    const store = mockStore({ namespaces: { selected: 'default' } });
-
-    renderWithRouter(
-      <Provider store={store}>
-        <StepDetails stepStatus={{}} />
-      </Provider>
-    );
+    renderWithRouter(<StepDetails stepStatus={{}} />);
   });
 
   it('renders terminated state', () => {
-    const mockStore = configureStore();
-    const store = mockStore({ namespaces: { selected: 'default' } });
-
     renderWithRouter(
-      <Provider store={store}>
-        <StepDetails stepStatus={{ terminated: { reason: 'Completed' } }} />
-      </Provider>
+      <StepDetails stepStatus={{ terminated: { reason: 'Completed' } }} />
     );
   });
 
   it('renders cancelled state', () => {
-    const mockStore = configureStore();
-    const store = mockStore({ namespaces: { selected: 'default' } });
-
     renderWithRouter(
-      <Provider store={store}>
-        <StepDetails
-          stepStatus={{}}
-          taskRun={{
-            status: {
-              conditions: [
-                {
-                  type: 'Succeeded',
-                  status: 'False',
-                  reason: 'TaskRunCancelled'
-                }
-              ]
-            }
-          }}
-        />
-      </Provider>
+      <StepDetails
+        stepStatus={{}}
+        taskRun={{
+          status: {
+            conditions: [
+              {
+                type: 'Succeeded',
+                status: 'False',
+                reason: 'TaskRunCancelled'
+              }
+            ]
+          }
+        }}
+      />
     );
   });
 
   it('renders with selected view', () => {
-    const mockStore = configureStore();
-    const store = mockStore({ namespaces: { selected: 'default' } });
-
     const { getByText } = renderWithRouter(
-      <Provider store={store}>
-        <StepDetails stepStatus={{}} view="details" />
-      </Provider>
+      <StepDetails stepStatus={{}} view="details" />
     );
 
     fireEvent.click(getByText(/status/i));

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -98,10 +98,7 @@ export function getNamespaces() {
 }
 
 export function useNamespaces(queryConfig) {
-  return useCollection('Namespace', getNamespaces, null, {
-    select: namespaces => namespaces.map(namespace => namespace.metadata.name),
-    ...queryConfig
-  });
+  return useCollection('Namespace', getNamespaces, null, queryConfig);
 }
 
 export function getPodLogURL({ container, name, namespace, follow }) {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -126,7 +126,7 @@ it('useNamespaces', async () => {
   });
   await waitFor(() => result.current.isFetching);
   await waitFor(() => !result.current.isFetching);
-  expect(result.current.data).toEqual(['namespace1', 'namespace2']);
+  expect(result.current.data).toEqual(namespaces.items);
   fetchMock.restore();
 });
 

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.test.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.test.js
@@ -16,19 +16,11 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { Route } from 'react-router-dom';
-import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
+import { paths, urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/clusterInterceptors';
 import ClusterInterceptorsContainer from './ClusterInterceptors';
-
-const namespacesTestStore = {
-  namespaces: {
-    selected: ALL_NAMESPACES,
-    byName: {},
-    isFetching: false
-  }
-};
 
 const clusterInterceptor = {
   metadata: {
@@ -43,7 +35,6 @@ const clusterInterceptor = {
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
-  ...namespacesTestStore,
   notifications: {
     webSocketConnected: false
   }
@@ -52,7 +43,6 @@ const testStore = {
 describe('ClusterInterceptors', () => {
   it('renders loading state', async () => {
     const mockTestStore = mockStore({
-      ...namespacesTestStore,
       notifications: {}
     });
     jest

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.test.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.test.js
@@ -25,19 +25,6 @@ import * as API from '../../api/clusterTriggerBindings';
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 
-const namespaces = {
-  byName: {
-    default: {
-      metadata: {
-        name: 'default'
-      }
-    }
-  },
-  errorMessage: null,
-  isFetching: false,
-  selected: '*'
-};
-
 const clusterTriggerBinding = {
   apiVersion: 'triggers.tekton.dev/v1alpha1',
   kind: 'ClusterTriggerBinding',
@@ -55,7 +42,6 @@ it('ClusterTriggerBindings renders with no bindings', () => {
   }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -79,7 +65,6 @@ it('ClusterTriggerBindings renders with one binding', () => {
     .mockImplementation(() => ({ data: [clusterTriggerBinding] }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -105,7 +90,6 @@ it('ClusterTriggerBindings can be filtered on a single label filter', async () =
     }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -134,7 +118,6 @@ it('ClusterTriggerBindings renders in loading state', () => {
     .mockImplementation(() => ({ isLoading: true }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -160,7 +143,6 @@ it('ClusterTriggerBindings renders in error state', () => {
     .mockImplementation(() => ({ error }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 

--- a/src/containers/Conditions/Conditions.test.js
+++ b/src/containers/Conditions/Conditions.test.js
@@ -23,16 +23,6 @@ import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/conditions';
 import ConditionsContainer from './Conditions';
 
-const namespacesTestStore = {
-  namespaces: {
-    selected: 'namespace-1',
-    byName: {
-      'namespace-1': ''
-    },
-    isFetching: false
-  }
-};
-
 const conditionWithSingleLabel = {
   metadata: {
     name: 'conditionWithSingleLabel',
@@ -59,7 +49,6 @@ const conditionWithTwoLabels = {
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
-  ...namespacesTestStore,
   notifications: {
     webSocketConnected: false
   }
@@ -71,7 +60,6 @@ describe('Conditions', () => {
       .spyOn(API, 'useConditions')
       .mockImplementation(() => ({ isLoading: true }));
     const mockTestStore = mockStore({
-      ...namespacesTestStore,
       notifications: {}
     });
     const { queryByText } = renderWithRouter(

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
@@ -33,9 +33,9 @@ const store = mockStore({
 
 describe('CreatePipelineResource', () => {
   beforeEach(() => {
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['default'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: 'default' } }]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));

--- a/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResourceErrorNotification.test.js
@@ -30,7 +30,7 @@ it('CreatePipelineResource error notification appears', async () => {
   };
   jest
     .spyOn(API, 'useNamespaces')
-    .mockImplementation(() => ({ data: ['default'] }));
+    .mockImplementation(() => ({ data: [{ metadata: { name: 'default' } }] }));
   jest
     .spyOn(PipelineResourcesAPI, 'createPipelineResource')
     .mockImplementation(() => Promise.reject(errorResponseMock));

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -116,9 +116,12 @@ describe('CreatePipelineRun', () => {
     jest
       .spyOn(PipelineRunsAPI, 'usePipelineRuns')
       .mockImplementation(() => ({ data: [] }));
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['namespace-1', 'namespace-2'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [
+        { metadata: { name: 'namespace-1' } },
+        { metadata: { name: 'namespace-2' } }
+      ]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: 'namespace-1' }));

--- a/src/containers/CreateTaskRun/CreateTaskRun.test.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.js
@@ -154,9 +154,12 @@ describe('CreateTaskRun', () => {
       .spyOn(TaskRunsAPI, 'getTaskRuns')
       .mockImplementation(() => taskRuns.byId);
 
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['namespace-1', 'namespace-2'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [
+        { metadata: { name: 'namespace-1' } },
+        { metadata: { name: 'namespace-2' } }
+      ]
+    }));
 
     const mockTestStore = mockStore(testStore);
     jest.spyOn(store, 'getStore').mockImplementation(() => mockTestStore);

--- a/src/containers/EventListeners/EventListeners.test.js
+++ b/src/containers/EventListeners/EventListeners.test.js
@@ -41,9 +41,9 @@ const eventListener = {
 
 describe('EventListeners', () => {
   beforeEach(() => {
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['default'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: 'default' } }]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));

--- a/src/containers/ImportResources/ImportResources.test.js
+++ b/src/containers/ImportResources/ImportResources.test.js
@@ -34,9 +34,12 @@ describe('ImportResources component', () => {
     jest
       .spyOn(API, 'useDashboardNamespace')
       .mockImplementation(() => 'namespace1');
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['namespace1', 'default'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [
+        { metadata: { name: 'namespace1' } },
+        { metadata: { name: 'default' } }
+      ]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));

--- a/src/containers/ListPageLayout/ListPageLayout.test.js
+++ b/src/containers/ListPageLayout/ListPageLayout.test.js
@@ -23,9 +23,9 @@ import { ListPageLayout } from './ListPageLayout';
 describe('ListPageLayout', () => {
   it('add namespace to URL when selected', async () => {
     const otherNamespace = 'foo';
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: [otherNamespace] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: otherNamespace } }]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));
@@ -55,9 +55,12 @@ describe('ListPageLayout', () => {
   it('updates namespace in URL', async () => {
     const namespace = 'default';
     const otherNamespace = 'foo';
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: [namespace, otherNamespace] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [
+        { metadata: { name: namespace } },
+        { metadata: { name: otherNamespace } }
+      ]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: namespace }));
@@ -87,9 +90,9 @@ describe('ListPageLayout', () => {
   it('removes namespace from URL when ALL_NAMESPACES is selected', async () => {
     const namespace = 'default';
     const selectNamespace = jest.fn();
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: [namespace] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: namespace } }]
+    }));
     jest.spyOn(APIUtils, 'useSelectedNamespace').mockImplementation(() => ({
       selectedNamespace: namespace,
       selectNamespace
@@ -117,9 +120,9 @@ describe('ListPageLayout', () => {
   it('removes namespace from URL when clearing selection', async () => {
     const namespace = 'default';
     const selectNamespace = jest.fn();
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: [namespace] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: namespace } }]
+    }));
     jest.spyOn(APIUtils, 'useSelectedNamespace').mockImplementation(() => ({
       selectedNamespace: namespace,
       selectNamespace

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -58,7 +58,9 @@ const NamespacesDropdown = ({
     selectedItem.text = allNamespacesString;
   }
 
-  const items = tenantNamespace ? [tenantNamespace] : namespaces;
+  const items = tenantNamespace
+    ? [tenantNamespace]
+    : namespaces.map(namespace => namespace.metadata.name);
   if (!tenantNamespace && showAllNamespaces) {
     items.unshift({ id: ALL_NAMESPACES, text: allNamespacesString });
   }

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.js
@@ -24,13 +24,16 @@ const props = {
 };
 
 const namespaces = ['namespace-1', 'namespace-2', 'namespace-3'];
+const namespaceResources = namespaces.map(namespace => ({
+  metadata: { name: namespace }
+}));
 
 const initialTextRegExp = new RegExp('select namespace', 'i');
 
 it('NamespacesDropdown renders items', () => {
   jest
     .spyOn(API, 'useNamespaces')
-    .mockImplementation(() => ({ data: namespaces }));
+    .mockImplementation(() => ({ data: namespaceResources }));
   const { getAllByText, getByPlaceholderText, queryByText } = render(
     <NamespacesDropdown {...props} />
   );
@@ -46,7 +49,7 @@ it('NamespacesDropdown renders items', () => {
 it('NamespacesDropdown renders controlled selection', () => {
   jest
     .spyOn(API, 'useNamespaces')
-    .mockImplementation(() => ({ data: namespaces }));
+    .mockImplementation(() => ({ data: namespaceResources }));
   // Select item 'namespace-1'
   const { queryByPlaceholderText, queryByDisplayValue, rerender } = render(
     <NamespacesDropdown {...props} selectedItem={{ text: 'namespace-1' }} />
@@ -80,7 +83,7 @@ it('NamespacesDropdown renders loading skeleton based on Redux state', () => {
 it('NamespacesDropdown handles onChange event', () => {
   jest
     .spyOn(API, 'useNamespaces')
-    .mockImplementation(() => ({ data: namespaces }));
+    .mockImplementation(() => ({ data: namespaceResources }));
   const onChange = jest.fn();
   const { getByPlaceholderText, getByText } = render(
     <NamespacesDropdown {...props} onChange={onChange} />

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.test.js
@@ -87,9 +87,9 @@ const mockStore = configureStore(middleware);
 
 describe('PipelineResourcesDropdown', () => {
   beforeEach(() => {
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['blue', 'green'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: 'blue' } }, { metadata: { name: 'green' } }]
+    }));
   });
 
   it('renders items', () => {

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -25,15 +25,6 @@ import * as PipelinesAPI from '../../api/pipelines';
 import * as PipelineRunsAPI from '../../api/pipelineRuns';
 import PipelineRunsContainer from './PipelineRuns';
 
-const namespacesTestStore = {
-  namespaces: {
-    selected: 'namespace-1',
-    byName: {
-      'namespace-1': ''
-    },
-    isFetching: false
-  }
-};
 const pipelines = [
   {
     metadata: {
@@ -116,7 +107,6 @@ const pipelineRuns = [
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
-  ...namespacesTestStore,
   notifications: {}
 };
 

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.test.js
@@ -83,9 +83,9 @@ const mockStore = configureStore(middleware);
 
 describe('ServiceAccountsDropdown', () => {
   beforeEach(() => {
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['blue', 'green'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: 'blue' } }, { metadata: { name: 'green' } }]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: 'blue' }));

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -25,15 +25,6 @@ import * as taskRunsAPI from '../../api/taskRuns';
 import * as store from '../../store';
 import TaskRunsContainer from './TaskRuns';
 
-const namespacesTestStore = {
-  namespaces: {
-    selected: 'namespace-1',
-    byName: {
-      'namespace-1': ''
-    },
-    isFetching: false
-  }
-};
 const taskRuns = [
   {
     status: {
@@ -77,7 +68,6 @@ const taskRuns = [
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
-  ...namespacesTestStore,
   notifications: {}
 };
 

--- a/src/containers/TasksDropdown/TasksDropdown.test.js
+++ b/src/containers/TasksDropdown/TasksDropdown.test.js
@@ -76,9 +76,9 @@ const mockStore = configureStore(middleware);
 
 describe('TasksDropdown', () => {
   beforeEach(() => {
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['blue', 'green'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: 'blue' } }, { metadata: { name: 'green' } }]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: 'blue' }));

--- a/src/containers/TriggerBindings/TriggerBindings.test.js
+++ b/src/containers/TriggerBindings/TriggerBindings.test.js
@@ -41,9 +41,9 @@ const triggerBinding = {
 
 describe('TriggerBindings', () => {
   beforeEach(() => {
-    jest
-      .spyOn(API, 'useNamespaces')
-      .mockImplementation(() => ({ data: ['default'] }));
+    jest.spyOn(API, 'useNamespaces').mockImplementation(() => ({
+      data: [{ metadata: { name: 'default' } }]
+    }));
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));

--- a/src/containers/TriggerTemplates/TriggerTemplates.test.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.test.js
@@ -39,8 +39,6 @@ const triggerTemplate = {
   }
 };
 
-const namespaces = ['default'];
-
 it('TriggerTemplates renders with no templates', () => {
   jest
     .spyOn(TriggerTemplatesAPI, 'useTriggerTemplates')
@@ -48,7 +46,7 @@ it('TriggerTemplates renders with no templates', () => {
 
   jest
     .spyOn(API, 'useNamespaces')
-    .mockImplementation(() => ({ data: namespaces }));
+    .mockImplementation(() => ({ data: [{ metadata: { name: 'default' } }] }));
   jest
     .spyOn(APIUtils, 'useSelectedNamespace')
     .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));
@@ -76,7 +74,6 @@ it('TriggerTemplates renders with one template', () => {
     .mockImplementation(() => ({ data: [triggerTemplate] }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -103,7 +100,6 @@ it('TriggerTemplates can be filtered on a single label filter', async () => {
     }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -132,7 +128,6 @@ it('TriggerTemplates renders in loading state', () => {
     .mockImplementation(() => ({ isLoading: true }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 
@@ -157,7 +152,6 @@ it('TriggerTemplates renders in error state', () => {
     .mockImplementation(() => ({ error }));
 
   const store = mockStore({
-    namespaces,
     notifications: {}
   });
 

--- a/src/containers/Triggers/Triggers.test.js
+++ b/src/containers/Triggers/Triggers.test.js
@@ -22,20 +22,9 @@ import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/triggers';
 import TriggersContainer from './Triggers';
 
-const namespacesTestStore = {
-  namespaces: {
-    selected: 'namespace-1',
-    byName: {
-      'namespace-1': ''
-    },
-    isFetching: false
-  }
-};
-
 const middleware = [thunk];
 const mockStore = configureStore(middleware);
 const testStore = {
-  ...namespacesTestStore,
   notifications: {
     webSocketConnected: false
   }
@@ -51,7 +40,6 @@ describe('Triggers', () => {
       .spyOn(API, 'useTriggers')
       .mockImplementation(() => ({ isLoading: true }));
     const mockTestStore = mockStore({
-      ...namespacesTestStore,
       notifications: {}
     });
     const { queryByText } = renderWithRouter(


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1842

Instead of using react-query's `select` feature in the `useNamespace` hook
to return just the names of the namespaces, return the full list of resources
as we do with other types. This ensures the same logic for handling websocket
events will apply to namespaces and avoids needing to add a special case to
handle this one resource type.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
