### PR TITLE
Fix SideNav links when navigation from a cluster-scoped page

### DIFF
--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -48,7 +48,7 @@ function SideNav({ expanded, intl, showKubernetesResources }) {
   const location = useLocation();
   const { namespace } = useParams();
 
-  const { selectNamespace } = useSelectedNamespace();
+  const { selectedNamespace, selectNamespace } = useSelectedNamespace();
   const tenantNamespace = useTenantNamespace();
   const { data: extensions = [] } = useExtensions(
     {
@@ -74,8 +74,15 @@ function SideNav({ expanded, intl, showKubernetesResources }) {
   }
 
   function getPath(path, namespaced = true) {
-    if (namespaced && namespace && namespace !== ALL_NAMESPACES) {
-      return urls.byNamespace({ namespace, path });
+    if (
+      namespaced &&
+      selectedNamespace &&
+      selectedNamespace !== ALL_NAMESPACES
+    ) {
+      return urls.byNamespace({
+        namespace: selectedNamespace,
+        path
+      });
     }
 
     return path;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When navigating from a cluster-scoped resource / list, e.g. ClusterTasks,
to any namespaced resource / list, the URL should include the namespace
of the currently selected global namespace filter. This will become
even more important once the namespace dropdown is moved to the header
in the very near future.

Use the selected namespace instead of the URL as the source of truth
when determining whether the target URL should include the namespace
as it will not be present in the current URL when viewing cluster scoped
resources.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
