### PR TITLE
Capture video of failed E2E tests

### DIFF
--- a/packages/e2e/cypress.config.js
+++ b/packages/e2e/cypress.config.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 const { defineConfig } = require('cypress');
+const { unlink } = require('node:fs/promises');
 
 const isCI = process.env.CI === 'true';
 
@@ -19,10 +20,20 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8000',
     // experimentalSessionAndOrigin: true, // default is false
-    experimentalStudio: true
+    experimentalStudio: true,
+    setupNodeEvents(on, _config) {
+      on('after:spec', (spec, results) => {
+        if (isCI && results && results.video && results.stats.failures === 0) {
+          console.log('Deleting video for passing test'); // eslint-disable-line no-console
+          return unlink(results.video);
+        }
+
+        return null;
+      });
+    }
   },
   screenshotOnRunFailure: !isCI,
-  video: !isCI,
+  video: true,
   viewportHeight: 800, // default 660
   viewportWidth: 1280 // default 1000
   // waitForAnimations: true // disable to account for spinners?

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -163,8 +163,15 @@ test_dashboard() {
   fi
 
   echo "Running browser E2E tests…"
-  docker run --rm --network=host dashboard-e2e || fail_test "Browser E2E tests failed"
+  VIDEO_PATH=$ARTIFACTS/videos
+  mkdir -p $VIDEO_PATH
+  chmod -R 777 $VIDEO_PATH
+  # In case of failure we'll upload videos of the failing tests
+  # Our Cypress config will delete videos of passing tests before exiting
+  docker run --rm --network=host -v $VIDEO_PATH:/home/node/cypress/videos dashboard-e2e || fail_test "Browser E2E tests failed"
 
+  # If we get here the tests passed, no need to upload artifacts
+  rm -rf $VIDEO_PATH
   kill -9 $dashboardForwardPID
 
   $tekton_repo_dir/scripts/installer uninstall ${@:2}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update Cypress config to record video, but delete if a spec passes.

Mount the prow artifacts folder so we upload videos on failure.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
