### PR TITLE
Add support for injecting a custom icon into the PipelineRun header

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -186,6 +186,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       customNotification,
       error,
       handleTaskSelected,
+      icon,
       intl,
       loading,
       onViewChange,
@@ -257,6 +258,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       return (
         <>
           <RunHeader
+            icon={icon}
             lastTransitionTime={lastTransitionTime}
             loading={loading}
             pipelineRun={pipelineRun}
@@ -314,6 +316,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     return (
       <>
         <RunHeader
+          icon={icon}
           lastTransitionTime={lastTransitionTime}
           loading={loading}
           message={pipelineRunStatusMessage}

--- a/packages/components/src/components/RunHeader/RunHeader.js
+++ b/packages/components/src/components/RunHeader/RunHeader.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -26,6 +26,7 @@ class RunHeader extends Component {
 
   render() {
     const {
+      icon,
       intl,
       lastTransitionTime,
       loading,
@@ -61,6 +62,7 @@ class RunHeader extends Component {
                   <div className="tkn--run-name" title={runName}>
                     {runName}
                   </div>
+                  {icon}
                   <span className="tkn--time">
                     {lastTransitionTime
                       ? intl.formatMessage(


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add an `icon` prop to the PipelineRun component that is passed through
to the RunHeader and displayed immediately after the PipelineRun name.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
