### PR TITLE
Add metadata to our publish task for Tekton Chains to observe & sign

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -4,6 +4,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: publish-tekton-dashboard
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
     - name: versionTag
@@ -31,6 +33,10 @@ spec:
     env:
       - name: HOME
         value: /tekton/home
+  results:
+    # IMAGES result is picked up by Tekton Chains to sign the release.
+    # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
+    - name: IMAGES
   steps:
     - name: link-input-bucket-to-output
       image: busybox
@@ -152,6 +158,10 @@ spec:
           for IMAGE in "${BUILT_IMAGES[@]}"
           do
             IMAGE_WITHOUT_SHA=${IMAGE%%@*}
+            IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
+            IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
+            echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
             if [[ "$(inputs.params.releaseAsLatest)" == "true" ]]
             then
               gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:latest
@@ -168,6 +178,7 @@ spec:
               else
                 TAG="$(params.versionTag)"
                 gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:$TAG
+                echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
               fi
             done
           done


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds an annotation to indicate that build provenance should be
generated and an IMAGES result composed of a comma-separated list of
imageNames+digest to be signed.

This change is based on
https://github.com/tektoncd/chains/blob/main/release/publish.yaml and
https://github.com/tektoncd/plumbing/blob/main/docs/signing.md

/kind misc

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
