### PR TITLE
Ensure existing timer is cleared before creating a new one

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -68,7 +68,7 @@ export class LogContainer extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('scroll', this.handleLogScroll, true);
-    clearInterval(this.timer);
+    clearTimeout(this.timer);
     this.cancelled = true;
   }
 
@@ -370,6 +370,7 @@ export class LogContainer extends Component {
           logs: logs ? logs.split('\n') : undefined
         });
         if (continuePolling) {
+          clearTimeout(this.timer);
           this.timer = setTimeout(this.loadLog, pollingInterval);
         }
       }
@@ -385,6 +386,7 @@ export class LogContainer extends Component {
         ]
       });
       if (continuePolling) {
+        clearTimeout(this.timer);
         this.timer = setTimeout(this.loadLog, pollingInterval);
       }
     }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
We have seen some unexpected network requests for logs in error cases,
e.g. pod not ready, but have not been able to reliably reproduce them.

Ensure we clear any existing timer before starting a new one to ensure
we're not left with any remaining unaccounted for timers when navigating
away from the logs tab.

Also change existing use of `clearInterval` to `clearTimeout` for clarity.
Both use the same pool of ids and so are interchangeable, but we should be
consistent to avoid confusion.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
