### PR TITLE
Reduce front end bundle size

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -39,5 +39,6 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/*.test.js',
     '<rootDir>/packages/**/src/**/*.test.js'
-  ]
+  ],
+  transformIgnorePatterns: ['/node_modules/(?!(react-syntax-highlighter)/)']
 };

--- a/packages/components/src/components/ViewYAML/ViewYAML.js
+++ b/packages/components/src/components/ViewYAML/ViewYAML.js
@@ -15,18 +15,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import jsYaml from 'js-yaml';
 import classNames from 'classnames';
-import { Prism as SyntaxHighlight } from 'react-syntax-highlighter';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import yamlRules from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
+
+SyntaxHighlighter.registerLanguage('yaml', yamlRules);
 
 function YAMLHighlighter({ children, className }) {
   return (
-    <SyntaxHighlight
+    <SyntaxHighlighter
       className={className}
-      language="yaml"
-      useInlineStyles={false}
       codeTagProps={{}}
+      language="yaml"
+      showLineNumbers
+      useInlineStyles={false}
     >
       {children}
-    </SyntaxHighlight>
+    </SyntaxHighlighter>
   );
 }
 

--- a/packages/components/src/components/ViewYAML/ViewYAML.test.js
+++ b/packages/components/src/components/ViewYAML/ViewYAML.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -63,5 +63,5 @@ it('render syntax highlight', () => {
     enableSyntaxHighlighting: true
   };
   const { container } = render(<ViewYAML {...props} />);
-  expect(container.firstChild.className).toMatch(/prism/);
+  expect(container.firstChild.className).toMatch(/hljs/);
 });

--- a/src/containers/Extension/Extension.js
+++ b/src/containers/Extension/Extension.js
@@ -10,15 +10,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 import React, { Suspense, useState } from 'react';
 import { injectIntl } from 'react-intl';
 import { ErrorBoundary } from '@tektoncd/dashboard-components';
 import { paths, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 
-import './globals';
+// TODO: restore this when adding support for custom UI extensions
+// import './globals';
 
-/* istanbul ignore next */
 function Extension({ displayName: resourceName, intl, source }) {
   const [ExtensionComponent] = useState(() =>
     React.lazy(() => import(/* webpackIgnore: true */ source))

--- a/src/containers/Extension/globals.js
+++ b/src/containers/Extension/globals.js
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Reduce the amount of code shipped to users' browsers by ensuring we're
only loading code that's actually required and making smart use of
our dependencies and support for tree shaking where available.

This change reduces the size of the vendor JS bundle by ~1MB (~50%)
by making two relatively small changes:
- disable the import of carbon-components-react for the custom UI
  extensions which are not currently supported (~500KB savings)
- switch the `react-syntax-highlighter` from using Prism to highlight.js,
  also ensure we're only loading the language definition required

As a result of the switch to loading the highlight.js language definition
from an esmodule, we also need to update the jest config for unit tests
to exclude the react-syntax-highlighter package from some of its processing
to avoid errors related to imports used outside of modules.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
