### PR TITLE
Switch log retrieval to use streaming by default

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -37,7 +37,7 @@ var (
 	tenantNamespace    = flag.String("namespace", "", "If set, limits the scope of resources watched to this namespace only")
 	logLevel           = flag.String("log-level", "info", "Minimum log level output by the logger")
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
-	streamLogs         = flag.Bool("stream-logs", false, "Enable log streaming instead of polling")
+	streamLogs         = flag.Bool("stream-logs", true, "Enable log streaming instead of polling")
 	externalLogs       = flag.String("external-logs", "", "External logs provider url")
 	xFrameOptions      = flag.String("x-frame-options", "DENY", "Value for the X-Frame-Options response header, set '' to omit it")
 )

--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -76,7 +76,7 @@ Accepted options:
         [--pipelines-namespace <namespace>]     Override the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)
         [--platform <platform>]                 Override the platform to build for
         [--read-only]                           Will build manifests for a readonly deployment
-        [--stream-logs]                         Will enable log streaming instead of polling
+        [--stream-logs false]                   Will disable log streaming and use polling instead
         [--tenant-namespace <namespace>]        Will limit the visibility to the specified namespace only
         [--triggers-namespace <namespace>]      Override the namespace where Tekton Triggers is installed (defaults to tekton-pipelines)
         [--version <version>]                   Will download manifests for specified version or build everything using kustomize/ko

--- a/scripts/installer
+++ b/scripts/installer
@@ -25,7 +25,7 @@ LOGOUT_URL=""
 LOG_LEVEL="info"
 LOG_FORMAT="json"
 TENANT_NAMESPACE=""
-STREAM_LOGS="false"
+STREAM_LOGS="true"
 EXTERNAL_LOGS=""
 BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard"
 
@@ -457,7 +457,7 @@ help () {
   echo -e "\t[--pipelines-namespace <namespace>]\tOverride the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)"
   echo -e "\t[--platform <platform>]\t\t\tOverride the platform to build for"
   echo -e "\t[--read-only]\t\t\t\tWill build manifests for a readonly deployment"
-  echo -e "\t[--stream-logs]\t\t\t\tWill enable log streaming instead of polling"
+  echo -e "\t[--stream-logs false]\t\t\t\tWill disable log streaming and use polling instead"
   echo -e "\t[--tenant-namespace <namespace>]\tWill limit the visibility to the specified namespace only"
   echo -e "\t[--triggers-namespace <namespace>]\tOverride the namespace where Tekton Triggers is installed (defaults to tekton-pipelines)"
   echo -e "\t[--version <version>]\t\t\tWill download manifests for specified version or build everything using kustomize/ko"
@@ -525,7 +525,8 @@ while [[ $# -gt 0 ]]; do
       READONLY="true"
       ;;
     '--stream-logs')
-      STREAM_LOGS="true"
+      shift
+      STREAM_LOGS="${1}"
       ;;
     '--external-logs')
       shift

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -14,7 +14,7 @@
 set -e
 
 CLUSTERNAME=tekton-dashboard
-DEFAULT_OPTIONS="--log-format console --stream-logs --ingress-url tekton-dashboard.127.0.0.1.nip.io"
+DEFAULT_OPTIONS="--log-format console --ingress-url tekton-dashboard.127.0.0.1.nip.io"
 
 create_cluster() {
 kind create cluster --name $CLUSTERNAME --config - <<EOF


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Switch the default setting for the `stream-logs` flag to `true`.

Users can still switch back to polling by passing `--stream-logs false`
to the installer script or updating the flag in the deployment directly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
