### PR TITLE
Prevent webpack dev server blocking UI on warnings

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -35,6 +35,12 @@ module.exports = merge(common({ mode }), {
   mode,
   devtool: 'eval-source-map',
   devServer: {
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false
+      }
+    },
     historyApiFallback: true,
     hot: true,
     liveReload: false,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
By default the new webpack-dev-server displays a full-screen
overlay in the browser when there are compiler errors or
warnings. Warnings include those from the linter, such as
use of `console.log`. This makes the overlay quite disruptive
during development.

Disable the overlay in case of warnings but keep it for errors
so developers still receive valuable feedback. Warnings will
still be displayed in the terminal and as output of the linter
as appropriate.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
