### PR TITLE
Improve display of pod and event details

### DIFF
--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -11,12 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { getParams, getResources, urls } from '@tektoncd/dashboard-utils';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CarbonLink,
+  ContentSwitcher,
+  Switch
+} from 'carbon-components-react';
 
 import {
   DetailsHeader,
@@ -89,6 +93,9 @@ const TaskRunDetails = ({
 
   const paramsDescriptions = getDescriptions(taskSpec?.params);
   const resultsDescriptions = getDescriptions(taskSpec?.results);
+
+  const [podContent, setPodContent] = useState('resource');
+  const hasEvents = pod?.events?.length > 0;
 
   const headers = [
     {
@@ -259,24 +266,41 @@ const TaskRunDetails = ({
         {pod && (
           <Tab id={`${displayName}-pod`} label="Pod">
             <div className="tkn--step-status">
-              <ViewYAML
-                dark
-                resource={pod.resource}
-                title={intl.formatMessage({
-                  id: 'dashboard.pod.resource',
-                  defaultMessage: 'Resource'
-                })}
-              />
-              {pod.events && pod.events.length > 0 && (
+              {hasEvents ? (
+                <ContentSwitcher onChange={({ name }) => setPodContent(name)}>
+                  <Switch
+                    name="resource"
+                    text={intl.formatMessage({
+                      id: 'dashboard.pod.resource',
+                      defaultMessage: 'Resource'
+                    })}
+                  />
+                  <Switch
+                    name="events"
+                    text={intl.formatMessage({
+                      id: 'dashboard.pod.events',
+                      defaultMessage: 'Events'
+                    })}
+                  />
+                </ContentSwitcher>
+              ) : null}
+              {podContent === 'resource' ? (
                 <ViewYAML
                   dark
-                  resource={pod.events}
-                  title={intl.formatMessage({
-                    id: 'dashboard.pod.events',
-                    defaultMessage: 'Events'
-                  })}
+                  resource={pod.resource}
+                  {...(hasEvents
+                    ? null
+                    : {
+                        title: intl.formatMessage({
+                          id: 'dashboard.pod.resource',
+                          defaultMessage: 'Resource'
+                        })
+                      })}
                 />
-              )}
+              ) : null}
+              {hasEvents && podContent === 'events' ? (
+                <ViewYAML dark resource={pod.events} />
+              ) : null}
             </div>
           </Tab>
         )}

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
@@ -17,4 +17,8 @@ limitations under the License.
   flex-wrap: nowrap;
   align-items: stretch;
   overflow: hidden;
+
+  .bx--content-switcher {
+    margin-bottom: 1rem;
+  }
 }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -171,8 +171,11 @@ describe('TaskRunDetails', () => {
       />
     );
     expect(queryByText('Pod')).toBeTruthy();
-    expect(queryByText(events)).toBeTruthy();
+    expect(queryByText('Resource')).toBeTruthy();
     expect(queryByText(pod)).toBeTruthy();
+    expect(queryByText('Events')).toBeTruthy();
+    fireEvent.click(queryByText('Events'));
+    expect(queryByText(events)).toBeTruthy();
   });
 
   it('renders both input and output resources', () => {

--- a/src/scss/_carbon.scss
+++ b/src/scss/_carbon.scss
@@ -59,6 +59,7 @@ $feature-flags: (
 @import 'carbon-components/scss/components/copy-button/copy-button';
 @import 'carbon-components/scss/components/checkbox/checkbox';
 @import 'carbon-components/scss/components/combo-box/combo-box';
+@import 'carbon-components/scss/components/content-switcher/content-switcher';
 @import 'carbon-components/scss/components/radio-button/radio-button';
 @import 'carbon-components/scss/components/search/search';
 @import 'carbon-components/scss/components/text-input/text-input';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/2103

The original plan for this UI was to add a user-friendly code viewer
with syntax highlighting and code folding with the majority of nodes
collapsed by default, allowing the user to easily identify the 'interesting'
parts and expand those for more detail. Unfortunately many of the 3rd-party
components available have severe limitations, such as not being keyboard
accessible, or not being marked up correctly for screen readers, with no
easy way to customise them to resolve these issues. Other available solutions
are much heavier, requiring fully featured editors which significantly
increase the bundle size even though we only require a small subset of their
functionality.

While we determine how best to resolve this, we're implementing a minor
change to make it easier for users to quickly view the events by adding a
`ContentSwitcher` component (similar to tabs), so they no longer need to
scroll / search the page looking for the 'Events' heading.

![image](https://user-images.githubusercontent.com/2829095/131497646-b1033eec-51bf-454b-96b7-9d6771c6efc5.png)
![image](https://user-images.githubusercontent.com/2829095/131497697-0ff9e101-6718-486d-b19b-4f5bed0dc1be.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
