### PR TITLE
Update browser compatibility data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2211,12 +2211,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001297",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
-          "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.4.37",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.37.tgz",
@@ -14332,7 +14326,6 @@
       "version": "file:packages/components",
       "requires": {
         "@babel/cli": "^7.15.4",
-        "@formatjs/intl-relativetimeformat": "^7.3.6",
         "@tektoncd/dashboard-utils": "file:packages/utils",
         "@visx/event": "^2.1.0",
         "@visx/network": "^2.1.0",
@@ -16763,11 +16756,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001255",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-          "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ=="
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -17402,12 +17390,6 @@
         "node-releases": "^1.1.73"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001249",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-          "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -17839,10 +17821,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001219",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
-      "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
-      "dev": true
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -19079,12 +19060,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.75"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001257",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-          "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
-          "dev": true
         },
         "colorette": {
           "version": "1.4.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@babel/cli": "^7.15.4",
-    "@formatjs/intl-relativetimeformat": "^7.3.6",
     "@tektoncd/dashboard-utils": "file:../utils",
     "@visx/event": "^2.1.0",
     "@visx/network": "^2.1.0",

--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,6 +13,3 @@ limitations under the License.
 /* istanbul ignore file */
 
 import 'core-js/stable';
-
-import '@formatjs/intl-relativetimeformat/polyfill';
-import '@formatjs/intl-relativetimeformat/locale-data/en';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update browserslist/caniuse-lite to ensure we're using current browser
compatibility data. This prevents us from unnecessarily including
polyfills for features that are natively supported in newer browsers.

Reduce vendor bundle size by ~100K:
- ~42K by updating caniuse-lite `npx browserslist@latest --update-db`
- ~57K by removing relativetimeformat polyfill since it was only
  required for Safari 13 or older. Current supported versions are 14 and 15

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
