### PR TITLE
Add support for rendering PipelineRun header before a complete resource is available

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -242,7 +242,8 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       );
     }
 
-    const pipelineRunName = pipelineRun.metadata.name;
+    const pipelineRunName =
+      pipelineRun.metadata.name || pipelineRun.metadata.generateName;
     const pipelineRunError = this.getPipelineRunError();
 
     const {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Some consumers of the Dashboard components provide their own queueing / pipeline orchestration
layer in front of Tekton Pipelines. In this case the PipelineRun resource they attempt to
render may not be complete (i.e. may not contain complete metadata or status).

Make a best effort attempt to render the PipelineRun details based on the data provided.
For example, if metadata is incomplete but there is a `generateName` field, use this as
a temporary display name until the 'real' run resource is available.

This allows for display of additional information that may be provided by the consumer
such as the triggering event or other payload information.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
