### PR TITLE
Fix component imports within components package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "carbon-components": "^10.52.0",
         "carbon-components-react": "^7.52.0",
         "carbon-icons": "^7.0.7",
-        "classnames": "^2.2.6",
         "core-js": "^3.20.3",
         "git-url-parse": "^11.3.0",
         "history": "^4.10.1",
@@ -33637,6 +33636,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tektoncd/dashboard-utils": "file:../utils",
+        "classnames": "^2.3.1",
         "js-yaml": "^3.13.0",
         "linkify-it": "^3.0.2",
         "prop-types": "^15.7.2",
@@ -42157,6 +42157,7 @@
       "version": "file:packages/components",
       "requires": {
         "@tektoncd/dashboard-utils": "file:../utils",
+        "classnames": "^2.3.1",
         "js-yaml": "^3.13.0",
         "linkify-it": "^3.0.2",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "carbon-components": "^10.52.0",
     "carbon-components-react": "^7.52.0",
     "carbon-icons": "^7.0.7",
-    "classnames": "^2.2.6",
     "core-js": "^3.20.3",
     "git-url-parse": "^11.3.0",
     "history": "^4.10.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@tektoncd/dashboard-utils": "file:../utils",
+    "classnames": "^2.3.1",
     "js-yaml": "^3.13.0",
     "linkify-it": "^3.0.2",
     "prop-types": "^15.7.2",

--- a/packages/components/src/components/DeleteModal/DeleteModal.js
+++ b/packages/components/src/components/DeleteModal/DeleteModal.js
@@ -15,7 +15,7 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Modal } from 'carbon-components-react';
-import { Table } from '@tektoncd/dashboard-components';
+import { Table } from '..';
 
 const DeleteModal = ({
   onClose,

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,12 +14,17 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { StatusIcon, Table } from '@tektoncd/dashboard-components';
 import { getStatus, taskRunHasWarning, urls } from '@tektoncd/dashboard-utils';
 import { Pending24 as DefaultIcon } from '@carbon/icons-react';
 import { Link as CarbonLink } from 'carbon-components-react';
 
-import { FormattedDate, FormattedDuration, RunDropdown } from '..';
+import {
+  FormattedDate,
+  FormattedDuration,
+  RunDropdown,
+  StatusIcon,
+  Table
+} from '..';
 
 const PipelineRuns = ({
   batchActionButtons = [],

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.js
@@ -16,12 +16,7 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { InlineNotification, SkeletonText, Tag } from 'carbon-components-react';
 import { formatLabels, getErrorMessage } from '@tektoncd/dashboard-utils';
-import {
-  FormattedDate,
-  Tab,
-  Tabs,
-  ViewYAML
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Tab, Tabs, ViewYAML } from '..';
 
 const tabs = ['overview', 'yaml'];
 

--- a/packages/components/src/components/RunDropdown/RunDropdown.js
+++ b/packages/components/src/components/RunDropdown/RunDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
-import { Modal } from '@tektoncd/dashboard-components';
+import { Modal } from '..';
 
 class RunDropdown extends Component {
   state = { showDialog: false };

--- a/packages/components/src/components/Task/Task.js
+++ b/packages/components/src/components/Task/Task.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,11 +16,12 @@ import {
   PendingFilled20 as DefaultIcon,
   ChevronDown20 as ExpandIcon
 } from '@carbon/icons-react';
-import { StatusIcon, Step } from '@tektoncd/dashboard-components';
 import {
   getStepStatusReason,
   updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
+
+import { StatusIcon, Step } from '..';
 
 class Task extends Component {
   state = { hasWarning: false, selectedStepId: null };

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,11 +14,16 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { StatusIcon } from '@tektoncd/dashboard-components';
 import { getStatus, taskRunHasWarning, urls } from '@tektoncd/dashboard-utils';
 import { Link as CarbonLink } from 'carbon-components-react';
 
-import { FormattedDate, FormattedDuration, RunDropdown, Table } from '..';
+import {
+  FormattedDate,
+  FormattedDuration,
+  RunDropdown,
+  StatusIcon,
+  Table
+} from '..';
 
 const TaskRuns = ({
   batchActionButtons = [],

--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -22,7 +22,7 @@ import {
   UnorderedList
 } from 'carbon-components-react';
 import { urls } from '@tektoncd/dashboard-utils';
-import { Table, ViewYAML } from '@tektoncd/dashboard-components';
+import { Table, ViewYAML } from '..';
 
 const Trigger = ({ intl, namespace, trigger }) => {
   const tableHeaders = [


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Instead of referencing `@tektoncd/dashboard-components`, imports
within the `components` package that reference other components
should load them locally from the index. This will be more important
in future when we provide the ability to override / customise parts
of the UI via extensions.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
