### PR TITLE
Enable webpack cache for production builds

### DIFF
--- a/packages/components/src/components/Log/Log.js
+++ b/packages/components/src/components/Log/Log.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -414,7 +414,7 @@ export class LogContainer extends Component {
     const { toolbar } = this.props;
     const { loading } = this.state;
     return (
-      <pre className="tkn--log" ref={this.logRef}>
+      <pre className="tkn--log tkn--theme-dark" ref={this.logRef}>
         {loading ? (
           <SkeletonText paragraph width="60%" />
         ) : (

--- a/packages/components/src/components/Log/Log.scss
+++ b/packages/components/src/components/Log/Log.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,8 +12,6 @@ limitations under the License.
 */
 
 pre.tkn--log {
-  @include carbon--theme($carbon--theme--g90, true);
-
   position: relative;
   padding: 2rem 1.6rem 1.3rem 1.6rem;
   font-family: ibm-plex-mono, monospace;

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -21,6 +21,12 @@ const common = require('./webpack.common');
 const mode = 'production';
 
 module.exports = merge(common({ mode }), {
+  cache: {
+    type: 'filesystem',
+    buildDependencies: {
+      config: [__filename]
+    }
+  },
   mode,
   output: {
     filename: '[name].[contenthash].js',


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Improve performance of `npm run build` by enabling webpack's
filesystem cache.

Build time on an 'old' machine for a clean build is ~90 seconds.
Without cache, any subsequent re-build regardless of whether it
contains code changes also takes ~90 seconds.

With cache enabled, a re-build with no changes is <5 seconds,
and with a handful of changes in both the core application (`src/`)
and in the sub-packages (`packages/`) is <10 seconds.

Changes to dependencies, imports, etc. will incur a higher cost
as parts of the cache are invalidated, but should still be
significantly faster than the full clean build with no cache.
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
