### PR TITLE
Handle invalid params in Task spec

### DIFF
--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -37,7 +37,11 @@ import {
   ViewYAML
 } from '..';
 
-function getDescriptions(array = []) {
+function getDescriptions(array) {
+  if (!array) {
+    return {};
+  }
+
   return array.reduce((accumulator, { name, description }) => {
     accumulator[name] = description;
     return accumulator;

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -176,6 +176,32 @@ describe('TaskRunDetails', () => {
     expect(queryByText('Events')).toBeTruthy();
     fireEvent.click(queryByText('Events'));
     expect(queryByText(events)).toBeTruthy();
+  });
+
+  it('renders pod with no events', () => {
+    const pod = 'fake-pod';
+    const taskRun = {
+      metadata: { name: 'task-run-name' },
+      spec: {},
+      status: {}
+    };
+    const { queryByText } = render(
+      <TaskRunDetails
+        pod={{
+          resource: pod
+        }}
+        task={{
+          metadata: 'task',
+          spec: {}
+        }}
+        taskRun={taskRun}
+        view="pod"
+      />
+    );
+    expect(queryByText('Pod')).toBeTruthy();
+    expect(queryByText('Resource')).toBeFalsy();
+    expect(queryByText(pod)).toBeTruthy();
+    expect(queryByText('Events')).toBeFalsy();
   });
 
   it('renders both input and output resources', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
If we somehow get `params: null`, ensure the UI handles this gracefully
and doesn't fall over. The previous code would fail in this case as
the default value was only used if `params` was `undefined`. Update
the code to use the default for all falsy values.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
