### PR TITLE
Improve contrast of status label in dark mode

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -65,7 +65,7 @@ header.tkn--step-details-header {
 
   &[data-status] {
     .tkn--status-label {
-      color: $gray-70;
+      color: $text-02;
     }
   }
   &[data-status='running'] {

--- a/packages/components/src/components/RunHeader/RunHeader.scss
+++ b/packages/components/src/components/RunHeader/RunHeader.scss
@@ -77,7 +77,7 @@ header.tkn--pipeline-run-header {
   // catch all for unknown states
   &:not([data-succeeded]) {
     .tkn--status-label {
-      color: $gray-70;
+      color: $text-02;
     }
   }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Replace the hardcoded `gray-70` with the correct `text-02` token
so it switches to `gray-30` as expected in dark mode, maintaining
the minimum required contrast ratio.

This style is used for waiting, pending, and unknown status in
the TaskRun and step details header.

A similar change was previously made in https://github.com/tektoncd/dashboard/pull/2151

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
