### PR TITLE
Pass PipelineRun metadata when getting icon

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -220,7 +220,9 @@ const PipelineRuns = ({
             ) : (
               pipelineRunName
             )}
-            {getPipelineRunIcon()}
+            {getPipelineRunIcon({
+              pipelineRunMetadata: pipelineRun.metadata
+            })}
           </span>
           <span className="tkn--table--sub">
             {getPipelineRunTriggerInfo(pipelineRun)}&nbsp;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Consumers may have additional logic they need to apply depending
on the PipelineRun, status, or related data. Pass the metadata
in the same way we do for `getPipelineRunDisplayName` and other
similar props so they can use this to retrieve the relevant info
to determine the icon to display.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
