### PR TITLE
Fix URL handling on first load of PipelineRun or TaskRun

### DIFF
--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -221,7 +221,12 @@ export /* istanbul ignore next */ function PipelineRunContainer({ intl }) {
     }
 
     const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
-    history.push(browserURL);
+    if (currentPipelineTaskName) {
+      history.push(browserURL);
+    } else {
+      // auto-selecting task & step on first load
+      history.replace(browserURL);
+    }
   }
 
   function cancel() {

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -201,7 +201,12 @@ export function TaskRunContainer({ intl }) {
     }
 
     const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
-    history.push(browserURL);
+    if (showTaskRunDetails || selectedStepId) {
+      history.push(browserURL);
+    } else {
+      // auto-selecting step on first load
+      history.replace(browserURL);
+    }
   }
 
   function cancel() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Avoid invalid / unexpected interim state when navigating back using browser history by ensure we call `history.replace` instead of `history.push` when we automatically update the URL to include the selected task and/or step when rendering the PipelineRun or TaskRun resource.

If the URL query params already specify a selected task and/or step then push the new history entry into the stack as normal.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
