### PR TITLE
Fix display of short values in SyntaxHighlighter for Firefox

### DIFF
--- a/packages/components/src/components/ViewYAML/ViewYAML.scss
+++ b/packages/components/src/components/ViewYAML/ViewYAML.scss
@@ -46,6 +46,7 @@ pre.tkn--syntax-highlighter {
 
 .tkn--code-line-content {
   display: inline-block;
+  flex-grow: 1;
 }
 
 .bx--snippet--multi {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Due to slight difference in behaviour between Firefox and other browsers
(tested with recent Chrome and Safari releases) handling layout of `inline-block`
elements within `inline-flex`, short values were being forced onto a new line
unnecessarily and making the resulting output difficult to read.

Ensure the line content expands to fill the available space to avoid wrapping
until absolutely necessary due to hitting the bounds of the container.

Before:
![image](https://user-images.githubusercontent.com/2829095/143918090-0f29f0df-2f78-48ad-85d7-4944e3a63c32.png)

After:
![image](https://user-images.githubusercontent.com/2829095/143918159-cfd2fb40-1591-41a3-9e0b-94ed3e7acb2d.png)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
