### PR TITLE
Fix warning about invalid prop `navigate` on anchor tag

### DIFF
--- a/packages/components/src/components/Link/Link.js
+++ b/packages/components/src/components/Link/Link.js
@@ -1,0 +1,20 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+import React from 'react';
+import { Link as CarbonLink } from 'carbon-components-react';
+
+export default function Link({ navigate, ...rest }) {
+  return <CarbonLink {...rest} />;
+}

--- a/packages/components/src/components/Link/index.js
+++ b/packages/components/src/components/Link/index.js
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+export { default } from './Link';

--- a/packages/components/src/components/PipelineResources/PipelineResources.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
-import { Link as CarbonLink } from 'carbon-components-react';
+import { Link as CustomLink } from '@tektoncd/dashboard-components';
 
 import { FormattedDate, Table } from '..';
 
@@ -71,7 +71,7 @@ const PipelineResources = ({
     return {
       id: pipelineResource.metadata.uid,
       name: url ? (
-        <Link component={CarbonLink} to={url} title={pipelineResourceName}>
+        <Link component={CustomLink} to={url} title={pipelineResourceName}>
           {pipelineResourceName}
         </Link>
       ) : (

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -21,10 +21,10 @@ import {
   Time16 as TimeIcon,
   Lightning16 as TriggersIcon
 } from '@carbon/icons-react';
-import { Link as CarbonLink } from 'carbon-components-react';
 
 import {
   Actions,
+  Link as CustomLink,
   FormattedDate,
   FormattedDuration,
   StatusIcon,
@@ -211,7 +211,7 @@ const PipelineRuns = ({
           <span>
             {pipelineRunURL ? (
               <Link
-                component={CarbonLink}
+                component={CustomLink}
                 to={pipelineRunURL}
                 title={pipelineRunNameTooltip}
               >
@@ -235,7 +235,7 @@ const PipelineRuns = ({
             {(pipelineRefName &&
               (pipelineRunsByPipelineURL ? (
                 <Link
-                  component={CarbonLink}
+                  component={CustomLink}
                   to={pipelineRunsByPipelineURL}
                   title={pipelineRefName}
                 >

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -21,13 +21,10 @@ import {
   taskRunHasWarning,
   urls
 } from '@tektoncd/dashboard-utils';
-import {
-  Link as CarbonLink,
-  ContentSwitcher,
-  Switch
-} from 'carbon-components-react';
+import { ContentSwitcher, Switch } from 'carbon-components-react';
 
 import {
+  Link as CustomLink,
   DetailsHeader,
   Param,
   ResourceTable,
@@ -58,7 +55,7 @@ function resourceTable(title, namespace, resources, intl) {
         value:
           resourceRef && resourceRef.name ? (
             <Link
-              component={CarbonLink}
+              component={CustomLink}
               to={urls.pipelineResources.byName({
                 namespace,
                 pipelineResourceName: resourceRef.name

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -20,10 +20,10 @@ import {
   Lightning16 as TriggersIcon
 } from '@carbon/icons-react';
 import { getStatus, taskRunHasWarning, urls } from '@tektoncd/dashboard-utils';
-import { Link as CarbonLink } from 'carbon-components-react';
 
 import {
   Actions,
+  Link as CustomLink,
   FormattedDate,
   FormattedDuration,
   StatusIcon,
@@ -170,7 +170,7 @@ const TaskRuns = ({
         <div>
           <span>
             {taskRunURL ? (
-              <Link component={CarbonLink} to={taskRunURL} title={taskRunName}>
+              <Link component={CustomLink} to={taskRunURL} title={taskRunName}>
                 {taskRunName}
               </Link>
             ) : (
@@ -186,7 +186,7 @@ const TaskRuns = ({
         <div>
           <span>
             {taskRefName ? (
-              <Link component={CarbonLink} to={taskRunsURL} title={taskRefName}>
+              <Link component={CustomLink} to={taskRunsURL} title={taskRefName}>
                 {taskRefName}
               </Link>
             ) : (

--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -17,12 +17,11 @@ import { Link } from 'react-router-dom';
 import {
   Accordion,
   AccordionItem,
-  Link as CarbonLink,
   ListItem,
   UnorderedList
 } from 'carbon-components-react';
 import { urls } from '@tektoncd/dashboard-utils';
-import { Table, ViewYAML } from '..';
+import { Link as CustomLink, Table, ViewYAML } from '..';
 
 const Trigger = ({ intl, namespace, trigger }) => {
   const tableHeaders = [
@@ -67,7 +66,7 @@ const Trigger = ({ intl, namespace, trigger }) => {
                   {binding.ref ? (
                     <Link
                       className="tkn--trigger-resourcelink"
-                      component={CarbonLink}
+                      component={CustomLink}
                       to={
                         binding.kind === 'ClusterTriggerBinding'
                           ? urls.clusterTriggerBindings.byName({
@@ -102,7 +101,7 @@ const Trigger = ({ intl, namespace, trigger }) => {
           ) : (
             <Link
               className="tkn--trigger-resourcelink"
-              component={CarbonLink}
+              component={CustomLink}
               to={urls.triggerTemplates.byName({
                 namespace,
                 triggerTemplateName
@@ -320,7 +319,7 @@ const Trigger = ({ intl, namespace, trigger }) => {
                 const clusterInterceptorName = interceptor.ref.name;
                 content = (
                   <Link
-                    component={CarbonLink}
+                    component={CustomLink}
                     to={urls.clusterInterceptors.byName({
                       clusterInterceptorName
                     })}

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -23,6 +23,7 @@ export { default as FormattedDuration } from './FormattedDuration';
 export { default as Header } from './Header';
 export { default as KeyValueList } from './KeyValueList';
 export { default as LabelFilter } from './LabelFilter';
+export { default as Link } from './Link';
 export { default as LoadingShell } from './LoadingShell';
 export { default as Log } from './Log';
 export { default as LogFormat } from './LogFormat';

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import { useClusterInterceptors } from '../../api';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: clusterInterceptor.metadata.uid,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.rawCRD.cluster({
           name: clusterInterceptor.metadata.name,
           type: 'clusterinterceptors'

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -17,11 +17,12 @@ import { Link, useLocation } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
+  Link as CustomLink,
   DeleteModal,
   FormattedDate,
   Table
 } from '@tektoncd/dashboard-components';
-import { Button, Link as CarbonLink } from 'carbon-components-react';
+import { Button } from 'carbon-components-react';
 import {
   TrashCan16 as DeleteIcon,
   PlayOutline16 as RunIcon,
@@ -42,7 +43,7 @@ function getFormattedResources({
     id: clusterTask.metadata.uid,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.rawCRD.cluster({
           type: 'clustertasks',
           name: clusterTask.metadata.name

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import { useClusterTriggerBindings } from '../../api';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: `${binding.metadata.name}`,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.clusterTriggerBindings.byName({
           clusterTriggerBindingName: binding.metadata.name
         })}

--- a/src/containers/Conditions/Conditions.js
+++ b/src/containers/Conditions/Conditions.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { useConditions, useSelectedNamespace } from '../../api';
 import { ListPageLayout } from '..';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: condition.metadata.uid,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.conditions.byName({
           namespace: condition.metadata.namespace,
           conditionName: condition.metadata.name

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,8 +16,11 @@ import React from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  ResourceDetails,
+  Trigger
+} from '@tektoncd/dashboard-components';
 
 import { useEventListener } from '../../api';
 import { getViewChangeHandler } from '../../utils';
@@ -109,7 +112,7 @@ export function EventListenerContainer({ intl }) {
               <div className="tkn--trigger-resourcelinks">
                 <span>Trigger:</span>
                 <Link
-                  component={CarbonLink}
+                  component={CustomLink}
                   to={urls.triggers.byName({
                     namespace,
                     triggerName: trigger.triggerRef

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import { useEventListeners, useSelectedNamespace } from '../../api';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: `${listener.metadata.namespace}:${listener.metadata.name}`,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.eventListeners.byName({
           namespace: listener.metadata.namespace,
           eventListenerName: listener.metadata.name

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,17 +15,14 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import {
-  Link as CarbonLink,
-  InlineNotification
-} from 'carbon-components-react';
+import { InlineNotification } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getErrorMessage,
   urls,
   useTitleSync
 } from '@tektoncd/dashboard-utils';
-import { Table } from '@tektoncd/dashboard-components';
+import { Link as CustomLink, Table } from '@tektoncd/dashboard-components';
 
 import { useExtensions, useTenantNamespace } from '../../api';
 
@@ -89,7 +86,7 @@ function Extensions({ intl }) {
           id: name,
           name: (
             <Link
-              component={CarbonLink}
+              component={CustomLink}
               to={urls.kubernetesResources.all({
                 group: apiGroup,
                 version: apiVersion,

--- a/src/containers/NotFound/NotFound.js
+++ b/src/containers/NotFound/NotFound.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,8 @@ limitations under the License.
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { Link as CarbonLink, Column, Grid, Row } from 'carbon-components-react';
+import { Column, Grid, Row } from 'carbon-components-react';
+import { Link as CustomLink } from '@tektoncd/dashboard-components';
 import { urls } from '@tektoncd/dashboard-utils';
 
 import robocat from '../../images/robocat_404.svg';
@@ -61,7 +62,7 @@ function NotFound({ intl }) {
 
           <ul>
             <li>
-              <Link component={CarbonLink} to="/">
+              <Link component={CustomLink} to="/">
                 {intl.formatMessage({
                   id: 'dashboard.home.title',
                   defaultMessage: 'Home'
@@ -69,12 +70,12 @@ function NotFound({ intl }) {
               </Link>
             </li>
             <li>
-              <Link component={CarbonLink} to={urls.pipelineRuns.all()}>
+              <Link component={CustomLink} to={urls.pipelineRuns.all()}>
                 PipelineRuns
               </Link>
             </li>
             <li>
-              <Link component={CarbonLink} to={urls.taskRuns.all()}>
+              <Link component={CustomLink} to={urls.taskRuns.all()}>
                 TaskRuns
               </Link>
             </li>

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -21,7 +21,7 @@ import {
 } from '@carbon/icons-react';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
-import { Button, Link as CarbonLink } from 'carbon-components-react';
+import { Button } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getFilters,
@@ -29,6 +29,7 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import {
+  Link as CustomLink,
   DeleteModal,
   FormattedDate,
   Table
@@ -52,7 +53,7 @@ function getFormattedResources({
     id: pipeline.metadata.uid,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.rawCRD.byNamespace({
           namespace: pipeline.metadata.namespace,
           type: 'pipelines',

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { injectIntl } from 'react-intl';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import {
@@ -127,7 +130,7 @@ export function ResourceListContainer({ intl }) {
               id: uid,
               name: (
                 <Link
-                  component={CarbonLink}
+                  component={CustomLink}
                   to={
                     resourceNamespace
                       ? urls.kubernetesResources.byName({

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -16,7 +16,7 @@ import React, { useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
-import { Button, Link as CarbonLink } from 'carbon-components-react';
+import { Button } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
   getFilters,
@@ -24,6 +24,7 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import {
+  Link as CustomLink,
   DeleteModal,
   FormattedDate,
   Table
@@ -52,7 +53,7 @@ function getFormattedResources({
     id: task.metadata.uid,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.rawCRD.byNamespace({
           namespace: task.metadata.namespace,
           type: 'tasks',

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import { useSelectedNamespace, useTriggerBindings } from '../../api';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: `${binding.metadata.namespace}:${binding.metadata.name}`,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.triggerBindings.byName({
           namespace: binding.metadata.namespace,
           triggerBindingName: binding.metadata.name

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import { useSelectedNamespace, useTriggerTemplates } from '../../api';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: `${template.metadata.namespace}:${template.metadata.name}`,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.triggerTemplates.byName({
           namespace: template.metadata.namespace,
           triggerTemplateName: template.metadata.name

--- a/src/containers/Triggers/Triggers.js
+++ b/src/containers/Triggers/Triggers.js
@@ -15,8 +15,11 @@ import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import { FormattedDate, Table } from '@tektoncd/dashboard-components';
-import { Link as CarbonLink } from 'carbon-components-react';
+import {
+  Link as CustomLink,
+  FormattedDate,
+  Table
+} from '@tektoncd/dashboard-components';
 
 import { ListPageLayout } from '..';
 import { useSelectedNamespace, useTriggers } from '../../api';
@@ -26,7 +29,7 @@ function getFormattedResources(resources) {
     id: trigger.metadata.uid,
     name: (
       <Link
-        component={CarbonLink}
+        component={CustomLink}
         to={urls.triggers.byName({
           namespace: trigger.metadata.namespace,
           triggerName: trigger.metadata.name


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
When using the react-router `Link` component with the Carbon `Link`
component we need to filter out the `navigate` prop to prevent
the console being spammed with warnings. This is particularly
noticeable in the unit tests where >20% of the output is related
to these warnings.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
