### PR TITLE
Allow custom status detail on the PipelineRuns page

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -31,6 +31,17 @@ import {
   Table
 } from '..';
 
+function getDefaultPipelineRunStatusDetail(pipelineRun) {
+  const { status } = getStatus(pipelineRun);
+  return status === 'False' ? (
+    <span className="tkn--table--sub" title={getStatus(pipelineRun).message}>
+      {getStatus(pipelineRun).message}&nbsp;
+    </span>
+  ) : (
+    <span className="tkn--table--sub">&nbsp;</span>
+  );
+}
+
 const PipelineRuns = ({
   batchActionButtons = [],
   columns = ['run', 'status', 'pipeline', 'time'],
@@ -63,6 +74,7 @@ const PipelineRuns = ({
       })
     );
   },
+  getPipelineRunStatusDetail = getDefaultPipelineRunStatusDetail,
   getPipelineRunStatusIcon = pipelineRun => {
     const { reason, status } = getStatus(pipelineRun);
     let hasWarning = false;
@@ -174,9 +186,13 @@ const PipelineRuns = ({
         pipelineName: pipelineRefName
       });
 
-    const duration = (
-      <FormattedDuration milliseconds={getPipelineRunDuration(pipelineRun)} />
-    );
+    let duration = getPipelineRunDuration(pipelineRun);
+    // zero is a valid duration
+    if (duration == null) {
+      duration = '-';
+    } else {
+      duration = <FormattedDuration milliseconds={duration} />;
+    }
 
     const pipelineRunActions = getRunActions(pipelineRun);
     if (pipelineRunActions.length) {
@@ -242,16 +258,8 @@ const PipelineRuns = ({
               {getPipelineRunStatus(pipelineRun, intl)}
             </div>
           </div>
-          {status === 'False' ? (
-            <span
-              className="tkn--table--sub"
-              title={getStatus(pipelineRun).message}
-            >
-              {getStatus(pipelineRun).message}&nbsp;
-            </span>
-          ) : (
-            <span className="tkn--table--sub">&nbsp;</span>
-          )}
+          {getPipelineRunStatusDetail(pipelineRun) ||
+            getDefaultPipelineRunStatusDetail(pipelineRun)}
         </div>
       ),
       time: (

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.test.js
@@ -116,11 +116,36 @@ describe('PipelineRuns', () => {
     expect(queryByText(/Custom Column Value/i)).toBeTruthy();
   });
 
+  it('renders custom content', () => {
+    const statusDetail = 'custom status detail';
+    const { queryByText, queryByTitle } = render(
+      <PipelineRuns
+        columns={['status']}
+        getPipelineRunDuration={() => null}
+        getPipelineRunStatusDetail={() => statusDetail}
+        pipelineRuns={[
+          {
+            metadata: {
+              name: 'pipelineRunName',
+              namespace: 'default',
+              uid: '72160103-d8d4-43c7-bd98-170c6a7eb679'
+            },
+            spec: {}
+          }
+        ]}
+      />
+    );
+
+    expect(queryByText(statusDetail)).toBeTruthy();
+    expect(queryByTitle(/Duration:/i)).toBeFalsy();
+  });
+
   it('renders data', () => {
     const pipelineRunName = 'pipeline-run-20190816124708';
     const eventListenerName = 'fake_eventListenerName';
     const { queryAllByTitle, queryByText, queryByTitle } = renderWithRouter(
       <PipelineRuns
+        getPipelineRunStatusDetail={() => null} // should fallback to default
         pipelineRuns={[
           {
             metadata: {
@@ -165,7 +190,7 @@ describe('PipelineRuns', () => {
                   lastTransitionTime: '2022-05-10T14:33:11Z',
                   message: 'some message',
                   reason: 'some reason',
-                  status: 'True',
+                  status: 'False',
                   type: 'Succeeded'
                 }
               ]
@@ -183,6 +208,9 @@ describe('PipelineRuns', () => {
     expect(queryByText(eventListenerName)).toBeTruthy();
     expect(queryByTitle(/FAKE_REASON/i)).toBeTruthy();
     expect(queryAllByTitle(/FAKE_MESSAGE/i).length).toBeTruthy();
+    expect(queryByText('FAKE_MESSAGE')).toBeFalsy();
+    expect(queryByText('some message')).toBeTruthy(); // we only display message for failed / errored runs
+    expect(queryAllByTitle(/Duration:/i).length).toBeTruthy();
   });
 
   it('renders with custom link creators', () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Allow consumers of the PipelineRun component to specify custom content
for the status details sub-row. If the provided function returns `null`,
fallback to the default status details.

Also allow consumers to prevent display of duration. If a consumer has
a queueing system or other custom mechanism in place they may not want
to display a duration until the run is actually processed / accepted
for execution.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
