### PR TITLE
Add status information to Runs and Run pages

### DIFF
--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -133,7 +133,12 @@ const TaskRuns = ({
     });
     const taskRefName = taskRun.spec.taskRef?.name;
     const taskRefKind = taskRun.spec.taskRef?.kind;
-    const { lastTransitionTime, reason, status } = getStatus(taskRun);
+    const {
+      lastTransitionTime,
+      reason,
+      status,
+      message: statusMessage
+    } = getStatus(taskRun);
     const statusIcon = getTaskRunStatusIcon(taskRun);
     const taskRunURL = getTaskRunURL({
       namespace,
@@ -212,11 +217,8 @@ const TaskRuns = ({
             </div>
           </div>
           {status === 'False' ? (
-            <span
-              className="tkn--table--sub"
-              title={getStatus(taskRun).message}
-            >
-              {getStatus(taskRun).message}&nbsp;
+            <span className="tkn--table--sub" title={statusMessage}>
+              {statusMessage}&nbsp;
             </span>
           ) : (
             <span className="tkn--table--sub">&nbsp;</span>

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "Dauer: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "Error loading {type}",
     "dashboard.resourceList.viewRuns": "View {kind} of {resource}",
     "dashboard.run.duration": "Duration: {duration}",
+    "dashboard.run.duration.label": "Duration:",
     "dashboard.run.rerunStatusMessage": "View status",
     "dashboard.runs.error": "Error loading Runs",
     "dashboard.serviceAccountLabel.optional": "ServiceAccount (optional)",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "Duración: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "Durée: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "Durata: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "{type}のロード中にエラーが発生しました",
     "dashboard.resourceList.viewRuns": "{resource}の{kind}を表示",
     "dashboard.run.duration": "実行時間：{duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "ステータスを表示",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "ServiceAccount（オプション）",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "지속 기간: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "Duração: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "加载 {type} 时发生错误",
     "dashboard.resourceList.viewRuns": "查看 {resource} 的 {kind}",
     "dashboard.run.duration": "持续时间：{duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "查看状态",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "ServiceAccount（可选）",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -219,6 +219,7 @@
     "dashboard.resourceList.errorLoading": "",
     "dashboard.resourceList.viewRuns": "",
     "dashboard.run.duration": "持續時間: {duration}",
+    "dashboard.run.duration.label": "",
     "dashboard.run.rerunStatusMessage": "",
     "dashboard.runs.error": "",
     "dashboard.serviceAccountLabel.optional": "",

--- a/src/scss/Triggers.scss
+++ b/src/scss/Triggers.scss
@@ -56,4 +56,9 @@ limitations under the License.
   & + h4 {
     margin-bottom: 0.5rem;
   }
+
+  svg {
+    vertical-align: sub;
+    margin-right: 0.5rem;
+  }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/1970

Update the list page for Run resources to match the design for the
PipelineRuns and TaskRuns pages, including PipelineRun/Trigger info,
status, time, etc.

Add status info to the additional metadata section on the details
page, using the same content displayed in the status tooltip on the
Runs list page.

Ensure Runs are sorted by creation time so their display is consistent
with TaskRuns, PipelineRuns, etc., and newer runs appear at the top.

Since we do not know all of the possible status reasons for custom tasks,
we assign a default status icon to keep text alignment while the Run is
in a non-terminal state.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
