### PR TITLE
Add type to results of report task in release pipeline

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -166,12 +166,16 @@ spec:
         results:
           - name: release
             description: The full URL of the release file in the bucket
+            type: string
           - name: release-readonly
             description: The full URL of the release file (read-only) in the bucket
+            type: string
           - name: release-openshift
             description: The full URL of the release file (OpenShift) in the bucket
+            type: string
           - name: release-openshift-readonly
             description: The full URL of the release file (OpenShift read-only) in the bucket
+            type: string
         steps:
           - name: create-results
             image: alpine


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Nightly releases for all components have been failing for a few days
since the update to Pipelines v0.37 on the dogfooding cluster. It seems
like v0.36 introduced an unintended breaking change related to results.
When introducing the new 'array' type for results, the default type 'string'
was not correctly set.

Update the release pipeline definition to include the `type` field for
results in the `report-bucket` task to work around this until a patch
release is deployed with the fix.

The issue was likely introduced in Pipelines PR 4818

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
