### PR TITLE
Add support for specifying tag to installer script used for releases

### DIFF
--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -77,6 +77,7 @@ Accepted options:
         [--platform <platform>]                 Override the platform to build for
         [--read-only]                           Will build manifests for a readonly deployment
         [--stream-logs false]                   Will disable log streaming and use polling instead
+        [--tag <tag>]                           Tag used for the image produced by ko
         [--tenant-namespace <namespace>]        Will limit the visibility to the specified namespace only
         [--triggers-namespace <namespace>]      Override the namespace where Tekton Triggers is installed (defaults to tekton-pipelines)
         [--version <version>]                   Will download manifests for specified version or build everything using kustomize/ko

--- a/scripts/installer
+++ b/scripts/installer
@@ -394,7 +394,8 @@ help () {
   echo -e "\t[--pipelines-namespace <namespace>]\tOverride the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)"
   echo -e "\t[--platform <platform>]\t\t\tOverride the platform to build for"
   echo -e "\t[--read-only]\t\t\t\tWill build manifests for a readonly deployment"
-  echo -e "\t[--stream-logs false]\t\t\t\tWill disable log streaming and use polling instead"
+  echo -e "\t[--stream-logs false]\t\t\tWill disable log streaming and use polling instead"
+  echo -e "\t[--tag <tag>]\t\t\t\tTag used for the image produced by ko"
   echo -e "\t[--tenant-namespace <namespace>]\tWill limit the visibility to the specified namespace only"
   echo -e "\t[--triggers-namespace <namespace>]\tOverride the namespace where Tekton Triggers is installed (defaults to tekton-pipelines)"
   echo -e "\t[--version <version>]\t\t\tWill download manifests for specified version or build everything using kustomize/ko"
@@ -518,6 +519,10 @@ while [[ $# -gt 0 ]]; do
     '--platform')
       shift
       KO_RESOLVE_OPTIONS="$KO_RESOLVE_OPTIONS --platform=${1}"
+      ;;
+    '--tag')
+      shift
+      KO_RESOLVE_OPTIONS="$KO_RESOLVE_OPTIONS -t ${1}"
       ;;
     *)
       echo "ERROR: Unknown option $1"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add a new `--tag` flag which can be specified by the release pipeline
to ensure the images produced by `ko resolve` are correctly tagged with
the release version.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
