### PR TITLE
Handle incomplete TriggerBinding in a more graceful way

### DIFF
--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -64,7 +64,7 @@ export function TriggerBindingContainer({ intl }) {
   ];
 
   const rowsForParameters =
-    triggerBinding?.spec.params.map(({ name, value }) => ({
+    triggerBinding?.spec?.params?.map(({ name, value }) => ({
       id: name,
       name,
       value


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
If a user creates a TriggerBinding with no `spec`, this causes
the Dashboard to display an error when attempting to render the
details page as it assumed that `spec.params` was always present.

Update the code that access the params to ensure it checks for
presence of these fields so we can continue to display the available
information and the placeholder empty table for params.

Example:
```
apiVersion: triggers.tekton.dev/v1beta1
kind: TriggerBinding
metadata:
  name: no-spec
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
