### PR TITLE
Improve display of syntax highlighted content

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,6 +39,5 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/*.test.js',
     '<rootDir>/packages/**/src/**/*.test.js'
-  ],
-  transformIgnorePatterns: ['/node_modules/(?!(react-syntax-highlighter)/)']
+  ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14883,7 +14883,6 @@
         "linkify-it": "^3.0.2",
         "prop-types": "^15.7.2",
         "react-intl-formatted-duration": "^4.0.0",
-        "react-syntax-highlighter": "^15.4.3",
         "react-window": "^1.8.6",
         "tlds": "^1.208.0"
       },
@@ -14957,18 +14956,6 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
-          }
-        },
-        "react-syntax-highlighter": {
-          "version": "15.4.3",
-          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz",
-          "integrity": "sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "highlight.js": "^10.4.1",
-            "lowlight": "^1.17.0",
-            "prismjs": "^1.22.0",
-            "refractor": "^3.2.0"
           }
         },
         "readdirp": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,6 @@
     "linkify-it": "^3.0.2",
     "prop-types": "^15.7.2",
     "react-intl-formatted-duration": "^4.0.0",
-    "react-syntax-highlighter": "^15.4.3",
     "react-window": "^1.8.6",
     "tlds": "^1.208.0"
   },

--- a/packages/components/src/components/StepDefinition/StepDefinition.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.js
@@ -23,6 +23,7 @@ class StepDefinition extends PureComponent {
     return (
       <>
         <ViewYAML
+          dark
           enableSyntaxHighlighting
           resource={
             definition ||

--- a/packages/components/src/components/StepDefinition/StepDefinition.test.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.test.js
@@ -17,13 +17,7 @@ import StepDefinition from './StepDefinition';
 
 it('StepDefinition renders default content', () => {
   const { queryByText } = render(<StepDefinition taskRun={{}} />);
-  // due to an issue with the react-syntax-highlighter
-  // the message is rendered in multiple spans (space delimited)
-  // TODO: revert this when react-syntax-highlighter is updated or we replace it
-  expect(queryByText(/Step/i)).toBeTruthy();
-  expect(queryByText(/definition/i)).toBeTruthy();
-  expect(queryByText(/not/i)).toBeTruthy();
-  expect(queryByText(/available/i)).toBeTruthy();
+  expect(queryByText(/Step definition not available/i)).toBeTruthy();
 });
 
 it('StepDefinition renders the provided content', () => {
@@ -38,10 +32,6 @@ it('StepDefinition renders the provided content', () => {
 
   expect(queryByText(/--someArg/)).toBeTruthy();
   expect(queryByText('test-name')).toBeTruthy();
-  // due to an issue with the react-syntax-highlighter
-  // these strings are rendered in multiple spans (space delimited)
-  // TODO: revert this when react-syntax-highlighter is updated or we replace it
-  expect(queryByText('Input')).toBeNull();
-  expect(queryByText('resources')).toBeNull();
-  expect(queryByText('Output')).toBeNull();
+  expect(queryByText('Input resources')).toBeNull();
+  expect(queryByText('Output resources')).toBeNull();
 });

--- a/packages/components/src/components/StepStatus/StepStatus.js
+++ b/packages/components/src/components/StepStatus/StepStatus.js
@@ -19,6 +19,7 @@ import { ViewYAML } from '..';
 const StepStatus = ({ intl, status }) => (
   <div className="tkn--step-status">
     <ViewYAML
+      dark
       enableSyntaxHighlighting
       resource={
         status ||

--- a/packages/components/src/components/StepStatus/StepStatus.test.js
+++ b/packages/components/src/components/StepStatus/StepStatus.test.js
@@ -18,12 +18,7 @@ import { render } from '../../utils/test';
 describe('StepStatus', () => {
   it('renders default content', () => {
     const { queryByText } = render(<StepStatus />);
-    // due to an issue with the react-syntax-highlighter
-    // the message is rendered in 3 spans (space delimited)
-    // TODO: revert this when react-syntax-highlighter is updated or we replace it
-    expect(queryByText(/Status/i)).toBeTruthy();
-    expect(queryByText(/not/i)).toBeTruthy();
-    expect(queryByText(/available/i)).toBeTruthy();
+    expect(queryByText(/Status not available/i)).toBeTruthy();
   });
 
   it('renders the provided content', () => {

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -256,6 +256,7 @@ const TaskRunDetails = ({
         >
           <div className="tkn--step-status">
             <ViewYAML
+              dark
               enableSyntaxHighlighting
               resource={
                 taskRun.status ||
@@ -289,10 +290,14 @@ const TaskRunDetails = ({
                 </ContentSwitcher>
               ) : null}
               {podContent === 'resource' ? (
-                <ViewYAML enableSyntaxHighlighting resource={pod.resource} />
+                <ViewYAML
+                  dark
+                  enableSyntaxHighlighting
+                  resource={pod.resource}
+                />
               ) : null}
               {hasEvents && podContent === 'events' ? (
-                <ViewYAML enableSyntaxHighlighting resource={pod.events} />
+                <ViewYAML dark enableSyntaxHighlighting resource={pod.events} />
               ) : null}
             </div>
           </Tab>

--- a/packages/components/src/components/ViewYAML/SyntaxHighlighter.js
+++ b/packages/components/src/components/ViewYAML/SyntaxHighlighter.js
@@ -1,0 +1,199 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+import React from 'react';
+import jsYaml from 'js-yaml';
+
+function addLine({ addBullet, key, level, lines, path, rawString, value }) {
+  let valueNode;
+
+  if (rawString) {
+    valueNode = (
+      <>
+        <span className="hljs-string">{value}</span>
+      </>
+    );
+  } else if (value === null) {
+    valueNode = (
+      <>
+        <span> </span>
+        <span className="hljs-literal">null</span>
+      </>
+    );
+  } else if (typeof value === 'string') {
+    if (value.includes('\n')) {
+      // only display the literal block style indicator,
+      // the actual value will be handled later
+      valueNode = (
+        <>
+          <span> </span>
+          <span className="hljs-string">|</span>
+        </>
+      );
+    } else {
+      // wrap value in quotes if it could be mistaken for another type,
+      // e.g. 'False', '123'
+      valueNode = (
+        <>
+          <span> </span>
+          <span className="hljs-string">
+            {jsYaml.dump(value, { lineWidth: -1 })}
+          </span>
+        </>
+      );
+    }
+  } else if (typeof value === 'number') {
+    valueNode = (
+      <>
+        <span> </span>
+        <span className="hljs-number">{value}</span>
+      </>
+    );
+  } else if (typeof value === 'boolean') {
+    valueNode = (
+      <>
+        <span> </span>
+        <span className="hljs-literal">{value.toString()}</span>
+      </>
+    );
+  } else if (Array.isArray(value) && value.length === 0) {
+    valueNode = (
+      <>
+        <span> </span>
+        <span>[]</span>
+      </>
+    );
+  } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+    valueNode = (
+      <>
+        <span> </span>
+        <span>{'{}'}</span>
+      </>
+    );
+  }
+
+  let indent;
+  if (level) {
+    const spaces = '  '.repeat(level - (addBullet ? 1 : 0));
+    indent = <span>{spaces}</span>;
+  }
+
+  let bullet;
+  if (!rawString) {
+    bullet = <span className="hljs-bullet">-</span>;
+  }
+
+  lines.push(
+    <span className="tkn--code-line" key={`${path}.${key}`}>
+      <span className="tkn--code-line-content">
+        {indent}
+        {addBullet ? <span className="hljs-bullet">- </span> : null}
+        {typeof key === 'number' ? (
+          bullet
+        ) : (
+          <span className="hljs-attr">{`${jsYaml.dump(key).trim()}:`}</span>
+        )}
+        {valueNode}
+      </span>
+    </span>
+  );
+
+  if (!value) {
+    return;
+  }
+
+  const newPath = `${path}.${key}`;
+
+  if (typeof value === 'string' && value.includes('\n')) {
+    // add a new code line for each line of a multiline string value
+    // preserving the correct indentation and skipping any additional
+    // formatting of the content
+    value.split('\n').forEach((line, index) =>
+      addLine({
+        key: index,
+        level: level + 1,
+        lines,
+        path,
+        rawString: true,
+        value: line
+      })
+    );
+  } else if (Array.isArray(value)) {
+    const valueToUse = [...value];
+    let offset = 0;
+    if (typeof key === 'number' && valueToUse.length) {
+      // first item of a nested array appears on the same line as the parent
+      offset = 1;
+      lines.pop();
+      const firstItem = valueToUse.shift();
+      addLine({
+        addBullet: true,
+        key: 0,
+        level: level + 1,
+        lines,
+        path: newPath,
+        value: firstItem
+      });
+    }
+
+    valueToUse.forEach((arrayItem, index) =>
+      addLine({
+        key: index + offset,
+        level: level + 1,
+        lines,
+        path: newPath,
+        value: arrayItem
+      })
+    );
+  } else if (typeof value === 'object') {
+    const valueToUse = { ...value };
+    if (typeof key === 'number' && Object.keys(valueToUse).length) {
+      // first key of an object in an array appears on same line as the parent
+      lines.pop();
+      const firstKey = Object.keys(valueToUse).shift();
+      addLine({
+        addBullet: true,
+        key: firstKey,
+        level: level + 1,
+        lines,
+        path: newPath,
+        value: valueToUse[firstKey]
+      });
+      delete valueToUse[firstKey];
+    }
+
+    getLines({ level: level + 1, lines, path: newPath, resource: valueToUse }); // eslint-disable-line no-use-before-define
+  }
+}
+
+function getLines({ level = 0, lines, path, resource }) {
+  return Object.keys(resource).reduce((acc, key) => {
+    addLine({ key, level, lines: acc, path, value: resource[key] });
+    return acc;
+  }, lines);
+}
+
+export default function SyntaxHighlighter({ resource }) {
+  const lines = getLines({ lines: [], path: '', resource });
+  const minWidth = `${lines.length.toString().length - 1}rem`;
+
+  return (
+    <pre
+      className="tkn--syntax-highlighter bx--snippet--multi hljs"
+      style={{ '--tkn--line-number--min-width': minWidth }}
+    >
+      <code>{lines}</code>
+    </pre>
+  );
+}

--- a/packages/components/src/components/ViewYAML/ViewYAML.js
+++ b/packages/components/src/components/ViewYAML/ViewYAML.js
@@ -15,23 +15,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import jsYaml from 'js-yaml';
 import classNames from 'classnames';
-import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import yamlRules from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
-
-SyntaxHighlighter.registerLanguage('yaml', yamlRules);
-
-function YAMLHighlighter({ children, className }) {
-  return (
-    <SyntaxHighlighter
-      className={className}
-      language="yaml"
-      showLineNumbers
-      useInlineStyles={false}
-    >
-      {children}
-    </SyntaxHighlighter>
-  );
-}
+import SyntaxHighlighter from './SyntaxHighlighter';
 
 function YAMLRaw({ children, className }) {
   return (
@@ -50,16 +34,21 @@ function ViewYAML({
   resource,
   title
 }) {
-  const clz = classNames('bx--snippet--multi', className, {
-    'tkn--view-yaml--dark': dark
-  });
-  const yaml = jsYaml.dump(resource);
-  const Wrapper = enableSyntaxHighlighting ? YAMLHighlighter : YAMLRaw;
+  let yamlComponent;
+  if (enableSyntaxHighlighting && typeof resource !== 'string') {
+    yamlComponent = <SyntaxHighlighter resource={resource} />;
+  } else {
+    const clz = classNames('bx--snippet--multi', className, {
+      'tkn--view-yaml--dark': dark
+    });
+    const yaml = jsYaml.dump(resource);
+    yamlComponent = <YAMLRaw className={clz}>{yaml}</YAMLRaw>;
+  }
 
   return (
     <>
       {title && <span className="tkn--view-yaml--title">{title}</span>}
-      <Wrapper className={clz}>{yaml}</Wrapper>
+      {yamlComponent}
     </>
   );
 }

--- a/packages/components/src/components/ViewYAML/ViewYAML.scss
+++ b/packages/components/src/components/ViewYAML/ViewYAML.scss
@@ -25,6 +25,29 @@ limitations under the License.
   }
 }
 
+pre.tkn--syntax-highlighter {
+  white-space: pre-wrap;
+}
+
+.tkn--code-line {
+  counter-increment: tkn--code-line;
+  display: inline-flex;
+  width: 100%;
+}
+
+.tkn--code-line::before {
+  content: counter(tkn--code-line);
+  display: inline-block;
+  text-align: right;
+  min-width: var(--tkn--line-number--min-width, 1rem);
+  padding-right: 1rem;
+  user-select: none;
+}
+
+.tkn--code-line-content {
+  display: inline-block;
+}
+
 .bx--snippet--multi {
   max-width: none;
 
@@ -33,8 +56,8 @@ limitations under the License.
     background: #2b2b2b;
     color: #f8f8f2;
 
-    .react-syntax-highlighter-line-number {
-      color: #f8f8f2;
+    .tkn--code-line::before {
+      color: #b8b8b8;
     }
 
     .hljs-comment {

--- a/packages/components/src/components/ViewYAML/ViewYAML.test.js
+++ b/packages/components/src/components/ViewYAML/ViewYAML.test.js
@@ -57,11 +57,21 @@ it('YAML renders correctly', () => {
   expect(getByText(/value: valueParameter1/i)).toBeTruthy();
 });
 
-it('render syntax highlight', () => {
+it('renders syntax highlight', () => {
   const props = {
     resource,
     enableSyntaxHighlighting: true
   };
   const { container } = render(<ViewYAML {...props} />);
   expect(container.firstChild.className).toMatch(/hljs/);
+});
+
+it('renders title', () => {
+  const title = 'fake_title';
+  const props = {
+    resource,
+    title
+  };
+  const { queryByText } = render(<ViewYAML {...props} />);
+  expect(queryByText(title)).toBeTruthy();
 });

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
@@ -19,9 +20,7 @@ import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { useClusterTriggerBinding } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export /* istanbul ignore next */ function ClusterTriggerBindingContainer({
-  intl
-}) {
+export function ClusterTriggerBindingContainer({ intl }) {
   const history = useHistory();
   const location = useLocation();
   const params = useParams();

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* istanbul ignore file */
 
 import React from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
@@ -21,7 +22,7 @@ import { Link as CarbonLink } from 'carbon-components-react';
 import { useEventListener } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export /* istanbul ignore next */ function EventListenerContainer({ intl }) {
+export function EventListenerContainer({ intl }) {
   const history = useHistory();
   const location = useLocation();
   const params = useParams();


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- reduce number of DOM nodes output. Treat whole value as a single unit
  instead of relying on string parsing to split / tokenise and detect type on
  individual parts
- as a result of this change we now render all strings correctly instead of
  occasionally detecting them as a different type (e.g. IP addresses were
  regularly detected as type number, or parts of a UUID would be detected as a
  number and highlighted separately from the surrounding string content)
- remove dependency on react-syntax-highlighter, highlight.js, and related
  packages, reduces bundle size
- remove workaround for jest config as we no longer load react-syntax-highlighter
- remove workaround in tests due to react-syntax-highlighter splitting values,
  we can now reliably assert on values within a single element
- handle line wrapping so content does not appear below line numbers

Examples of some problematic content in previous version:

String incorrectly detected as number:
![image](https://user-images.githubusercontent.com/2829095/137141529-f51628c1-2ada-4695-a8e7-02a40095a848.png)

Part of UUID incorrectly detected as number:
![image](https://user-images.githubusercontent.com/2829095/137141609-e3dafabb-9d1f-4356-958e-7ccd7b1f826d.png)

Part of string ('no') incorrectly detected as boolean:
![image](https://user-images.githubusercontent.com/2829095/137141680-db981753-410c-4c77-a81c-8ef581410c55.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
