### PR TITLE
Avoid use of concatenation when producing CSS classnames

### DIFF
--- a/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,6 +14,14 @@ limitations under the License.
 
 import PropTypes from 'prop-types';
 import React from 'react';
+
+const tableSizeClassNames = {
+  xs: 'bx--data-table--xs',
+  sm: 'bx--data-table--sm',
+  md: 'bx--data-table--md',
+  lg: 'bx--data-table--lg',
+  xl: 'bx--data-table--xl'
+};
 
 const DataTableSkeleton = ({
   className,
@@ -35,7 +43,7 @@ const DataTableSkeleton = ({
     </tr>
   ));
 
-  const sizeClassName = size ? `bx--data-table--${size}` : '';
+  const sizeClassName = tableSizeClassNames[size] || '';
 
   return (
     <table

--- a/packages/components/src/components/StatusIcon/StatusIcon.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -27,14 +27,6 @@ import { isRunning } from '@tektoncd/dashboard-utils';
 import { Spinner } from '..';
 
 const icons = {
-  normal: {
-    cancelled: CloseFilled,
-    error: CloseFilled,
-    pending: Pending,
-    running: Spinner,
-    success: CheckmarkFilled,
-    warning: CheckmarkFilledWarning
-  },
   inverse: {
     cancelled: CloseOutline,
     error: CloseOutline,
@@ -42,7 +34,29 @@ const icons = {
     running: Spinner,
     success: CheckmarkOutline,
     warning: WarningFilled
+  },
+  normal: {
+    cancelled: CloseFilled,
+    error: CloseFilled,
+    pending: Pending,
+    running: Spinner,
+    success: CheckmarkFilled,
+    warning: CheckmarkFilledWarning
   }
+};
+
+const statusClassNames = {
+  cancelled: 'tkn--status-icon--cancelled',
+  error: 'tkn--status-icon--error',
+  pending: 'tkn--status-icon--pending',
+  running: 'tkn--status-icon--running',
+  success: 'tkn--status-icon--success',
+  warning: 'tkn--status-icon--warning'
+};
+
+const typeClassNames = {
+  inverse: 'tkn--status-icon--type-inverse',
+  normal: 'tkn--status-icon--type-normal'
 };
 
 export default function StatusIcon({
@@ -84,13 +98,9 @@ export default function StatusIcon({
 
   return Icon ? (
     <Icon
-      className={classNames(
-        'tkn--status-icon',
-        {
-          [`tkn--status-icon--${statusClass}`]: statusClass
-        },
-        `tkn--status-icon--type-${type}`
-      )}
+      className={classNames('tkn--status-icon', typeClassNames[type], {
+        [statusClassNames[statusClass]]: statusClass
+      })}
     >
       {title && <title>{title}</title>}
     </Icon>

--- a/packages/components/src/components/StatusIcon/StatusIcon.scss
+++ b/packages/components/src/components/StatusIcon/StatusIcon.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,23 +16,23 @@ limitations under the License.
   width: 20px;
   height: 20px;
 
-  &--cancelled {
+  &.tkn--status-icon--cancelled {
     fill: $ui-04;
   }
 
-  &--error {
+  &.tkn--status-icon--error {
     fill: $support-01;
   }
 
-  &--running {
+  &.tkn--status-icon--running {
     fill: $support-04;
   }
 
-  &--success {
+  &.tkn--status-icon--success {
     fill: $support-02;
   }
 
-  &--warning {
+  &.tkn--status-icon--warning {
     &.tkn--status-icon--type-normal {
       fill: $support-02;
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Dynamically concatenating values to produce CSS classnames makes it
difficult to identify which values are / may be used, often leading
to stale styles being left behind as developers are unsure whether
they're safe to remove.

Where possible we should ensure the entire CSS classname appears
as a single string in the codebase so it's easily searchable. This
also becomes increasingly important when using tooling to identify
unused styles.

Some components such as `LogFormat` are exceptions to this rule
due to the potentially large number of values involved, and the
affected classnames already have an easily searchable prefix. These
prefixes can be excluded from the tooling to avoid them being pruned
as they depend on user content only available at runtime.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
