### PR TITLE
Further improvements to websocket connections

### DIFF
--- a/src/api/clusterInterceptors.js
+++ b/src/api/clusterInterceptors.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   triggersAPIGroup,
@@ -31,7 +30,7 @@ function getClusterInterceptorsAPI({ filters, isWebSocket, name }) {
 
 export function getClusterInterceptors({ filters = [] } = {}) {
   const uri = getClusterInterceptorsAPI({ filters });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getClusterInterceptor({ name }) {

--- a/src/api/clusterInterceptors.test.js
+++ b/src/api/clusterInterceptors.test.js
@@ -21,7 +21,7 @@ it('getClusterInterceptors', () => {
   };
   fetchMock.get(/clusterinterceptors/, data);
   return API.getClusterInterceptors().then(tasks => {
-    expect(tasks).toEqual(data.items);
+    expect(tasks).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/clusterTasks.js
+++ b/src/api/clusterTasks.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { deleteRequest, get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -30,7 +29,7 @@ function getClusterTasksAPI({ filters, isWebSocket, name }) {
 
 export function getClusterTasks({ filters = [] } = {}) {
   const uri = getClusterTasksAPI({ filters });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getClusterTask({ name }) {

--- a/src/api/clusterTasks.test.js
+++ b/src/api/clusterTasks.test.js
@@ -21,7 +21,7 @@ it('getClusterTasks', () => {
   };
   fetchMock.get(/clustertasks/, data);
   return API.getClusterTasks().then(tasks => {
-    expect(tasks).toEqual(data.items);
+    expect(tasks).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/clusterTriggerBindings.js
+++ b/src/api/clusterTriggerBindings.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   triggersAPIGroup,
@@ -31,7 +30,7 @@ function getClusterTriggerBindingsAPI({ filters, isWebSocket, name }) {
 
 export function getClusterTriggerBindings({ filters = [] } = {}) {
   const uri = getClusterTriggerBindingsAPI({ filters });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getClusterTriggerBinding({ name }) {

--- a/src/api/clusterTriggerBindings.test.js
+++ b/src/api/clusterTriggerBindings.test.js
@@ -31,7 +31,7 @@ it('getClusterTriggerBindings', () => {
   };
   fetchMock.get(/clustertriggerbindings/, data);
   return API.getClusterTriggerBindings().then(clusterTriggerBindings => {
-    expect(clusterTriggerBindings).toEqual(data.items);
+    expect(clusterTriggerBindings).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -21,6 +21,7 @@ const defaultOptions = {
   credentials: 'same-origin'
 };
 
+/* istanbul ignore next */
 export function createWebSocket(url) {
   return new ReconnectingWebSocket(url);
 }

--- a/src/api/conditions.js
+++ b/src/api/conditions.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -30,7 +29,7 @@ function getConditionsAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getConditions({ filters = [], namespace } = {}) {
   const uri = getConditionsAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getCondition({ name, namespace }) {

--- a/src/api/conditions.test.js
+++ b/src/api/conditions.test.js
@@ -21,7 +21,7 @@ it('getConditions', () => {
   };
   fetchMock.get(/conditions/, data);
   return API.getConditions().then(conditions => {
-    expect(conditions).toEqual(data.items);
+    expect(conditions).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/eventListeners.js
+++ b/src/api/eventListeners.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   triggersAPIGroup,
@@ -31,7 +30,7 @@ function getEventListenersAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getEventListeners({ filters = [], namespace } = {}) {
   const uri = getEventListenersAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getEventListener({ name, namespace }) {

--- a/src/api/eventListeners.test.js
+++ b/src/api/eventListeners.test.js
@@ -31,7 +31,7 @@ it('getEventListeners', () => {
   };
   fetchMock.get(/eventlisteners/, data);
   return API.getEventListeners().then(eventListeners => {
-    expect(eventListeners).toEqual(data.items);
+    expect(eventListeners).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -19,7 +19,6 @@ import { useTask } from './tasks';
 import { get, post } from './comms';
 import {
   apiRoot,
-  checkData,
   getKubeAPI,
   getQueryParams,
   getResourcesAPI,
@@ -52,7 +51,7 @@ function getCustomResourcesAPI({ filters, name, ...rest }) {
 
 export function getCustomResources({ filters = [], ...rest }) {
   const uri = getCustomResourcesAPI({ filters, ...rest });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getCustomResource(params) {
@@ -104,7 +103,7 @@ function getNamespacesAPI({ isWebSocket } = {}) {
 
 export function getNamespaces() {
   const uri = getNamespacesAPI();
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function useNamespaces(queryConfig) {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -47,7 +47,7 @@ it('getCustomResources', () => {
   fetchMock.get(`end:${type}/`, data);
   return API.getCustomResources({ group, version, type, namespace }).then(
     resources => {
-      expect(resources).toEqual(data.items);
+      expect(resources).toEqual(data);
       fetchMock.restore();
     }
   );
@@ -110,13 +110,14 @@ it('getNamespaces returns the correct data', () => {
   };
   fetchMock.get(/namespaces/, data);
   return API.getNamespaces().then(response => {
-    expect(response).toEqual(data.items);
+    expect(response).toEqual(data);
     fetchMock.restore();
   });
 });
 
 it('useNamespaces', async () => {
   const namespaces = {
+    metadata: {},
     items: [
       { metadata: { name: 'namespace1' } },
       { metadata: { name: 'namespace2' } }

--- a/src/api/pipelineResources.js
+++ b/src/api/pipelineResources.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { deleteRequest, get, post } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -50,7 +49,7 @@ export function getPipelineResources({ filters = [], namespace } = {}) {
     filters,
     namespace
   });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getPipelineResource({ name, namespace }) {

--- a/src/api/pipelineResources.test.js
+++ b/src/api/pipelineResources.test.js
@@ -63,7 +63,7 @@ it('getPipelineResources', () => {
   };
   fetchMock.get(/pipelineresources/, data);
   return API.getPipelineResources().then(pipelineResources => {
-    expect(pipelineResources).toEqual(data.items);
+    expect(pipelineResources).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/pipelineRuns.js
+++ b/src/api/pipelineRuns.js
@@ -16,7 +16,6 @@ import deepClone from 'lodash.clonedeep';
 
 import { deleteRequest, get, patch, post } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -33,7 +32,7 @@ function getPipelineRunsAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getPipelineRuns({ filters = [], namespace } = {}) {
   const uri = getPipelineRunsAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getPipelineRun({ name, namespace }) {

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -165,7 +165,7 @@ it('getPipelineRuns', () => {
   };
   fetchMock.get(/pipelineruns/, data);
   return API.getPipelineRuns({ filters: [] }).then(pipelineRuns => {
-    expect(pipelineRuns).toEqual(data.items);
+    expect(pipelineRuns).toEqual(data);
     fetchMock.restore();
   });
 });
@@ -178,7 +178,7 @@ it('getPipelineRuns With Query Params', () => {
   fetchMock.get(/pipelineruns/, data);
   return API.getPipelineRuns({ pipelineName, filters: [] }).then(
     pipelineRuns => {
-      expect(pipelineRuns).toEqual(data.items);
+      expect(pipelineRuns).toEqual(data);
       fetchMock.restore();
     }
   );

--- a/src/api/pipelines.js
+++ b/src/api/pipelines.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { deleteRequest, get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -30,7 +29,7 @@ function getPipelinesAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getPipelines({ filters = [], namespace } = {}) {
   const uri = getPipelinesAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getPipeline({ name, namespace }) {

--- a/src/api/pipelines.test.js
+++ b/src/api/pipelines.test.js
@@ -21,7 +21,7 @@ it('getPipelines', () => {
   };
   fetchMock.get(/pipelines/, data);
   return API.getPipelines().then(pipelines => {
-    expect(pipelines).toEqual(data.items);
+    expect(pipelines).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/serviceAccounts.js
+++ b/src/api/serviceAccounts.js
@@ -12,11 +12,11 @@ limitations under the License.
 */
 
 import { get } from './comms';
-import { checkData, getKubeAPI, useCollection } from './utils';
+import { getKubeAPI, useCollection } from './utils';
 
 export function getServiceAccounts({ namespace } = {}) {
   const uri = getKubeAPI('serviceaccounts', { namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function useServiceAccounts(params, queryConfig) {

--- a/src/api/serviceAccounts.test.js
+++ b/src/api/serviceAccounts.test.js
@@ -19,7 +19,7 @@ it('getServiceAccounts returns the correct data', () => {
   const data = { items: 'serviceaccounts' };
   fetchMock.get(/serviceaccounts/, data);
   return API.getServiceAccounts().then(response => {
-    expect(response).toEqual(data.items);
+    expect(response).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/taskRuns.js
+++ b/src/api/taskRuns.js
@@ -16,7 +16,6 @@ import deepClone from 'lodash.clonedeep';
 
 import { deleteRequest, get, patch, post } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -38,7 +37,7 @@ function getTaskRunsAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getTaskRuns({ filters = [], namespace } = {}) {
   const uri = getTaskRunsAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getTaskRun({ name, namespace }) {

--- a/src/api/taskRuns.test.js
+++ b/src/api/taskRuns.test.js
@@ -182,7 +182,7 @@ it('getTaskRuns', () => {
   };
   fetchMock.get(/taskruns/, data);
   return API.getTaskRuns().then(taskRuns => {
-    expect(taskRuns).toEqual(data.items);
+    expect(taskRuns).toEqual(data);
     fetchMock.restore();
   });
 });
@@ -194,7 +194,7 @@ it('getTaskRuns With Query Params', () => {
   };
   fetchMock.get(/taskruns/, data);
   return API.getTaskRuns({ taskName }).then(taskRuns => {
-    expect(taskRuns).toEqual(data.items);
+    expect(taskRuns).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { deleteRequest, get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   useCollection,
@@ -30,7 +29,7 @@ function getTasksAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getTasks({ filters = [], namespace } = {}) {
   const uri = getTasksAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getTask({ name, namespace }) {

--- a/src/api/tasks.test.js
+++ b/src/api/tasks.test.js
@@ -21,7 +21,7 @@ it('getTasks', () => {
   };
   fetchMock.get(/tasks/, data);
   return API.getTasks().then(tasks => {
-    expect(tasks).toEqual(data.items);
+    expect(tasks).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/triggerBindings.js
+++ b/src/api/triggerBindings.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   triggersAPIGroup,
@@ -31,7 +30,7 @@ function getTriggerBindingsAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getTriggerBindings({ filters = [], namespace } = {}) {
   const uri = getTriggerBindingsAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getTriggerBinding({ name, namespace }) {

--- a/src/api/triggerBindings.test.js
+++ b/src/api/triggerBindings.test.js
@@ -31,7 +31,7 @@ it('getTriggerBindings', () => {
   };
   fetchMock.get(/triggerbindings/, data);
   return API.getTriggerBindings().then(triggerBindings => {
-    expect(triggerBindings).toEqual(data.items);
+    expect(triggerBindings).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/triggerTemplates.js
+++ b/src/api/triggerTemplates.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   triggersAPIGroup,
@@ -31,7 +30,7 @@ function getTriggerTemplatesAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getTriggerTemplates({ filters = [], namespace } = {}) {
   const uri = getTriggerTemplatesAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getTriggerTemplate({ name, namespace }) {

--- a/src/api/triggerTemplates.test.js
+++ b/src/api/triggerTemplates.test.js
@@ -31,7 +31,7 @@ it('getTriggerTemplates', () => {
   };
   fetchMock.get(/triggertemplates/, data);
   return API.getTriggerTemplates().then(triggerTemplates => {
-    expect(triggerTemplates).toEqual(data.items);
+    expect(triggerTemplates).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/api/triggers.js
+++ b/src/api/triggers.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import { get } from './comms';
 import {
-  checkData,
   getQueryParams,
   getTektonAPI,
   triggersAPIGroup,
@@ -31,7 +30,7 @@ function getTriggersAPI({ filters, isWebSocket, name, namespace }) {
 
 export function getTriggers({ filters = [], namespace } = {}) {
   const uri = getTriggersAPI({ filters, namespace });
-  return get(uri).then(checkData);
+  return get(uri);
 }
 
 export function getTrigger({ name, namespace }) {

--- a/src/api/triggers.test.js
+++ b/src/api/triggers.test.js
@@ -31,7 +31,7 @@ it('getTriggers', () => {
   };
   fetchMock.get(/triggers/, data);
   return API.getTriggers().then(triggers => {
-    expect(triggers).toEqual(data.items);
+    expect(triggers).toEqual(data);
     fetchMock.restore();
   });
 });

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -40,9 +40,12 @@ function Extensions(props) {
   });
 
   const tenantNamespace = useTenantNamespace();
-  const { data: extensions = [], error, isFetching } = useExtensions({
-    namespace: tenantNamespace || ALL_NAMESPACES
-  });
+  const { data: extensions = [], error, isFetching } = useExtensions(
+    {
+      namespace: tenantNamespace || ALL_NAMESPACES
+    },
+    { disableWebSocket: true }
+  );
 
   const emptyText = intl.formatMessage({
     id: 'dashboard.extensions.emptyState',

--- a/src/containers/ListPageLayout/ListPageLayout.stories.js
+++ b/src/containers/ListPageLayout/ListPageLayout.stories.js
@@ -46,7 +46,10 @@ export default {
   component: ListPageLayoutContainer,
   decorators: [
     storyFn => {
-      queryClient.setQueryData('Namespace', namespaces);
+      queryClient.setQueryData('Namespace', () => ({
+        items: namespaces,
+        metadata: {}
+      }));
 
       return (
         <QueryClientProvider client={queryClient}>

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -51,7 +51,9 @@ const NamespacesDropdown = ({
     });
 
   const tenantNamespace = useTenantNamespace();
-  const { data: namespaces = [], isFetching } = useNamespaces();
+  const { data: namespaces = [], isFetching } = useNamespaces({
+    disableWebSocket: true
+  });
 
   const selectedItem = { ...originalSelectedItem };
   if (selectedItem && selectedItem.id === ALL_NAMESPACES) {

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -51,9 +51,12 @@ function SideNav(props) {
 
   const { selectNamespace } = useSelectedNamespace();
   const tenantNamespace = useTenantNamespace();
-  const { data: extensions = [] } = useExtensions({
-    namespace: tenantNamespace || ALL_NAMESPACES
-  });
+  const { data: extensions = [] } = useExtensions(
+    {
+      namespace: tenantNamespace || ALL_NAMESPACES
+    },
+    { disableWebSocket: true }
+  );
 
   useEffect(() => {
     if (namespace) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When making a websocket connection pass the `resourceVersion` of
the previously retrieved list so we only start watching for updates
from that point rather than receiving duplicate websocket events
for all of the resources retrieved via the initial GET request.

To achieve this, the API functions must return the API response
fully intact, including the `metadata` object containing the
`resourceVersion` for the returned list result. The `useCollection`
hook will then transform the returned data for the query to match
the structure expected by consumers (i.e. it will return `data = response.items`)

Also ensure we don't have duplicate websocket connections for
Namespaces and Extensions. The App component will be responsible
for subscribing to these, and any individual page that requires
them will receive updates via the query without needing their
own websocket connection.

These changes further reduce the number of requests made by the
Dashboard client as well as reducing the processing overhead in browser.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
