### PR TITLE
Avoid displaying stack trace for 404 with missing statusText

### DIFF
--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -94,7 +94,12 @@ export function checkStatus(response = {}, stream = false) {
     }
   }
 
-  const error = new Error(response.statusText);
+  let { statusText } = response;
+  if (!statusText && response.status === 404) {
+    statusText = 'Not Found';
+  }
+
+  const error = new Error(statusText);
   error.response = response;
   throw error;
 }

--- a/src/api/comms.test.js
+++ b/src/api/comms.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -117,6 +117,15 @@ describe('checkStatus', () => {
     );
   });
 
+  it('handles no content response', () => {
+    const status = 204;
+    const response = {
+      ok: true,
+      status
+    };
+    expect(checkStatus(response)).toEqual({});
+  });
+
   it('throws an error on failure', () => {
     const status = 400;
     expect(() => checkStatus({ status })).toThrow();
@@ -124,6 +133,11 @@ describe('checkStatus', () => {
 
   it('throws an error on empty response', () => {
     expect(() => checkStatus()).toThrow();
+  });
+
+  it('handles 404 with missing statusText', () => {
+    const status = 404;
+    expect(() => checkStatus({ status })).toThrowError('Not Found');
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
I noticed on both robocat and dogfooding that the error notification
displayed for 404 responses contains a stringified version of the
error object instead of the expected 'Not Found' message.

Testing the same builds locally produce the expected results and there's
no obvious difference in the HTTP responses that I can find.

Update the `checkStatus` util to handle this case and avoid outputting
the verbose error object as well as adding missing tests for this behaviour.

Before:
![image](https://user-images.githubusercontent.com/2829095/165319509-c2921078-83a5-4fda-8c78-e30e4c047a1d.png)

After:
![image](https://user-images.githubusercontent.com/2829095/165319568-af0c0073-73d1-4156-9a4d-36e24e25e122.png)


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
