### PR TITLE
Support different button kinds in Table toolbarButtons

### DIFF
--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -191,14 +191,15 @@ const Table = props => {
                   </TableBatchActions>
                 )}
                 <TableToolbarContent>
-                  {toolbarButtons.map(button => (
+                  {toolbarButtons.map(({ icon, onClick, text, ...rest }) => (
                     <Button
                       disabled={loading}
-                      onClick={button.onClick}
-                      renderIcon={button.icon}
-                      key={`${button.text}Button`}
+                      key={`${text}Button`}
+                      onClick={onClick}
+                      renderIcon={icon}
+                      {...rest}
                     >
-                      {button.text}
+                      {text}
                     </Button>
                   ))}
                 </TableToolbarContent>

--- a/packages/components/src/components/Table/Table.stories.js
+++ b/packages/components/src/components/Table/Table.stories.js
@@ -185,11 +185,16 @@ export const Sorting = args => {
       size={args.size}
       title={args.title}
       toolbarButtons={[
-        { onClick: action('handleNew'), text: 'Add', icon: Add },
         {
+          icon: RerunAll,
+          kind: 'secondary',
           onClick: action('handleRerunAll'),
-          text: 'RerunAll',
-          icon: RerunAll
+          text: 'RerunAll'
+        },
+        {
+          icon: Add,
+          onClick: action('handleNew'),
+          text: 'Add'
         }
       ]}
     />


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the Table component to support passing additional props to
the toolbar buttons, e.g. `kind` to have a mixture of primary and
secondary actions on the table.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
