### PR TITLE
Update route definitions to prepare for react-router update

### DIFF
--- a/.storybook/Container.js
+++ b/.storybook/Container.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -28,7 +28,7 @@ export default function Container({ story, notes }) {
       {notes && <p>{notes}</p>}
       <div data-floating-menu-container role="main">
         <Router history={history}>
-          <Route path="/" component={() => story()} />
+          <Route path="/">{() => story()}</Route>
         </Router>
       </div>
     </IntlProvider>

--- a/packages/components/src/components/PageErrorBoundary/PageErrorBoundary.js
+++ b/packages/components/src/components/PageErrorBoundary/PageErrorBoundary.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,11 +13,12 @@ limitations under the License.
 
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { withRouter } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 import { ErrorBoundary } from '..';
 
-const PageErrorBoundary = ({ children, intl, location }) => {
+const PageErrorBoundary = ({ children, intl }) => {
+  const location = useLocation();
   const message = intl.formatMessage({
     id: 'dashboard.errorBoundary.pageError',
     defaultMessage: 'Error loading page'
@@ -30,4 +31,4 @@ const PageErrorBoundary = ({ children, intl, location }) => {
   );
 };
 
-export default withRouter(injectIntl(PageErrorBoundary));
+export default injectIntl(PageErrorBoundary);

--- a/packages/components/src/utils/test.js
+++ b/packages/components/src/utils/test.js
@@ -12,16 +12,18 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Route } from 'react-router-dom';
 import { render as baseRender } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-function RouterWrapper({ children }) {
+function RouterWrapper({ children, path }) {
   return (
     <BrowserRouter>
-      <IntlProvider locale="en" defaultLocale="en" messages={{}}>
-        {children}
-      </IntlProvider>
+      <Route path={path}>
+        <IntlProvider locale="en" defaultLocale="en" messages={{}}>
+          {children}
+        </IntlProvider>
+      </Route>
     </BrowserRouter>
   );
 }
@@ -29,6 +31,7 @@ function RouterWrapper({ children }) {
 export function renderWithRouter(
   ui,
   {
+    path = '/',
     rerender,
     route = '/',
     wrapper: Wrapper = React.Fragment,
@@ -41,7 +44,7 @@ export function renderWithRouter(
     route,
     wrapper: ({ children }) => (
       <Wrapper>
-        <RouterWrapper>{children}</RouterWrapper>
+        <RouterWrapper path={path}>{children}</RouterWrapper>
       </Wrapper>
     ),
     ...otherOptions

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -167,16 +167,16 @@ export function getFilters({ search }) {
   return filters;
 }
 
-export function getAddFilterHandler({ history, location, match }) {
+export function getAddFilterHandler({ history, location }) {
   return function handleAddFilter(labelFilters) {
     const queryParams = new URLSearchParams(location.search);
     queryParams.set('labelSelector', labelFilters);
-    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   };
 }
 
-export function getDeleteFilterHandler({ history, location, match }) {
+export function getDeleteFilterHandler({ history, location }) {
   return function handleDeleteFilter(filter) {
     const queryParams = new URLSearchParams(location.search);
     const labelFilters = queryParams.getAll('labelSelector');
@@ -190,16 +190,18 @@ export function getDeleteFilterHandler({ history, location, match }) {
       queryParams.set('labelSelector', labelFiltersArray);
     }
     const queryString = queryParams.toString();
-    const browserURL = match.url.concat(queryString ? `?${queryString}` : '');
+    const browserURL = location.pathname.concat(
+      queryString ? `?${queryString}` : ''
+    );
     history.push(browserURL);
   };
 }
 
-export function getClearFiltersHandler({ history, location, match }) {
+export function getClearFiltersHandler({ history, location }) {
   return function handleClearFilters() {
     const queryParams = new URLSearchParams(location.search);
     queryParams.delete('labelSelector');
-    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   };
 }
@@ -221,7 +223,7 @@ export function getStatusFilter({ search }) {
   return status;
 }
 
-export function getStatusFilterHandler({ history, location, match }) {
+export function getStatusFilterHandler({ history, location }) {
   return function setStatusFilter(statusFilter) {
     const queryParams = new URLSearchParams(location.search);
     if (!statusFilter) {
@@ -229,7 +231,7 @@ export function getStatusFilterHandler({ history, location, match }) {
     } else {
       queryParams.set('status', statusFilter);
     }
-    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   };
 }

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -205,9 +205,8 @@ it('getFilters', () => {
 it('getAddFilterHandler', () => {
   const url = 'someURL';
   const history = { push: jest.fn() };
-  const location = { search: '?nonFilterQueryParam=someValue' };
-  const match = { url };
-  const handleAddFilter = getAddFilterHandler({ history, location, match });
+  const location = { pathname: url, search: '?nonFilterQueryParam=someValue' };
+  const handleAddFilter = getAddFilterHandler({ history, location });
   const labelFilters = ['foo1=bar1', 'foo2=bar2'];
   handleAddFilter(labelFilters);
   expect(history.push).toHaveBeenCalledWith(
@@ -222,12 +221,10 @@ describe('getDeleteFilterHandler', () => {
     const search = `?labelSelector=${encodeURIComponent('foo=bar')}`;
     const url = 'someURL';
     const history = { push: jest.fn() };
-    const location = { search };
-    const match = { url };
+    const location = { pathname: url, search };
     const handleDeleteFilter = getDeleteFilterHandler({
       history,
-      location,
-      match
+      location
     });
     handleDeleteFilter('foo=bar');
     expect(history.push).toHaveBeenCalledWith(url);
@@ -239,12 +236,10 @@ describe('getDeleteFilterHandler', () => {
     )}`;
     const url = 'someURL';
     const history = { push: jest.fn() };
-    const location = { search };
-    const match = { url };
+    const location = { pathname: url, search };
     const handleDeleteFilter = getDeleteFilterHandler({
       history,
-      location,
-      match
+      location
     });
     handleDeleteFilter('foo1=bar1');
     expect(history.push).toHaveBeenCalledWith(
@@ -430,12 +425,10 @@ describe('getStatusFilter', () => {
     )}`;
     const url = 'someURL';
     const history = { push: jest.fn() };
-    const location = { search };
-    const match = { url };
+    const location = { pathname: url, search };
     const handleDeleteFilter = getDeleteFilterHandler({
       history,
-      location,
-      match
+      location
     });
     handleDeleteFilter('foo1=bar1');
     expect(history.push).toHaveBeenCalledWith(
@@ -449,12 +442,10 @@ describe('getStatusFilterHandler', () => {
     const search = '?nonFilterQueryParam=someValue&status=cancelled';
     const url = 'someURL';
     const history = { push: jest.fn() };
-    const location = { search };
-    const match = { url };
+    const location = { pathname: url, search };
     const setStatusFilter = getStatusFilterHandler({
       history,
-      location,
-      match
+      location
     });
     setStatusFilter('');
     expect(history.push).toHaveBeenCalledWith(
@@ -465,12 +456,13 @@ describe('getStatusFilterHandler', () => {
   it('should set a valid status filter in the URL', () => {
     const url = 'someURL';
     const history = { push: jest.fn() };
-    const location = { search: '?nonFilterQueryParam=someValue' };
-    const match = { url };
+    const location = {
+      pathname: url,
+      search: '?nonFilterQueryParam=someValue'
+    };
     const setStatusFilter = getStatusFilterHandler({
       history,
-      location,
-      match
+      location
     });
     const statusFilter = 'cancelled';
     setStatusFilter(statusFilter);
@@ -482,12 +474,10 @@ describe('getStatusFilterHandler', () => {
   it('should update the status filter in the URL', () => {
     const url = 'someURL';
     const history = { push: jest.fn() };
-    const location = { search: '?status=cancelled' };
-    const match = { url };
+    const location = { pathname: url, search: '?status=cancelled' };
     const setStatusFilter = getStatusFilterHandler({
       history,
-      location,
-      match
+      location
     });
     const statusFilter = 'completed';
     setStatusFilter(statusFilter);

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -217,7 +217,7 @@ export function App({ lang }) {
                 }}
               />
               <Route path={paths.byNamespace({ path: '/*' })}>
-                {props => <SideNav {...props} expanded={isSideNavExpanded} />}
+                {() => <SideNav expanded={isSideNavExpanded} />}
               </Route>
 
               <Content
@@ -228,55 +228,39 @@ export function App({ lang }) {
               >
                 <PageErrorBoundary>
                   <Switch>
-                    <Route
-                      path={paths.pipelines.all()}
-                      exact
-                      component={Pipelines}
-                    />
-                    <Route
-                      path={paths.pipelines.byNamespace()}
-                      exact
-                      component={Pipelines}
-                    />
+                    <Route path={paths.pipelines.all()} exact>
+                      <Pipelines />
+                    </Route>
+                    <Route path={paths.pipelines.byNamespace()} exact>
+                      <Pipelines />
+                    </Route>
                     <ReadWriteRoute
                       isReadOnly={isReadOnly}
                       path={paths.pipelineRuns.create()}
                       exact
                       component={CreatePipelineRun}
                     />
-                    <Route
-                      path={paths.pipelineRuns.all()}
-                      component={PipelineRuns}
-                    />
-                    <Route
-                      path={paths.pipelineRuns.byNamespace()}
-                      exact
-                      component={PipelineRuns}
-                    />
-                    <Route
-                      path={paths.pipelineRuns.byPipeline()}
-                      exact
-                      component={PipelineRuns}
-                    />
-                    <Route
-                      path={paths.pipelineRuns.byName()}
-                      component={PipelineRun}
-                    />
-                    <Route
-                      path={paths.pipelineResources.all()}
-                      exact
-                      component={PipelineResources}
-                    />
-                    <Route
-                      path={paths.pipelineResources.byNamespace()}
-                      exact
-                      component={PipelineResources}
-                    />
-                    <Route
-                      path={paths.pipelineResources.byName()}
-                      exact
-                      component={PipelineResource}
-                    />
+                    <Route path={paths.pipelineRuns.all()}>
+                      <PipelineRuns />
+                    </Route>
+                    <Route path={paths.pipelineRuns.byNamespace()} exact>
+                      <PipelineRuns />
+                    </Route>
+                    <Route path={paths.pipelineRuns.byPipeline()} exact>
+                      <PipelineRuns />
+                    </Route>
+                    <Route path={paths.pipelineRuns.byName()}>
+                      <PipelineRun />
+                    </Route>
+                    <Route path={paths.pipelineResources.all()} exact>
+                      <PipelineResources />
+                    </Route>
+                    <Route path={paths.pipelineResources.byNamespace()} exact>
+                      <PipelineResources />
+                    </Route>
+                    <Route path={paths.pipelineResources.byName()} exact>
+                      <PipelineResource />
+                    </Route>
                     <ReadWriteRoute
                       isReadOnly={isReadOnly}
                       path={paths.pipelineResources.create()}
@@ -284,55 +268,49 @@ export function App({ lang }) {
                       component={CreatePipelineResource}
                     />
 
-                    <Route path={paths.tasks.all()} exact component={Tasks} />
-                    <Route
-                      path={paths.tasks.byNamespace()}
-                      exact
-                      component={Tasks}
-                    />
+                    <Route path={paths.tasks.all()} exact>
+                      <Tasks />
+                    </Route>
+                    <Route path={paths.tasks.byNamespace()} exact>
+                      <Tasks />
+                    </Route>
                     <ReadWriteRoute
                       isReadOnly={isReadOnly}
                       path={paths.taskRuns.create()}
                       exact
                       component={CreateTaskRun}
                     />
-                    <Route path={paths.taskRuns.all()} component={TaskRuns} />
-                    <Route
-                      path={paths.taskRuns.byNamespace()}
-                      exact
-                      component={TaskRuns}
-                    />
-                    <Route
-                      path={paths.taskRuns.byTask()}
-                      exact
-                      component={TaskRuns}
-                    />
-                    <Route
-                      path={paths.taskRuns.byName()}
-                      exact
-                      component={TaskRun}
-                    />
-                    <Route
-                      path={paths.clusterTasks.all()}
-                      exact
-                      component={ClusterTasks}
-                    />
-                    <Route
-                      path={paths.conditions.all()}
-                      component={Conditions}
-                    />
-                    <Route
-                      path={paths.conditions.byNamespace()}
-                      exact
-                      component={Conditions}
-                    />
-                    <Route
-                      path={paths.conditions.byName()}
-                      component={Condition}
-                    />
+                    <Route path={paths.taskRuns.all()}>
+                      <TaskRuns />
+                    </Route>
+                    <Route path={paths.taskRuns.byNamespace()} exact>
+                      <TaskRuns />
+                    </Route>
+                    <Route path={paths.taskRuns.byTask()} exact>
+                      <TaskRuns />
+                    </Route>
+                    <Route path={paths.taskRuns.byName()} exact>
+                      <TaskRun />
+                    </Route>
+                    <Route path={paths.clusterTasks.all()} exact>
+                      <ClusterTasks />
+                    </Route>
+                    <Route path={paths.conditions.all()}>
+                      <Conditions />
+                    </Route>
+                    <Route path={paths.conditions.byNamespace()} exact>
+                      <Conditions />
+                    </Route>
+                    <Route path={paths.conditions.byName()}>
+                      <Condition />
+                    </Route>
 
-                    <Route path={paths.about()} component={About} />
-                    <Route path={paths.settings()} component={Settings} />
+                    <Route path={paths.about()}>
+                      <About />
+                    </Route>
+                    <Route path={paths.settings()}>
+                      <Settings />
+                    </Route>
 
                     <ReadWriteRoute
                       isReadOnly={isReadOnly}
@@ -340,132 +318,86 @@ export function App({ lang }) {
                       component={ImportResources}
                     />
 
-                    <Route
-                      path={paths.eventListeners.all()}
-                      exact
-                      component={EventListeners}
-                    />
-                    <Route
-                      path={paths.eventListeners.byNamespace()}
-                      exact
-                      component={EventListeners}
-                    />
-                    <Route
-                      path={paths.eventListeners.byName()}
-                      exact
-                      component={EventListener}
-                    />
-                    <Route
-                      path={paths.triggers.byName()}
-                      exact
-                      component={Trigger}
-                    />
-                    <Route
-                      path={paths.triggers.all()}
-                      exact
-                      component={Triggers}
-                    />
-                    <Route
-                      path={paths.triggers.byNamespace()}
-                      exact
-                      component={Triggers}
-                    />
-                    <Route
-                      path={paths.triggerBindings.byName()}
-                      exact
-                      component={TriggerBinding}
-                    />
-                    <Route
-                      path={paths.triggerBindings.all()}
-                      exact
-                      component={TriggerBindings}
-                    />
-                    <Route
-                      path={paths.triggerBindings.byNamespace()}
-                      exact
-                      component={TriggerBindings}
-                    />
-                    <Route
-                      path={paths.clusterTriggerBindings.byName()}
-                      exact
-                      component={ClusterTriggerBinding}
-                    />
-                    <Route
-                      path={paths.clusterTriggerBindings.all()}
-                      exact
-                      component={ClusterTriggerBindings}
-                    />
-                    <Route
-                      path={paths.triggerTemplates.byName()}
-                      exact
-                      component={TriggerTemplate}
-                    />
-                    <Route
-                      path={paths.triggerTemplates.all()}
-                      exact
-                      component={TriggerTemplates}
-                    />
-                    <Route
-                      path={paths.triggerTemplates.byNamespace()}
-                      exact
-                      component={TriggerTemplates}
-                    />
-                    <Route
-                      path={paths.clusterInterceptors.all()}
-                      exact
-                      component={ClusterInterceptors}
-                    />
-                    <Route
-                      path={paths.extensions.all()}
-                      exact
-                      component={Extensions}
-                    />
+                    <Route path={paths.eventListeners.all()} exact>
+                      <EventListeners />
+                    </Route>
+                    <Route path={paths.eventListeners.byNamespace()} exact>
+                      <EventListeners />
+                    </Route>
+                    <Route path={paths.eventListeners.byName()} exact>
+                      <EventListener />
+                    </Route>
+                    <Route path={paths.triggers.byName()} exact>
+                      <Trigger />
+                    </Route>
+                    <Route path={paths.triggers.all()} exact>
+                      <Triggers />
+                    </Route>
+                    <Route path={paths.triggers.byNamespace()} exact>
+                      <Triggers />
+                    </Route>
+                    <Route path={paths.triggerBindings.byName()} exact>
+                      <TriggerBinding />
+                    </Route>
+                    <Route path={paths.triggerBindings.all()} exact>
+                      <TriggerBindings />
+                    </Route>
+                    <Route path={paths.triggerBindings.byNamespace()} exact>
+                      <TriggerBindings />
+                    </Route>
+                    <Route path={paths.clusterTriggerBindings.byName()} exact>
+                      <ClusterTriggerBinding />
+                    </Route>
+                    <Route path={paths.clusterTriggerBindings.all()} exact>
+                      <ClusterTriggerBindings />
+                    </Route>
+                    <Route path={paths.triggerTemplates.byName()} exact>
+                      <TriggerTemplate />
+                    </Route>
+                    <Route path={paths.triggerTemplates.all()} exact>
+                      <TriggerTemplates />
+                    </Route>
+                    <Route path={paths.triggerTemplates.byNamespace()} exact>
+                      <TriggerTemplates />
+                    </Route>
+                    <Route path={paths.clusterInterceptors.all()} exact>
+                      <ClusterInterceptors />
+                    </Route>
+                    <Route path={paths.extensions.all()} exact>
+                      <Extensions />
+                    </Route>
                     {extensions
                       .filter(extension => !extension.type)
                       .map(({ displayName, name, source }) => (
                         <Route
                           key={name}
                           path={paths.extensions.byName({ name })}
-                          render={({ match }) => (
-                            <Extension
-                              displayName={displayName}
-                              match={match}
-                              source={source}
-                            />
-                          )}
-                        />
+                        >
+                          <Extension
+                            displayName={displayName}
+                            source={source}
+                          />
+                        </Route>
                       ))}
 
-                    <Route
-                      path={paths.rawCRD.byNamespace()}
-                      exact
-                      component={CustomResourceDefinition}
-                    />
-                    <Route
-                      path={paths.rawCRD.cluster()}
-                      exact
-                      component={CustomResourceDefinition}
-                    />
-                    <Route
-                      path={paths.kubernetesResources.all()}
-                      exact
-                      component={ResourceList}
-                    />
-                    <Route
-                      path={paths.kubernetesResources.byNamespace()}
-                      exact
-                      component={ResourceList}
-                    />
-                    <Route
-                      path={paths.kubernetesResources.byName()}
-                      exact
-                      component={CustomResourceDefinition}
-                    />
-                    <Route
-                      path={paths.kubernetesResources.cluster()}
-                      exact
-                      component={CustomResourceDefinition}
-                    />
+                    <Route path={paths.rawCRD.byNamespace()} exact>
+                      <CustomResourceDefinition />
+                    </Route>
+                    <Route path={paths.rawCRD.cluster()} exact>
+                      <CustomResourceDefinition />
+                    </Route>
+                    <Route path={paths.kubernetesResources.all()} exact>
+                      <ResourceList />
+                    </Route>
+                    <Route path={paths.kubernetesResources.byNamespace()} exact>
+                      <ResourceList />
+                    </Route>
+                    <Route path={paths.kubernetesResources.byName()} exact>
+                      <CustomResourceDefinition />
+                    </Route>
+                    <Route path={paths.kubernetesResources.cluster()} exact>
+                      <CustomResourceDefinition />
+                    </Route>
 
                     <Redirect to={urls.pipelineRuns.all()} />
                   </Switch>

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,8 +21,8 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { ListPageLayout } from '..';
 import { useClusterInterceptors } from '../../api';
 
-function ClusterInterceptors(props) {
-  const { intl, location } = props;
+function ClusterInterceptors({ intl }) {
+  const location = useLocation();
   const filters = getFilters(location);
 
   useTitleSync({ page: 'ClusterInterceptors' });
@@ -93,7 +93,6 @@ function ClusterInterceptors(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
       hideNamespacesDropdown

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.test.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.test.js
@@ -12,8 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Route } from 'react-router-dom';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/clusterInterceptors';
@@ -34,13 +33,9 @@ describe('ClusterInterceptors', () => {
     jest
       .spyOn(API, 'useClusterInterceptors')
       .mockImplementation(() => ({ isLoading: true }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.clusterInterceptors.all()}
-        render={props => <ClusterInterceptorsContainer {...props} />}
-      />,
-      { route: urls.clusterInterceptors.all() }
-    );
+    const { queryByText } = renderWithRouter(<ClusterInterceptorsContainer />, {
+      route: urls.clusterInterceptors.all()
+    });
     expect(queryByText('ClusterInterceptors')).toBeTruthy();
   });
 
@@ -48,13 +43,9 @@ describe('ClusterInterceptors', () => {
     jest
       .spyOn(API, 'useClusterInterceptors')
       .mockImplementation(() => ({ data: [clusterInterceptor] }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.clusterInterceptors.all()}
-        render={props => <ClusterInterceptorsContainer {...props} />}
-      />,
-      { route: urls.clusterInterceptors.all() }
-    );
+    const { queryByText } = renderWithRouter(<ClusterInterceptorsContainer />, {
+      route: urls.clusterInterceptors.all()
+    });
 
     expect(queryByText('clusterInterceptorWithSingleLabel')).toBeTruthy();
   });
@@ -64,13 +55,9 @@ describe('ClusterInterceptors', () => {
     jest
       .spyOn(API, 'useClusterInterceptors')
       .mockImplementation(() => ({ error }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.clusterInterceptors.all()}
-        render={props => <ClusterInterceptorsContainer {...props} />}
-      />,
-      { route: urls.clusterInterceptors.all() }
-    );
+    const { queryByText } = renderWithRouter(<ClusterInterceptorsContainer />, {
+      route: urls.clusterInterceptors.all()
+    });
 
     expect(queryByText(error)).toBeTruthy();
   });

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
@@ -31,8 +31,8 @@ import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { ListPageLayout } from '..';
 import { deleteClusterTask, useClusterTasks, useIsReadOnly } from '../../api';
 
-function ClusterTasksContainer(props) {
-  const { intl, location } = props;
+function ClusterTasksContainer({ intl }) {
+  const location = useLocation();
   const [cancelSelection, setCancelSelection] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -198,7 +198,6 @@ function ClusterTasksContainer(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
       hideNamespacesDropdown

--- a/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.js
+++ b/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.js
@@ -18,9 +18,12 @@ import { TooltipDropdown } from '@tektoncd/dashboard-components';
 import { useClusterTasks } from '../../api';
 
 function ClusterTasksDropdown({ disabled, intl, label, ...rest }) {
-  const { data: clusterTasks = [], isFetching } = useClusterTasks(null, {
-    enabled: !disabled
-  });
+  const { data: clusterTasks = [], isFetching } = useClusterTasks(
+    {},
+    {
+      enabled: !disabled
+    }
+  );
 
   const items = clusterTasks.map(clusterTask => clusterTask.metadata.name);
 

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -12,18 +12,20 @@ limitations under the License.
 */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { useClusterTriggerBinding } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export /* istanbul ignore next */ function ClusterTriggerBindingContainer(
-  props
-) {
-  const { intl, location, match } = props;
-  const { clusterTriggerBindingName } = match.params;
+export /* istanbul ignore next */ function ClusterTriggerBindingContainer({
+  intl
+}) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
+  const { clusterTriggerBindingName } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -72,7 +74,7 @@ export /* istanbul ignore next */ function ClusterTriggerBindingContainer(
     <ResourceDetails
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={clusterTriggerBinding}
       view={view}
     >
@@ -90,13 +92,5 @@ export /* istanbul ignore next */ function ClusterTriggerBindingContainer(
     </ResourceDetails>
   );
 }
-
-ClusterTriggerBindingContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      clusterTriggerBindingName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(ClusterTriggerBindingContainer);

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.test.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.test.js
@@ -12,10 +12,9 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Route } from 'react-router-dom';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { urls } from '@tektoncd/dashboard-utils';
 
 import * as API from '../../api/clusterTriggerBindings';
 import { renderWithRouter } from '../../utils/test';
@@ -68,14 +67,9 @@ it('ClusterTriggerBindingContainer handles error state', async () => {
   jest
     .spyOn(API, 'useClusterTriggerBinding')
     .mockImplementation(() => ({ error }));
-  const match = {
-    params: {
-      clusterTriggerBindingName: 'foo'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <ClusterTriggerBindingContainer intl={intl} location={{}} match={match} />
+    <ClusterTriggerBindingContainer intl={intl} />
   );
   await waitFor(() => getByText('Error loading resource'));
   await waitFor(() => getByText(error));
@@ -85,14 +79,9 @@ it('ClusterTriggerBindingContainer renders overview', async () => {
   jest
     .spyOn(API, 'useClusterTriggerBinding')
     .mockImplementation(() => ({ data: clusterTriggerBindingSimple }));
-  const match = {
-    params: {
-      clusterTriggerBindingName: 'cluster-trigger-binding-simple'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <ClusterTriggerBindingContainer intl={intl} location={{}} match={match} />
+    <ClusterTriggerBindingContainer intl={intl} />
   );
 
   await waitFor(() => getByText('cluster-trigger-binding-simple'));
@@ -110,12 +99,7 @@ it('ClusterTriggerBindingContainer renders YAML', async () => {
   const clusterTriggerBindingName = 'cluster-trigger-binding-simple';
 
   const { getByText } = renderWithRouter(
-    <Route
-      path={paths.clusterTriggerBindings.byName()}
-      render={props => (
-        <ClusterTriggerBindingContainer {...props} intl={intl} />
-      )}
-    />,
+    <ClusterTriggerBindingContainer intl={intl} />,
     {
       route: urls.clusterTriggerBindings.byName({
         clusterTriggerBindingName
@@ -137,14 +121,9 @@ it('ClusterTriggerBindingContainer does not render label section if they are not
   jest
     .spyOn(API, 'useClusterTriggerBinding')
     .mockImplementation(() => ({ data: clusterTriggerBindingSimple }));
-  const match = {
-    params: {
-      clusterTriggerBindingName: 'cluster-trigger-binding-simple'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <ClusterTriggerBindingContainer intl={intl} location={{}} match={match} />
+    <ClusterTriggerBindingContainer intl={intl} />
   );
 
   await waitFor(() => getByText('cluster-trigger-binding-simple'));
@@ -155,14 +134,9 @@ it('ClusterTriggerBindingContainer renders labels section if they are present', 
   jest
     .spyOn(API, 'useClusterTriggerBinding')
     .mockImplementation(() => ({ data: clusterTriggerBindingWithLabels }));
-  const match = {
-    params: {
-      clusterTriggerBindingName: 'cluster-trigger-binding-labels'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <ClusterTriggerBindingContainer intl={intl} location={{}} match={match} />
+    <ClusterTriggerBindingContainer intl={intl} />
   );
 
   await waitFor(() => getByText('cluster-trigger-binding-labels'));

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,8 +21,8 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { ListPageLayout } from '..';
 import { useClusterTriggerBindings } from '../../api';
 
-function ClusterTriggerBindings(props) {
-  const { intl, location } = props;
+function ClusterTriggerBindings({ intl }) {
+  const location = useLocation();
   const filters = getFilters(location);
 
   useTitleSync({ page: 'ClusterTriggerBindings' });
@@ -78,7 +78,6 @@ function ClusterTriggerBindings(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
       hideNamespacesDropdown

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.test.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { Route } from 'react-router-dom';
 
 import { renderWithRouter } from '../../utils/test';
 import ClusterTriggerBindings from '.';
@@ -35,13 +34,9 @@ it('ClusterTriggerBindings renders with no bindings', () => {
     data: []
   }));
 
-  const { getByText } = renderWithRouter(
-    <Route
-      path="/clustertriggerbindings"
-      render={props => <ClusterTriggerBindings {...props} />}
-    />,
-    { route: '/clustertriggerbindings' }
-  );
+  const { getByText } = renderWithRouter(<ClusterTriggerBindings />, {
+    route: '/clustertriggerbindings'
+  });
 
   expect(getByText('ClusterTriggerBindings')).toBeTruthy();
   expect(getByText('No matching ClusterTriggerBindings found')).toBeTruthy();
@@ -52,13 +47,9 @@ it('ClusterTriggerBindings renders with one binding', () => {
     .spyOn(API, 'useClusterTriggerBindings')
     .mockImplementation(() => ({ data: [clusterTriggerBinding] }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/clusterTriggerBindings"
-      render={props => <ClusterTriggerBindings {...props} />}
-    />,
-    { route: '/clusterTriggerBindings' }
-  );
+  const { queryByText } = renderWithRouter(<ClusterTriggerBindings />, {
+    route: '/clustertriggerbindings'
+  });
 
   expect(queryByText('ClusterTriggerBindings')).toBeTruthy();
   expect(queryByText(clusterTriggerBinding.metadata.name)).toBeTruthy();
@@ -71,16 +62,11 @@ it('ClusterTriggerBindings can be filtered on a single label filter', async () =
       data: filters.length ? [] : [clusterTriggerBinding]
     }));
 
-  const {
-    queryByText,
-    getByPlaceholderText,
-    getByText
-  } = renderWithRouter(
-    <Route
-      path="/clustertriggerbindings"
-      render={props => <ClusterTriggerBindings {...props} />}
-    />,
-    { route: '/clustertriggerbindings' }
+  const { queryByText, getByPlaceholderText, getByText } = renderWithRouter(
+    <ClusterTriggerBindings />,
+    {
+      route: '/clustertriggerbindings'
+    }
   );
 
   const filterValue = 'baz:bam';
@@ -97,13 +83,9 @@ it('ClusterTriggerBindings renders in loading state', () => {
     .spyOn(API, 'useClusterTriggerBindings')
     .mockImplementation(() => ({ isLoading: true }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/clustertriggerbindings"
-      render={props => <ClusterTriggerBindings {...props} />}
-    />,
-    { route: '/clustertriggerbindings' }
-  );
+  const { queryByText } = renderWithRouter(<ClusterTriggerBindings />, {
+    route: '/clustertriggerbindings'
+  });
 
   expect(queryByText(/ClusterTriggerBindings/i)).toBeTruthy();
   expect(queryByText('No matching ClusterTriggerBindings found')).toBeFalsy();
@@ -116,13 +98,9 @@ it('ClusterTriggerBindings renders in error state', () => {
     .spyOn(API, 'useClusterTriggerBindings')
     .mockImplementation(() => ({ error }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/clustertriggerbindings"
-      render={props => <ClusterTriggerBindings {...props} />}
-    />,
-    { route: '/clustertriggerbindings' }
-  );
+  const { queryByText } = renderWithRouter(<ClusterTriggerBindings />, {
+    route: '/clustertriggerbindings'
+  });
 
   expect(queryByText(error)).toBeTruthy();
 });

--- a/src/containers/Condition/Condition.js
+++ b/src/containers/Condition/Condition.js
@@ -12,8 +12,8 @@ limitations under the License.
 */
 
 import React from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
-import PropTypes from 'prop-types';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 
@@ -70,9 +70,11 @@ function ConditionParameters({ condition, intl }) {
   );
 }
 
-export function ConditionContainer(props) {
-  const { intl, location, match } = props;
-  const { conditionName, namespace } = match.params;
+export function ConditionContainer({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
+  const { conditionName, namespace } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -91,7 +93,7 @@ export function ConditionContainer(props) {
     <ResourceDetails
       error={error}
       kind="Condition"
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={condition}
       view={view}
     >
@@ -99,13 +101,5 @@ export function ConditionContainer(props) {
     </ResourceDetails>
   );
 }
-
-ConditionContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      conditionName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(ConditionContainer);

--- a/src/containers/Condition/Condition.test.js
+++ b/src/containers/Condition/Condition.test.js
@@ -15,7 +15,7 @@ import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 
-import { render } from '../../utils/test';
+import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/conditions';
 import { ConditionContainer } from './Condition';
 
@@ -26,18 +26,10 @@ const intl = createIntl({
 
 describe('ConditionContainer', () => {
   it('handles error state', async () => {
-    const match = {
-      params: {
-        conditionName: 'bar'
-      }
-    };
-
     const error = 'fake_errorMessage';
     jest.spyOn(API, 'useCondition').mockImplementation(() => ({ error }));
 
-    const { getByText } = render(
-      <ConditionContainer intl={intl} location={{}} match={match} />
-    );
+    const { getByText } = renderWithRouter(<ConditionContainer intl={intl} />);
     await waitFor(() => getByText('Error loading resource'));
     expect(getByText(error)).toBeTruthy();
   });
@@ -55,16 +47,8 @@ describe('ConditionContainer', () => {
     jest
       .spyOn(API, 'useCondition')
       .mockImplementation(() => ({ data: condition }));
-    const match = {
-      params: {
-        conditionName: 'bar',
-        namespace: 'default'
-      }
-    };
 
-    const { getByText } = render(
-      <ConditionContainer intl={intl} location={{}} match={match} />
-    );
+    const { getByText } = renderWithRouter(<ConditionContainer intl={intl} />);
     expect(getByText(/parameters/i)).toBeTruthy();
     expect(getByText('param1')).toBeTruthy();
     expect(getByText('param2')).toBeTruthy();
@@ -80,15 +64,9 @@ describe('ConditionContainer', () => {
     jest
       .spyOn(API, 'useCondition')
       .mockImplementation(() => ({ data: condition }));
-    const match = {
-      params: {
-        conditionName: 'bar',
-        namespace: 'default'
-      }
-    };
 
-    const { queryByText } = render(
-      <ConditionContainer intl={intl} location={{}} match={match} />
+    const { queryByText } = renderWithRouter(
+      <ConditionContainer intl={intl} />
     );
     expect(queryByText(/parameters/i)).toBeFalsy();
   });

--- a/src/containers/Conditions/Conditions.js
+++ b/src/containers/Conditions/Conditions.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,12 +21,13 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { useConditions, useSelectedNamespace } from '../../api';
 import { ListPageLayout } from '..';
 
-function Conditions(props) {
-  const { intl, location, match } = props;
+function Conditions({ intl }) {
+  const location = useLocation();
+  const params = useParams();
   useTitleSync({ page: 'Conditions' });
 
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
   const filters = getFilters(location);
 
   const { data: conditions = [], error, isLoading } = useConditions({
@@ -90,12 +91,7 @@ function Conditions(props) {
   }));
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="Conditions"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="Conditions">
       <Table
         headers={headers}
         rows={conditionsFormatted}

--- a/src/containers/Conditions/Conditions.test.js
+++ b/src/containers/Conditions/Conditions.test.js
@@ -13,8 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { Route } from 'react-router-dom';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/conditions';
@@ -48,13 +47,9 @@ describe('Conditions', () => {
     jest
       .spyOn(API, 'useConditions')
       .mockImplementation(() => ({ isLoading: true }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.conditions.all()}
-        render={props => <ConditionsContainer {...props} />}
-      />,
-      { route: urls.conditions.all() }
-    );
+    const { queryByText } = renderWithRouter(<ConditionsContainer />, {
+      route: urls.conditions.all()
+    });
     expect(queryByText('Conditions')).toBeTruthy();
   });
 
@@ -64,16 +59,11 @@ describe('Conditions', () => {
         ? [conditionWithTwoLabels]
         : [conditionWithSingleLabel, conditionWithTwoLabels]
     }));
-    const {
-      getByPlaceholderText,
-      getByText,
-      queryByText
-    } = renderWithRouter(
-      <Route
-        path={paths.conditions.all()}
-        render={props => <ConditionsContainer {...props} />}
-      />,
-      { route: urls.conditions.all() }
+    const { getByPlaceholderText, getByText, queryByText } = renderWithRouter(
+      <ConditionsContainer />,
+      {
+        route: urls.conditions.all()
+      }
     );
 
     expect(queryByText('conditionWithSingleLabel')).toBeTruthy();
@@ -91,13 +81,9 @@ describe('Conditions', () => {
   it('handles error', async () => {
     const error = 'fake_errorMessage';
     jest.spyOn(API, 'useConditions').mockImplementation(() => ({ error }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.conditions.all()}
-        render={props => <ConditionsContainer {...props} />}
-      />,
-      { route: urls.conditions.all() }
-    );
+    const { queryByText } = renderWithRouter(<ConditionsContainer />, {
+      route: urls.conditions.all()
+    });
 
     expect(queryByText(error)).toBeTruthy();
   });

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { Button, InlineNotification } from 'carbon-components-react';
 import {
@@ -49,9 +50,8 @@ function validateInputs(value, id) {
   return true;
 }
 
-export /* istanbul ignore next */ function CreatePipelineResource(props) {
-  const { history, intl } = props;
-
+export /* istanbul ignore next */ function CreatePipelineResource({ intl }) {
+  const history = useHistory();
   const { selectedNamespace: defaultNamespace } = useSelectedNamespace();
   const [creating, setCreating] = useState(false);
   const [gitSource, setGitSource] = useState(true);

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.test.js
@@ -12,9 +12,8 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Route } from 'react-router-dom';
 import { fireEvent } from '@testing-library/react';
-import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
+import { ALL_NAMESPACES, urls } from '@tektoncd/dashboard-utils';
 
 import { render, renderWithRouter } from '../../utils/test';
 import CreatePipelineResource from '.';
@@ -40,21 +39,17 @@ describe('CreatePipelineResource', () => {
 
   it('redirects to PipelineResources on cancel', () => {
     jest.spyOn(API, 'getNamespaces').mockImplementation(() => []);
-    const history = { push: jest.fn() };
+    jest.spyOn(window.history, 'pushState');
 
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.pipelineResources.create()}
-        render={props => (
-          <CreatePipelineResource {...props} history={history} />
-        )}
-      />,
-      {
-        route: urls.pipelineResources.create()
-      }
-    );
+    const { queryByText } = renderWithRouter(<CreatePipelineResource />, {
+      route: urls.pipelineResources.create()
+    });
     fireEvent.click(queryByText(/cancel/i));
-    expect(history.push).toHaveBeenCalledWith(urls.pipelineResources.all());
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      urls.pipelineResources.all()
+    );
   });
 
   const nameValidationErrorMsgRegExp = /Must be less than 64 characters and contain only lowercase alphanumeric characters or -/i;

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -13,6 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import keyBy from 'lodash.keyby';
 import {
   Button,
@@ -86,8 +87,9 @@ const initialResourcesState = resourceSpecs => {
   return resourceSpecs.reduce(resourcesReducer, {});
 };
 
-function CreatePipelineRun(props) {
-  const { history, intl, location } = props;
+function CreatePipelineRun({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
 
   function getPipelineName() {
     const urlSearchParams = new URLSearchParams(location.search);

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
-import { render } from '../../utils/test';
+import { renderWithRouter } from '../../utils/test';
 
 import CreatePipelineRun from './CreatePipelineRun';
 import * as API from '../../api';
@@ -82,14 +82,7 @@ const pipelineResource2 = {
   spec: { type: 'type-2' }
 };
 
-const props = {
-  history: {
-    push: () => {}
-  },
-  location: {
-    search: ''
-  }
-};
+const history = { push: () => {} };
 
 describe('CreatePipelineRun', () => {
   beforeEach(() => {
@@ -116,6 +109,8 @@ describe('CreatePipelineRun', () => {
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: 'namespace-1' }));
+
+    jest.spyOn(history, 'push');
   });
 
   it('renders labels', () => {
@@ -124,7 +119,7 @@ describe('CreatePipelineRun', () => {
       getByText,
       getByPlaceholderText,
       queryByDisplayValue
-    } = render(<CreatePipelineRun {...props} />);
+    } = renderWithRouter(<CreatePipelineRun />);
     fireEvent.click(getAllByText(/Add/i)[0]);
     fireEvent.change(getByPlaceholderText(/key/i), {
       target: { value: 'foo' }
@@ -140,17 +135,17 @@ describe('CreatePipelineRun', () => {
   });
 
   it('handles onClose event', () => {
-    jest.spyOn(props.history, 'push');
-    const { getByText } = render(<CreatePipelineRun {...props} />);
+    jest.spyOn(window.history, 'pushState');
+    const { getByText } = renderWithRouter(<CreatePipelineRun />);
     fireEvent.click(getByText(/cancel/i));
-    expect(props.history.push).toHaveBeenCalledTimes(1);
+    // will be called once for render (from test utils) and once for navigation
+    expect(window.history.pushState).toHaveBeenCalledTimes(2);
   });
 
   it('handles close', () => {
-    jest.spyOn(props.history, 'push');
-    const { getByText } = render(<CreatePipelineRun {...props} />);
-
+    jest.spyOn(window.history, 'pushState');
+    const { getByText } = renderWithRouter(<CreatePipelineRun />);
     fireEvent.click(getByText(/cancel/i));
-    expect(props.history.push).toHaveBeenCalledTimes(1);
+    expect(window.history.pushState).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/containers/CreateTaskRun/CreateTaskRun.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.js
@@ -13,6 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import keyBy from 'lodash.keyby';
 import {
   Button,
@@ -99,8 +100,9 @@ const initialResourcesState = resourceSpecs => {
 
 const itemToString = ({ text }) => text;
 
-function CreateTaskRun(props) {
-  const { history, intl, location } = props;
+function CreateTaskRun({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
 
   function getTaskDetails() {
     const urlSearchParams = new URLSearchParams(location.search);

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -13,6 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
@@ -41,9 +42,11 @@ function useResource({ group, name, namespace, type, version }) {
   }
 }
 
-function CustomResourceDefinition(props) {
-  const { location, match } = props;
-  const { group, name, namespace, type, version } = match.params;
+function CustomResourceDefinition() {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
+  const { group, name, namespace, type, version } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -65,7 +68,7 @@ function CustomResourceDefinition(props) {
     <ResourceDetails
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={data}
       view={view}
     />

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -12,8 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
@@ -22,9 +21,11 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { useEventListener } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export /* istanbul ignore next */ function EventListenerContainer(props) {
-  const { intl, location, match } = props;
-  const { eventListenerName, namespace } = match.params;
+export /* istanbul ignore next */ function EventListenerContainer({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
+  const { eventListenerName, namespace } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -130,7 +131,7 @@ export /* istanbul ignore next */ function EventListenerContainer(props) {
       additionalMetadata={getAdditionalMetadata()}
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={eventListener}
       view={view}
     >
@@ -138,13 +139,5 @@ export /* istanbul ignore next */ function EventListenerContainer(props) {
     </ResourceDetails>
   );
 }
-
-EventListenerContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      eventListenerName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(EventListenerContainer);

--- a/src/containers/EventListener/EventListener.stories.js
+++ b/src/containers/EventListener/EventListener.stories.js
@@ -122,12 +122,6 @@ const eventListener = {
     ]
   }
 };
-const match = {
-  params: {
-    namespace,
-    eventListenerName: name
-  }
-};
 const intl = createIntl({
   locale: 'en',
   defaultLocale: 'en'
@@ -144,11 +138,7 @@ const queryClient = new QueryClient({
   }
 });
 
-const props = {
-  location: {},
-  match,
-  intl
-};
+const props = { intl };
 
 export default {
   component: EventListenerContainer,

--- a/src/containers/EventListener/EventListener.test.js
+++ b/src/containers/EventListener/EventListener.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import { paths, urls } from '@tektoncd/dashboard-utils';
 import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 
@@ -125,22 +126,18 @@ const fakeEventListenerWithLabels = {
   }
 };
 
-const match = {
-  params: { eventListenerName, namespace }
-};
-
-const props = {
-  intl,
-  location: {},
-  match
-};
+const props = { intl };
 
 it('EventListener displays with formatted labels', async () => {
   jest
     .spyOn(API, 'useEventListener')
     .mockImplementation(() => ({ data: fakeEventListenerWithLabels }));
   const { queryByText, getByText } = renderWithRouter(
-    <EventListenerContainer {...props} />
+    <EventListenerContainer {...props} />,
+    {
+      path: paths.eventListeners.byName(),
+      route: urls.eventListeners.byName({ eventListenerName, namespace })
+    }
   );
 
   await waitFor(() => getByText(eventListenerName));
@@ -179,7 +176,11 @@ it('EventListener handles no serviceAccountName', async () => {
     .spyOn(API, 'useEventListener')
     .mockImplementation(() => ({ data: eventListener }));
   const { queryByText, getByText } = renderWithRouter(
-    <EventListenerContainer {...props} />
+    <EventListenerContainer {...props} />,
+    {
+      path: paths.eventListeners.byName(),
+      route: urls.eventListeners.byName({ eventListenerName, namespace })
+    }
   );
 
   await waitFor(() => getByText(eventListenerName));
@@ -198,7 +199,11 @@ it('EventListener handles no service type', async () => {
     .spyOn(API, 'useEventListener')
     .mockImplementation(() => ({ data: eventListener }));
   const { queryByText, getByText } = renderWithRouter(
-    <EventListenerContainer {...props} />
+    <EventListenerContainer {...props} />,
+    {
+      path: paths.eventListeners.byName(),
+      route: urls.eventListeners.byName({ eventListenerName, namespace })
+    }
   );
 
   await waitFor(() => getByText(eventListenerName));

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,16 +21,15 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { ListPageLayout } from '..';
 import { useEventListeners, useSelectedNamespace } from '../../api';
 
-function EventListeners(props) {
-  const { intl, location } = props;
+function EventListeners({ intl }) {
+  const location = useLocation();
+  const params = useParams();
   const filters = getFilters(location);
 
   useTitleSync({ page: 'EventListeners' });
 
   const { selectedNamespace: defaultNamespace } = useSelectedNamespace();
-  const {
-    namespace: selectedNamespace = defaultNamespace
-  } = props.match.params;
+  const { namespace: selectedNamespace = defaultNamespace } = params;
 
   const { data: eventListeners = [], error, isLoading } = useEventListeners({
     filters,
@@ -85,12 +84,7 @@ function EventListeners(props) {
   }));
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="EventListeners"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="EventListeners">
       <Table
         headers={initialHeaders}
         rows={eventListenersFormatted}

--- a/src/containers/EventListeners/EventListeners.test.js
+++ b/src/containers/EventListeners/EventListeners.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { Route } from 'react-router-dom';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
@@ -47,13 +46,9 @@ describe('EventListeners', () => {
       .spyOn(EventListenersAPI, 'useEventListeners')
       .mockImplementation(() => ({ data: [] }));
 
-    const { getByText } = renderWithRouter(
-      <Route
-        path="/eventlisteners"
-        render={props => <EventListeners {...props} />}
-      />,
-      { route: '/eventlisteners' }
-    );
+    const { getByText } = renderWithRouter(<EventListeners />, {
+      route: '/eventlisteners'
+    });
 
     expect(getByText('EventListeners')).toBeTruthy();
     expect(getByText('No matching EventListeners found')).toBeTruthy();
@@ -64,13 +59,9 @@ describe('EventListeners', () => {
       .spyOn(EventListenersAPI, 'useEventListeners')
       .mockImplementation(() => ({ data: [eventListener] }));
 
-    const { queryByText, queryByTitle } = renderWithRouter(
-      <Route
-        path="/eventlisteners"
-        render={props => <EventListeners {...props} />}
-      />,
-      { route: '/eventlisteners' }
-    );
+    const { queryByText, queryByTitle } = renderWithRouter(<EventListeners />, {
+      route: '/eventlisteners'
+    });
 
     expect(queryByText('EventListeners')).toBeTruthy();
     expect(queryByText('No matching EventListeners found')).toBeFalsy();
@@ -89,13 +80,7 @@ describe('EventListeners', () => {
       getByPlaceholderText,
       getByText,
       queryByText
-    } = renderWithRouter(
-      <Route
-        path="/eventlisteners"
-        render={props => <EventListeners {...props} />}
-      />,
-      { route: '/eventlisteners' }
-    );
+    } = renderWithRouter(<EventListeners />, { route: '/eventlisteners' });
 
     const filterValue = 'baz:bam';
     const filterInputField = getByPlaceholderText(/Input a label filter/);
@@ -111,13 +96,9 @@ describe('EventListeners', () => {
       .spyOn(EventListenersAPI, 'useEventListeners')
       .mockImplementation(() => ({ isLoading: true }));
 
-    const { queryByText } = renderWithRouter(
-      <Route
-        path="/eventlisteners"
-        render={props => <EventListeners {...props} />}
-      />,
-      { route: '/eventlisteners' }
-    );
+    const { queryByText } = renderWithRouter(<EventListeners />, {
+      route: '/eventlisteners'
+    });
 
     expect(queryByText(/EventListeners/i)).toBeTruthy();
     expect(queryByText('No matching EventListeners found')).toBeFalsy();
@@ -130,13 +111,9 @@ describe('EventListeners', () => {
       .spyOn(EventListenersAPI, 'useEventListeners')
       .mockImplementation(() => ({ error }));
 
-    const { queryByText } = renderWithRouter(
-      <Route
-        path="/eventlisteners"
-        render={props => <EventListeners {...props} />}
-      />,
-      { route: '/eventlisteners' }
-    );
+    const { queryByText } = renderWithRouter(<EventListeners />, {
+      route: '/eventlisteners'
+    });
 
     expect(queryByText(error)).toBeTruthy();
   });

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -29,9 +29,7 @@ import { Table } from '@tektoncd/dashboard-components';
 
 import { useExtensions, useTenantNamespace } from '../../api';
 
-function Extensions(props) {
-  const { intl } = props;
-
+function Extensions({ intl }) {
   useTitleSync({
     page: intl.formatMessage({
       id: 'dashboard.extensions.title',
@@ -106,9 +104,5 @@ function Extensions(props) {
     </>
   );
 }
-
-Extensions.defaultProps = {
-  extensions: []
-};
 
 export default injectIntl(Extensions);

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -59,9 +59,7 @@ const HelpIcon = ({ title }) => (
   </TooltipIcon>
 );
 
-export function ImportResources(props) {
-  const { intl } = props;
-
+export function ImportResources({ intl }) {
   const { selectedNamespace: navNamespace } = useSelectedNamespace();
   const dashboardNamespace = useDashboardNamespace();
 

--- a/src/containers/ListPageLayout/ListPageLayout.js
+++ b/src/containers/ListPageLayout/ListPageLayout.js
@@ -12,7 +12,13 @@ limitations under the License.
 */
 
 import React from 'react';
-import { generatePath } from 'react-router-dom';
+import {
+  generatePath,
+  useHistory,
+  useLocation,
+  useParams,
+  useRouteMatch
+} from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { InlineNotification } from 'carbon-components-react';
 import {
@@ -29,12 +35,13 @@ export const ListPageLayout = ({
   error,
   filters,
   hideNamespacesDropdown,
-  history,
   intl,
-  location,
-  match,
   title
 }) => {
+  const history = useHistory();
+  const location = useLocation();
+  const match = useRouteMatch();
+  const params = useParams();
   const tenantNamespace = useTenantNamespace();
   const {
     selectedNamespace: namespace,
@@ -52,16 +59,16 @@ export const ListPageLayout = ({
       selectNamespace(selectedNamespace);
       setPath(
         generatePath(match.path.replace(paths.byNamespace(), ''), {
-          ...match.params
+          ...params
         })
       );
       return;
     }
 
-    const prefix = match?.params?.namespace ? '' : paths.byNamespace();
+    const prefix = params?.namespace ? '' : paths.byNamespace();
 
     const newURL = generatePath(`${prefix}${match.path}`, {
-      ...match.params,
+      ...params,
       namespace: selectedNamespace
     });
     setPath(newURL);
@@ -83,12 +90,7 @@ export const ListPageLayout = ({
         )}
       </div>
       {filters && (
-        <LabelFilter
-          filters={filters}
-          history={history}
-          location={location}
-          match={match}
-        />
+        <LabelFilter filters={filters} history={history} location={location} />
       )}
       {error && (
         <InlineNotification

--- a/src/containers/ListPageLayout/ListPageLayout.stories.js
+++ b/src/containers/ListPageLayout/ListPageLayout.stories.js
@@ -36,12 +36,6 @@ const namespaces = [
   'tekton-pipelines'
 ].map(namespace => ({ metadata: { name: namespace } }));
 
-const props = {
-  history: { push: () => {} },
-  location: {},
-  match: { path: '/' }
-};
-
 export default {
   component: ListPageLayoutContainer,
   decorators: [
@@ -69,7 +63,7 @@ export default {
 };
 
 export const Base = args => (
-  <ListPageLayoutContainer {...props} {...args}>
+  <ListPageLayoutContainer {...args}>
     page content goes here
   </ListPageLayoutContainer>
 );
@@ -79,7 +73,7 @@ Base.args = {
 };
 
 export const WithFilters = args => (
-  <ListPageLayoutContainer {...props} filters={[]} {...args}>
+  <ListPageLayoutContainer filters={[]} {...args}>
     page content goes here
   </ListPageLayoutContainer>
 );

--- a/src/containers/ListPageLayout/ListPageLayout.test.js
+++ b/src/containers/ListPageLayout/ListPageLayout.test.js
@@ -29,25 +29,22 @@ describe('ListPageLayout', () => {
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));
-    const history = {
-      push: jest.fn()
-    };
+    jest.spyOn(window.history, 'pushState');
     const path = '/fake/path';
-    const match = { path };
     const selectNamespace = jest.fn();
     const { getByText, getByDisplayValue } = renderWithRouter(
       <ListPageLayout
-        history={history}
-        location={{ search: '' }}
-        match={match}
         namespace={ALL_NAMESPACES}
         selectNamespace={selectNamespace}
-      />
+      />,
+      { path, route: path }
     );
     fireEvent.click(getByDisplayValue(/All Namespaces/i));
     fireEvent.click(getByText(otherNamespace));
     expect(selectNamespace).not.toHaveBeenCalled();
-    expect(history.push).toHaveBeenCalledWith(
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
       `/namespaces/${otherNamespace}${path}`
     );
   });
@@ -64,25 +61,22 @@ describe('ListPageLayout', () => {
     jest
       .spyOn(APIUtils, 'useSelectedNamespace')
       .mockImplementation(() => ({ selectedNamespace: namespace }));
-    const history = {
-      push: jest.fn()
-    };
     const path = '/namespaces/:namespace/fake/path';
-    const match = { path, params: { namespace } };
     const selectNamespace = jest.fn();
+    jest.spyOn(window.history, 'pushState');
     const { getByText, getByDisplayValue } = renderWithRouter(
       <ListPageLayout
-        history={history}
-        location={{ search: '' }}
-        match={match}
         namespace={namespace}
         selectNamespace={selectNamespace}
-      />
+      />,
+      { path, route: `/namespaces/${namespace}/fake/path` }
     );
     fireEvent.click(getByDisplayValue(namespace));
     fireEvent.click(getByText(otherNamespace));
     expect(selectNamespace).not.toHaveBeenCalled();
-    expect(history.push).toHaveBeenCalledWith(
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
       `/namespaces/${otherNamespace}/fake/path`
     );
   });
@@ -97,24 +91,26 @@ describe('ListPageLayout', () => {
       selectedNamespace: namespace,
       selectNamespace
     }));
-    const history = {
-      push: jest.fn()
-    };
+    jest.spyOn(window.history, 'pushState');
     const path = '/namespaces/:namespace/fake/path';
-    const match = { path, params: { namespace } };
     const { getByText, getByDisplayValue } = renderWithRouter(
       <ListPageLayout
-        history={history}
-        location={{ search: '' }}
-        match={match}
         namespace={namespace}
         selectNamespace={selectNamespace}
-      />
+      />,
+      {
+        path,
+        route: `/namespaces/${namespace}/fake/path`
+      }
     );
     fireEvent.click(getByDisplayValue(namespace));
     fireEvent.click(getByText(/All Namespaces/i));
     expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
-    expect(history.push).toHaveBeenCalledWith(`/fake/path`);
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      '/fake/path'
+    );
   });
 
   it('removes namespace from URL when clearing selection', async () => {
@@ -127,23 +123,22 @@ describe('ListPageLayout', () => {
       selectedNamespace: namespace,
       selectNamespace
     }));
-    const history = {
-      push: jest.fn()
-    };
+    jest.spyOn(window.history, 'pushState');
     const path = '/namespaces/:namespace/fake/path';
-    const match = { path, params: { namespace } };
     const { getByTitle } = renderWithRouter(
       <ListPageLayout
-        history={history}
-        location={{ search: '' }}
-        match={match}
         namespace={namespace}
         selectNamespace={selectNamespace}
-      />
+      />,
+      { path, route: `/namespaces/${namespace}/fake/path` }
     );
     fireEvent.click(getByTitle(/clear selected item/i));
     expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
-    expect(history.push).toHaveBeenCalledWith(`/fake/path`);
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      '/fake/path'
+    );
   });
 
   it('does not render namespaces dropdown in single namespace visibility mode', () => {

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -12,8 +12,8 @@ limitations under the License.
 */
 
 import React from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
-import PropTypes from 'prop-types';
 import { DataTable } from 'carbon-components-react';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
@@ -32,9 +32,10 @@ const {
 } = DataTable;
 
 /* istanbul ignore next */
-function PipelineResource(props) {
-  const { intl, location, match } = props;
-  const { namespace, pipelineResourceName: resourceName } = match.params;
+function PipelineResource({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const { namespace, pipelineResourceName: resourceName } = useParams();
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -66,7 +67,7 @@ function PipelineResource(props) {
       }
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={pipelineResource}
       view={view}
     >
@@ -190,14 +191,5 @@ function PipelineResource(props) {
     </ResourceDetails>
   );
 }
-
-PipelineResource.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      namespace: PropTypes.string.isRequired,
-      pipelineResourceName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(PipelineResource);

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -13,6 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useState } from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
@@ -35,12 +36,14 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function PipelineResources(props) {
-  const { history, intl, location, match } = props;
+export function PipelineResources({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
   const filters = getFilters(location);
 
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
 
   const [cancelSelection, setCancelSelection] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
@@ -145,7 +148,6 @@ export function PipelineResources(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
       title="PipelineResources"

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import React, { useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import { PipelineRun, RunAction } from '@tektoncd/dashboard-components';
 import {
   getTaskRunsWithPlaceholders,
@@ -23,7 +22,7 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import { InlineNotification } from 'carbon-components-react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 
 import {
@@ -49,10 +48,12 @@ import {
 
 const { PIPELINE_TASK, RETRY, STEP, VIEW } = queryParamConstants;
 
-export /* istanbul ignore next */ function PipelineRunContainer(props) {
-  const { history, intl, location, match } = props;
+export /* istanbul ignore next */ function PipelineRunContainer({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
 
-  const { namespace, pipelineRunName } = match.params;
+  const { namespace, pipelineRunName } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const currentPipelineTaskName = queryParams.get(PIPELINE_TASK);
@@ -99,7 +100,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
   const {
     data: clusterTasks = [],
     isLoading: isLoadingClusterTasks
-  } = useClusterTasks();
+  } = useClusterTasks({});
 
   const pipelineName = pipelineRun?.spec.pipelineRef?.name;
   const { data: pipeline, isLoading: isLoadingPipeline } = usePipeline(
@@ -199,7 +200,7 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
       queryParams.delete(VIEW);
     }
 
-    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   }
 
@@ -318,11 +319,15 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
           isLoadingClusterTasks ||
           isLoadingPipeline
         }
-        getLogsToolbar={params =>
-          getLogsToolbar({ ...params, externalLogsURL, isUsingExternalLogs })
+        getLogsToolbar={toolbarParams =>
+          getLogsToolbar({
+            ...toolbarParams,
+            externalLogsURL,
+            isUsingExternalLogs
+          })
         }
         maximizedLogsContainer={maximizedLogsContainer.current}
-        onViewChange={getViewChangeHandler(props)}
+        onViewChange={getViewChangeHandler({ history, location })}
         pipelineRun={pipelineRun}
         pod={podDetails}
         runaction={runAction}
@@ -336,13 +341,5 @@ export /* istanbul ignore next */ function PipelineRunContainer(props) {
     </>
   );
 }
-
-PipelineRunContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      pipelineRunName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(PipelineRunContainer);

--- a/src/containers/PipelineRun/PipelineRun.test.js
+++ b/src/containers/PipelineRun/PipelineRun.test.js
@@ -35,13 +35,6 @@ const pipelineRun = {
 };
 
 it('PipelineRunContainer renders data', async () => {
-  const pipelineRunName = 'bar';
-  const match = {
-    params: {
-      pipelineName: 'foo',
-      pipelineRunName
-    }
-  };
   jest
     .spyOn(PipelineRunsAPI, 'usePipelineRun')
     .mockImplementation(() => ({ data: pipelineRun }));
@@ -53,43 +46,24 @@ it('PipelineRunContainer renders data', async () => {
     .spyOn(ClusterTasksAPI, 'useClusterTasks')
     .mockImplementation(() => ({ data: [] }));
 
-  const { getByText } = renderWithRouter(
-    <PipelineRunContainer intl={intl} location={{}} match={match} />
-  );
+  const { getByText } = renderWithRouter(<PipelineRunContainer intl={intl} />);
   await waitFor(() => getByText(pipelineRun.metadata.name));
 });
 
 it('PipelineRunContainer renders not found state', async () => {
-  const pipelineRunName = 'bar';
-  const match = {
-    params: {
-      pipelineName: 'foo',
-      pipelineRunName
-    }
-  };
   jest
     .spyOn(PipelineRunsAPI, 'usePipelineRun')
     .mockImplementation(() => ({ data: null, error: null }));
 
-  const { getByText } = renderWithRouter(
-    <PipelineRunContainer intl={intl} location={{}} match={match} />
-  );
+  const { getByText } = renderWithRouter(<PipelineRunContainer intl={intl} />);
   await waitFor(() => getByText(`PipelineRun not found`));
 });
 
 it('PipelineRunContainer renders error state', async () => {
-  const match = {
-    params: {
-      pipelineName: 'foo',
-      pipelineRunName: 'bar'
-    }
-  };
   jest
     .spyOn(PipelineRunsAPI, 'usePipelineRun')
     .mockImplementation(() => ({ data: null, error: 'some error' }));
 
-  const { getByText } = renderWithRouter(
-    <PipelineRunContainer intl={intl} location={{}} match={match} />
-  );
+  const { getByText } = renderWithRouter(<PipelineRunContainer intl={intl} />);
   await waitFor(() => getByText('Error loading PipelineRun'));
 });

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -13,6 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useEffect, useState } from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
@@ -48,15 +49,17 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function PipelineRuns(props) {
-  const { history, intl, location, match } = props;
+export function PipelineRuns({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
 
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
 
   const filters = getFilters(location);
   const statusFilter = getStatusFilter(location);
-  const setStatusFilter = getStatusFilterHandler(props);
+  const setStatusFilter = getStatusFilterHandler({ history, location });
 
   const pipelineFilter =
     filters.find(filter => filter.indexOf(`${labels.PIPELINE}=`) !== -1) || '';
@@ -301,12 +304,7 @@ export function PipelineRuns(props) {
   );
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="PipelineRuns"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="PipelineRuns">
       <PipelineRunsList
         batchActionButtons={batchActionButtons}
         filters={filtersUI}

--- a/src/containers/PipelineRuns/PipelineRuns.test.js
+++ b/src/containers/PipelineRuns/PipelineRuns.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
@@ -113,27 +112,15 @@ describe('PipelineRuns container', () => {
   });
 
   it('Duplicate label filters are prevented', async () => {
-    const match = {
-      params: {},
-      url: '/pipelineruns'
-    };
-
     const {
       queryByText,
       getByPlaceholderText,
       getByText
     } = renderWithRouter(
-      <Route
-        path="/pipelineruns"
-        render={props => (
-          <PipelineRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <PipelineRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: '/pipelineruns' }
     );
@@ -151,27 +138,15 @@ describe('PipelineRuns container', () => {
   });
 
   it('An invalid filter value is disallowed and reported', async () => {
-    const match = {
-      params: {},
-      url: '/pipelineruns'
-    };
-
     const {
       queryByText,
       getByPlaceholderText,
       getByText
     } = renderWithRouter(
-      <Route
-        path="/pipelineruns"
-        render={props => (
-          <PipelineRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <PipelineRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: '/pipelineruns' }
     );
@@ -191,23 +166,15 @@ describe('PipelineRuns container', () => {
   it('Creation, deletion and stop events are possible when not in read-only mode', async () => {
     jest.spyOn(API, 'useIsReadOnly').mockImplementation(() => false);
 
-    const match = {
-      params: {},
-      url: '/pipelineruns'
-    };
-
-    const { getByText, getAllByTitle, queryAllByText } = renderWithRouter(
-      <Route
-        path="/pipelineruns"
-        render={props => (
-          <PipelineRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+    const {
+      getByText,
+      getAllByTitle,
+      queryAllByText
+    } = renderWithRouter(
+      <PipelineRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: '/pipelineruns' }
     );
@@ -221,28 +188,16 @@ describe('PipelineRuns container', () => {
   it('Creation, deletion and stop events are not possible when in read-only mode', async () => {
     jest.spyOn(API, 'useIsReadOnly').mockImplementation(() => true);
 
-    const match = {
-      params: {},
-      url: '/pipelineruns'
-    };
-
     const {
       getByText,
       queryAllByLabelText,
       queryAllByText,
       queryAllByTitle
     } = renderWithRouter(
-      <Route
-        path="/pipelineruns"
-        render={props => (
-          <PipelineRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <PipelineRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: '/pipelineruns' }
     );
@@ -262,11 +217,10 @@ describe('PipelineRuns container', () => {
       .spyOn(PipelineRunsAPI, 'rerunPipelineRun')
       .mockImplementation(() => []);
     const { getAllByTitle, getByText } = renderWithRouter(
-      <Route
-        path={urls.pipelineRuns.all()}
-        render={props => <PipelineRunsContainer {...props} />}
-      />,
-      { route: urls.pipelineRuns.all() }
+      <PipelineRunsContainer />,
+      {
+        route: urls.pipelineRuns.all()
+      }
     );
     await waitFor(() => getByText(/pipelineRunWithTwoLabels/i));
     fireEvent.click(await waitFor(() => getAllByTitle('Actions')[0]));
@@ -287,11 +241,10 @@ describe('PipelineRuns container', () => {
       .spyOn(PipelineRunsAPI, 'startPipelineRun')
       .mockImplementation(() => []);
     const { getAllByTitle, getByText } = renderWithRouter(
-      <Route
-        path={urls.pipelineRuns.all()}
-        render={props => <PipelineRunsContainer {...props} />}
-      />,
-      { route: urls.pipelineRuns.all() }
+      <PipelineRunsContainer />,
+      {
+        route: urls.pipelineRuns.all()
+      }
     );
     await waitFor(() => getByText(/pipelineRunPending/i));
     fireEvent.click(await waitFor(() => getAllByTitle('Actions')[0]));

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import {
   TrashCan16 as DeleteIcon,
   Playlist16 as RunsIcon
@@ -41,12 +41,13 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function Pipelines(props) {
-  const { intl, location, match } = props;
+export function Pipelines({ intl }) {
+  const location = useLocation();
+  const params = useParams();
   const filters = getFilters(location);
 
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
 
   const [cancelSelection, setCancelSelection] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
@@ -223,12 +224,7 @@ export function Pipelines(props) {
   }));
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="Pipelines"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="Pipelines">
       <Table
         batchActionButtons={batchActionButtons}
         className="tkn--table--inline-actions"

--- a/src/containers/ReadWriteRoute/ReadWriteRoute.js
+++ b/src/containers/ReadWriteRoute/ReadWriteRoute.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,14 +21,9 @@ const ReadWriteRoute = ({
   path,
   ...rest
 }) => (
-  <Route
-    {...rest}
-    exact={exact}
-    path={path}
-    render={props =>
-      isReadOnly ? <Redirect to="/" /> : <Component {...props} />
-    }
-  />
+  <Route {...rest} exact={exact} path={path}>
+    {isReadOnly ? <Redirect to="/" /> : <Component />}
+  </Route>
 );
 
 export default ReadWriteRoute;

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
 import { Link as CarbonLink } from 'carbon-components-react';
@@ -25,9 +25,9 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function ResourceListContainer(props) {
-  const { intl, location, match } = props;
-  const { group, namespace: namespaceParam, version, type } = match.params;
+export function ResourceListContainer({ intl }) {
+  const location = useLocation();
+  const { group, namespace: namespaceParam, version, type } = useParams();
 
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceParam || selectedNamespace;
@@ -85,11 +85,10 @@ export function ResourceListContainer(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
-      title={`${group}/${version}/${type}`}
       hideNamespacesDropdown={!isNamespaced}
+      title={`${group}/${version}/${type}`}
     >
       <Table
         headers={[

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React, { useEffect } from 'react';
-import { matchPath, NavLink } from 'react-router-dom';
+import { matchPath, NavLink, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import {
   SideNav as CarbonSideNav,
@@ -40,14 +40,13 @@ import {
 import { ReactComponent as KubernetesIcon } from '../../images/kubernetes.svg';
 import { ReactComponent as TektonIcon } from '../../images/tekton-logo-20x20.svg';
 
-function SideNav(props) {
-  const { expanded, intl, match, showKubernetesResources } = props;
-
+function SideNav({ expanded, intl, showKubernetesResources }) {
   if (!expanded) {
     return null;
   }
 
-  const { namespace } = match?.params || {};
+  const location = useLocation();
+  const { namespace } = useParams();
 
   const { selectNamespace } = useSelectedNamespace();
   const tenantNamespace = useTenantNamespace();
@@ -65,8 +64,6 @@ function SideNav(props) {
   }, [namespace]);
 
   function getMenuItemProps(to) {
-    const { location } = props;
-
     return {
       element: NavLink,
       isActive: !!matchPath(location.pathname, {

--- a/src/containers/SideNav/SideNav.test.js
+++ b/src/containers/SideNav/SideNav.test.js
@@ -37,20 +37,10 @@ const mockExtensions = [
 ];
 
 it('SideNav renders only when expanded', () => {
-  const namespace = 'default';
-  const { queryByText, rerender } = renderWithRouter(
-    <SideNav
-      expanded
-      location={{ search: '' }}
-      match={{ params: { namespace } }}
-    />
-  );
+  const { queryByText, rerender } = renderWithRouter(<SideNav expanded />);
   expect(queryByText(/Tekton/)).toBeTruthy();
 
-  renderWithRouter(
-    <SideNav location={{ search: '' }} match={{ params: { namespace } }} />,
-    { rerender }
-  );
+  renderWithRouter(<SideNav />, { rerender });
   expect(queryByText(/Tekton/)).toBeFalsy();
 });
 
@@ -58,9 +48,7 @@ it('SideNav renders with extensions', () => {
   jest
     .spyOn(extensionsAPI, 'useExtensions')
     .mockImplementation(() => ({ data: mockExtensions }));
-  const { queryByText } = renderWithRouter(
-    <SideNav expanded location={{ search: '' }} />
-  );
+  const { queryByText } = renderWithRouter(<SideNav expanded />);
   expect(queryByText('Pipelines')).toBeTruthy();
   expect(queryByText('Tasks')).toBeTruthy();
   expect(queryByText(/dashboard_crd_extension/i)).toBeTruthy();
@@ -68,9 +56,7 @@ it('SideNav renders with extensions', () => {
 
 it('SideNav renders with triggers', async () => {
   jest.spyOn(API, 'useIsTriggersInstalled').mockImplementation(() => true);
-  const { queryByText } = renderWithRouter(
-    <SideNav expanded location={{ search: '' }} />
-  );
+  const { queryByText } = renderWithRouter(<SideNav expanded />);
   await waitFor(() => queryByText(/about/i));
   expect(queryByText('Pipelines')).toBeTruthy();
   expect(queryByText('Tasks')).toBeTruthy();
@@ -85,60 +71,29 @@ it('SideNav selects namespace based on URL', () => {
   jest
     .spyOn(APIUtils, 'useSelectedNamespace')
     .mockImplementation(() => ({ selectedNamespace: null, selectNamespace }));
-  const { rerender } = renderWithRouter(
-    <SideNav
-      expanded
-      location={{ search: '' }}
-      match={{ params: { namespace } }}
-      selectNamespace={selectNamespace}
-    />
-  );
+  const path = '/namespaces/:namespace/foo';
+  renderWithRouter(<SideNav expanded selectNamespace={selectNamespace} />, {
+    path,
+    route: `/namespaces/${namespace}/foo`
+  });
   expect(selectNamespace).toHaveBeenCalledWith(namespace);
-
-  const updatedNamespace = 'another';
-
-  renderWithRouter(
-    <SideNav
-      expanded
-      location={{ search: '' }}
-      match={{ params: { namespace: updatedNamespace } }}
-      selectNamespace={selectNamespace}
-    />,
-    { rerender }
-  );
-  expect(selectNamespace).toHaveBeenCalledWith(updatedNamespace);
-
-  renderWithRouter(
-    <SideNav
-      expanded
-      location={{ search: '' }}
-      match={{ params: { namespace: updatedNamespace } }}
-      selectNamespace={selectNamespace}
-    />,
-    { rerender }
-  );
-  expect(selectNamespace).toHaveBeenCalledTimes(2);
 });
 
 it('SideNav renders import in the default read-write mode', async () => {
-  const { queryByText } = renderWithRouter(
-    <SideNav expanded location={{ search: '' }} />
-  );
+  const { queryByText } = renderWithRouter(<SideNav expanded />);
   await waitFor(() => queryByText(/Import/i));
 });
 
 it('SideNav does not render import in read-only mode', async () => {
   jest.spyOn(API, 'useIsReadOnly').mockImplementation(() => true);
-  const { queryByText } = renderWithRouter(
-    <SideNav expanded isReadOnly location={{ search: '' }} />
-  );
+  const { queryByText } = renderWithRouter(<SideNav expanded isReadOnly />);
   await waitFor(() => queryByText(/about/i));
   expect(queryByText(/import/i)).toBeFalsy();
 });
 
 it('SideNav renders kubernetes resources placeholder', async () => {
   const { queryByText } = renderWithRouter(
-    <SideNav expanded location={{ search: '' }} showKubernetesResources />
+    <SideNav expanded showKubernetesResources />
   );
   await waitFor(() => queryByText('placeholder'));
 });

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -14,8 +14,7 @@ limitations under the License.
 
 import React, { useRef, useState } from 'react';
 import { injectIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { InlineNotification, SkeletonText } from 'carbon-components-react';
 import {
   Log,
@@ -77,10 +76,12 @@ function notification({ intl, kind, message }) {
   );
 }
 
-export function TaskRunContainer(props) {
-  const { history, intl, location, match } = props;
+export function TaskRunContainer({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
 
-  const { namespace: namespaceParam, taskRunName } = match.params;
+  const { namespace: namespaceParam, taskRunName } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const selectedStepId = queryParams.get(STEP);
@@ -185,7 +186,7 @@ export function TaskRunContainer(props) {
       queryParams.delete(VIEW);
     }
 
-    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   }
 
@@ -238,7 +239,7 @@ export function TaskRunContainer(props) {
     taskRun
   });
 
-  const onViewChange = getViewChangeHandler(props);
+  const onViewChange = getViewChangeHandler({ history, location });
 
   const rerun = !isReadOnly &&
     !taskRun.metadata?.labels?.['tekton.dev/pipeline'] && (
@@ -328,13 +329,5 @@ export function TaskRunContainer(props) {
     </>
   );
 }
-
-TaskRunContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      taskRunName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(TaskRunContainer);

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import React, { useEffect, useState } from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
@@ -48,10 +49,12 @@ import {
 const { CLUSTER_TASK, TASK } = labels;
 
 /* istanbul ignore next */
-function TaskRuns(props) {
-  const { history, intl, location, match } = props;
+function TaskRuns({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
 
-  const { namespace: namespaceParam } = match.params;
+  const { namespace: namespaceParam } = params;
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceParam || selectedNamespace;
 
@@ -75,7 +78,7 @@ function TaskRuns(props) {
       ? clusterTaskFilter.replace(`${CLUSTER_TASK}=`, '')
       : taskFilter.replace(`${TASK}=`, '');
 
-  const setStatusFilter = getStatusFilterHandler(props);
+  const setStatusFilter = getStatusFilterHandler({ history, location });
 
   useTitleSync({ page: 'TaskRuns' });
 
@@ -290,12 +293,7 @@ function TaskRuns(props) {
   );
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="TaskRuns"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="TaskRuns">
       <TaskRunsList
         batchActionButtons={batchActionButtons}
         filters={statusFilters}

--- a/src/containers/TaskRuns/TaskRuns.test.js
+++ b/src/containers/TaskRuns/TaskRuns.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { Route } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
@@ -69,27 +68,15 @@ describe('TaskRuns container', () => {
   });
 
   it('Duplicate label filters are prevented', async () => {
-    const match = {
-      params: {},
-      url: urls.taskRuns.all()
-    };
-
     const {
       queryByText,
       getByPlaceholderText,
       getByText
     } = renderWithRouter(
-      <Route
-        path={urls.taskRuns.all()}
-        render={props => (
-          <TaskRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <TaskRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: urls.taskRuns.all() }
     );
@@ -107,27 +94,15 @@ describe('TaskRuns container', () => {
   });
 
   it('An invalid filter value is disallowed and reported', async () => {
-    const match = {
-      params: {},
-      url: urls.taskRuns.all()
-    };
-
     const {
       queryByText,
       getByPlaceholderText,
       getByText
     } = renderWithRouter(
-      <Route
-        path={urls.taskRuns.all()}
-        render={props => (
-          <TaskRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <TaskRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: urls.taskRuns.all() }
     );
@@ -147,23 +122,11 @@ describe('TaskRuns container', () => {
   it('TaskRun actions are available when not in read-only mode', async () => {
     jest.spyOn(API, 'useIsReadOnly').mockImplementation(() => false);
 
-    const match = {
-      params: {},
-      url: urls.taskRuns.all()
-    };
-
     const { getAllByTitle, getByText } = renderWithRouter(
-      <Route
-        path={urls.taskRuns.all()}
-        render={props => (
-          <TaskRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <TaskRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: urls.taskRuns.all() }
     );
@@ -175,27 +138,15 @@ describe('TaskRuns container', () => {
   it('TaskRun actions are not available when in read-only mode', async () => {
     jest.spyOn(API, 'useIsReadOnly').mockImplementation(() => true);
 
-    const match = {
-      params: {},
-      url: urls.taskRuns.all()
-    };
-
     const {
       getByText,
       queryAllByLabelText,
       queryAllByTitle
     } = renderWithRouter(
-      <Route
-        path={urls.taskRuns.all()}
-        render={props => (
-          <TaskRunsContainer
-            {...props}
-            match={match}
-            error={null}
-            loading={false}
-            namespace="namespace-1"
-          />
-        )}
+      <TaskRunsContainer
+        error={null}
+        loading={false}
+        namespace="namespace-1"
       />,
       { route: urls.taskRuns.all() }
     );
@@ -209,10 +160,7 @@ describe('TaskRuns container', () => {
     jest.spyOn(API, 'useIsReadOnly').mockImplementation(() => false);
     jest.spyOn(taskRunsAPI, 'rerunTaskRun').mockImplementation(() => []);
     const { getAllByTitle, getByText } = renderWithRouter(
-      <Route
-        path={urls.taskRuns.all()}
-        render={props => <TaskRunsContainer {...props} />}
-      />,
+      <TaskRunsContainer />,
       { route: urls.taskRuns.all() }
     );
     await waitFor(() => getByText(/taskRunWithTwoLabels/i));

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import { Button, Link as CarbonLink } from 'carbon-components-react';
@@ -41,11 +41,12 @@ import {
   useTasks
 } from '../../api';
 
-function Tasks(props) {
-  const { intl, location, match } = props;
+function Tasks({ intl }) {
+  const location = useLocation();
+  const params = useParams();
 
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
 
   const [deleteError, setDeleteError] = useState(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -220,12 +221,7 @@ function Tasks(props) {
   }));
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="Tasks"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="Tasks">
       <Table
         batchActionButtons={batchActionButtons}
         className="tkn--table--inline-actions"

--- a/src/containers/Trigger/Trigger.js
+++ b/src/containers/Trigger/Trigger.js
@@ -12,17 +12,19 @@ limitations under the License.
 */
 
 import React from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
-import PropTypes from 'prop-types';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
 
 import { useTrigger } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export function TriggerContainer(props) {
-  const { location, match } = props;
-  const { triggerName, namespace } = match.params;
+export function TriggerContainer() {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
+  const { triggerName, namespace } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -41,7 +43,7 @@ export function TriggerContainer(props) {
     <ResourceDetails
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={trigger}
       view={view}
     >
@@ -53,13 +55,5 @@ export function TriggerContainer(props) {
     </ResourceDetails>
   );
 }
-
-TriggerContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      triggerName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(TriggerContainer);

--- a/src/containers/Trigger/Trigger.test.js
+++ b/src/containers/Trigger/Trigger.test.js
@@ -16,7 +16,7 @@ import { waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
 
 import * as API from '../../api/triggers';
-import { render, renderWithRouter } from '../../utils/test';
+import { renderWithRouter } from '../../utils/test';
 import { TriggerContainer } from './Trigger';
 
 const intl = createIntl({
@@ -26,20 +26,12 @@ const intl = createIntl({
 
 describe('TriggerContainer', () => {
   it('handles error state', async () => {
-    const match = {
-      params: {
-        triggerName: 'bar'
-      }
-    };
-
     const errorMessage = 'fake_errorMessage';
     jest
       .spyOn(API, 'useTrigger')
       .mockImplementation(() => ({ error: errorMessage }));
 
-    const { getByText } = render(
-      <TriggerContainer intl={intl} location={{}} match={match} />
-    );
+    const { getByText } = renderWithRouter(<TriggerContainer intl={intl} />);
     await waitFor(() => getByText('Error loading resource'));
     expect(getByText(errorMessage)).toBeTruthy();
   });
@@ -47,23 +39,20 @@ describe('TriggerContainer', () => {
   it('renders the trigger resource', async () => {
     const triggerName = 'fake_triggerName';
     const templateName = 'fake_templateName';
-    const match = {
-      params: {
-        triggerName,
-        namespace: 'default'
-      }
-    };
+    const namespace = 'fake_namespace';
 
     jest.spyOn(API, 'useTrigger').mockImplementation(() => ({
       data: {
-        metadata: { name: triggerName },
+        metadata: { name: triggerName, namespace },
         spec: { template: { ref: templateName } }
       }
     }));
 
-    const { queryByText } = renderWithRouter(
-      <TriggerContainer intl={intl} location={{}} match={match} />
-    );
+    const path = '/namespaces/:namespace/triggers/:triggerName';
+    const { queryByText } = renderWithRouter(<TriggerContainer intl={intl} />, {
+      path,
+      route: `/namespaces/${namespace}/triggers/${triggerName}`
+    });
     expect(queryByText(triggerName)).toBeTruthy();
     expect(queryByText(templateName)).toBeTruthy();
   });

--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
@@ -20,9 +20,11 @@ import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { useSelectedNamespace, useTriggerBinding } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export function TriggerBindingContainer(props) {
-  const { intl, location, match } = props;
-  const { namespace, triggerBindingName: resourceName } = match.params;
+export function TriggerBindingContainer({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const params = useParams();
+  const { namespace, triggerBindingName: resourceName } = params;
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -73,7 +75,7 @@ export function TriggerBindingContainer(props) {
     <ResourceDetails
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={triggerBinding}
       view={view}
     >
@@ -92,13 +94,5 @@ export function TriggerBindingContainer(props) {
     </ResourceDetails>
   );
 }
-
-TriggerBindingContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      triggerBindingName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(TriggerBindingContainer);

--- a/src/containers/TriggerBinding/TriggerBinding.test.js
+++ b/src/containers/TriggerBinding/TriggerBinding.test.js
@@ -12,10 +12,9 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Route } from 'react-router-dom';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { urls } from '@tektoncd/dashboard-utils';
 
 import * as API from '../../api/triggerBindings';
 import { renderWithRouter } from '../../utils/test';
@@ -70,14 +69,9 @@ const triggerBindingWithLabels = {
 it('TriggerBindingContainer handles error state', async () => {
   const error = 'fake_error_message';
   jest.spyOn(API, 'useTriggerBinding').mockImplementation(() => ({ error }));
-  const match = {
-    params: {
-      triggerBindingName: 'foo'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerBindingContainer intl={intl} location={{}} match={match} />
+    <TriggerBindingContainer intl={intl} />
   );
   await waitFor(() => getByText('Error loading resource'));
 });
@@ -86,14 +80,9 @@ it('TriggerBindingContainer renders details', async () => {
   jest
     .spyOn(API, 'useTriggerBinding')
     .mockImplementation(() => ({ data: triggerBindingSimple }));
-  const match = {
-    params: {
-      triggerBindingName: 'trigger-binding-simple'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerBindingContainer intl={intl} location={{}} match={match} />
+    <TriggerBindingContainer intl={intl} />
   );
 
   await waitFor(() => getByText('trigger-binding-simple'));
@@ -112,10 +101,7 @@ it('TriggerBindingContainer renders YAML', async () => {
   const triggerBindingName = 'trigger-binding-simple';
 
   const { getByText } = renderWithRouter(
-    <Route
-      path={paths.triggerBindings.byName()}
-      render={props => <TriggerBindingContainer {...props} intl={intl} />}
-    />,
+    <TriggerBindingContainer intl={intl} />,
     {
       route: urls.triggerBindings.byName({
         namespace,
@@ -139,14 +125,9 @@ it('TriggerBindingContainer does not render label section if they are not presen
   jest
     .spyOn(API, 'useTriggerBinding')
     .mockImplementation(() => ({ data: triggerBindingSimple }));
-  const match = {
-    params: {
-      triggerBindingName: 'trigger-binding-simple'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerBindingContainer intl={intl} location={{}} match={match} />
+    <TriggerBindingContainer intl={intl} />
   );
 
   await waitFor(() => getByText('trigger-binding-simple'));
@@ -157,14 +138,9 @@ it('TriggerBindingContainer renders labels section if they are present', async (
   jest
     .spyOn(API, 'useTriggerBinding')
     .mockImplementation(() => ({ data: triggerBindingWithLabels }));
-  const match = {
-    params: {
-      triggerBindingName: 'trigger-binding-labels'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerBindingContainer intl={intl} location={{}} match={match} />
+    <TriggerBindingContainer intl={intl} />
   );
 
   await waitFor(() => getByText('trigger-binding-labels'));

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,12 +21,13 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { ListPageLayout } from '..';
 import { useSelectedNamespace, useTriggerBindings } from '../../api';
 
-export function TriggerBindings(props) {
-  const { intl, location, match } = props;
+export function TriggerBindings({ intl }) {
+  const location = useLocation();
+  const params = useParams();
   const filters = getFilters(location);
 
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
 
   useTitleSync({ page: 'TriggerBindings' });
 
@@ -84,7 +85,6 @@ export function TriggerBindings(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
       title="TriggerBindings"

--- a/src/containers/TriggerBindings/TriggerBindings.test.js
+++ b/src/containers/TriggerBindings/TriggerBindings.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { Route } from 'react-router-dom';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
@@ -48,13 +47,9 @@ describe('TriggerBindings', () => {
       .spyOn(TriggerBindingsAPI, 'useTriggerBindings')
       .mockImplementation(() => ({ data: [] }));
 
-    const { getByText } = renderWithRouter(
-      <Route
-        path="/triggerbindings"
-        render={props => <TriggerBindings {...props} />}
-      />,
-      { route: '/triggerbindings' }
-    );
+    const { getByText } = renderWithRouter(<TriggerBindings />, {
+      route: '/triggerbindings'
+    });
 
     expect(getByText('TriggerBindings')).toBeTruthy();
     expect(getByText('No matching TriggerBindings found')).toBeTruthy();
@@ -65,13 +60,9 @@ describe('TriggerBindings', () => {
       .spyOn(TriggerBindingsAPI, 'useTriggerBindings')
       .mockImplementation(() => ({ data: [triggerBinding] }));
 
-    const { queryByText } = renderWithRouter(
-      <Route
-        path="/triggerbindings"
-        render={props => <TriggerBindings {...props} />}
-      />,
-      { route: '/triggerbindings' }
-    );
+    const { queryByText } = renderWithRouter(<TriggerBindings />, {
+      route: '/triggerbindings'
+    });
 
     expect(queryByText('TriggerBindings')).toBeTruthy();
     expect(queryByText('No matching TriggerBindings found')).toBeFalsy();
@@ -89,13 +80,7 @@ describe('TriggerBindings', () => {
       queryByText,
       getByPlaceholderText,
       getByText
-    } = renderWithRouter(
-      <Route
-        path="/triggerbindings"
-        render={props => <TriggerBindings {...props} />}
-      />,
-      { route: '/triggerbindings' }
-    );
+    } = renderWithRouter(<TriggerBindings />, { route: '/triggerbindings' });
 
     const filterValue = 'baz:bam';
     const filterInputField = getByPlaceholderText(/Input a label filter/);
@@ -111,13 +96,9 @@ describe('TriggerBindings', () => {
       .spyOn(TriggerBindingsAPI, 'useTriggerBindings')
       .mockImplementation(() => ({ isLoading: true }));
 
-    const { queryByText } = renderWithRouter(
-      <Route
-        path="/triggerbindings"
-        render={props => <TriggerBindings {...props} />}
-      />,
-      { route: '/triggerbindings' }
-    );
+    const { queryByText } = renderWithRouter(<TriggerBindings />, {
+      route: '/triggerbindings'
+    });
 
     expect(queryByText(/TriggerBindings/i)).toBeTruthy();
     expect(queryByText('No matching TriggerBindings found')).toBeFalsy();
@@ -130,13 +111,9 @@ describe('TriggerBindings', () => {
       .spyOn(TriggerBindingsAPI, 'useTriggerBindings')
       .mockImplementation(() => ({ error }));
 
-    const { queryByText } = renderWithRouter(
-      <Route
-        path="/triggerbindings"
-        render={props => <TriggerBindings {...props} />}
-      />,
-      { route: '/triggerbindings' }
-    );
+    const { queryByText } = renderWithRouter(<TriggerBindings />, {
+      route: '/triggerbindings'
+    });
 
     expect(queryByText(error)).toBeTruthy();
   });

--- a/src/containers/TriggerTemplate/TriggerTemplate.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { DataTable } from 'carbon-components-react';
 import {
@@ -38,9 +38,10 @@ const {
   TableRow
 } = DataTable;
 
-export /* istanbul ignore next */ function TriggerTemplateContainer(props) {
-  const { intl, location, match } = props;
-  const { namespace, triggerTemplateName: resourceName } = match.params;
+export /* istanbul ignore next */ function TriggerTemplateContainer({ intl }) {
+  const history = useHistory();
+  const location = useLocation();
+  const { namespace, triggerTemplateName: resourceName } = useParams();
 
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
@@ -206,7 +207,7 @@ export /* istanbul ignore next */ function TriggerTemplateContainer(props) {
     <ResourceDetails
       error={error}
       loading={isFetching}
-      onViewChange={getViewChangeHandler(props)}
+      onViewChange={getViewChangeHandler({ history, location })}
       resource={triggerTemplate}
       view={view}
     >
@@ -214,13 +215,5 @@ export /* istanbul ignore next */ function TriggerTemplateContainer(props) {
     </ResourceDetails>
   );
 }
-
-TriggerTemplateContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      triggerTemplateName: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
 
 export default injectIntl(TriggerTemplateContainer);

--- a/src/containers/TriggerTemplate/TriggerTemplate.test.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.test.js
@@ -12,10 +12,9 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Route } from 'react-router-dom';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { createIntl } from 'react-intl';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { urls } from '@tektoncd/dashboard-utils';
 
 import * as API from '../../api/triggerTemplates';
 import { renderWithRouter } from '../../utils/test';
@@ -185,14 +184,9 @@ const fakeTriggerTemplateWithLabels = {
 it('TriggerTemplateContainer handles error state', async () => {
   const error = 'fake_error_message';
   jest.spyOn(API, 'useTriggerTemplate').mockImplementation(() => ({ error }));
-  const match = {
-    params: {
-      triggerTemplateName: 'foo'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerTemplateContainer intl={intl} location={{}} match={match} />
+    <TriggerTemplateContainer intl={intl} />
   );
   await waitFor(() => getByText('Error loading resource'));
 });
@@ -201,14 +195,9 @@ it('TriggerTemplateContainer renders', async () => {
   jest
     .spyOn(API, 'useTriggerTemplate')
     .mockImplementation(() => ({ data: fakeTriggerTemplate }));
-  const match = {
-    params: {
-      triggerTemplateName: 'pipeline-template'
-    }
-  };
 
   const { getAllByText, getByText } = renderWithRouter(
-    <TriggerTemplateContainer intl={intl} location={{}} match={match} />
+    <TriggerTemplateContainer intl={intl} />
   );
   await waitFor(() => getByText(/pipeline-template/i));
   await waitFor(() => getByText('Default'));
@@ -234,14 +223,9 @@ it('TriggerTemplateContainer contains overview tab with accurate information', a
   jest
     .spyOn(API, 'useTriggerTemplate')
     .mockImplementation(() => ({ data: fakeTriggerTemplate }));
-  const match = {
-    params: {
-      triggerTemplateName: 'pipeline-template'
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerTemplateContainer intl={intl} location={{}} match={match} />
+    <TriggerTemplateContainer intl={intl} />
   );
   await waitFor(() => getByText('pipeline-template'));
   const overviewTab = getByText(/overview/i);
@@ -255,10 +239,7 @@ it('TriggerTemplateContainer contains YAML tab with accurate information', async
     .spyOn(API, 'useTriggerTemplate')
     .mockImplementation(() => ({ data: fakeTriggerTemplate }));
   const { getByText } = renderWithRouter(
-    <Route
-      path={paths.triggerTemplates.byName()}
-      render={props => <TriggerTemplateContainer {...props} intl={intl} />}
-    />,
+    <TriggerTemplateContainer intl={intl} />,
     {
       route: urls.triggerTemplates.byName({
         namespace,
@@ -282,14 +263,9 @@ it('TriggerTemplateContainer does not render label section if they are not prese
   jest
     .spyOn(API, 'useTriggerTemplate')
     .mockImplementation(() => ({ data: fakeTriggerTemplate }));
-  const match = {
-    params: {
-      triggerTemplateName: 'pipeline-template'
-    }
-  };
 
   const { getByText, queryByText } = renderWithRouter(
-    <TriggerTemplateContainer intl={intl} location={{}} match={match} />
+    <TriggerTemplateContainer intl={intl} />
   );
 
   await waitFor(() => getByText('pipeline-template'));
@@ -300,14 +276,9 @@ it('TriggerTemplateContainer renders labels section if they are present', async 
   jest
     .spyOn(API, 'useTriggerTemplate')
     .mockImplementation(() => ({ data: fakeTriggerTemplateWithLabels }));
-  const match = {
-    params: {
-      triggerTemplateName
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerTemplateContainer intl={intl} location={{}} match={match} />
+    <TriggerTemplateContainer intl={intl} />
   );
 
   await waitFor(() => getByText(triggerTemplateName));
@@ -324,14 +295,9 @@ it('TriggerTemplateContainer contains formatted labels', async () => {
   jest
     .spyOn(API, 'useTriggerTemplate')
     .mockImplementation(() => ({ data: fakeTriggerTemplateWithLabels }));
-  const match = {
-    params: {
-      triggerTemplateName
-    }
-  };
 
   const { getByText } = renderWithRouter(
-    <TriggerTemplateContainer intl={intl} location={{}} match={match} />
+    <TriggerTemplateContainer intl={intl} />
   );
 
   await waitFor(() => getByText(triggerTemplateName));

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,14 +21,14 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { ListPageLayout } from '..';
 import { useSelectedNamespace, useTriggerTemplates } from '../../api';
 
-function TriggerTemplates(props) {
-  const { intl, location, match } = props;
-
+function TriggerTemplates({ intl }) {
   useTitleSync({ page: 'TriggerTemplates' });
 
+  const location = useLocation();
+  const params = useParams();
   const filters = getFilters(location);
   const { selectedNamespace: defaultNamespace } = useSelectedNamespace();
-  const { namespace: selectedNamespace = defaultNamespace } = match.params;
+  const { namespace: selectedNamespace = defaultNamespace } = params;
 
   const {
     data: triggerTemplates = [],
@@ -85,7 +85,6 @@ function TriggerTemplates(props) {
 
   return (
     <ListPageLayout
-      {...props}
       error={getError()}
       filters={filters}
       title="TriggerTemplates"

--- a/src/containers/TriggerTemplates/TriggerTemplates.test.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.test.js
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { Route } from 'react-router-dom';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
@@ -45,13 +44,9 @@ it('TriggerTemplates renders with no templates', () => {
     .spyOn(APIUtils, 'useSelectedNamespace')
     .mockImplementation(() => ({ selectedNamespace: ALL_NAMESPACES }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/triggerTemplates"
-      render={props => <TriggerTemplates {...props} />}
-    />,
-    { route: '/triggerTemplates' }
-  );
+  const { queryByText } = renderWithRouter(<TriggerTemplates />, {
+    route: '/triggerTemplates'
+  });
 
   expect(queryByText('TriggerTemplates')).toBeTruthy();
   expect(queryByText('No matching TriggerTemplates found')).toBeTruthy();
@@ -62,13 +57,9 @@ it('TriggerTemplates renders with one template', () => {
     .spyOn(TriggerTemplatesAPI, 'useTriggerTemplates')
     .mockImplementation(() => ({ data: [triggerTemplate] }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/triggerTemplates"
-      render={props => <TriggerTemplates {...props} />}
-    />,
-    { route: '/triggerTemplates' }
-  );
+  const { queryByText } = renderWithRouter(<TriggerTemplates />, {
+    route: '/triggerTemplates'
+  });
 
   expect(queryByText(/TriggerTemplates/i)).toBeTruthy();
   expect(queryByText('No matching TriggerTemplates found')).toBeFalsy();
@@ -86,13 +77,7 @@ it('TriggerTemplates can be filtered on a single label filter', async () => {
     queryByText,
     getByPlaceholderText,
     getByText
-  } = renderWithRouter(
-    <Route
-      path="/triggerTemplates"
-      render={props => <TriggerTemplates {...props} />}
-    />,
-    { route: '/triggerTemplates' }
-  );
+  } = renderWithRouter(<TriggerTemplates />, { route: '/triggerTemplates' });
 
   const filterValue = 'baz:bam';
   const filterInputField = getByPlaceholderText(/Input a label filter/);
@@ -108,13 +93,9 @@ it('TriggerTemplates renders in loading state', () => {
     .spyOn(TriggerTemplatesAPI, 'useTriggerTemplates')
     .mockImplementation(() => ({ isLoading: true }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/triggerTemplates"
-      render={props => <TriggerTemplates {...props} />}
-    />,
-    { route: '/triggerTemplates' }
-  );
+  const { queryByText } = renderWithRouter(<TriggerTemplates />, {
+    route: '/triggerTemplates'
+  });
 
   expect(queryByText(/TriggerTemplates/i)).toBeTruthy();
   expect(queryByText('No matching TriggerTemplates found')).toBeFalsy();
@@ -126,13 +107,9 @@ it('TriggerTemplates renders in error state', () => {
     .spyOn(TriggerTemplatesAPI, 'useTriggerTemplates')
     .mockImplementation(() => ({ error }));
 
-  const { queryByText } = renderWithRouter(
-    <Route
-      path="/triggerTemplates"
-      render={props => <TriggerTemplates {...props} />}
-    />,
-    { route: '/triggerTemplates' }
-  );
+  const { queryByText } = renderWithRouter(<TriggerTemplates />, {
+    route: '/triggerTemplates'
+  });
 
   expect(queryByText(error)).toBeTruthy();
 });

--- a/src/containers/Triggers/Triggers.js
+++ b/src/containers/Triggers/Triggers.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Table } from '@tektoncd/dashboard-components';
@@ -21,13 +21,14 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { ListPageLayout } from '..';
 import { useSelectedNamespace, useTriggers } from '../../api';
 
-function Triggers(props) {
-  const { intl, location, match } = props;
+function Triggers({ intl }) {
   useTitleSync({ page: 'Triggers' });
 
+  const location = useLocation();
+  const params = useParams();
   const filters = getFilters(location);
   const { selectedNamespace } = useSelectedNamespace();
-  const { namespace = selectedNamespace } = match.params;
+  const { namespace = selectedNamespace } = params;
 
   const { data: triggers = [], error, isLoading } = useTriggers({
     filters,
@@ -93,12 +94,7 @@ function Triggers(props) {
   }));
 
   return (
-    <ListPageLayout
-      {...props}
-      error={getError()}
-      filters={filters}
-      title="Triggers"
-    >
+    <ListPageLayout error={getError()} filters={filters} title="Triggers">
       <Table
         headers={headers}
         rows={triggersFormatted}

--- a/src/containers/Triggers/Triggers.test.js
+++ b/src/containers/Triggers/Triggers.test.js
@@ -12,8 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Route } from 'react-router-dom';
-import { paths, urls } from '@tektoncd/dashboard-utils';
+import { urls } from '@tektoncd/dashboard-utils';
 
 import { renderWithRouter } from '../../utils/test';
 import * as API from '../../api/triggers';
@@ -28,13 +27,9 @@ describe('Triggers', () => {
     jest
       .spyOn(API, 'useTriggers')
       .mockImplementation(() => ({ isLoading: true }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.triggers.all()}
-        render={props => <TriggersContainer {...props} />}
-      />,
-      { route: urls.triggers.all() }
-    );
+    const { queryByText } = renderWithRouter(<TriggersContainer />, {
+      route: urls.triggers.all()
+    });
     expect(queryByText('Triggers')).toBeTruthy();
   });
 
@@ -53,13 +48,9 @@ describe('Triggers', () => {
         }
       ]
     }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.triggers.all()}
-        render={props => <TriggersContainer {...props} />}
-      />,
-      { route: urls.triggers.all() }
-    );
+    const { queryByText } = renderWithRouter(<TriggersContainer />, {
+      route: urls.triggers.all()
+    });
 
     expect(queryByText('triggerWithSingleLabel')).toBeTruthy();
   });
@@ -69,13 +60,9 @@ describe('Triggers', () => {
     jest
       .spyOn(API, 'useTriggers')
       .mockImplementation(() => ({ error: errorMessage }));
-    const { queryByText } = renderWithRouter(
-      <Route
-        path={paths.triggers.all()}
-        render={props => <TriggersContainer {...props} />}
-      />,
-      { route: urls.triggers.all() }
-    );
+    const { queryByText } = renderWithRouter(<TriggersContainer />, {
+      route: urls.triggers.all()
+    });
 
     expect(queryByText(errorMessage)).toBeTruthy();
   });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -124,13 +124,13 @@ export function isValidLabel(type, value) {
   return regex.test(value);
 }
 
-export function getViewChangeHandler({ history, location, match }) {
+export function getViewChangeHandler({ history, location }) {
   return function handleViewChange(view) {
     const queryParams = new URLSearchParams(location.search);
 
     queryParams.set('view', view);
 
-    const browserURL = match.url.concat(`?${queryParams.toString()}`);
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
     history.push(browserURL);
   };
 }

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -231,9 +231,8 @@ describe('getLogsRetriever', () => {
 it('getViewChangeHandler', () => {
   const url = 'someURL';
   const history = { push: jest.fn() };
-  const location = { search: '?nonViewQueryParam=someValue' };
-  const match = { url };
-  const handleViewChange = getViewChangeHandler({ history, location, match });
+  const location = { pathname: url, search: '?nonViewQueryParam=someValue' };
+  const handleViewChange = getViewChangeHandler({ history, location });
   const view = 'someView';
   handleViewChange(view);
   expect(history.push).toHaveBeenCalledWith(


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The next release of react-router (v6) makes some changes to the way
routes are defined and behave. The `render` and `component` props
should no longer be used in v5.1+ to prepare for this change, instead
favouring `children`.

Instead of passing through the `location` and `match` props from the
`Route`, we should instead retrieve them when / where needed via the
hooks provided by `react-router`, i.e. `useLocation`, `useParams`, etc.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
