### PR TITLE
Update prepare-kind-cluster script to pin Kubernetes 1.24

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -288,6 +288,24 @@ fi
 }
 
 ingress() {
+INGRESS_DEFAULT_CLASS_NAME_CONFIG=""
+if [ "$INGRESS_DEFAULT_CLASS" == "true" ]; then
+INGRESS_DEFAULT_CLASS_NAME_CONFIG="ingressClassName: nginx"
+cat <<EOF >> $TMP_FILE
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx
+EOF
+fi
+
 if [ ! -z "$INGRESS_URL" ] && [ ! -z "$INGRESS_SECRET" ]; then
 cat <<EOF >> $TMP_FILE
 ---
@@ -297,6 +315,7 @@ metadata:
   name: tekton-dashboard
   namespace: $INSTALL_NAMESPACE
 spec:
+  $INGRESS_DEFAULT_CLASS_NAME_CONFIG
   tls:
   - hosts:
     - $INGRESS_URL
@@ -321,6 +340,7 @@ metadata:
   name: tekton-dashboard
   namespace: $INSTALL_NAMESPACE
 spec:
+  $INGRESS_DEFAULT_CLASS_NAME_CONFIG
   rules:
   - host: $INGRESS_URL
     http:
@@ -514,6 +534,9 @@ while [[ $# -gt 0 ]]; do
     '--tenant-namespace')
       shift
       TENANT_NAMESPACE="${1}"
+      ;;
+    '--ingress-default-class')
+      INGRESS_DEFAULT_CLASS="true"
       ;;
     '--ingress-url')
       shift

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2021 The Tekton Authors
+# Copyright 2020-2022 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,16 +16,24 @@ set -e
 CLUSTERNAME=tekton-dashboard
 DEFAULT_OPTIONS="--log-format console"
 ENABLE_INGRESS="false"
+KUBERNETES_NODE_IMAGE="kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98"
 
 create_cluster() {
 if [ "$ENABLE_INGRESS" == "false" ]; then
-  kind create cluster --name $CLUSTERNAME
+  kind create cluster --name $CLUSTERNAME --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: $KUBERNETES_NODE_IMAGE
+EOF
 else
   kind create cluster --name $CLUSTERNAME --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: $KUBERNETES_NODE_IMAGE
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -58,7 +66,7 @@ header() {
 
 install_ingress_nginx() {
   header 'Installing ingress controller'
-  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-0.32.0/deploy/static/provider/kind/deploy.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.3.1/deploy/static/provider/kind/deploy.yaml
   sleep 20
   kubectl wait -n ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
 }
@@ -102,7 +110,7 @@ case $1 in
     install_ingress_nginx
     install_pipelines
     install_triggers
-    install_dashboard --ingress-url tekton-dashboard.127.0.0.1.nip.io $@
+    install_dashboard --ingress-url tekton-dashboard.127.0.0.1.nip.io --ingress-default-class $@
     ;;
   'update'|u)
     shift


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
There are a number of changes required in both the Triggers and Pipelines projects to support Kubernetes 1.25+. Pin to Kubernetes 1.24 until releases are available with support for a newer version.

Also update NGINX Ingress Controller to the v1.x releases, including the addition of the new IngressClass resource and config. This is required for compatibility with Kubernetes 1.24+.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
