### PR TITLE
Update walkthroughs to pin Kubernetes version

### DIFF
--- a/docs/walkthrough/walkthrough-kind.md
+++ b/docs/walkthrough/walkthrough-kind.md
@@ -28,6 +28,8 @@ The first thing to do is to create a Kubernetes cluster.
 
 Kind is an easy solution to run a local cluster, all it needs is to have `docker` installed.
 
+This walkthrough has been tested on Kind v0.14 with Kubernetes v1.21.
+
 Create a cluster by running the following command:
 
 ```bash
@@ -36,6 +38,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/docs/walkthrough/walkthrough-logs.md
+++ b/docs/walkthrough/walkthrough-logs.md
@@ -31,6 +31,8 @@ Then, you will create a service to serve those logs and will plug the Tekton Das
 
 ## Installing a working Tekton Dashboard locally from scratch
 
+This walkthrough has been tested on Kind v0.14 with Kubernetes v1.21.
+
 If you didn't follow the [Tekton Dashboard walk-through with Kind](./walkthrough-kind.md) yet, start there to get a local cluster with a working Tekton Dashboard installed.
 
 The following steps will focus on collecting, storing and serving pod logs to finally plug the logs service on the Tekton Dashboard.

--- a/docs/walkthrough/walkthrough-oauth2-proxy.md
+++ b/docs/walkthrough/walkthrough-oauth2-proxy.md
@@ -35,6 +35,8 @@ The picture below illustrates the deployed components and interactions between t
 
 ## Installing a working Tekton Dashboard locally from scratch
 
+This walkthrough has been tested on Kind v0.14 with Kubernetes v1.21.
+
 If you didn't follow the [Tekton Dashboard walk-through with Kind](./walkthrough-kind.md) yet, start there to get a local cluster with a working Tekton Dashboard installed.
 
 The following steps will focus on getting `oauth2-proxy` installed in your cluster and securing the Tekton Dashboard `Ingress`.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Pin Kubernetes version in the walkthroughs to v1.21 since there are
a number of breaking changes in v1.22 (e.g. Ingress) that are incompatible
with other tools used in the walkthroughs, in particular minio and
the logging-operator in the logs persistence walkthrough. The latest
Pipelines releases are compatible with v1.21.

In future these walkthroughs will be rewritten for inclusion with the other
Dashboard docs on the website. At that point we will need to update them to
newer versions of the tools, find alternatives, or restructure these docs
to avoid reliance on specific releases.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
