### PR TITLE
Set content-type header only on valid request methods

### DIFF
--- a/pkg/utils/proxy.go
+++ b/pkg/utils/proxy.go
@@ -17,7 +17,9 @@ func Proxy(request *http.Request, response http.ResponseWriter, url string, clie
 
 	req = req.WithContext(request.Context())
 
-	req.Header.Set("Content-Type", request.Header.Get("Content-Type"))
+	if request.Method == "POST" || request.Method == "PATCH" || request.Method == "PUT" || request.Method == "DELETE" {
+		req.Header.Set("Content-Type", request.Header.Get("Content-Type"))
+	}
 
 	resp, err := client.Do(req)
 	defer func() {


### PR DESCRIPTION
Avoid sending an empty Header on requests, that should not have a body.
Resolves https://github.com/tektoncd/dashboard/issues/2242

compare with https://developer.mozilla.org/de/docs/Web/HTTP/Methods
which method should and may have a body.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Avoid sending an empty Header on requests, that should not have a body.
https://github.com/tektoncd/dashboard/issues/2242

compare with https://developer.mozilla.org/de/docs/Web/HTTP/Methods
which method should and may have a body.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
