### PR TITLE
Add Dockerfile and docs for E2E tests

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,6 +15,7 @@ This guide explains how to build, deploy and test the Tekton Dashboard. It cover
   - [Integration tests](#integration-tests)
 - [Run frontend tests](#run-frontend-tests)
   - [Frontend unit tests](#frontend-unit-tests)
+  - [Frontend E2E tests](#frontend-e2e-tests)
   - [Linter](#linter)
 - [i18n](#i18n)
 - [Storybook](#storybook)
@@ -185,6 +186,18 @@ Run `npm test` to execute the unit tests via [Jest](https://jestjs.io/) in inter
 Coverage threshold is set to 90%, if it falls below the threshold the test script will fail.
 
 Tests are defined in `*.test.js` files alongside the code under test.
+
+### Frontend E2E tests
+
+Run `npm run e2e` to execute the end-to-end UI tests via [Cypress](https://www.cypress.io/) in interactive mode.
+
+Tests are defined in `*.cy.js` files in `packages/e2e/cypress`.
+
+By default tests are run using Chrome but you can override this by specifying an alternative supported browser available on your system, for example:
+
+`npm run e2e -- -- --browser firefox`
+
+To find the list of supported browsers and versions on your system, run `npx cypress info`
 
 ### Linter
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39977,7 +39977,7 @@
           "integrity": "sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==",
           "dev": true,
           "requires": {
-            "git-up": "^4.0.0"
+            "git-up": "4.0.2"
           }
         },
         "locate-path": {
@@ -46871,8 +46871,7 @@
       }
     },
     "git-up": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
+      "version": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
       "integrity": "sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==",
       "dev": true,
       "requires": {
@@ -46885,12 +46884,11 @@
       "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-12.0.0.tgz",
       "integrity": "sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==",
       "requires": {
-        "git-up": "^6.0.0"
+        "git-up": "4.0.2"
       },
       "dependencies": {
         "git-up": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/git-up/-/git-up-6.0.0.tgz",
+          "version": "https://registry.npmjs.org/git-up/-/git-up-6.0.0.tgz",
           "integrity": "sha512-6RUFSNd1c/D0xtGnyWN2sxza2bZtZ/EmI9448n6rCZruFwV/ezeEn2fJP7XnUQGwf0RAtd/mmUCbtH6JPYA2SA==",
           "requires": {
             "is-ssh": "^1.4.0",

--- a/packages/e2e/.dockerignore
+++ b/packages/e2e/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -1,0 +1,11 @@
+FROM cypress/browsers:node16.14.2-slim-chrome103-ff102
+USER node
+WORKDIR /home/node
+ENV CI=true
+ENTRYPOINT ["npm", "run", "test:ci"]
+CMD ["--", "--browser", "chrome"]
+
+COPY package.json .
+RUN npm install
+COPY cypress.config.js .
+COPY cypress cypress/


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Document the steps needed to run E2E tests in development / interactive
mode, as well as how to determine which browsers can be used.

Add a Dockerfile to be used during our integration test job so that
we can cache the npm install and other config steps between multiple
runs for each of the install variations tested (read-only, single tenant, etc.)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
