### PR TITLE
Reset selected ContentSwitcher panel on view change

### DIFF
--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
@@ -94,8 +94,12 @@ const TaskRunDetails = ({
   const paramsDescriptions = getDescriptions(taskSpec?.params);
   const resultsDescriptions = getDescriptions(taskSpec?.results);
 
-  const [podContent, setPodContent] = useState('resource');
+  const [podContent, setPodContent] = useState();
   const hasEvents = pod?.events?.length > 0;
+
+  useEffect(() => {
+    setPodContent('resource');
+  }, [displayName, view]);
 
   const headers = [
     {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When either the selected view (tab) or TaskRun changes, reset
the selected ContentSwitcher panel so the UI indication and the
displayed content are kept in sync.

Prior to this change if a user selected the events switch, then
clicked a different tab (e.g. Status), and returned to the Pod tab,
the resources switch would be selected, but the events content
would be displayed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
