### PR TITLE
Suppress correction to CRLF in binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 **/zz_generated.*.go linguist-generated=true
 /pkg/client/** linguist-generated=true
 go.sum linguist-generated=true
+*.jpg binary
+*.png binary


### PR DESCRIPTION
Suppress correction to CRLF in binary files

This is to prevent forced changes in line feed codes for image files such as:
```
warning: CRLF will be replaced by LF in docs/dashboard-ui.png.
The file will have its original line endings in your working directory.
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
