### PR TITLE
Add rerun and delete actions to Run details page

### DIFF
--- a/packages/components/src/components/ResourceDetails/ResourceDetails.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.js
@@ -21,6 +21,7 @@ import { FormattedDate, Tab, Tabs, ViewYAML } from '..';
 const tabs = ['overview', 'yaml'];
 
 const ResourceDetails = ({
+  actions,
   additionalMetadata,
   children,
   error,
@@ -63,7 +64,10 @@ const ResourceDetails = ({
 
   return (
     <div className="tkn--resourcedetails">
-      <h1>{resource.metadata.name}</h1>
+      <div className="tkn--resourcedetails--header">
+        <h1>{resource.metadata.name}</h1>
+        {actions}
+      </div>
       <Tabs
         aria-label={intl.formatMessage({
           id: 'dashboard.resourceDetails.ariaLabel',
@@ -146,6 +150,7 @@ const ResourceDetails = ({
 };
 
 ResourceDetails.defaultProps = {
+  actions: null,
   additionalMetadata: null,
   children: null,
   error: null,
@@ -155,6 +160,7 @@ ResourceDetails.defaultProps = {
 };
 
 ResourceDetails.propTypes = {
+  actions: PropTypes.node,
   additionalMetadata: PropTypes.node,
   children: PropTypes.node,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),

--- a/src/containers/Run/Run.js
+++ b/src/containers/Run/Run.js
@@ -12,19 +12,21 @@ limitations under the License.
 */
 /* istanbul ignore file */
 
-import React from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { UndefinedFilled20 as UndefinedIcon } from '@carbon/icons-react';
 import {
+  Actions,
   FormattedDuration,
   ResourceDetails,
   StatusIcon,
   Table
 } from '@tektoncd/dashboard-components';
-import { getStatus, useTitleSync } from '@tektoncd/dashboard-utils';
+import { getStatus, urls, useTitleSync } from '@tektoncd/dashboard-utils';
+import { InlineNotification } from 'carbon-components-react';
 
-import { useRun } from '../../api';
+import { deleteRun, rerunRun, useIsReadOnly, useRun } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
 function getRunDuration(run) {
@@ -87,6 +89,9 @@ function Run({ intl }) {
   const queryParams = new URLSearchParams(location.search);
   const view = queryParams.get('view');
 
+  const [showNotification, setShowNotification] = useState(null);
+  const isReadOnly = useIsReadOnly();
+
   useTitleSync({
     page: 'Run',
     resourceName
@@ -128,89 +133,228 @@ function Run({ intl }) {
       value
     })) || [];
 
-  return (
-    <ResourceDetails
-      additionalMetadata={
-        <>
-          <p>
-            <span>
-              {intl.formatMessage({
-                id: 'dashboard.run.duration.label',
-                defaultMessage: 'Duration:'
-              })}
-            </span>
-            {getRunDuration(run)}
-          </p>
-          <p>
-            <span>
-              {intl.formatMessage({
-                id: 'dashboard.filter.status.title',
-                defaultMessage: 'Status:'
-              })}
-            </span>
-            {getRunStatusIcon(run)}
-            {getRunStatusTooltip(run)}
-          </p>
-        </>
+  function deleteResource() {
+    deleteRun({
+      name: run.metadata.name,
+      namespace: run.metadata.namespace
+    })
+      .then(() => {
+        history.push(urls.runs.byNamespace({ namespace }));
+      })
+      .catch(err => {
+        err.response.text().then(text => {
+          const statusCode = err.response.status;
+          let errorMessage = `error code ${statusCode}`;
+          if (text) {
+            errorMessage = `${text} (error code ${statusCode})`;
+          }
+          setShowNotification({
+            kind: 'error',
+            message: errorMessage
+          });
+        });
+      });
+  }
+
+  function rerun() {
+    rerunRun(run)
+      .then(newRun => {
+        setShowNotification({
+          kind: 'success',
+          logsURL: urls.runs.byName({
+            namespace,
+            runName: newRun.metadata.name
+          }),
+          message: intl.formatMessage({
+            id: 'dashboard.rerun.triggered',
+            defaultMessage: 'Triggered rerun'
+          })
+        });
+      })
+      .catch(rerunError => {
+        setShowNotification({
+          kind: 'error',
+          message: intl.formatMessage(
+            {
+              id: 'dashboard.rerun.error',
+              defaultMessage:
+                'An error occurred when rerunning {runName}: check the dashboard logs for details. Status code: {statusCode}'
+            },
+            {
+              runName: run.metadata.name,
+              statusCode: rerunError.response.status
+            }
+          )
+        });
+      });
+  }
+
+  function runActions() {
+    if (isReadOnly) {
+      return [];
+    }
+    return [
+      {
+        action: rerun,
+        actionText: intl.formatMessage({
+          id: 'dashboard.rerun.actionText',
+          defaultMessage: 'Rerun'
+        }),
+        disable: resource => !!resource.metadata.labels?.['tekton.dev/pipeline']
+      },
+      {
+        actionText: intl.formatMessage({
+          id: 'dashboard.actions.deleteButton',
+          defaultMessage: 'Delete'
+        }),
+        action: deleteResource,
+        danger: true,
+        disable: resource => {
+          const { status } = getStatus(resource);
+          return status === 'Unknown';
+        },
+        hasDivider: true,
+        modalProperties: {
+          danger: true,
+          heading: intl.formatMessage(
+            {
+              id: 'dashboard.deleteResources.heading',
+              defaultMessage: 'Delete {kind}'
+            },
+            { kind: 'Run' }
+          ),
+          primaryButtonText: intl.formatMessage({
+            id: 'dashboard.actions.deleteButton',
+            defaultMessage: 'Delete'
+          }),
+          body: resource =>
+            intl.formatMessage(
+              {
+                id: 'dashboard.deleteRun.body',
+                defaultMessage:
+                  'Are you sure you would like to delete Run {name}?'
+              },
+              { name: resource.metadata.name }
+            )
+        }
       }
-      error={error}
-      loading={isFetching}
-      onViewChange={getViewChangeHandler({ history, location })}
-      resource={run}
-      view={view}
-    >
-      <>
-        <h4>
-          {intl.formatMessage({
-            id: 'dashboard.customTask.heading',
-            defaultMessage: 'Custom Task'
-          })}
-        </h4>
-        <div className="tkn--resourcedetails-metadata">
-          <p>
-            <span>
-              {intl.formatMessage({
-                id: 'dashboard.resource.apiVersion',
-                defaultMessage: 'API version:'
-              })}
-            </span>
-            {apiVersion}
-          </p>
-          <p>
-            <span>
-              {intl.formatMessage({
-                id: 'dashboard.resource.kind',
-                defaultMessage: 'Kind:'
-              })}
-            </span>
-            {kind}
-          </p>
-          {customTaskName ? (
+    ];
+  }
+
+  return (
+    <>
+      {showNotification && (
+        <InlineNotification
+          lowContrast
+          actions={
+            showNotification.logsURL ? (
+              <Link
+                className="bx--inline-notification__text-wrapper"
+                to={showNotification.logsURL}
+              >
+                {intl.formatMessage({
+                  id: 'dashboard.run.rerunStatusMessage',
+                  defaultMessage: 'View status'
+                })}
+              </Link>
+            ) : (
+              ''
+            )
+          }
+          title={showNotification.message}
+          kind={showNotification.kind}
+          caption=""
+        />
+      )}
+
+      <ResourceDetails
+        actions={
+          isReadOnly ? null : (
+            <Actions items={runActions()} kind="button" resource={run} />
+          )
+        }
+        additionalMetadata={
+          <>
             <p>
               <span>
                 {intl.formatMessage({
-                  id: 'dashboard.resource.name',
-                  defaultMessage: 'Name:'
+                  id: 'dashboard.run.duration.label',
+                  defaultMessage: 'Duration:'
                 })}
               </span>
-              {customTaskName}
+              {getRunDuration(run)}
             </p>
-          ) : null}
-        </div>
-        {rowsForParameters.length ? (
-          <Table
-            title={intl.formatMessage({
-              id: 'dashboard.parameters.title',
-              defaultMessage: 'Parameters'
+            <p>
+              <span>
+                {intl.formatMessage({
+                  id: 'dashboard.filter.status.title',
+                  defaultMessage: 'Status:'
+                })}
+              </span>
+              {getRunStatusIcon(run)}
+              {getRunStatusTooltip(run)}
+            </p>
+          </>
+        }
+        error={error}
+        loading={isFetching}
+        onViewChange={getViewChangeHandler({ history, location })}
+        resource={run}
+        view={view}
+      >
+        <>
+          <h4>
+            {intl.formatMessage({
+              id: 'dashboard.customTask.heading',
+              defaultMessage: 'Custom Task'
             })}
-            headers={headersForParameters}
-            rows={rowsForParameters}
-            size="sm"
-          />
-        ) : null}
-        {/* TODO: results */}
-      </>
-    </ResourceDetails>
+          </h4>
+          <div className="tkn--resourcedetails-metadata">
+            <p>
+              <span>
+                {intl.formatMessage({
+                  id: 'dashboard.resource.apiVersion',
+                  defaultMessage: 'API version:'
+                })}
+              </span>
+              {apiVersion}
+            </p>
+            <p>
+              <span>
+                {intl.formatMessage({
+                  id: 'dashboard.resource.kind',
+                  defaultMessage: 'Kind:'
+                })}
+              </span>
+              {kind}
+            </p>
+            {customTaskName ? (
+              <p>
+                <span>
+                  {intl.formatMessage({
+                    id: 'dashboard.resource.name',
+                    defaultMessage: 'Name:'
+                  })}
+                </span>
+                {customTaskName}
+              </p>
+            ) : null}
+          </div>
+          {rowsForParameters.length ? (
+            <Table
+              title={intl.formatMessage({
+                id: 'dashboard.parameters.title',
+                defaultMessage: 'Parameters'
+              })}
+              headers={headersForParameters}
+              rows={rowsForParameters}
+              size="sm"
+            />
+          ) : null}
+          {/* TODO: results */}
+        </>
+      </ResourceDetails>
+    </>
   );
 }
 

--- a/src/scss/Triggers.scss
+++ b/src/scss/Triggers.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,6 +12,14 @@ limitations under the License.
 */
 
 .tkn--resourcedetails {
+  .tkn--resourcedetails--header {
+    display: flex;
+
+    .tkn--actions-dropdown {
+      margin-left: auto;
+      margin-right: 1rem;
+    }
+  }
   .tkn--details {
     p:not(:empty) {
       margin-top: $spacing-03;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2261

In read-only mode, no actions are rendered.

Rerun is only enabled for standalone Run resources, same as for TaskRuns,
if they are a child of a Pipeline the action is disabled.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
