### PR TITLE
Make required kustomize version clearer in the docs

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -31,8 +31,9 @@ You will also need the following tools in order to build the Dashboard locally a
 1. [Node.js & npm](https://nodejs.org/): For building and running the frontend locally. See `engines` in [package.json](../../package.json) for versions used. _Node.js 14.x is recommended_
 1. [`ko`](https://github.com/google/ko): For development. `ko` version v0.7.2 or higher is required for `dashboard` to work correctly
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For interacting with your kube cluster
-1. [`kustomize`](https://kubernetes-sigs.github.io/kustomize/installation/): For building the Dashboard manifests. You need a recent version - v3.5.4 is recommended
-See [here](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md#try-go) - `GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v3` works correctly
+1. [`kustomize`](https://kubernetes-sigs.github.io/kustomize/installation/): For building the Dashboard manifests. v3.5.4 is recommended, the installer script is not currently compatible with v4
+
+   See [here](https://kubectl.docs.kubernetes.io/installation/kustomize/source/) - `GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v3` works correctly
 
 ## Checkout your fork
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
kustomize v4 includes a breaking change to the `--load_restrictor` flag,
so we need to make it clear to contributors that they should stick with
v3 for now.

At some point in the future we will update to v4 and fix the flag but for
now we consume our kustomize version via a shared image used by multiple
Tekton projects.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
