### PR TITLE
Fix external logs

### DIFF
--- a/pkg/endpoints/externallogs.go
+++ b/pkg/endpoints/externallogs.go
@@ -30,7 +30,7 @@ func (r Resource) LogsProxy(response http.ResponseWriter, request *http.Request)
 
 	uri := strings.TrimPrefix(request.URL.Path, "/v1/logs-proxy") + "?" + parsedURL.RawQuery
 
-	if statusCode, err := utils.Proxy(request, response, r.Options.ExternalLogsURL+"/"+uri, http.DefaultClient); err != nil {
+	if statusCode, err := utils.Proxy(request, response, r.Options.ExternalLogsURL+uri, http.DefaultClient); err != nil {
 		utils.RespondError(response, err, statusCode)
 	}
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -80,7 +80,7 @@ func registerPropertiesEndpoint(r endpoints.Resource, mux *http.ServeMux) {
 func registerLogsProxy(r endpoints.Resource, mux *http.ServeMux) {
 	if r.Options.ExternalLogsURL != "" {
 		logging.Log.Info("Adding API for logs proxy")
-		mux.HandleFunc("/v1/logs-proxy", r.LogsProxy)
+		mux.HandleFunc("/v1/logs-proxy/", r.LogsProxy)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2168

External logs were broken in the switch to `ServeMux` as the
API prefix `/v1/logs-proxy` caused an exact match which failed.

In order to get the previous behaviour of a wildcard match,
the pattern string passed to `HandleFunc` must end in a `/`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
