### PR TITLE
Display pod details to help with debugging run failures

### DIFF
--- a/base/200-clusterrole-tenant.yaml
+++ b/base/200-clusterrole-tenant.yaml
@@ -41,9 +41,11 @@ rules:
   - apiGroups:
       - ''
     resources:
-      - serviceaccounts
-      - pods/log
+      - events
       - namespaces
+      - pods
+      - pods/log
+      - serviceaccounts
     verbs:
       - get
       - list

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -259,7 +259,15 @@ const TaskRunDetails = ({
         {pod && (
           <Tab id={`${displayName}-pod`} label="Pod">
             <div className="tkn--step-status">
-              {pod.events && (
+              <ViewYAML
+                dark
+                resource={pod.resource}
+                title={intl.formatMessage({
+                  id: 'dashboard.pod.resource',
+                  defaultMessage: 'Resource'
+                })}
+              />
+              {pod.events && pod.events.length > 0 && (
                 <ViewYAML
                   dark
                   resource={pod.events}
@@ -269,14 +277,6 @@ const TaskRunDetails = ({
                   })}
                 />
               )}
-              <ViewYAML
-                dark
-                resource={pod.resource}
-                title={intl.formatMessage({
-                  id: 'dashboard.pod.resource',
-                  defaultMessage: 'Resource'
-                })}
-              />
             </div>
           </Tab>
         )}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -45,8 +45,17 @@ export * from './triggerBindings';
 export * from './triggers';
 export * from './triggerTemplates';
 
-function getCustomResourcesAPI({ filters, name, ...rest }) {
-  return getResourcesAPI(rest, getQueryParams({ filters, name }));
+function getCustomResourcesAPI({
+  filters,
+  involvedObjectKind,
+  involvedObjectName,
+  name,
+  ...rest
+}) {
+  return getResourcesAPI(
+    rest,
+    getQueryParams({ filters, involvedObjectKind, involvedObjectName, name })
+  );
 }
 
 export function getCustomResources({ filters = [], ...rest }) {
@@ -111,6 +120,47 @@ export function useNamespaces(queryConfig) {
   return useCollection({
     api: getNamespaces,
     kind: 'Namespace',
+    queryConfig,
+    webSocketURL
+  });
+}
+
+export function usePod(params, queryConfig) {
+  const gvt = { group: 'core', type: 'pods', version: 'v1' };
+  const webSocketURL = getCustomResourcesAPI({
+    ...gvt,
+    ...params,
+    isWebSocket: true
+  });
+  return useResource({
+    api: getCustomResource,
+    kind: 'customResource',
+    params: { ...gvt, ...params },
+    queryConfig,
+    webSocketURL
+  });
+}
+
+export function useEvents(
+  { involvedObjectKind, involvedObjectName, namespace },
+  queryConfig
+) {
+  const params = {
+    group: 'core',
+    involvedObjectKind,
+    involvedObjectName,
+    namespace,
+    type: 'events',
+    version: 'v1'
+  };
+  const webSocketURL = getCustomResourcesAPI({
+    ...params,
+    isWebSocket: true
+  });
+  return useCollection({
+    api: getCustomResources,
+    kind: 'customResource',
+    params,
     queryConfig,
     webSocketURL
   });

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -133,6 +133,47 @@ it('useNamespaces', async () => {
   fetchMock.restore();
 });
 
+it('usePod', async () => {
+  const name = 'fake_name';
+  const namespace = 'fake_namespace';
+  const pod = {
+    metadata: {},
+    spec: 'fake_spec'
+  };
+  fetchMock.get(/pods/, pod);
+  const { result, waitFor } = renderHook(
+    () => API.usePod({ name, namespace }),
+    {
+      wrapper: getAPIWrapper()
+    }
+  );
+  await waitFor(() => result.current.isFetching);
+  await waitFor(() => !result.current.isFetching);
+  expect(result.current.data).toEqual(pod);
+  fetchMock.restore();
+});
+
+it('useEvents', async () => {
+  const involvedObjectKind = 'fake_kind';
+  const involvedObjectName = 'fake_name';
+  const namespace = 'fake_namespace';
+  const events = {
+    metadata: {},
+    items: [{ metadata: { name: 'event1' } }, { metadata: { name: 'event2' } }]
+  };
+  fetchMock.get(/events/, events);
+  const { result, waitFor } = renderHook(
+    () => API.useEvents({ involvedObjectKind, involvedObjectName, namespace }),
+    {
+      wrapper: getAPIWrapper()
+    }
+  );
+  await waitFor(() => result.current.isFetching);
+  await waitFor(() => !result.current.isFetching);
+  expect(result.current.data).toEqual(events.items);
+  fetchMock.restore();
+});
+
 it('getPodLog', () => {
   const namespace = 'default';
   const name = 'foo';

--- a/src/api/utils.test.js
+++ b/src/api/utils.test.js
@@ -15,31 +15,13 @@ import { act, renderHook } from '@testing-library/react-hooks';
 
 import * as comms from './comms';
 import * as utils from './utils';
-import { useCollection, useResource, useWebSocket } from './utils';
+import {
+  getQueryParams,
+  useCollection,
+  useResource,
+  useWebSocket
+} from './utils';
 import { getAPIWrapper, getQueryClient, getWebSocket } from '../utils/test';
-
-describe('getAPI', () => {
-  it('returns a URI containing the given type', () => {
-    const uri = utils.getAPI('pipelines');
-    expect(uri).toContain('pipelines');
-  });
-
-  it('returns a URI containing the given type and name', () => {
-    const uri = utils.getAPI('pipelines', { name: 'somename' });
-    expect(uri).toContain('pipelines');
-    expect(uri).toContain('somename');
-  });
-
-  it('returns a URI containing the given type, name, and namespace', () => {
-    const uri = utils.getAPI('pipelines', {
-      name: 'somename',
-      namespace: 'customnamespace'
-    });
-    expect(uri).toContain('pipelines');
-    expect(uri).toContain('somename');
-    expect(uri).toContain('customnamespace');
-  });
-});
 
 describe('getTektonAPI', () => {
   it('returns a URI containing the given type', () => {
@@ -132,6 +114,32 @@ describe('getResourcesAPI', () => {
     expect(uri).toContain('testname');
     expect(uri).toContain('namespaces');
     expect(uri).toContain('testnamespace');
+  });
+});
+
+describe('getQueryParams', () => {
+  it('should handle label filters', () => {
+    const filters = ['fakeLabel=fakeValue'];
+    expect(getQueryParams({ filters })).toEqual({ labelSelector: filters });
+    expect(getQueryParams({ filters: [] })).toEqual('');
+  });
+
+  it('should handle name for a single resource', () => {
+    const name = 'fake_name';
+    expect(getQueryParams({ name })).toEqual({
+      fieldSelector: `metadata.name=${name}`
+    });
+  });
+
+  it('should handle involvedObject for events', () => {
+    const involvedObjectKind = 'fake_kind';
+    const involvedObjectName = 'fake_name';
+    expect(getQueryParams({ involvedObjectKind, involvedObjectName })).toEqual({
+      fieldSelector: [
+        `involvedObject.kind=${involvedObjectKind}`,
+        `involvedObject.name=${involvedObjectName}`
+      ]
+    });
   });
 });
 

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -43,9 +43,11 @@ import {
 
 import {
   rerunTaskRun,
+  useEvents,
   useExternalLogsURL,
   useIsLogStreamingEnabled,
   useIsReadOnly,
+  usePod,
   useSelectedNamespace,
   useTaskByKind,
   useTaskRun
@@ -113,6 +115,17 @@ export function TaskRunContainer(props) {
       namespace
     },
     { enabled: !!taskRun?.spec.taskRef }
+  );
+
+  const podName = taskRun?.status?.podName;
+  const { data: pod = {} } = usePod(
+    { name: podName, namespace },
+    { enabled: !!podName && view === 'pod' }
+  );
+
+  const { data: events = [] } = useEvents(
+    { involvedObjectKind: 'Pod', involvedObjectName: podName, namespace },
+    { enabled: !!podName && view === 'pod' }
   );
 
   function toggleLogsMaximized() {
@@ -239,6 +252,11 @@ export function TaskRunContainer(props) {
       />
     );
 
+  let podDetails;
+  if (!selectedStepId) {
+    podDetails = (events || pod) && { events, resource: pod };
+  }
+
   return (
     <>
       <div id="tkn--maximized-logs-container" ref={maximizedLogsContainer} />
@@ -296,6 +314,7 @@ export function TaskRunContainer(props) {
         )) || (
           <TaskRunDetails
             onViewChange={onViewChange}
+            pod={podDetails}
             task={task}
             taskRun={taskRun}
             view={view}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2103

When the new 'pod' tab on the TaskRun details is selected, get
and watch the pod associated with the TaskRun as well as the
relevant events. These resources may contain additional information
useful to debugging failures of the TaskRun that is not otherwise
surfaced in the UI.

This applies to both the TaskRun and PipelineRun details pages,
including support for the pods assocated with TaskRun retries.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
