### PR TITLE
Add ability to inject a custom icon after the PipelineRun name

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -63,6 +63,7 @@ const PipelineRuns = ({
 
     return endTime - new Date(creationTimestamp).getTime();
   },
+  getPipelineRunIcon = () => null,
   getPipelineRunId = pipelineRun => pipelineRun.metadata.uid,
   getPipelineRunsByPipelineURL = urls.pipelineRuns.byPipeline,
   getPipelineRunStatus = (pipelineRun, intl) => {
@@ -219,6 +220,7 @@ const PipelineRuns = ({
             ) : (
               pipelineRunName
             )}
+            {getPipelineRunIcon()}
           </span>
           <span className="tkn--table--sub">
             {getPipelineRunTriggerInfo(pipelineRun)}&nbsp;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/pull/2359

The icon is rendered after the name / link to the run details,
outside of the anchor tag. This can be used to decorate runs with
specific attributes of interest to the user.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
