### PR TITLE
chore: Add node selector to run dashboard on Linux nodes

### DIFF
--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -51,6 +51,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
         - name: tekton-dashboard
           image: dashboardImage


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Now with [Windows support](https://github.com/tektoncd/pipeline/issues/1826) on the way, many may also want to run the dashboard in a mixed Kubernetes cluster with Windows and Linux nodes. To make sure the dashboard deployment isn't scheduled to a Windows node, I added a node selector.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added) **-> not needed**
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing) **-> not needed**
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
