### PR TITLE
Add websocket support to list pages generated for extensions

### DIFF
--- a/src/api/extensions.js
+++ b/src/api/extensions.js
@@ -24,29 +24,33 @@ function getExtensionsAPI({ isWebSocket, namespace }) {
   });
 }
 
-export async function getExtensions({ namespace } = {}) {
+export function getExtensions({ namespace } = {}) {
   const resourceExtensionsUri = getExtensionsAPI({ namespace });
-  const resourceExtensions = await get(resourceExtensionsUri);
-  return (resourceExtensions?.items || []).map(({ spec }) => {
-    const { displayname: displayName, name, namespaced } = spec;
-    const [apiGroup, apiVersion] = spec.apiVersion.split('/');
-    return {
-      apiGroup,
-      apiVersion,
-      displayName,
-      name,
-      namespaced
-    };
-  });
+  return get(resourceExtensionsUri);
 }
 
 export function useExtensions(params, queryConfig) {
   const webSocketURL = getExtensionsAPI({ ...params, isWebSocket: true });
-  return useCollection({
+  const { data, ...query } = useCollection({
     api: getExtensions,
     kind: 'Extension',
     params,
     queryConfig,
     webSocketURL
   });
+
+  return {
+    ...query,
+    data: (data || []).map(({ spec }) => {
+      const { displayname: displayName, name, namespaced } = spec;
+      const [apiGroup, apiVersion] = spec.apiVersion.split('/');
+      return {
+        apiGroup,
+        apiVersion,
+        displayName,
+        name,
+        namespaced
+      };
+    })
+  };
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -63,6 +63,17 @@ export function getCustomResources({ filters = [], ...rest }) {
   return get(uri);
 }
 
+export function useCustomResources(params, queryConfig) {
+  const webSocketURL = getCustomResourcesAPI({ ...params, isWebSocket: true });
+  return useCollection({
+    api: getCustomResources,
+    kind: params.type,
+    params,
+    queryConfig,
+    webSocketURL
+  });
+}
+
 export function getCustomResource(params) {
   const uri = getResourcesAPI(params);
   return get(uri);
@@ -72,7 +83,7 @@ export function useCustomResource(params) {
   const webSocketURL = getCustomResourcesAPI({ ...params, isWebSocket: true });
   return useResource({
     api: getCustomResource,
-    kind: 'customResource',
+    kind: params.type,
     params,
     webSocketURL
   });
@@ -359,6 +370,17 @@ export function getAPIResource({ group, version, type }) {
 
   return get(uri).then(({ resources }) =>
     resources.find(({ name }) => name === type)
+  );
+}
+
+export function useAPIResource(params) {
+  return useResource(
+    {
+      api: getAPIResource,
+      kind: params.type,
+      params
+    },
+    { disableWebSocket: true }
   );
 }
 

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -54,7 +54,8 @@ it('getCustomResources', () => {
 });
 
 it('useCustomResource', () => {
-  const params = { fake: 'params' };
+  const type = 'fake_type';
+  const params = { fake: 'params', type };
   const query = { fake: 'query' };
   jest.spyOn(utils, 'useResource').mockImplementation(() => query);
   const returnValue = API.useCustomResource(params);
@@ -62,9 +63,51 @@ it('useCustomResource', () => {
   expect(utils.useResource).toHaveBeenCalledWith(
     expect.objectContaining({
       api: API.getCustomResource,
-      kind: 'customResource',
+      kind: type,
       params
     })
+  );
+  expect(returnValue).toEqual(query);
+});
+
+it('useCustomResources', async () => {
+  const group = 'fake_group';
+  const type = 'fake_type';
+  const version = 'fake_version';
+  const resources = {
+    metadata: {},
+    items: [
+      { metadata: { name: 'resource1' } },
+      { metadata: { name: 'resource2' } }
+    ]
+  };
+  fetchMock.get(/fake_type/, resources);
+  const { result, waitFor } = renderHook(
+    () => API.useCustomResources({ group, type, version }),
+    {
+      wrapper: getAPIWrapper()
+    }
+  );
+  await waitFor(() => result.current.isFetching);
+  await waitFor(() => !result.current.isFetching);
+  expect(result.current.data).toEqual(resources.items);
+  fetchMock.restore();
+});
+
+it('useAPIResource', () => {
+  const type = 'fake_type';
+  const params = { fake: 'params', type };
+  const query = { fake: 'query' };
+  jest.spyOn(utils, 'useResource').mockImplementation(() => query);
+  const returnValue = API.useAPIResource(params);
+
+  expect(utils.useResource).toHaveBeenCalledWith(
+    expect.objectContaining({
+      api: API.getAPIResource,
+      kind: type,
+      params
+    }),
+    { disableWebSocket: true }
   );
   expect(returnValue).toEqual(query);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Refactor the ResourceList container used on pages generated for
displaying lists of resources specified by an extension so they
can make use of the new react-query and websocket support.

Lists will now update in real time based on websocket messages
and are consistent with all other list views in the app.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
