### PR TITLE
Remove status and finalizers subresources from roles

### DIFF
--- a/base/200-clusterrole-backend.yaml
+++ b/base/200-clusterrole-backend.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tekton Authors
+# Copyright 2019-2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ rules:
       - tekton.dev
     resources:
       - clustertasks
-      - clustertasks/status
     verbs:
       - get
       - list

--- a/base/200-clusterrole-tenant.yaml
+++ b/base/200-clusterrole-tenant.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Tekton Authors
+# Copyright 2019-2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,12 +49,6 @@ rules:
       - pipelines
       - pipelineruns
       - pipelineresources
-      - tasks/status
-      - taskruns/status
-      - pipelines/status
-      - pipelineruns/status
-      - taskruns/finalizers
-      - pipelineruns/finalizers
     verbs:
       - get
       - list

--- a/overlays/patches/read-write/clusterrole-backend-patch.yaml
+++ b/overlays/patches/read-write/clusterrole-backend-patch.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Tekton Authors
+# Copyright 2020-2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@
       - tekton.dev
     resources:
       - clustertasks
-      - clustertasks/status
     verbs:
       - create
       - update

--- a/overlays/patches/read-write/clusterrole-tenant-patch.yaml
+++ b/overlays/patches/read-write/clusterrole-tenant-patch.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Tekton Authors
+# Copyright 2020-2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,12 +24,6 @@
       - pipelines
       - pipelineruns
       - pipelineresources
-      - taskruns/finalizers
-      - pipelineruns/finalizers
-      - tasks/status
-      - taskruns/status
-      - pipelines/status
-      - pipelineruns/status
     verbs:
       - create
       - update


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The status and finalizers subresources are not used so we do not
need to specify them in the roles included in the default RBAC
for the Dashboard.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
