### PR TITLE
Surface details of step onError continue in lists and details

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.js
@@ -53,7 +53,7 @@ class DetailsHeader extends Component {
   }
 
   statusLabel() {
-    const { intl, reason, status, taskRun } = this.props;
+    const { exitCode, hasWarning, intl, reason, status, taskRun } = this.props;
     const { reason: taskReason, status: taskStatus } = getStatus(taskRun);
 
     if (
@@ -75,10 +75,18 @@ class DetailsHeader extends Component {
     }
     if (status === 'terminated') {
       if (reason === 'Completed') {
-        return intl.formatMessage({
-          id: 'dashboard.taskRun.status.succeeded',
-          defaultMessage: 'Completed'
-        });
+        return hasWarning
+          ? intl.formatMessage(
+              {
+                id: 'dashboard.taskRun.status.succeeded.warning',
+                defaultMessage: 'Completed with exit code {exitCode}'
+              },
+              { exitCode }
+            )
+          : intl.formatMessage({
+              id: 'dashboard.taskRun.status.succeeded',
+              defaultMessage: 'Completed'
+            });
       }
       return intl.formatMessage({
         id: 'dashboard.taskRun.status.failed',
@@ -100,7 +108,13 @@ class DetailsHeader extends Component {
   }
 
   render() {
-    const { intl, displayName, taskRun, type = 'step' } = this.props;
+    const {
+      displayName,
+      hasWarning,
+      intl,
+      taskRun,
+      type = 'step'
+    } = this.props;
     let { reason, status } = this.props;
     let statusLabel;
 
@@ -127,6 +141,7 @@ class DetailsHeader extends Component {
         <h2 className="tkn--details-header--heading">
           <StatusIcon
             DefaultIcon={DefaultIcon}
+            hasWarning={hasWarning}
             reason={reason}
             status={status}
             {...(type === 'step' ? { type: 'inverse' } : null)}

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.scss
@@ -49,6 +49,12 @@ header.tkn--step-details-header {
         top: -1px;
         left: -1px;
       }
+
+      &.tkn--status-icon--warning.tkn--status-icon--type-normal {
+        width: 28px;
+        height: 28px;
+        margin-right: 0.5rem;
+      }
     }
 
     > .tkn--status-label {

--- a/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -66,6 +66,19 @@ export const Completed = args => (
     {...args}
   />
 );
+
+export const CompletedWithWarning = args => (
+  <DetailsHeader
+    exitCode={1}
+    hasWarning
+    reason="Completed"
+    status="terminated"
+    displayName="build"
+    taskRun={getTaskRun({ reason: 'Succeeded', status: 'True' })}
+    {...args}
+  />
+);
+CompletedWithWarning.storyName = 'Completed with warning';
 
 export const Failed = args => (
   <DetailsHeader

--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.js
@@ -36,46 +36,54 @@ const task = {
   }
 };
 
-const taskRun = {
-  metadata: { labels: {}, name: 'sampleTaskRunName', namespace: 'default' },
-  spec: {
-    params: {},
-    resources: {
-      inputs: {},
-      outputs: {}
+function getTaskRun({ exitCode = 0, name }) {
+  return {
+    metadata: { labels: {}, name, namespace: 'default', uid: name },
+    spec: {
+      params: {},
+      resources: {
+        inputs: {},
+        outputs: {}
+      },
+      serviceAccountName: 'default',
+      taskRef: { kind: 'Task', name: 'task1' },
+      timeout: '24h0m0s'
     },
-    serviceAccountName: 'default',
-    taskRef: { kind: 'Task', name: 'task1' },
-    timeout: '24h0m0s'
-  },
-  status: {
-    completionTime: '2019-08-21T17:15:31Z',
-    conditions: [
-      {
-        lastTransitionTime: '2019-08-21T17:15:31Z',
-        message: 'All Steps have completed executing',
-        reason: 'Succeeded',
-        status: 'True',
-        type: 'Succeeded'
-      }
-    ],
-    podName: 'sample-task-run-pod-name',
-    startTime: '2019-08-21T17:12:21Z',
-    steps: [
-      {
-        name: 'build',
-        terminated: {
-          containerID:
-            'docker://88659459cb477936d2ee859822b024bf02768c9ff3dd048f7d8af85843064f95',
-          exitCode: 0,
-          finishedAt: '2019-08-21T17:12:29Z',
-          reason: 'Completed',
-          startedAt: '2019-08-21T17:12:26Z'
+    status: {
+      completionTime: '2019-08-21T17:15:31Z',
+      conditions: [
+        {
+          lastTransitionTime: '2019-08-21T17:15:31Z',
+          message: 'All Steps have completed executing',
+          reason: 'Succeeded',
+          status: 'True',
+          type: 'Succeeded'
         }
-      }
-    ]
-  }
-};
+      ],
+      podName: `sample-task-run-pod-name-${name}`,
+      startTime: '2019-08-21T17:12:21Z',
+      steps: [
+        {
+          name: 'build',
+          terminated: {
+            containerID:
+              'docker://88659459cb477936d2ee859822b024bf02768c9ff3dd048f7d8af85843064f95',
+            exitCode,
+            finishedAt: '2019-08-21T17:12:29Z',
+            reason: 'Completed',
+            startedAt: '2019-08-21T17:12:26Z'
+          }
+        }
+      ]
+    }
+  };
+}
+
+const taskRun = getTaskRun({ name: 'sampleTaskRunName' });
+const taskRunWithWarning = getTaskRun({
+  exitCode: 1,
+  name: 'sampleTaskRunName2'
+});
 
 const pipelineRun = {
   metadata: {
@@ -102,33 +110,11 @@ const pipelineRun = {
     taskRuns: {
       sampleTaskRunName: {
         pipelineTaskName: 'task1',
-        status: {
-          completionTime: '2019-08-21T17:15:31Z',
-          conditions: [
-            {
-              lastTransitionTime: '2019-08-21T17:15:31Z',
-              message: 'All Steps have completed executing',
-              reason: 'Succeeded',
-              status: 'True',
-              type: 'Succeeded'
-            }
-          ],
-          podName: 'sample-task-run-pod-name',
-          startTime: '2019-08-21T17:12:21Z',
-          steps: [
-            {
-              name: 'build',
-              terminated: {
-                containerID:
-                  'docker://88659459cb477936d2ee859822b024bf02768c9ff3dd048f7d8af85843064f95',
-                exitCode: 0,
-                finishedAt: '2019-08-21T17:12:29Z',
-                reason: 'Completed',
-                startedAt: '2019-08-21T17:12:26Z'
-              }
-            }
-          ]
-        }
+        status: taskRun.status
+      },
+      sampleTaskRunName2: {
+        pipelineTaskName: 'task2',
+        status: taskRunWithWarning.status
       }
     }
   }
@@ -153,7 +139,7 @@ export const Base = () => {
       pipelineRun={pipelineRun}
       selectedStepId={selectedStepId}
       selectedTaskId={selectedTaskId}
-      taskRuns={[taskRun]}
+      taskRuns={[taskRun, taskRunWithWarning]}
       tasks={[task]}
     />
   );

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -15,7 +15,7 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { StatusIcon, Table } from '@tektoncd/dashboard-components';
-import { getStatus, urls } from '@tektoncd/dashboard-utils';
+import { getStatus, taskRunHasWarning, urls } from '@tektoncd/dashboard-utils';
 import { Pending24 as DefaultIcon } from '@carbon/icons-react';
 import { Link as CarbonLink } from 'carbon-components-react';
 
@@ -40,8 +40,20 @@ const PipelineRuns = ({
   },
   getPipelineRunStatusIcon = pipelineRun => {
     const { reason, status } = getStatus(pipelineRun);
+    let hasWarning = false;
+    if (status === 'True' && reason === 'Succeeded') {
+      hasWarning = Object.values(
+        pipelineRun.status?.taskRuns || {}
+      ).some(taskRun => taskRunHasWarning(taskRun));
+    }
+
     return (
-      <StatusIcon DefaultIcon={DefaultIcon} reason={reason} status={status} />
+      <StatusIcon
+        DefaultIcon={DefaultIcon}
+        hasWarning={hasWarning}
+        reason={reason}
+        status={status}
+      />
     );
   },
   getPipelineRunStatusTooltip = (pipelineRun, intl) => {

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.scss
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.scss
@@ -18,5 +18,11 @@ limitations under the License.
     margin-right: 0.5em;
     vertical-align: sub;
     flex-shrink: 0;
+
+    &.tkn--status-icon--warning {
+      width: 24px;
+      height: 24px;
+      margin-top: 1px;
+    }
   }
 }

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -137,6 +137,51 @@ export const Base = () => (
               }
             }
           ]
+        }
+      },
+      {
+        metadata: {
+          name: 'pipeline-run-20211118145503',
+          namespace: 'cb4552a6-b2d7-45e2-9773-3d4ca33909ff',
+          uid: '90cde04b-ef64-4e3a-a74c-9cd7f78738d2',
+          creationTimestamp: '2021-11-18T14:55:00Z'
+        },
+        spec: {
+          pipelineRef: {
+            name: 'pipeline'
+          }
+        },
+        status: {
+          conditions: [
+            {
+              lastTransitionTime: '2021-11-18T14:58:47Z',
+              message: 'All Tasks have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded'
+            }
+          ],
+          taskRuns: {
+            foo: {
+              status: {
+                conditions: [
+                  {
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded'
+                  }
+                ],
+                steps: [
+                  {
+                    terminated: {
+                      exitCode: 1,
+                      reason: 'Completed'
+                    }
+                  }
+                ]
+              }
+            }
+          }
         }
       }
     ]}

--- a/packages/components/src/components/StatusIcon/StatusIcon.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.js
@@ -15,10 +15,12 @@ import React from 'react';
 import classNames from 'classnames';
 import {
   CheckmarkFilled20 as CheckmarkFilled,
+  CheckmarkFilledWarning20 as CheckmarkFilledWarning,
   CheckmarkOutline20 as CheckmarkOutline,
   CloseFilled20 as CloseFilled,
   CloseOutline20 as CloseOutline,
-  Time20 as Pending
+  Time20 as Pending,
+  WarningAltFilled20 as WarningFilled
 } from '@carbon/icons-react';
 import { isRunning } from '@tektoncd/dashboard-utils';
 
@@ -30,23 +32,26 @@ const icons = {
     error: CloseFilled,
     pending: Pending,
     running: Spinner,
-    success: CheckmarkFilled
+    success: CheckmarkFilled,
+    warning: CheckmarkFilledWarning
   },
   inverse: {
     cancelled: CloseOutline,
     error: CloseOutline,
     pending: Pending,
     running: Spinner,
-    success: CheckmarkOutline
+    success: CheckmarkOutline,
+    warning: WarningFilled
   }
 };
 
 export default function StatusIcon({
   DefaultIcon,
-  type = 'normal',
+  hasWarning,
   reason,
   status,
-  title
+  title,
+  type = 'normal'
 }) {
   let statusClass;
   if (
@@ -60,7 +65,7 @@ export default function StatusIcon({
     status === 'True' ||
     (status === 'terminated' && reason === 'Completed')
   ) {
-    statusClass = 'success';
+    statusClass = hasWarning ? 'warning' : 'success';
   } else if (
     status === 'False' &&
     (reason === 'PipelineRunCancelled' || reason === 'TaskRunCancelled')
@@ -79,9 +84,13 @@ export default function StatusIcon({
 
   return Icon ? (
     <Icon
-      className={classNames('tkn--status-icon', {
-        [`tkn--status-icon--${statusClass}`]: statusClass
-      })}
+      className={classNames(
+        'tkn--status-icon',
+        {
+          [`tkn--status-icon--${statusClass}`]: statusClass
+        },
+        `tkn--status-icon--type-${type}`
+      )}
     >
       {title && <title>{title}</title>}
     </Icon>

--- a/packages/components/src/components/StatusIcon/StatusIcon.scss
+++ b/packages/components/src/components/StatusIcon/StatusIcon.scss
@@ -31,4 +31,18 @@ limitations under the License.
   &--success {
     fill: $support-02;
   }
+
+  &--warning {
+    &.tkn--status-icon--type-normal {
+      fill: $support-02;
+
+      path:nth-child(2) {
+        fill: $support-03;
+      }
+    }
+
+    &.tkn--status-icon--type-inverse {
+      fill: $support-03;
+    }
+  }
 }

--- a/packages/components/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -45,5 +45,10 @@ export const Running = args => (
 );
 
 export const Succeeded = args => <StatusIcon status="True" {...args} />;
+
+export const SucceededWithWarning = args => (
+  <StatusIcon hasWarning status="True" {...args} />
+);
+SucceededWithWarning.storyName = 'Succeeded with warning';
 
 export const Failed = args => <StatusIcon status="False" {...args} />;

--- a/packages/components/src/components/Step/Step.js
+++ b/packages/components/src/components/Step/Step.js
@@ -26,7 +26,7 @@ class Step extends Component {
   };
 
   statusLabel() {
-    const { intl, reason, status } = this.props;
+    const { exitCode, intl, reason, status } = this.props;
 
     if (
       status === 'cancelled' ||
@@ -48,10 +48,18 @@ class Step extends Component {
 
     if (status === 'terminated') {
       if (reason === 'Completed') {
-        return intl.formatMessage({
-          id: 'dashboard.taskRun.status.succeeded',
-          defaultMessage: 'Completed'
-        });
+        return exitCode !== 0
+          ? intl.formatMessage(
+              {
+                id: 'dashboard.taskRun.status.succeeded.warning',
+                defaultMessage: 'Completed with exit code {exitCode}'
+              },
+              { exitCode }
+            )
+          : intl.formatMessage({
+              id: 'dashboard.taskRun.status.succeeded',
+              defaultMessage: 'Completed'
+            });
       }
       return intl.formatMessage({
         id: 'dashboard.taskRun.status.failed',
@@ -73,7 +81,7 @@ class Step extends Component {
   }
 
   render() {
-    const { reason, selected, status, stepName } = this.props;
+    const { exitCode, reason, selected, status, stepName } = this.props;
     const statusLabel = this.statusLabel();
 
     return (
@@ -91,10 +99,11 @@ class Step extends Component {
         >
           <StatusIcon
             DefaultIcon={DefaultIcon}
-            type="inverse"
+            hasWarning={exitCode !== 0}
             reason={reason}
             status={status}
             title={statusLabel}
+            type="inverse"
           />
           <span className="tkn--step-name" title={stepName}>
             {stepName}

--- a/packages/components/src/components/Step/Step.stories.js
+++ b/packages/components/src/components/Step/Step.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import { action } from '@storybook/addon-actions';
 import Step from './Step';
 
 const props = {
+  exitCode: 0,
   onSelect: action('selected'),
   stepName: 'build'
 };
@@ -42,6 +43,11 @@ export const Running = () => <Step {...props} status="running" />;
 export const Completed = () => (
   <Step {...props} status="terminated" reason="Completed" />
 );
+
+export const CompletedWithWarning = () => (
+  <Step {...props} exitCode={1} status="terminated" reason="Completed" />
+);
+CompletedWithWarning.storyName = 'Completed with warning';
 
 export const Error = () => (
   <Step {...props} status="terminated" reason="Error" />

--- a/packages/components/src/components/Step/Step.test.js
+++ b/packages/components/src/components/Step/Step.test.js
@@ -63,9 +63,16 @@ it('Step renders cancelled state for TaskRunTimeout', () => {
 
 it('Step renders completed state', () => {
   const { queryByText } = render(
-    <Step status="terminated" reason="Completed" />
+    <Step exitCode={0} status="terminated" reason="Completed" />
   );
   expect(queryByText(/Completed/i)).toBeTruthy();
+});
+
+it('Step renders completed with warning state', () => {
+  const { queryByText } = render(
+    <Step exitCode={1} status="terminated" reason="Completed" />
+  );
+  expect(queryByText(/Completed with exit code 1/i)).toBeTruthy();
 });
 
 it('Step renders error state', () => {

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -31,7 +31,7 @@ const StepDetails = props => {
     taskRun,
     view
   } = props;
-  const { reason, status } = getStepStatusReason(stepStatus);
+  const { exitCode, reason, status } = getStepStatusReason(stepStatus);
   const statusValue =
     getStatus(taskRun).reason === 'TaskRunCancelled' && status !== 'terminated'
       ? 'cancelled'
@@ -46,6 +46,8 @@ const StepDetails = props => {
     <div className="tkn--step-details">
       <DetailsHeader
         displayName={stepName}
+        exitCode={exitCode}
+        hasWarning={exitCode !== 0}
         reason={reason}
         status={statusValue}
         stepStatus={stepStatus}

--- a/packages/components/src/components/StepDetails/StepDetails.stories.js
+++ b/packages/components/src/components/StepDetails/StepDetails.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2021 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,15 +16,18 @@ import { Log } from '..';
 
 import StepDetails from './StepDetails';
 
+function getStepStatus({ exitCode = 0 } = {}) {
+  return { terminated: { exitCode, reason: 'Completed' } };
+}
+
 const ansiLog =
   '\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-git-source-skaffold-git-ml8j4 ===\n{"level":"info","ts":1553865693.943092,"logger":"fallback-logger","caller":"git-init/main.go:100","msg":"Successfully cloned https://github.com/GoogleContainerTools/skaffold @ \\"master\\" in path \\"/workspace\\""}\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: build-step-build-and-push ===\n\u001b[36mINFO\u001b[0m[0000] Downloading base image golang:1.10.1-alpine3.7\n2019/03/29 13:21:34 No matching credentials were found, falling back on anonymous\n\u001b[36mINFO\u001b[0m[0001] Executing 0 build triggers\n\u001b[36mINFO\u001b[0m[0001] Unpacking rootfs as cmd RUN go build -o /app . requires it.\n\u001b[36mINFO\u001b[0m[0010] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0015] Using files from context: [/workspace/examples/microservices/leeroy-app/app.go]\n\u001b[36mINFO\u001b[0m[0015] COPY app.go .\n\u001b[36mINFO\u001b[0m[0015] Taking snapshot of files...\n\u001b[36mINFO\u001b[0m[0015] RUN go build -o /app .\n\u001b[36mINFO\u001b[0m[0015] cmd: /bin/sh\n\u001b[36mINFO\u001b[0m[0015] args: [-c go build -o /app .]\n\u001b[36mINFO\u001b[0m[0016] Taking snapshot of full filesystem...\n\u001b[36mINFO\u001b[0m[0036] CMD ["./app"]\n\u001b[36mINFO\u001b[0m[0036] COPY --from=builder /app .\n\u001b[36mINFO\u001b[0m[0036] Taking snapshot of files...\nerror pushing image: failed to push to destination gcr.io/christiewilson-catfactory/leeroy-app:latest: Get https://gcr.io/v2/token?scope=repository%3Achristiewilson-catfactory%2Fleeroy-app%3Apush%2Cpull\u0026scope=repository%3Alibrary%2Falpine%3Apull\u0026service=gcr.io exit status 1\n\n=== demo-pipeline-run-1-build-skaffold-app-2mrdg-pod-59e217: nop ===\nBuild successful\n';
 
-const logContainer = (
-  <Log
-    fetchLogs={() => ansiLog}
-    stepStatus={{ terminated: { reason: 'Completed' } }}
-  />
-);
+function getLogContainer({ exitCode = 0 } = {}) {
+  return (
+    <Log fetchLogs={() => ansiLog} stepStatus={getStepStatus({ exitCode })} />
+  );
+}
 
 export default {
   component: StepDetails,
@@ -39,9 +42,22 @@ export default {
 export const Base = () => (
   <StepDetails
     definition="this will show the Task.spec or TaskRun.spec.taskSpec"
-    logContainer={logContainer}
+    logContainer={getLogContainer()}
     stepName="build"
-    stepStatus={{ terminated: { reason: 'Completed' } }}
+    stepStatus={getStepStatus()}
     taskRun={{}}
   />
 );
+
+export const WithWarning = () => {
+  const exitCode = 1;
+  return (
+    <StepDetails
+      definition="this will show the Task.spec or TaskRun.spec.taskSpec"
+      logContainer={getLogContainer({ exitCode })}
+      stepName="build"
+      stepStatus={getStepStatus({ exitCode })}
+      taskRun={{}}
+    />
+  );
+};

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -23,10 +23,47 @@ import {
 } from '@tektoncd/dashboard-utils';
 
 class Task extends Component {
-  state = { selectedStepId: null };
+  state = { hasWarning: false, selectedStepId: null };
 
   componentDidMount() {
     this.selectDefaultStep();
+    this.getStepData({ propagateWarning: true });
+  }
+
+  componentDidUpdate(prevProps) {
+    const { reason } = this.props;
+    if (prevProps.reason !== reason && reason === 'Succeeded') {
+      this.getStepData({ propagateWarning: true });
+    }
+  }
+
+  getStepData({ propagateWarning = false } = {}) {
+    const { reason, selectedStepId, steps } = this.props;
+    let hasWarning = false;
+    const stepData = updateUnexecutedSteps(steps).map(step => {
+      const { name } = step;
+      const { exitCode, status, reason: stepReason } = getStepStatusReason(
+        step
+      );
+
+      if (stepReason === 'Completed') {
+        hasWarning = hasWarning || exitCode !== 0;
+      }
+
+      const selected = selectedStepId === name;
+      const stepStatus =
+        reason === 'TaskRunCancelled' && status !== 'terminated'
+          ? 'cancelled'
+          : status;
+
+      return { exitCode, name, selected, stepReason, stepStatus };
+    });
+
+    if (propagateWarning) {
+      this.setState({ hasWarning });
+    }
+
+    return stepData;
   }
 
   handleClick = () => {
@@ -68,9 +105,9 @@ class Task extends Component {
       displayName,
       reason,
       selectedStepId,
-      steps,
       succeeded
     } = this.props;
+    const { hasWarning } = this.state;
 
     const expandIcon = expanded ? null : (
       <ExpandIcon className="tkn--task--expand-icon" />
@@ -79,10 +116,11 @@ class Task extends Component {
     return (
       <li
         className="tkn--task"
-        data-succeeded={succeeded}
-        data-reason={reason}
-        data-selected={(expanded && !selectedStepId) || undefined}
         data-active={expanded || undefined}
+        data-has-warning={hasWarning}
+        data-reason={reason}
+        data-succeeded={succeeded}
+        data-selected={(expanded && !selectedStepId) || undefined}
       >
         <a
           className="tkn--task-link"
@@ -92,6 +130,7 @@ class Task extends Component {
         >
           <StatusIcon
             DefaultIcon={DefaultIcon}
+            hasWarning={hasWarning}
             reason={reason}
             status={succeeded}
           />
@@ -100,17 +139,11 @@ class Task extends Component {
         </a>
         {expanded && (
           <ol className="tkn--step-list">
-            {updateUnexecutedSteps(steps).map(step => {
-              const { name } = step;
-              const { status, reason: stepReason } = getStepStatusReason(step);
-
-              const selected = selectedStepId === name;
-              const stepStatus =
-                reason === 'TaskRunCancelled' && status !== 'terminated'
-                  ? 'cancelled'
-                  : status;
+            {this.getStepData().map(step => {
+              const { exitCode, name, selected, stepReason, stepStatus } = step;
               return (
                 <Step
+                  exitCode={exitCode}
                   id={name}
                   key={name}
                   onSelect={this.handleStepSelected}

--- a/packages/components/src/components/Task/Task.scss
+++ b/packages/components/src/components/Task/Task.scss
@@ -32,6 +32,13 @@ limitations under the License.
 
     > .tkn--status-icon {
       margin-right: 0.75rem;
+
+      &.tkn--status-icon--warning {
+        width: 24px;
+        height: 24px;
+        margin-top: 2px;
+        margin-right: 0.5rem;
+      }
     }
 
     &:focus, &:hover {

--- a/packages/components/src/components/Task/Task.stories.js
+++ b/packages/components/src/components/Task/Task.stories.js
@@ -22,8 +22,8 @@ const props = {
 };
 
 const steps = [
-  { name: 'lint', terminated: { reason: 'Completed' } },
-  { name: 'test', terminated: { reason: 'Completed' } },
+  { name: 'lint', terminated: { exitCode: 0, reason: 'Completed' } },
+  { name: 'test', terminated: { exitCode: 1, reason: 'Completed' } },
   { name: 'build', running: {} },
   { name: 'deploy', running: {} }
 ];
@@ -41,6 +41,15 @@ export default {
 };
 
 export const Succeeded = () => <Task {...props} succeeded="True" />;
+
+export const SucceededWithWarning = () => (
+  <Task
+    {...props}
+    steps={[{ terminated: { exitCode: 1, reason: 'Completed' } }]}
+    succeeded="True"
+  />
+);
+SucceededWithWarning.storyName = 'Succeeded with warning';
 
 export const Failed = () => <Task {...props} succeeded="False" />;
 

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -15,7 +15,12 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-import { getParams, getResources, urls } from '@tektoncd/dashboard-utils';
+import {
+  getParams,
+  getResources,
+  taskRunHasWarning,
+  urls
+} from '@tektoncd/dashboard-utils';
 import {
   Link as CarbonLink,
   ContentSwitcher,
@@ -39,45 +44,47 @@ function getDescriptions(array = []) {
   }, {});
 }
 
-const resourceTable = (title, namespace, resources, intl) => (
-  <ResourceTable
-    title={title}
-    rows={resources.map(({ name, resourceRef, resourceSpec }) => ({
-      id: name,
-      name,
-      value:
-        resourceRef && resourceRef.name ? (
-          <Link
-            component={CarbonLink}
-            to={urls.pipelineResources.byName({
-              namespace,
-              pipelineResourceName: resourceRef.name
-            })}
-          >
-            {resourceRef.name}
-          </Link>
-        ) : (
-          <ViewYAML resource={resourceSpec} dark />
-        )
-    }))}
-    headers={[
-      {
-        key: 'name',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.name',
-          defaultMessage: 'Name'
-        })
-      },
-      {
-        key: 'value',
-        header: intl.formatMessage({
-          id: 'dashboard.tableHeader.value',
-          defaultMessage: 'Value'
-        })
-      }
-    ]}
-  />
-);
+function resourceTable(title, namespace, resources, intl) {
+  return (
+    <ResourceTable
+      title={title}
+      rows={resources.map(({ name, resourceRef, resourceSpec }) => ({
+        id: name,
+        name,
+        value:
+          resourceRef && resourceRef.name ? (
+            <Link
+              component={CarbonLink}
+              to={urls.pipelineResources.byName({
+                namespace,
+                pipelineResourceName: resourceRef.name
+              })}
+            >
+              {resourceRef.name}
+            </Link>
+          ) : (
+            <ViewYAML resource={resourceSpec} dark />
+          )
+      }))}
+      headers={[
+        {
+          key: 'name',
+          header: intl.formatMessage({
+            id: 'dashboard.tableHeader.name',
+            defaultMessage: 'Name'
+          })
+        },
+        {
+          key: 'value',
+          header: intl.formatMessage({
+            id: 'dashboard.tableHeader.value',
+            defaultMessage: 'Value'
+          })
+        }
+      ]}
+    />
+  );
+}
 
 const TaskRunDetails = ({
   intl,
@@ -206,6 +213,7 @@ const TaskRunDetails = ({
     <div className="tkn--step-details">
       <DetailsHeader
         displayName={displayName}
+        hasWarning={taskRunHasWarning(taskRun)}
         taskRun={taskRun}
         type="taskRun"
       />

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
@@ -62,6 +62,40 @@ export const Base = () => (
   />
 );
 
+export const WithWarning = () => (
+  <TaskRunDetails
+    taskRun={{
+      metadata: { name: 'my-task', namespace: 'my-namespace' },
+      spec: {
+        params,
+        resources
+      },
+      status: {
+        completionTime: '2021-03-03T15:25:34Z',
+        podName: 'my-task-h7d6j-pod-pdtb7',
+        conditions: [
+          {
+            reason: 'Succeeded',
+            status: 'True',
+            type: 'Succeeded'
+          }
+        ],
+        steps: [
+          {
+            terminated: {
+              exitCode: 1,
+              reason: 'Completed'
+            }
+          }
+        ],
+        startTime: '2021-03-03T15:25:27Z',
+        taskResults: [{ name: 'message', value: 'hello' }]
+      }
+    }}
+    showIO
+  />
+);
+
 export const Pod = () => (
   <TaskRunDetails
     pod={{

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -15,7 +15,7 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { StatusIcon } from '@tektoncd/dashboard-components';
-import { getStatus, urls } from '@tektoncd/dashboard-utils';
+import { getStatus, taskRunHasWarning, urls } from '@tektoncd/dashboard-utils';
 import { Link as CarbonLink } from 'carbon-components-react';
 
 import { FormattedDate, FormattedDuration, RunDropdown, Table } from '..';
@@ -41,7 +41,13 @@ const TaskRuns = ({
   },
   getTaskRunStatusIcon = taskRun => {
     const { reason, status } = getStatus(taskRun);
-    return <StatusIcon reason={reason} status={status} />;
+    return (
+      <StatusIcon
+        hasWarning={taskRunHasWarning(taskRun)}
+        reason={reason}
+        status={status}
+      />
+    );
   },
   getTaskRunStatusTooltip = (taskRun, intl) => {
     const { message } = getStatus(taskRun);

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -529,3 +529,16 @@ export function getTaskRunsWithPlaceholders({
 
   return taskRunsToDisplay;
 }
+
+export function taskRunHasWarning(taskRun) {
+  const { reason, status } = getStatus(taskRun);
+  if (status !== 'True' || reason !== 'Succeeded') {
+    return false;
+  }
+
+  const onErrorContinueStep = taskRun.status?.steps?.find(
+    step =>
+      step.terminated?.reason === 'Completed' && step.terminated?.exitCode !== 0
+  );
+  return !!onErrorContinueStep;
+}

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "Anstehend",
     "dashboard.taskRun.status.running": "Wird ausgeführt",
     "dashboard.taskRun.status.succeeded": "Abgeschlossen",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "Wartestatus",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "Pending",
     "dashboard.taskRun.status.running": "Running",
     "dashboard.taskRun.status.succeeded": "Completed",
+    "dashboard.taskRun.status.succeeded.warning": "Completed with exit code {exitCode}",
     "dashboard.taskRun.status.waiting": "Waiting",
     "dashboard.taskRun.unavailable": "TaskRun not available",
     "dashboard.taskRunParams.name": "Name",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "Pendiente",
     "dashboard.taskRun.status.running": "En ejecución",
     "dashboard.taskRun.status.succeeded": "Completado",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "En espera",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "En attente",
     "dashboard.taskRun.status.running": "En cours d'exécution",
     "dashboard.taskRun.status.succeeded": "Terminé",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "En attente",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "In attesa",
     "dashboard.taskRun.status.running": "In esecuzione",
     "dashboard.taskRun.status.succeeded": "Completato",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "In attesa",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "保留中",
     "dashboard.taskRun.status.running": "実行中",
     "dashboard.taskRun.status.succeeded": "完了",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "待機中",
     "dashboard.taskRun.unavailable": "TaskRunは使用できません",
     "dashboard.taskRunParams.name": "名前",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "보류 중",
     "dashboard.taskRun.status.running": "실행 중",
     "dashboard.taskRun.status.succeeded": "완료됨",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "대기 중",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "Pendente",
     "dashboard.taskRun.status.running": "Executando",
     "dashboard.taskRun.status.succeeded": "Concluído",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "Aguardando",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "暂挂中",
     "dashboard.taskRun.status.running": "运行中",
     "dashboard.taskRun.status.succeeded": "已完成",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "等待中",
     "dashboard.taskRun.unavailable": "TaskRun 不可用",
     "dashboard.taskRunParams.name": "名称",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -239,6 +239,7 @@
     "dashboard.taskRun.status.pending": "擱置中",
     "dashboard.taskRun.status.running": "執行中",
     "dashboard.taskRun.status.succeeded": "已完成",
+    "dashboard.taskRun.status.succeeded.warning": "",
     "dashboard.taskRun.status.waiting": "等待中",
     "dashboard.taskRun.unavailable": "",
     "dashboard.taskRunParams.name": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the step and Task display in the UI to show indicators when
a non-zero exit code was ignored. Propagate the indicator all the
way up to the PipelineRuns and TaskRuns list pages, using the base
'success' icon.

When a step is selected, display the non-zero exit code in the
step details header so the user can easily identify why the status
is displayed differently. We have a similar message in the log trailer
but this may be below the fold depending on log length, window size, etc.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
