### PR TITLE
Rename string id

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -294,7 +294,7 @@ export class LogContainer extends Component {
         if (exitCode !== 0) {
           return intl.formatMessage(
             {
-              id: 'dashboard.pipelineRun.stepCompleted.withError',
+              id: 'dashboard.pipelineRun.stepCompleted.exitCode',
               defaultMessage: 'Step completed with exit code {exitCode}'
             },
             { exitCode }

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "PipelineRun nicht gefunden",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "Schritt abgeschlossen",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "Schritt fehlgeschlagen",
     "dashboard.pipelineRuns.error": "Fehler beim Laden von PipelineRuns",
     "dashboard.pipelines.errorLoading": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "PipelineRun not found",
     "dashboard.pipelineRun.pipelineTaskName.retry": "{pipelineTaskName} (retry {retryNumber, number})",
     "dashboard.pipelineRun.stepCompleted": "Step completed successfully",
-    "dashboard.pipelineRun.stepCompleted.withError": "Step completed with exit code {exitCode}",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "Step completed with exit code {exitCode}",
     "dashboard.pipelineRun.stepFailed": "Step failed",
     "dashboard.pipelineRuns.error": "Error loading PipelineRuns",
     "dashboard.pipelines.errorLoading": "Error loading Pipelines",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "No se ha encontrado PipelineRun",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "Paso completado",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "Paso fallido",
     "dashboard.pipelineRuns.error": "Error al cargar PipelineRuns",
     "dashboard.pipelines.errorLoading": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "PipelineRun introuvable",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "Etape terminée",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "Echec de l'étape",
     "dashboard.pipelineRuns.error": "Une erreur s'est produite lors du chargement des ressources PipelineRun",
     "dashboard.pipelines.errorLoading": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "Esecuzione pipeline non trovata",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "Passo completato",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "Passo non riuscito",
     "dashboard.pipelineRuns.error": "Errore nel caricamento delle esecuzioni pipeline",
     "dashboard.pipelines.errorLoading": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "PipelineRunが見つかりません",
     "dashboard.pipelineRun.pipelineTaskName.retry": "{pipelineTaskName}(retry{retryNumber,number})",
     "dashboard.pipelineRun.stepCompleted": "ステップが完了しました",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "ステップが失敗しました",
     "dashboard.pipelineRuns.error": "PipelineRunのロード中にエラーが発生しました",
     "dashboard.pipelines.errorLoading": "Pipelineのロード中にエラーが発生しました",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "PipelineRun을 찾을 수 없음",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "단계 완료",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "단계 실패",
     "dashboard.pipelineRuns.error": "PipelineRun 로드 중 오류 발생",
     "dashboard.pipelines.errorLoading": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "PipelineRun não localizado",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "Etapa concluída",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "Etapa com falha",
     "dashboard.pipelineRuns.error": "Erro ao carregar os PipelineRuns",
     "dashboard.pipelines.errorLoading": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "未找到 PipelineRun",
     "dashboard.pipelineRun.pipelineTaskName.retry": "{pipelineTaskName}（重试 {retryNumber, number}）",
     "dashboard.pipelineRun.stepCompleted": "步骤已完成",
-    "dashboard.pipelineRun.stepCompleted.withError": "步骤已完成，退出代码为 {exitCode}",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "步骤已完成，退出代码为 {exitCode}",
     "dashboard.pipelineRun.stepFailed": "步骤失败",
     "dashboard.pipelineRuns.error": "加载 PipelineRun 时出错",
     "dashboard.pipelines.errorLoading": "加载 Pipelines 时出错",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -183,7 +183,7 @@
     "dashboard.pipelineRun.notFound": "找不到 PipelineRun",
     "dashboard.pipelineRun.pipelineTaskName.retry": "",
     "dashboard.pipelineRun.stepCompleted": "步驟已完成",
-    "dashboard.pipelineRun.stepCompleted.withError": "",
+    "dashboard.pipelineRun.stepCompleted.exitCode": "",
     "dashboard.pipelineRun.stepFailed": "步驟失敗",
     "dashboard.pipelineRuns.error": "載入 PipelineRuns 時發生錯誤",
     "dashboard.pipelines.errorLoading": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The string is used for logs of steps which exited with non-zero exit code
that also have the `onError: continue` flag set in their definition. This
means that the non-zero exit code will not fail the step and should not be
considered an error. Update the id to reflect this. It may also be useful
in other scenarios in future, so keep the id generic.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
