### PR TITLE
allow clusterrole to use psp tekton-pipelines

### DIFF
--- a/base/200-clusterrole-tenant.yaml
+++ b/base/200-clusterrole-tenant.yaml
@@ -71,3 +71,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - tekton-pipelines
+    verbs:
+      - use


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Currently the dashboard pods can not be deployed due to missing capability of the `tekton-dashboard-tenant` clusterrole to use the `tekton-pipelines` psp.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
