### PR TITLE
Add rbac removal for when auth with proxy

### DIFF
--- a/base/201-clusterrolebinding-backend.yaml
+++ b/base/201-clusterrolebinding-backend.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tekton Authors
+# Copyright 2019-2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
 subjects:
   - kind: ServiceAccount
     name: tekton-dashboard

--- a/docs/install.md
+++ b/docs/install.md
@@ -199,6 +199,14 @@ By default the Dashboard accesses resources and performs actions in the cluster 
 
 Typically when configuring impersonation you would have the proxy forward its ServiceAccount token in the `Authorization` header, and details of the user and groups in the `Impersonate-User` and `Impersonate-Group` headers respectively. See the docs of your chosen solution for details.
 
+When using a reverse proxy, with impersonation headers or the user's account, you should remove the Dashboard's privileges to better maintain a "least privileged" approach.  This will make it less likely that the Dashboard's `ServiceAccount` will be abused:
+
+
+```
+kubectl delete clusterrolebinding -l rbac.dashboard.tekton.dev/subject=tekton-dashboard
+kubectl delete rolebinding -l rbac.dashboard.tekton.dev/subject=tekton-dashboard -n tekton-pipelines
+```
+
 If you're using one of these proxies to provide authentication but still want to use the Dashboard's ServiceAccount to access the Kubernetes APIs you may need to modify the proxy config to prevent it from sending the `Authorization` header on upstream requests to the Dashboard. Some examples of relevant config:
 - oauth2-proxy: add the `--pass-authorization-header=false` command line argument or its equivalent to your config https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options
 - Istio EnvoyFilter: the external authentication service should return a custom header `x-envoy-auth-headers-to-remove: Authorization` https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto

--- a/scripts/installer
+++ b/scripts/installer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 The Tekton Authors
+# Copyright 2021-2022 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -191,6 +191,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
   name: tekton-dashboard-tenant
   namespace: $TENANT_NAMESPACE
 roleRef:
@@ -213,6 +214,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
   name: tekton-dashboard-extensions
   namespace: $TENANT_NAMESPACE
 roleRef:
@@ -237,6 +239,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
   name: tekton-dashboard-tenant
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -258,6 +261,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
   name: tekton-dashboard-extensions
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/pull/2291

Updated docs with guidance to remove default RBAC for least privileged access
when using a reverse proxy for authentication.

Co-authored-by: Marc Boorshtein <marc.boorshtein@tremolosecurity.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
