### PR TITLE
 Add margin to prevent "Clear all btn" from moving fix #2062

### DIFF
--- a/packages/components/src/components/LabelFilter/LabelFilter.scss
+++ b/packages/components/src/components/LabelFilter/LabelFilter.scss
@@ -29,6 +29,10 @@ limitations under the License.
       flex-shrink: 0;
       margin: $spacing-05 $spacing-03 0 0;
     }
+
+    .bx--btn {
+      margin-top: calc(#{$spacing-04} - 1px );
+    }
   }
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fix #2062 

The "filter" has  `.bx--tag` class and the "Clear All button" has `.bx--btn` class.
`.bx--tag` class has margin but `.bx--btn` class has not margin. So, there was a gap between when there was a "filter" on the left and when there was no "filter".

I add margin to `.bx--btn` class to prevent "Clear all button" from moving.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
