### PR TITLE
Remove dependency on yq in e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -140,15 +140,14 @@ function dump_cluster_state() {
 # $1 = File name
 # $2 = HTTP Method
 # $3 = Endpoint
-# Assuming a yaml k8s resource file, do envsubst replacement as well as conversion into json. This payload is then curled as specified.
-function json_curl_envsubst_resource() {
+# Assuming a yaml k8s resource file, do envsubst replacement. This payload is then curled as specified.
+function curl_envsubst_resource() {
   if [ $# -ne 3 ];then
     echo "File/HTTP-Method/Endpoint not found."
     exit 1
   fi
-  yq --version
   set -x
-  cat "$1" | envsubst | yq e -j - | curl -sS -X "$2" --data-binary @- -H "Content-Type: application/json" "$3" -H "Tekton-Client: tektoncd/dashboard"
+  cat "$1" | envsubst | curl -sS -X "$2" --data-binary @- -H "Content-Type: application/yaml" "$3" -H "Tekton-Client: tektoncd/dashboard"
   set +x
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -107,7 +107,7 @@ test_dashboard() {
     echo "Creating resources using the dashboard proxy..."
     pipelineRunFiles=($(find ${tekton_repo_dir}/test/resources/envsubst -iname "pipelinerun*.yaml"))
     for file in ${pipelineRunFiles[@]};do
-      json_curl_envsubst_resource "${file}" "POST" "${TEKTON_PROXY_URL}/pipelineruns" || fail_test "Failed to create pipelinerun: ${file}"
+      curl_envsubst_resource "${file}" "POST" "${TEKTON_PROXY_URL}/pipelineruns" || fail_test "Failed to create pipelinerun: ${file}"
     done
   else
     fail_test "Unknown resources creation method: ${creationMethod}"

--- a/test/local-e2e-tests.sh
+++ b/test/local-e2e-tests.sh
@@ -34,11 +34,6 @@ verifySupported() {
     exit 1
   fi
 
-  if ! type "yq" > /dev/null; then
-    echo "yq is required"
-    exit 1
-  fi
-
   if ! type "ko" > /dev/null; then
     echo "ko is required"
     exit 1

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -51,14 +51,8 @@ source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-te
 function utility_install() {
   # Install envsubst
   apt-get install gettext-base
-  # Get yaml-to-json converter
-  echo "Getting yq"
-  wget https://github.com/mikefarah/yq/releases/download/v4.6.0/yq_linux_amd64 .
-
-  chmod +x yq_linux_amd64
-  mv yq_linux_amd64 /bin/yq
-  echo "yq being used from $(which yq), version is: $(yq --version)"
 }
+
 function get_node() {
   echo "Script is running as $(whoami) on $(hostname)"
   # It's Stretch and https://github.com/tektoncd/dashboard/blob/main/package.json


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The tests use yq to transform a YAML file to JSON to POST to the k8s
API server. This is an unnecessary step as we can POST the YAML as-is.

Removing the dependency on yq simplifies the script, reduces overhead
in running the tests as we no longer need to install the tool, and
reduces potential failure points.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
