### PR TITLE
Disable compression in webpack-dev-server to enable log streaming

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -41,6 +41,7 @@ module.exports = merge(common({ mode }), {
         warnings: false
       }
     },
+    compress: false,
     historyApiFallback: true,
     hot: true,
     liveReload: false,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2373

`http-proxy-middleware` has an issue with chunked responses and
gzip compression which prevents log streaming from working. The
result is that the logs sit in a loading state until the step is
complete when the entire response is received in full.

Disabling compression for the dev server has no impact on production
deployments of the Dashboard which can still use compression via
reverse proxies or other means if desired.

See `https://github.com/chimurai/http-proxy-middleware/issues/371`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
