### PR TITLE
Add support for Tekton Bundles

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -419,10 +419,16 @@ export function getTaskRunsWithPlaceholders({
       .concat(pipeline?.spec?.tasks)
       .concat(pipelineRun?.spec?.pipelineSpec?.tasks);
   }
-  pipelineTasks = pipelineTasks
-    .concat(pipeline?.spec?.finally)
-    .concat(pipelineRun?.spec?.pipelineSpec?.finally)
-    .filter(Boolean);
+  if (pipelineRun?.status?.pipelineSpec?.finally) {
+    pipelineTasks = pipelineTasks.concat(
+      pipelineRun.status.pipelineSpec.finally
+    );
+  } else {
+    pipelineTasks = pipelineTasks
+      .concat(pipeline?.spec?.finally)
+      .concat(pipelineRun?.spec?.pipelineSpec?.finally);
+  }
+  pipelineTasks = pipelineTasks.filter(Boolean);
 
   const taskRunsToDisplay = [];
   pipelineTasks.forEach(pipelineTask => {

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -50,9 +50,14 @@ export function getStepDefinition({ selectedStepId, task, taskRun }) {
     return null;
   }
 
-  const stepDefinitions =
-    (taskRun.spec?.taskSpec ? taskRun.spec.taskSpec.steps : task.spec?.steps) ||
-    [];
+  let stepDefinitions = [];
+  if (taskRun.status?.taskSpec?.steps) {
+    stepDefinitions = taskRun.status.taskSpec.steps;
+  } else if (taskRun.spec?.taskSpec?.steps) {
+    stepDefinitions = taskRun.spec.taskSpec.steps;
+  } else if (task?.spec?.steps) {
+    stepDefinitions = task.spec.steps;
+  }
 
   const definition = stepDefinitions?.find(
     step => step.name === selectedStepId
@@ -405,9 +410,16 @@ export function getTaskRunsWithPlaceholders({
   taskRuns,
   tasks
 }) {
-  const pipelineTasks = []
-    .concat(pipeline?.spec?.tasks)
-    .concat(pipelineRun?.spec?.pipelineSpec?.tasks)
+  let pipelineTasks = [];
+
+  if (pipelineRun?.status?.pipelineSpec?.tasks) {
+    pipelineTasks = pipelineTasks.concat(pipelineRun.status.pipelineSpec.tasks);
+  } else {
+    pipelineTasks = pipelineTasks
+      .concat(pipeline?.spec?.tasks)
+      .concat(pipelineRun?.spec?.pipelineSpec?.tasks);
+  }
+  pipelineTasks = pipelineTasks
     .concat(pipeline?.spec?.finally)
     .concat(pipelineRun?.spec?.pipelineSpec?.finally)
     .filter(Boolean);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Resolves https://github.com/tektoncd/dashboard/issues/2087

Add support for PipelineRun and TaskRun from a Tekton Bundle. The usual details for a PipelineRun or TaskRun are now properly rendered in the Dashboard UI, when they are defined in a tekton bundle.

For example: 
```---
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: my-pipeline-1
spec:
  pipelineRef:
    name: my-pipeline
    bundle: grc.io/my-catalog/my-pipeline:0.1
  params: []
```

Bundles doc: https://tekton.dev/docs/pipelines/pipelines/#tekton-bundles


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
