### PR TITLE
Split websocket connections by kind

### DIFF
--- a/src/api/clusterInterceptors.js
+++ b/src/api/clusterInterceptors.js
@@ -21,12 +21,16 @@ import {
   useResource
 } from './utils';
 
-export function getClusterInterceptors({ filters = [] } = {}) {
-  const uri = getTektonAPI(
+function getClusterInterceptorsAPI({ filters, isWebSocket, name }) {
+  return getTektonAPI(
     'clusterinterceptors',
-    { group: triggersAPIGroup, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { group: triggersAPIGroup, isWebSocket, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getClusterInterceptors({ filters = [] } = {}) {
+  const uri = getClusterInterceptorsAPI({ filters });
   return get(uri).then(checkData);
 }
 
@@ -40,9 +44,27 @@ export function getClusterInterceptor({ name }) {
 }
 
 export function useClusterInterceptors(params) {
-  return useCollection('ClusterInterceptor', getClusterInterceptors, params);
+  const webSocketURL = getClusterInterceptorsAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useCollection({
+    api: getClusterInterceptors,
+    kind: 'ClusterInterceptor',
+    params,
+    webSocketURL
+  });
 }
 
 export function useClusterInterceptor(params) {
-  return useResource('ClusterInterceptor', getClusterInterceptor, params);
+  const webSocketURL = getClusterInterceptorsAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useResource({
+    api: getClusterInterceptor,
+    kind: 'ClusterInterceptor',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/clusterInterceptors.test.js
+++ b/src/api/clusterInterceptors.test.js
@@ -42,9 +42,11 @@ it('useClusterInterceptors', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useClusterInterceptors(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'ClusterInterceptor',
-    API.getClusterInterceptors,
-    params
+    expect.objectContaining({
+      api: API.getClusterInterceptors,
+      kind: 'ClusterInterceptor',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useClusterInterceptor', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useClusterInterceptor(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'ClusterInterceptor',
-    API.getClusterInterceptor,
-    params
+    expect.objectContaining({
+      api: API.getClusterInterceptor,
+      kind: 'ClusterInterceptor',
+      params
+    })
   );
 });

--- a/src/api/clusterTasks.js
+++ b/src/api/clusterTasks.js
@@ -20,8 +20,16 @@ import {
   useResource
 } from './utils';
 
+function getClusterTasksAPI({ filters, isWebSocket, name }) {
+  return getTektonAPI(
+    'clustertasks',
+    { isWebSocket },
+    getQueryParams({ filters, name })
+  );
+}
+
 export function getClusterTasks({ filters = [] } = {}) {
-  const uri = getTektonAPI('clustertasks', undefined, getQueryParams(filters));
+  const uri = getClusterTasksAPI({ filters });
   return get(uri).then(checkData);
 }
 
@@ -36,9 +44,22 @@ export function deleteClusterTask({ name }) {
 }
 
 export function useClusterTasks(params) {
-  return useCollection('ClusterTask', getClusterTasks, params);
+  const webSocketURL = getClusterTasksAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getClusterTasks,
+    kind: 'ClusterTask',
+    params,
+    webSocketURL
+  });
 }
 
 export function useClusterTask(params, queryConfig) {
-  return useResource('ClusterTask', getClusterTask, params, queryConfig);
+  const webSocketURL = getClusterTasksAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getClusterTask,
+    kind: 'ClusterTask',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }

--- a/src/api/clusterTasks.test.js
+++ b/src/api/clusterTasks.test.js
@@ -52,9 +52,11 @@ it('useClusterTasks', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useClusterTasks(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'ClusterTask',
-    API.getClusterTasks,
-    params
+    expect.objectContaining({
+      api: API.getClusterTasks,
+      kind: 'ClusterTask',
+      params
+    })
   );
 });
 
@@ -64,18 +66,21 @@ it('useClusterTask', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useClusterTask(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'ClusterTask',
-    API.getClusterTask,
-    params,
-    undefined
+    expect.objectContaining({
+      api: API.getClusterTask,
+      kind: 'ClusterTask',
+      params
+    })
   );
 
   const queryConfig = { fake: 'queryConfig' };
   API.useClusterTask(params, queryConfig);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'ClusterTask',
-    API.getClusterTask,
-    params,
-    queryConfig
+    expect.objectContaining({
+      api: API.getClusterTask,
+      kind: 'ClusterTask',
+      params,
+      queryConfig
+    })
   );
 });

--- a/src/api/clusterTriggerBindings.js
+++ b/src/api/clusterTriggerBindings.js
@@ -21,12 +21,16 @@ import {
   useResource
 } from './utils';
 
-export function getClusterTriggerBindings({ filters = [] } = {}) {
-  const uri = getTektonAPI(
+function getClusterTriggerBindingsAPI({ filters, isWebSocket, name }) {
+  return getTektonAPI(
     'clustertriggerbindings',
-    { group: triggersAPIGroup, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { group: triggersAPIGroup, isWebSocket, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getClusterTriggerBindings({ filters = [] } = {}) {
+  const uri = getClusterTriggerBindingsAPI({ filters });
   return get(uri).then(checkData);
 }
 
@@ -40,13 +44,27 @@ export function getClusterTriggerBinding({ name }) {
 }
 
 export function useClusterTriggerBindings(params) {
-  return useCollection(
-    'ClusterTriggerBinding',
-    getClusterTriggerBindings,
-    params
-  );
+  const webSocketURL = getClusterTriggerBindingsAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useCollection({
+    api: getClusterTriggerBindings,
+    kind: 'ClusterTriggerBinding',
+    params,
+    webSocketURL
+  });
 }
 
 export function useClusterTriggerBinding(params) {
-  return useResource('ClusterTriggerBinding', getClusterTriggerBinding, params);
+  const webSocketURL = getClusterTriggerBindingsAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useResource({
+    api: getClusterTriggerBinding,
+    kind: 'ClusterTriggerBinding',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/clusterTriggerBindings.test.js
+++ b/src/api/clusterTriggerBindings.test.js
@@ -42,9 +42,11 @@ it('useClusterTriggerBindings', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useClusterTriggerBindings(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'ClusterTriggerBinding',
-    API.getClusterTriggerBindings,
-    params
+    expect.objectContaining({
+      api: API.getClusterTriggerBindings,
+      kind: 'ClusterTriggerBinding',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useClusterTriggerBinding', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useClusterTriggerBinding(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'ClusterTriggerBinding',
-    API.getClusterTriggerBinding,
-    params
+    expect.objectContaining({
+      api: API.getClusterTriggerBinding,
+      kind: 'ClusterTriggerBinding',
+      params
+    })
   );
 });

--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import ReconnectingWebSocket from 'reconnecting-websocket';
+
 const csrfHeader = {
   'Tekton-Client': 'tektoncd/dashboard'
 };
@@ -18,6 +20,10 @@ const defaultOptions = {
   method: 'GET',
   credentials: 'same-origin'
 };
+
+export function createWebSocket(url) {
+  return new ReconnectingWebSocket(url);
+}
 
 export function getAPIRoot() {
   const { host, pathname, protocol } = window.location;

--- a/src/api/conditions.js
+++ b/src/api/conditions.js
@@ -20,12 +20,16 @@ import {
   useResource
 } from './utils';
 
-export function getConditions({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getConditionsAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'conditions',
-    { namespace, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { isWebSocket, namespace, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getConditions({ filters = [], namespace } = {}) {
+  const uri = getConditionsAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -39,9 +43,21 @@ export function getCondition({ name, namespace }) {
 }
 
 export function useConditions(params) {
-  return useCollection('Condition', getConditions, params);
+  const webSocketURL = getConditionsAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getConditions,
+    kind: 'Condition',
+    params,
+    webSocketURL
+  });
 }
 
 export function useCondition(params) {
-  return useResource('Condition', getCondition, params);
+  const webSocketURL = getConditionsAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getCondition,
+    kind: 'Condition',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/conditions.test.js
+++ b/src/api/conditions.test.js
@@ -42,9 +42,11 @@ it('useConditions', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useConditions(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'Condition',
-    API.getConditions,
-    params
+    expect.objectContaining({
+      api: API.getConditions,
+      kind: 'Condition',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useCondition', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useCondition(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'Condition',
-    API.getCondition,
-    params
+    expect.objectContaining({
+      kind: 'Condition',
+      api: API.getCondition,
+      params
+    })
   );
 });

--- a/src/api/eventListeners.js
+++ b/src/api/eventListeners.js
@@ -21,12 +21,16 @@ import {
   useResource
 } from './utils';
 
-export function getEventListeners({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getEventListenersAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'eventlisteners',
-    { group: triggersAPIGroup, namespace, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getEventListeners({ filters = [], namespace } = {}) {
+  const uri = getEventListenersAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -41,9 +45,21 @@ export function getEventListener({ name, namespace }) {
 }
 
 export function useEventListeners(params) {
-  return useCollection('EventListener', getEventListeners, params);
+  const webSocketURL = getEventListenersAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getEventListeners,
+    kind: 'EventListener',
+    params,
+    webSocketURL
+  });
 }
 
 export function useEventListener(params) {
-  return useResource('EventListener', getEventListener, params);
+  const webSocketURL = getEventListenersAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getEventListener,
+    kind: 'EventListener',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/eventListeners.test.js
+++ b/src/api/eventListeners.test.js
@@ -42,9 +42,11 @@ it('useEventListeners', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useEventListeners(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'EventListener',
-    API.getEventListeners,
-    params
+    expect.objectContaining({
+      api: API.getEventListeners,
+      kind: 'EventListener',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useEventListener', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useEventListener(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'EventListener',
-    API.getEventListener,
-    params
+    expect.objectContaining({
+      api: API.getEventListener,
+      kind: 'EventListener',
+      params
+    })
   );
 });

--- a/src/api/extensions.js
+++ b/src/api/extensions.js
@@ -14,13 +14,18 @@ limitations under the License.
 import { get } from './comms';
 import { dashboardAPIGroup, getResourcesAPI, useCollection } from './utils';
 
-export async function getExtensions({ namespace } = {}) {
-  const resourceExtensionsUri = getResourcesAPI({
+function getExtensionsAPI({ isWebSocket, namespace }) {
+  return getResourcesAPI({
     group: dashboardAPIGroup,
+    isWebSocket,
     version: 'v1alpha1',
     type: 'extensions',
     namespace
   });
+}
+
+export async function getExtensions({ namespace } = {}) {
+  const resourceExtensionsUri = getExtensionsAPI({ namespace });
   const resourceExtensions = await get(resourceExtensionsUri);
   return (resourceExtensions?.items || []).map(({ spec }) => {
     const { displayname: displayName, name, namespaced } = spec;
@@ -36,5 +41,12 @@ export async function getExtensions({ namespace } = {}) {
 }
 
 export function useExtensions(params, queryConfig) {
-  return useCollection('Extension', getExtensions, params, queryConfig);
+  const webSocketURL = getExtensionsAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getExtensions,
+    kind: 'Extension',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }

--- a/src/api/extensions.test.js
+++ b/src/api/extensions.test.js
@@ -48,18 +48,21 @@ it('useExtensions', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useExtensions(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'Extension',
-    API.getExtensions,
-    params,
-    undefined
+    expect.objectContaining({
+      api: API.getExtensions,
+      kind: 'Extension',
+      params
+    })
   );
 
   const queryConfig = { fake: 'queryConfig' };
   API.useExtensions(params, queryConfig);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'Extension',
-    API.getExtensions,
-    params,
-    queryConfig
+    expect.objectContaining({
+      api: API.getExtensions,
+      kind: 'Extension',
+      params,
+      queryConfig
+    })
   );
 });

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -60,9 +60,11 @@ it('useCustomResource', () => {
   const returnValue = API.useCustomResource(params);
 
   expect(utils.useResource).toHaveBeenCalledWith(
-    'customResource',
-    API.getCustomResource,
-    params
+    expect.objectContaining({
+      api: API.getCustomResource,
+      kind: 'customResource',
+      params
+    })
   );
   expect(returnValue).toEqual(query);
 });

--- a/src/api/pipelineResources.js
+++ b/src/api/pipelineResources.js
@@ -37,12 +37,19 @@ export function deletePipelineResource({ name, namespace } = {}) {
   return deleteRequest(uri, name);
 }
 
-export function getPipelineResources({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getPipelineResourcesAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'pipelineresources',
-    { namespace, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { isWebSocket, namespace, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getPipelineResources({ filters = [], namespace } = {}) {
+  const uri = getPipelineResourcesAPI({
+    filters,
+    namespace
+  });
   return get(uri).then(checkData);
 }
 
@@ -60,9 +67,27 @@ export function getPipelineResource({ name, namespace }) {
 }
 
 export function usePipelineResources(params) {
-  return useCollection('PipelineResource', getPipelineResources, params);
+  const webSocketURL = getPipelineResourcesAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useCollection({
+    api: getPipelineResources,
+    kind: 'PipelineResource',
+    params,
+    webSocketURL
+  });
 }
 
 export function usePipelineResource(params) {
-  return useResource('PipelineResource', getPipelineResource, params);
+  const webSocketURL = getPipelineResourcesAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useResource({
+    api: getPipelineResource,
+    kind: 'PipelineResource',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/pipelineResources.test.js
+++ b/src/api/pipelineResources.test.js
@@ -84,9 +84,11 @@ it('usePipelineResources', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.usePipelineResources(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'PipelineResource',
-    API.getPipelineResources,
-    params
+    expect.objectContaining({
+      api: API.getPipelineResources,
+      kind: 'PipelineResource',
+      params
+    })
   );
 });
 
@@ -96,8 +98,10 @@ it('usePipelineResource', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.usePipelineResource(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'PipelineResource',
-    API.getPipelineResource,
-    params
+    expect.objectContaining({
+      api: API.getPipelineResource,
+      kind: 'PipelineResource',
+      params
+    })
   );
 });

--- a/src/api/pipelineRuns.js
+++ b/src/api/pipelineRuns.js
@@ -23,12 +23,16 @@ import {
   useResource
 } from './utils';
 
-export function getPipelineRuns({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getPipelineRunsAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'pipelineruns',
-    { namespace },
-    getQueryParams(filters)
+    { isWebSocket, namespace },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getPipelineRuns({ filters = [], namespace } = {}) {
+  const uri = getPipelineRunsAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -38,11 +42,24 @@ export function getPipelineRun({ name, namespace }) {
 }
 
 export function usePipelineRuns(params) {
-  return useCollection('PipelineRun', getPipelineRuns, params);
+  const webSocketURL = getPipelineRunsAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getPipelineRuns,
+    kind: 'PipelineRun',
+    params,
+    webSocketURL
+  });
 }
 
 export function usePipelineRun(params, queryConfig) {
-  return useResource('PipelineRun', getPipelineRun, params, queryConfig);
+  const webSocketURL = getPipelineRunsAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getPipelineRun,
+    kind: 'PipelineRun',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }
 
 export function cancelPipelineRun({ name, namespace }) {

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -190,9 +190,11 @@ it('usePipelineRuns', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.usePipelineRuns(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'PipelineRun',
-    API.getPipelineRuns,
-    params
+    expect.objectContaining({
+      api: API.getPipelineRuns,
+      kind: 'PipelineRun',
+      params
+    })
   );
 });
 
@@ -202,19 +204,22 @@ it('usePipelineRun', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.usePipelineRun(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'PipelineRun',
-    API.getPipelineRun,
-    params,
-    undefined
+    expect.objectContaining({
+      api: API.getPipelineRun,
+      kind: 'PipelineRun',
+      params
+    })
   );
 
   const queryConfig = { fake: 'queryConfig' };
   API.usePipelineRun(params, queryConfig);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'PipelineRun',
-    API.getPipelineRun,
-    params,
-    queryConfig
+    expect.objectContaining({
+      api: API.getPipelineRun,
+      kind: 'PipelineRun',
+      params,
+      queryConfig
+    })
   );
 });
 

--- a/src/api/pipelines.js
+++ b/src/api/pipelines.js
@@ -20,8 +20,16 @@ import {
   useResource
 } from './utils';
 
+function getPipelinesAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
+    'pipelines',
+    { isWebSocket, namespace },
+    getQueryParams({ filters, name })
+  );
+}
+
 export function getPipelines({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI('pipelines', { namespace }, getQueryParams(filters));
+  const uri = getPipelinesAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -35,10 +43,24 @@ export function deletePipeline({ name, namespace }) {
   return deleteRequest(uri);
 }
 
-export function usePipelines(params) {
-  return useCollection('Pipeline', getPipelines, params);
+export function usePipelines(params, queryConfig) {
+  const webSocketURL = getPipelinesAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getPipelines,
+    kind: 'Pipeline',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }
 
 export function usePipeline(params, queryConfig) {
-  return useResource('Pipeline', getPipeline, params, queryConfig);
+  const webSocketURL = getPipelinesAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getPipeline,
+    kind: 'Pipeline',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }

--- a/src/api/pipelines.test.js
+++ b/src/api/pipelines.test.js
@@ -52,9 +52,11 @@ it('usePipelines', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.usePipelines(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'Pipeline',
-    API.getPipelines,
-    params
+    expect.objectContaining({
+      api: API.getPipelines,
+      kind: 'Pipeline',
+      params
+    })
   );
 });
 
@@ -64,18 +66,21 @@ it('usePipeline', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.usePipeline(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'Pipeline',
-    API.getPipeline,
-    params,
-    undefined
+    expect.objectContaining({
+      api: API.getPipeline,
+      kind: 'Pipeline',
+      params
+    })
   );
 
   const queryConfig = { fake: 'queryConfig' };
   API.usePipeline(params, queryConfig);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'Pipeline',
-    API.getPipeline,
-    params,
-    queryConfig
+    expect.objectContaining({
+      api: API.getPipeline,
+      kind: 'Pipeline',
+      params,
+      queryConfig
+    })
   );
 });

--- a/src/api/serviceAccounts.js
+++ b/src/api/serviceAccounts.js
@@ -19,6 +19,16 @@ export function getServiceAccounts({ namespace } = {}) {
   return get(uri).then(checkData);
 }
 
-export function useServiceAccounts(params) {
-  return useCollection('ServiceAccount', getServiceAccounts, params);
+export function useServiceAccounts(params, queryConfig) {
+  const webSocketURL = getKubeAPI('serviceaccounts', {
+    ...params,
+    isWebSocket: true
+  });
+  return useCollection({
+    api: getServiceAccounts,
+    kind: 'ServiceAccount',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }

--- a/src/api/serviceAccounts.test.js
+++ b/src/api/serviceAccounts.test.js
@@ -30,8 +30,10 @@ it('useServiceAccounts', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useServiceAccounts(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'ServiceAccount',
-    API.getServiceAccounts,
-    params
+    expect.objectContaining({
+      api: API.getServiceAccounts,
+      kind: 'ServiceAccount',
+      params
+    })
   );
 });

--- a/src/api/taskRuns.js
+++ b/src/api/taskRuns.js
@@ -28,8 +28,16 @@ export function deleteTaskRun({ name, namespace }) {
   return deleteRequest(uri);
 }
 
+function getTaskRunsAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
+    'taskruns',
+    { isWebSocket, namespace },
+    getQueryParams({ filters, name })
+  );
+}
+
 export function getTaskRuns({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI('taskruns', { namespace }, getQueryParams(filters));
+  const uri = getTaskRunsAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -39,11 +47,24 @@ export function getTaskRun({ name, namespace }) {
 }
 
 export function useTaskRuns(params) {
-  return useCollection('TaskRun', getTaskRuns, params);
+  const webSocketURL = getTaskRunsAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getTaskRuns,
+    kind: 'TaskRun',
+    params,
+    webSocketURL
+  });
 }
 
 export function useTaskRun(params, queryConfig) {
-  return useResource('TaskRun', getTaskRun, params, queryConfig);
+  const webSocketURL = getTaskRunsAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getTaskRun,
+    kind: 'TaskRun',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }
 
 export function cancelTaskRun({ name, namespace }) {

--- a/src/api/taskRuns.test.js
+++ b/src/api/taskRuns.test.js
@@ -205,9 +205,11 @@ it('useTaskRuns', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useTaskRuns(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'TaskRun',
-    API.getTaskRuns,
-    params
+    expect.objectContaining({
+      api: API.getTaskRuns,
+      kind: 'TaskRun',
+      params
+    })
   );
 });
 
@@ -217,19 +219,22 @@ it('useTaskRun', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useTaskRun(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'TaskRun',
-    API.getTaskRun,
-    params,
-    undefined
+    expect.objectContaining({
+      api: API.getTaskRun,
+      kind: 'TaskRun',
+      params
+    })
   );
 
   const queryConfig = { fake: 'queryConfig' };
   API.useTaskRun(params, queryConfig);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'TaskRun',
-    API.getTaskRun,
-    params,
-    queryConfig
+    expect.objectContaining({
+      api: API.getTaskRun,
+      kind: 'TaskRun',
+      params,
+      queryConfig
+    })
   );
 });
 

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -20,8 +20,16 @@ import {
   useResource
 } from './utils';
 
+function getTasksAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
+    'tasks',
+    { isWebSocket, namespace },
+    getQueryParams({ filters, name })
+  );
+}
+
 export function getTasks({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI('tasks', { namespace }, getQueryParams(filters));
+  const uri = getTasksAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -36,9 +44,17 @@ export function deleteTask({ name, namespace }) {
 }
 
 export function useTasks(params) {
-  return useCollection('Task', getTasks, params);
+  const webSocketURL = getTasksAPI({ ...params, isWebSocket: true });
+  return useCollection({ api: getTasks, kind: 'Task', params, webSocketURL });
 }
 
 export function useTask(params, queryConfig) {
-  return useResource('Task', getTask, params, queryConfig);
+  const webSocketURL = getTasksAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getTask,
+    kind: 'Task',
+    params,
+    queryConfig,
+    webSocketURL
+  });
 }

--- a/src/api/tasks.test.js
+++ b/src/api/tasks.test.js
@@ -52,9 +52,11 @@ it('useTasks', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useTasks(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'Task',
-    API.getTasks,
-    params
+    expect.objectContaining({
+      api: API.getTasks,
+      kind: 'Task',
+      params
+    })
   );
 });
 
@@ -64,18 +66,21 @@ it('useTask', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useTask(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'Task',
-    API.getTask,
-    params,
-    undefined
+    expect.objectContaining({
+      api: API.getTask,
+      kind: 'Task',
+      params
+    })
   );
 
   const queryConfig = { fake: 'queryConfig' };
   API.useTask(params, queryConfig);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'Task',
-    API.getTask,
-    params,
-    queryConfig
+    expect.objectContaining({
+      api: API.getTask,
+      kind: 'Task',
+      params,
+      queryConfig
+    })
   );
 });

--- a/src/api/triggerBindings.js
+++ b/src/api/triggerBindings.js
@@ -21,12 +21,16 @@ import {
   useResource
 } from './utils';
 
-export function getTriggerBindings({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getTriggerBindingsAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'triggerbindings',
-    { group: triggersAPIGroup, namespace, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getTriggerBindings({ filters = [], namespace } = {}) {
+  const uri = getTriggerBindingsAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -41,9 +45,21 @@ export function getTriggerBinding({ name, namespace }) {
 }
 
 export function useTriggerBindings(params) {
-  return useCollection('TriggerBinding', getTriggerBindings, params);
+  const webSocketURL = getTriggerBindingsAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getTriggerBindings,
+    kind: 'TriggerBinding',
+    params,
+    webSocketURL
+  });
 }
 
 export function useTriggerBinding(params) {
-  return useResource('TriggerBinding', getTriggerBinding, params);
+  const webSocketURL = getTriggerBindingsAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getTriggerBinding,
+    kind: 'TriggerBinding',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/triggerBindings.test.js
+++ b/src/api/triggerBindings.test.js
@@ -42,9 +42,11 @@ it('useTriggerBindings', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useTriggerBindings(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'TriggerBinding',
-    API.getTriggerBindings,
-    params
+    expect.objectContaining({
+      api: API.getTriggerBindings,
+      kind: 'TriggerBinding',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useTriggerBinding', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useTriggerBinding(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'TriggerBinding',
-    API.getTriggerBinding,
-    params
+    expect.objectContaining({
+      api: API.getTriggerBinding,
+      kind: 'TriggerBinding',
+      params
+    })
   );
 });

--- a/src/api/triggerTemplates.js
+++ b/src/api/triggerTemplates.js
@@ -21,12 +21,16 @@ import {
   useResource
 } from './utils';
 
-export function getTriggerTemplates({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getTriggerTemplatesAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'triggertemplates',
-    { group: triggersAPIGroup, namespace, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getTriggerTemplates({ filters = [], namespace } = {}) {
+  const uri = getTriggerTemplatesAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -41,9 +45,21 @@ export function getTriggerTemplate({ name, namespace }) {
 }
 
 export function useTriggerTemplates(params) {
-  return useCollection('TriggerTemplate', getTriggerTemplates, params);
+  const webSocketURL = getTriggerTemplatesAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getTriggerTemplates,
+    kind: 'TriggerTemplate',
+    params,
+    webSocketURL
+  });
 }
 
 export function useTriggerTemplate(params) {
-  return useResource('TriggerTemplate', getTriggerTemplate, params);
+  const webSocketURL = getTriggerTemplatesAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getTriggerTemplate,
+    kind: 'TriggerTemplate',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/triggerTemplates.test.js
+++ b/src/api/triggerTemplates.test.js
@@ -42,9 +42,11 @@ it('useTriggerTemplates', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useTriggerTemplates(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'TriggerTemplate',
-    API.getTriggerTemplates,
-    params
+    expect.objectContaining({
+      api: API.getTriggerTemplates,
+      kind: 'TriggerTemplate',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useTriggerTemplate', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useTriggerTemplate(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'TriggerTemplate',
-    API.getTriggerTemplate,
-    params
+    expect.objectContaining({
+      api: API.getTriggerTemplate,
+      kind: 'TriggerTemplate',
+      params
+    })
   );
 });

--- a/src/api/triggers.js
+++ b/src/api/triggers.js
@@ -21,12 +21,16 @@ import {
   useResource
 } from './utils';
 
-export function getTriggers({ filters = [], namespace } = {}) {
-  const uri = getTektonAPI(
+function getTriggersAPI({ filters, isWebSocket, name, namespace }) {
+  return getTektonAPI(
     'triggers',
-    { group: triggersAPIGroup, namespace, version: 'v1alpha1' },
-    getQueryParams(filters)
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    getQueryParams({ filters, name })
   );
+}
+
+export function getTriggers({ filters = [], namespace } = {}) {
+  const uri = getTriggersAPI({ filters, namespace });
   return get(uri).then(checkData);
 }
 
@@ -41,9 +45,21 @@ export function getTrigger({ name, namespace }) {
 }
 
 export function useTriggers(params) {
-  return useCollection('Trigger', getTriggers, params);
+  const webSocketURL = getTriggersAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getTriggers,
+    kind: 'Trigger',
+    params,
+    webSocketURL
+  });
 }
 
 export function useTrigger(params) {
-  return useResource('Trigger', getTrigger, params);
+  const webSocketURL = getTriggersAPI({ ...params, isWebSocket: true });
+  return useResource({
+    api: getTrigger,
+    kind: 'Trigger',
+    params,
+    webSocketURL
+  });
 }

--- a/src/api/triggers.test.js
+++ b/src/api/triggers.test.js
@@ -42,9 +42,11 @@ it('useTriggers', () => {
   jest.spyOn(utils, 'useCollection').mockImplementation(() => query);
   expect(API.useTriggers(params)).toEqual(query);
   expect(utils.useCollection).toHaveBeenCalledWith(
-    'Trigger',
-    API.getTriggers,
-    params
+    expect.objectContaining({
+      api: API.getTriggers,
+      kind: 'Trigger',
+      params
+    })
   );
 });
 
@@ -54,8 +56,10 @@ it('useTrigger', () => {
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   expect(API.useTrigger(params)).toEqual(query);
   expect(utils.useResource).toHaveBeenCalledWith(
-    'Trigger',
-    API.getTrigger,
-    params
+    expect.objectContaining({
+      api: API.getTrigger,
+      kind: 'Trigger',
+      params
+    })
   );
 });

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -142,9 +142,7 @@ async function loadMessages(lang) {
 }
 
 /* istanbul ignore next */
-export function App({ lang, onUnload }) {
-  useEffect(() => onUnload, []);
-
+export function App({ lang }) {
   const [isSideNavExpanded, setIsSideNavExpanded] = useState(true);
   const [selectedNamespace, setSelectedNamespace] = useState(ALL_NAMESPACES);
 

--- a/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.js
+++ b/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.js
@@ -17,8 +17,10 @@ import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import { useClusterTasks } from '../../api';
 
-function ClusterTasksDropdown({ intl, label, ...rest }) {
-  const { data: clusterTasks = [], isFetching } = useClusterTasks();
+function ClusterTasksDropdown({ disabled, intl, label, ...rest }) {
+  const { data: clusterTasks = [], isFetching } = useClusterTasks(null, {
+    enabled: !disabled
+  });
 
   const items = clusterTasks.map(clusterTask => clusterTask.metadata.name);
 
@@ -37,6 +39,7 @@ function ClusterTasksDropdown({ intl, label, ...rest }) {
   return (
     <TooltipDropdown
       {...rest}
+      disabled={disabled}
       emptyText={emptyText}
       items={items}
       label={labelString}

--- a/src/containers/ListPageLayout/ListPageLayout.stories.js
+++ b/src/containers/ListPageLayout/ListPageLayout.stories.js
@@ -16,8 +16,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import ListPageLayoutContainer from './ListPageLayout';
-import { NamespaceContext, WebSocketContext } from '../../api/utils';
-import { getWebSocket } from '../../utils/test';
+import { NamespaceContext } from '../../api/utils';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -43,8 +42,6 @@ const props = {
   match: { path: '/' }
 };
 
-const webSocket = getWebSocket();
-
 export default {
   component: ListPageLayoutContainer,
   decorators: [
@@ -52,18 +49,16 @@ export default {
       queryClient.setQueryData('Namespace', namespaces);
 
       return (
-        <WebSocketContext.Provider value={webSocket}>
-          <QueryClientProvider client={queryClient}>
-            <NamespaceContext.Provider
-              value={{
-                selectedNamespace: ALL_NAMESPACES,
-                selectNamespace: () => {}
-              }}
-            >
-              {storyFn()}
-            </NamespaceContext.Provider>
-          </QueryClientProvider>
-        </WebSocketContext.Provider>
+        <QueryClientProvider client={queryClient}>
+          <NamespaceContext.Provider
+            value={{
+              selectedNamespace: ALL_NAMESPACES,
+              selectNamespace: () => {}
+            }}
+          >
+            {storyFn()}
+          </NamespaceContext.Provider>
+        </QueryClientProvider>
       );
     }
   ],

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -18,13 +18,22 @@ import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import { usePipelines, useSelectedNamespace } from '../../api';
 
-function PipelinesDropdown({ intl, label, namespace: namespaceProp, ...rest }) {
+function PipelinesDropdown({
+  disabled,
+  intl,
+  label,
+  namespace: namespaceProp,
+  ...rest
+}) {
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceProp || selectedNamespace;
 
-  const { data: pipelines = [], isFetching } = usePipelines({
-    namespace
-  });
+  const { data: pipelines = [], isFetching } = usePipelines(
+    {
+      namespace
+    },
+    { enabled: !disabled }
+  );
 
   const items = pipelines.map(pipeline => pipeline.metadata.name);
 
@@ -52,6 +61,7 @@ function PipelinesDropdown({ intl, label, namespace: namespaceProp, ...rest }) {
   return (
     <TooltipDropdown
       {...rest}
+      disabled={disabled}
       emptyText={emptyText}
       items={items}
       label={labelString}

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -19,6 +19,7 @@ import { TooltipDropdown } from '@tektoncd/dashboard-components';
 import { useSelectedNamespace, useServiceAccounts } from '../../api';
 
 function ServiceAccountsDropdown({
+  disabled,
   intl,
   label,
   namespace: namespaceProp,
@@ -27,9 +28,14 @@ function ServiceAccountsDropdown({
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceProp || selectedNamespace;
 
-  const { data: serviceAccounts = [], isFetching } = useServiceAccounts({
-    namespace
-  });
+  const { data: serviceAccounts = [], isFetching } = useServiceAccounts(
+    {
+      namespace
+    },
+    {
+      enabled: !disabled
+    }
+  );
 
   const items = serviceAccounts.map(sa => sa.metadata.name);
 
@@ -57,6 +63,7 @@ function ServiceAccountsDropdown({
   return (
     <TooltipDropdown
       {...rest}
+      disabled={disabled}
       emptyText={emptyText}
       items={items}
       label={labelString}

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import ReconnectingWebSocket from 'reconnecting-websocket';
 
 import './utils/polyfills';
-import { getWebSocketURL, WebSocketContext } from './api';
 import { getLocale, setTheme } from './utils';
 
 import App from './containers/App';
@@ -35,22 +33,15 @@ const queryClient = new QueryClient({
   }
 });
 
-const webSocket = new ReconnectingWebSocket(getWebSocketURL());
-function closeSocket() {
-  webSocket.close();
-}
-
 setTheme();
 
 const enableReactQueryDevTools =
   localStorage.getItem('tkn-devtools-rq') === 'true';
 
 ReactDOM.render(
-  <WebSocketContext.Provider value={webSocket}>
-    <QueryClientProvider client={queryClient}>
-      <App lang={getLocale(navigator.language)} onUnload={closeSocket} />
-      {enableReactQueryDevTools && <ReactQueryDevtools initialIsOpen={false} />}
-    </QueryClientProvider>
-  </WebSocketContext.Provider>,
+  <QueryClientProvider client={queryClient}>
+    <App lang={getLocale(navigator.language)} />
+    {enableReactQueryDevTools && <ReactQueryDevtools initialIsOpen={false} />}
+  </QueryClientProvider>,
   document.getElementById('root')
 );

--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -19,7 +19,7 @@ import {
   renderWithRouter as baseRenderWithRouter
 } from '@tektoncd/dashboard-components/src/utils/test';
 
-import { NamespaceContext, WebSocketContext } from '../api/utils';
+import { NamespaceContext } from '../api/utils';
 
 export function getQueryClient() {
   return new QueryClient({
@@ -40,6 +40,7 @@ export function getWebSocket() {
     addEventListener(type, listener) {
       this.listener = listener;
     },
+    close() {},
     removeEventListener() {},
     fireEvent(event) {
       this.listener(event);
@@ -47,22 +48,16 @@ export function getWebSocket() {
   };
 }
 
-export function getAPIWrapper({
-  queryClient = getQueryClient(),
-  // TODO: test-friendly replacement for this when we move to socket per kind
-  webSocket = getWebSocket()
-} = {}) {
+export function getAPIWrapper({ queryClient = getQueryClient() } = {}) {
   return function apiWrapper({ children }) {
     return (
-      <WebSocketContext.Provider value={webSocket}>
-        <NamespaceContext.Provider
-          value={{ selectedNamespace: null, selectNamespace: () => {} }}
-        >
-          <QueryClientProvider client={queryClient}>
-            {children}
-          </QueryClientProvider>
-        </NamespaceContext.Provider>
-      </WebSocketContext.Provider>
+      <NamespaceContext.Provider
+        value={{ selectedNamespace: null, selectNamespace: () => {} }}
+      >
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </NamespaceContext.Provider>
     );
   };
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Instead of connecting to a single websocket endpoint to receive
events for all potentially interesting resources on the cluster,
switch to a model where the page connects to a separate websocket
endpoint per kind it wants to watch for updates.

This means that any given page only has to process events for resources
it's actually displaying. It also has the added benefit of allowing us
to provide real-time updates for resources displayed by extensions
which was not supported under the previous model.

The Kubernetes API server supports a `watch` query parameter on 'list'
requests to make a websocket connection instead of the default HTTP
GET request. This is not supported on 'get' requests for a single resource.
To support watching updates for a single resource we use the
`fieldSelector` query param to limit the list request to the single
resource we're interested in via its `metadata.name` field.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
