### PR TITLE
Include stepTemplate in step definition details tab

### DIFF
--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -14,6 +14,7 @@ limitations under the License.
 import { labels } from '@tektoncd/dashboard-utils';
 
 import {
+  applyStepTemplate,
   formatLabels,
   generateId,
   getAddFilterHandler,
@@ -294,6 +295,37 @@ describe('getResources', () => {
     });
     expect(inputResources).toEqual(fakeInputResources);
     expect(outputResources).toEqual(fakeOutputResources);
+  });
+});
+
+it('applyStepTemplate', () => {
+  const stepTemplate = {
+    args: ['some_args'],
+    command: ['sh'],
+    env: [
+      { name: 'env1', value: 'value1' },
+      { name: 'env2', value: 'value2' }
+    ],
+    image: 'alpine',
+    ports: [{ containerPort: 8888 }, { containerPort: 7777, name: 'my-port' }]
+  };
+
+  const step = {
+    args: ['step_args'],
+    env: [
+      { name: 'env1', value: 'step_value1' },
+      { name: 'env3', value: 'step_value3' }
+    ],
+    image: 'ubuntu',
+    ports: [{ containerPort: 7777, name: 'my-step-port' }]
+  };
+
+  expect(applyStepTemplate({ step, stepTemplate })).toEqual({
+    args: step.args,
+    command: stepTemplate.command,
+    env: [step.env[0], stepTemplate.env[1], step.env[1]],
+    image: step.image,
+    ports: [stepTemplate.ports[0], step.ports[0]]
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Combine the step definition with the (optional) step template
and display the result in the details tab. The merge is accomplished
following the rules defined in the k8s apimachinery strategicpatch
according to the strategy defined by the Container struct (on which
the step is based).

The strategy is:
- fields defined in the step override those from the template
- fields with a list merge strategy defined are treated differently
  - any matching entry in the template list is replaced by the
    corresponding entry from the step list. Matches are determined
    based on a defined key in the list items.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
