### PR TITLE
Support custom tooltips for PipelineRun display name

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -51,6 +51,7 @@ const PipelineRuns = ({
     pipelineRun.metadata.creationTimestamp,
   getPipelineRunDisplayName = ({ pipelineRunMetadata }) =>
     pipelineRunMetadata.name,
+  getPipelineRunDisplayNameTooltip = getPipelineRunDisplayName,
   getPipelineRunDuration = pipelineRun => {
     const creationTimestamp = getPipelineRunCreatedTime(pipelineRun);
     const { lastTransitionTime, status } = getStatus(pipelineRun);
@@ -170,6 +171,9 @@ const PipelineRuns = ({
     const pipelineRunName = getPipelineRunDisplayName({
       pipelineRunMetadata: pipelineRun.metadata
     });
+    const pipelineRunNameTooltip = getPipelineRunDisplayNameTooltip({
+      pipelineRunMetadata: pipelineRun.metadata
+    });
     const pipelineRefName =
       pipelineRun.spec.pipelineRef && pipelineRun.spec.pipelineRef.name;
     const { reason, status } = getStatus(pipelineRun);
@@ -208,7 +212,7 @@ const PipelineRuns = ({
               <Link
                 component={CarbonLink}
                 to={pipelineRunURL}
-                title={pipelineRunName}
+                title={pipelineRunNameTooltip}
               >
                 {pipelineRunName}
               </Link>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
By default the tooltip displayed when hovering on the PipelineRun
display name will be the same content returned by `getPipelineRunDisplayName`.
However, if consumers are providing rich content for this the tooltip will
be displayed incorrectly as `[object Object]`. To support these cases,
add an extra `getPipelineRunDisplayNameTooltip` prop which can be used to
override the default behaviour and provide a plain text value for the tooltip.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
