### PR TITLE
Switch to new value for cancelling a PipelineRun

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Some of the features the Tekton Dashboard supports:
 
 | Version | Docs | Pipelines | Triggers |
 | ------- | ---- | --------- | -------- |
-| [HEAD](https://github.com/tektoncd/dashboard/blob/main/DEVELOPMENT.md) | [Docs @ HEAD](https://github.com/tektoncd/dashboard/tree/main/docs) | v0.25.x - v0.37.x | v0.15.x - 0.20.x |
+| [HEAD](https://github.com/tektoncd/dashboard/blob/main/DEVELOPMENT.md) | [Docs @ HEAD](https://github.com/tektoncd/dashboard/tree/main/docs) | v0.35.x - v0.37.x | v0.15.x - 0.20.x |
 | [v0.27.0](https://github.com/tektoncd/dashboard/releases/tag/v0.27.0) | [Docs @ v0.27.0](https://github.com/tektoncd/dashboard/tree/v0.27.0/docs) | v0.25.x - v0.36.x | v0.15.x - 0.20.x |
 | [v0.26.0](https://github.com/tektoncd/dashboard/releases/tag/v0.26.0) | [Docs @ v0.26.0](https://github.com/tektoncd/dashboard/tree/v0.26.0/docs) | v0.25.x - v0.35.x | v0.15.x - 0.19.x |
 | [v0.25.0](https://github.com/tektoncd/dashboard/releases/tag/v0.25.0) | [Docs @ v0.25.0](https://github.com/tektoncd/dashboard/tree/v0.25.0/docs) | v0.25.x - v0.34.x | v0.15.x - 0.19.x |

--- a/src/api/pipelineRuns.js
+++ b/src/api/pipelineRuns.js
@@ -62,9 +62,7 @@ export function usePipelineRun(params, queryConfig) {
 }
 
 export function cancelPipelineRun({ name, namespace }) {
-  const payload = [
-    { op: 'replace', path: '/spec/status', value: 'PipelineRunCancelled' }
-  ];
+  const payload = [{ op: 'replace', path: '/spec/status', value: 'Cancelled' }];
 
   const uri = getTektonAPI('pipelineruns', { name, namespace });
   return patch(uri, payload);

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,9 +19,7 @@ import * as utils from './utils';
 it('cancelPipelineRun', () => {
   const name = 'foo';
   const namespace = 'foospace';
-  const payload = [
-    { op: 'replace', path: '/spec/status', value: 'PipelineRunCancelled' }
-  ];
+  const payload = [{ op: 'replace', path: '/spec/status', value: 'Cancelled' }];
   const returnedPipelineRun = { fake: 'PipelineRun' };
   fetchMock.patch(`end:${name}`, returnedPipelineRun);
   return API.cancelPipelineRun({ name, namespace }).then(response => {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -219,11 +219,11 @@ if [ -z "$SKIP_BUILD_TEST" ]; then
 fi
 
 if [ -z "$PIPELINES_VERSION" ]; then
-  export PIPELINES_VERSION=v0.37.0
+  export PIPELINES_VERSION=v0.37.1
 fi
 
 if [ -z "$TRIGGERS_VERSION" ]; then
-  export TRIGGERS_VERSION=v0.20.0
+  export TRIGGERS_VERSION=v0.20.1
 fi
 
 header "Installing Pipelines and Triggers"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/2094

Update the `cancelPipelineRun` API to use the new `Cancelled` value
instead of the legacy `PipelineRunCancelled`. This is supported by
default since Pipelines v0.35 and is related to TEP-0058 graceful
termination. An additional change will be made later to add support
for the other status values (`StoppedRunFinally` and `CancelledRunFinally`).

As a result of this change, the minimum supported version of Pipelines
will be v0.35.0. Update the documentation to reflect this.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
