### PR TITLE
Make use of ingress in local dev cluster opt-in

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -136,13 +136,19 @@ e.g. to connect your local dev frontend to the Dashboard deployed on the robocat
 
 The Dashboard repository contains a script that will provision a [`kind` cluster](https://kind.sigs.k8s.io/) named 'tekton-dashboard' with the latest releases of Tekton Pipelines and Tekton Triggers installed, as well as a version of the Tekton Dashboard which can be customised by providing additional parameters matching those expected by the installer script described earlier.
 
-For example, the following will create a cluster with a local build of the Tekton Dashboard with log streaming enabled, exposed via ingress at `tekton-dashboard.127.0.0.1.nip.io`:
+For example, the following will create a cluster with a local build of the Tekton Dashboard with log streaming enabled:
 
 `./scripts/prepare-kind-cluster create`
 
 To delete the cluster:
 
 `./script/prepare-kind-cluster delete`
+
+To create a cluster with the Tekton Dashboard exposed via ingress at `tekton-dashboard.127.0.0.1.nip.io`:
+
+`./scripts/prepare-kind-cluster create-with-ingress`
+
+This ensures the cluster is created with the required node labels and port mappings (ports 80 and 443).
 
 ## Run backend tests
 

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -14,10 +14,14 @@
 set -e
 
 CLUSTERNAME=tekton-dashboard
-DEFAULT_OPTIONS="--log-format console --ingress-url tekton-dashboard.127.0.0.1.nip.io"
+DEFAULT_OPTIONS="--log-format console"
+ENABLE_INGRESS="false"
 
 create_cluster() {
-kind create cluster --name $CLUSTERNAME --config - <<EOF
+if [ "$ENABLE_INGRESS" == "false" ]; then
+  kind create cluster --name $CLUSTERNAME
+else
+  kind create cluster --name $CLUSTERNAME --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -36,6 +40,7 @@ nodes:
     hostPort: 443
     protocol: TCP
 EOF
+fi
 }
 
 # Display a box banner.
@@ -86,10 +91,18 @@ case $1 in
   'create'|c)
     shift
     create_cluster
-    install_ingress_nginx
     install_pipelines
     install_triggers
     install_dashboard $@
+    ;;
+  'create-with-ingress'|i)
+    shift
+    ENABLE_INGRESS="true"
+    create_cluster
+    install_ingress_nginx
+    install_pipelines
+    install_triggers
+    install_dashboard --ingress-url tekton-dashboard.127.0.0.1.nip.io $@
     ;;
   'update'|u)
     shift


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the behaviour of the `prepare-kind-cluster create` command
so it no longer installs and configures an ingress. This reduces
the resources required for the default dev environment as we no
longer need to install and configure the nginx ingress controller.

It also avoids issues where ports 80 or 443 are already bound to
other services on the host machine.

Add a new command `prepare-kind-cluster create-with-ingress` which
will behave in the same way as the previous `create` command,
allowing devs to opt-in to this behaviour if they wish.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
