### PR TITLE
Improve URL addressability for the create pages

### DIFF
--- a/packages/components/src/components/Table/Table.scss
+++ b/packages/components/src/components/Table/Table.scss
@@ -84,7 +84,7 @@ limitations under the License.
     .bx--data-table td {
       &.cell-actions {
         text-align: right;
-        width: 6rem;
+        width: 8rem;
       }
     }
   }

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -24,6 +24,7 @@ import {
 import { Button, Link as CarbonLink } from 'carbon-components-react';
 import {
   TrashCan16 as DeleteIcon,
+  PlayOutline16 as RunIcon,
   Playlist16 as RunsIcon
 } from '@carbon/icons-react';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
@@ -173,6 +174,28 @@ function ClusterTasksContainer({ intl }) {
             }
             renderIcon={DeleteIcon}
             size="sm"
+            tooltipAlignment="center"
+            tooltipPosition="left"
+          />
+        ) : null}
+        {!isReadOnly ? (
+          <Button
+            as={Link}
+            hasIconOnly
+            iconDescription={intl.formatMessage(
+              {
+                id: 'dashboard.actions.createRunButton',
+                defaultMessage: 'Create {kind}'
+              },
+              { kind: 'TaskRun' }
+            )}
+            kind="ghost"
+            renderIcon={RunIcon}
+            size="sm"
+            to={`${urls.taskRuns.create()}?${new URLSearchParams({
+              kind: 'ClusterTask',
+              taskName: clusterTask.metadata.name
+            }).toString()}`}
             tooltipAlignment="center"
             tooltipPosition="left"
           />

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -271,11 +271,19 @@ export function PipelineRuns({ intl }) {
     ? []
     : [
         {
-          onClick: () =>
+          onClick: () => {
+            let queryString;
+            if (namespace !== ALL_NAMESPACES) {
+              queryString = new URLSearchParams({
+                namespace,
+                ...(pipelineName && { pipelineName })
+              }).toString();
+            }
             history.push(
               urls.pipelineRuns.create() +
-                (pipelineName ? `?pipelineName=${pipelineName}` : '')
-            ),
+                (queryString ? `?${queryString}` : '')
+            );
+          },
           text: intl.formatMessage({
             id: 'dashboard.actions.createButton',
             defaultMessage: 'Create'

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -16,6 +16,7 @@ import React, { useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import {
   TrashCan16 as DeleteIcon,
+  PlayOutline16 as RunIcon,
   Playlist16 as RunsIcon
 } from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
@@ -199,6 +200,28 @@ export function Pipelines({ intl }) {
             }
             renderIcon={DeleteIcon}
             size="sm"
+            tooltipAlignment="center"
+            tooltipPosition="left"
+          />
+        ) : null}
+        {!isReadOnly ? (
+          <Button
+            as={Link}
+            hasIconOnly
+            iconDescription={intl.formatMessage(
+              {
+                id: 'dashboard.actions.createRunButton',
+                defaultMessage: 'Create {kind}'
+              },
+              { kind: 'PipelineRun' }
+            )}
+            kind="ghost"
+            renderIcon={RunIcon}
+            size="sm"
+            to={`${urls.pipelineRuns.create()}?${new URLSearchParams({
+              namespace: pipeline.metadata.namespace,
+              pipelineName: pipeline.metadata.name
+            }).toString()}`}
             tooltipAlignment="center"
             tooltipPosition="left"
           />

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -260,11 +260,19 @@ function TaskRuns({ intl }) {
     ? []
     : [
         {
-          onClick: () =>
+          onClick: () => {
+            let queryString;
+            if (namespace !== ALL_NAMESPACES || kind !== 'Task') {
+              queryString = new URLSearchParams({
+                ...(namespace !== ALL_NAMESPACES && { namespace }),
+                ...(kind && { kind }),
+                ...(taskName && { taskName })
+              }).toString();
+            }
             history.push(
-              urls.taskRuns.create() +
-                (taskName ? `?taskName=${taskName}&kind=${kind}` : '')
-            ),
+              urls.taskRuns.create() + (queryString ? `?${queryString}` : '')
+            );
+          },
           text: intl.formatMessage({
             id: 'dashboard.actions.createButton',
             defaultMessage: 'Create'

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -30,6 +30,7 @@ import {
 } from '@tektoncd/dashboard-components';
 import {
   TrashCan16 as DeleteIcon,
+  PlayOutline16 as RunIcon,
   Playlist16 as RunsIcon
 } from '@carbon/icons-react';
 
@@ -196,6 +197,29 @@ function Tasks({ intl }) {
             }
             renderIcon={DeleteIcon}
             size="sm"
+            tooltipAlignment="center"
+            tooltipPosition="left"
+          />
+        ) : null}
+        {!isReadOnly ? (
+          <Button
+            as={Link}
+            hasIconOnly
+            iconDescription={intl.formatMessage(
+              {
+                id: 'dashboard.actions.createRunButton',
+                defaultMessage: 'Create {kind}'
+              },
+              { kind: 'TaskRun' }
+            )}
+            kind="ghost"
+            renderIcon={RunIcon}
+            size="sm"
+            to={`${urls.taskRuns.create()}?${new URLSearchParams({
+              kind: 'Task',
+              namespace: task.metadata.namespace,
+              taskName: task.metadata.name
+            }).toString()}`}
             tooltipAlignment="center"
             tooltipPosition="left"
           />

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "Stoppen",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "True",
     "dashboard.about.version": "Version",
     "dashboard.actions.createButton": "Create",
+    "dashboard.actions.createRunButton": "Create {kind}",
     "dashboard.actions.deleteButton": "Delete",
     "dashboard.app.loadingConfigError": "Error loading configuration",
     "dashboard.cancelPipelineRun.actionText": "Stop",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "Detener",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "Arrêter",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "Arresta",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "バージョン",
     "dashboard.actions.createButton": "作成",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "削除",
     "dashboard.app.loadingConfigError": "構成のロード中にエラーが発生しました",
     "dashboard.cancelPipelineRun.actionText": "停止",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "중지",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "Parar",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "True",
     "dashboard.about.version": "版本",
     "dashboard.actions.createButton": "创建",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "删除",
     "dashboard.app.loadingConfigError": "配置加载时发生错误",
     "dashboard.cancelPipelineRun.actionText": "停止",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -23,6 +23,7 @@
     "dashboard.about.true": "",
     "dashboard.about.version": "",
     "dashboard.actions.createButton": "",
+    "dashboard.actions.createRunButton": "",
     "dashboard.actions.deleteButton": "",
     "dashboard.app.loadingConfigError": "",
     "dashboard.cancelPipelineRun.actionText": "停止",

--- a/src/scss/Create.scss
+++ b/src/scss/Create.scss
@@ -12,23 +12,7 @@ limitations under the License.
 */
 
 .tkn--create {
-  .tkn--create--heading {
-    display: flex;
-
-    h1 {
-      flex-grow: 1;
-    }
-
-    .bx--btn {
-      height: 100%;
-
-      &.bx--btn--secondary {
-        margin-right: $spacing-03;
-      }
-    }
-  }
-
-  .bx--fieldset {
+  .bx--fieldset:not(:last-of-type) {
     margin-bottom: 0;
   }
 
@@ -49,5 +33,9 @@ limitations under the License.
   .bx--form-item {
     margin-bottom: $spacing-06;
     max-width: 40rem;
+  }
+
+  .bx--btn.bx--btn--secondary {
+    margin-left: $spacing-03;
   }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2257

Keep the URL in sync with the selected values in the following dropdowns
to provide bookmarkable URLs for commonly executed workloads:
- Namespaces dropdown (common to both PipelineRun and TaskRun)
- Kind dropdown (TaskRun only)
- Pipeline / Task / ClusterTask dropdown

Move the Create / Cancel buttons to the bottom of the form to match updated Carbon guidelines.

Also update the respective buttons on the PipelineRuns and TaskRuns page
to ensure the namespace is included on the initial URL for consistency.

Resolves https://github.com/tektoncd/dashboard/issues/2256

Add links to 'create' page from Tasks, ClusterTasks, and Pipelines lists
Provide a simple mechanism for users to get to the 'Create' page with
a preselected Task / ClusterTask / Pipeline from the corresponding row
on the list page for that resource type.

A future change may introduce a similar action on the details page for
a single resource's details page.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
