### PR TITLE
Update installer script to detect Apple M1

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -31,13 +31,23 @@ BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard"
 
 # additional options passed to ko resolve
 KO_RESOLVE_OPTIONS=""
+PLATFORM=""
 
 initOS() {
   OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
 
   case "$OS" in
     # Minimalist GNU for Windows
-    mingw*) OS='windows';;
+    mingw*)
+      OS='windows'
+      ;;
+    darwin*)
+      ARCH=$(uname -m)
+      if [ "$ARCH" == "arm64" ] && [ -z "$PLATFORM" ]; then
+        debug "Detected Apple M1 and no custom platform specified"
+        PLATFORM="--platform linux/arm64"
+      fi
+      ;;
   esac
 
   debug "Detected OS: $OS"
@@ -88,7 +98,7 @@ compile() {
   fi
 
   debug "Building overlay $overlay ..."
-  kustomize build --load-restrictor LoadRestrictionsNone "$overlay" | ko resolve $KO_RESOLVE_OPTIONS -f - > "$TMP_FILE"
+  kustomize build --load-restrictor LoadRestrictionsNone "$overlay" | ko resolve $KO_RESOLVE_OPTIONS $PLATFORM -f - > "$TMP_FILE"
 }
 
 download() {
@@ -522,7 +532,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     '--platform')
       shift
-      KO_RESOLVE_OPTIONS="$KO_RESOLVE_OPTIONS --platform=${1}"
+      PLATFORM="--platform ${1}"
       ;;
     '--tag')
       shift


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the installer script to detect when running on an Apple M1 chip
and set the `--platform` flag correctly for the call to `ko resolve`.

The value used by default is `linux/amd64` but for M1 we need `linux/arm64`

A user can still explicitly specify `--platform` if they want to override this.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
