### PR TITLE
Fix for Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41105,7 +41105,8 @@
           }
         },
         "git-up": {
-          "version": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
           "integrity": "sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==",
           "dev": true,
           "requires": {
@@ -41119,7 +41120,7 @@
           "integrity": "sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==",
           "dev": true,
           "requires": {
-            "git-up": "4.0.2"
+            "git-up": "^4.0.0"
           }
         },
         "glob": {
@@ -48132,7 +48133,8 @@
       }
     },
     "git-up": {
-      "version": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
       "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
       "requires": {
         "is-ssh": "^1.4.0",
@@ -48144,7 +48146,7 @@
       "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-13.0.0.tgz",
       "integrity": "sha512-X1kozCqKL82dMrCLi4vie9SHDC+QugKskAMs4VUbIkhURKg5yDwxDmf6Ixg73J+/xVgK5TXKhzn8a94nHJHpnA==",
       "requires": {
-        "git-up": "4.0.2"
+        "git-up": "^7.0.0"
       }
     },
     "github-slugger": {

--- a/package.json
+++ b/package.json
@@ -102,11 +102,6 @@
     "node": "^16.13.2",
     "npm": "^8.1.2"
   },
-  "overrides": {
-    "git-url-parse": {
-      "git-up": "4.0.2"
-    }
-  },
   "//": "Workspaces must be listed explicitly to ensure they're processed in the correct order until npm natively supports detecting the topological order",
   "workspaces": [
     "packages/utils",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2465

Remove `git-up` override to avoid conflicts in package resolution that resulted in the wrong version of the package being used in production builds.

This lead to some regex code that's unsupported in Safari being included in the production bundle, but not being surfaced in development builds.

The version was originally pinned to fix this same problem Due to changes in other dependencies since the original fix was put in place, this approach does not work for this particular package (we have a transitive dependency on an older version via one of our dev dependencies, and for some reason this was being picked up in production builds).

Removing the override allows for newer (fixed) versions of the affected package to be picked up.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
