### PR TITLE
Ensure e2e tests set default language to English

### DIFF
--- a/packages/e2e/cypress/e2e/common/i18n.cy.js
+++ b/packages/e2e/cypress/e2e/common/i18n.cy.js
@@ -16,6 +16,7 @@ describe('Translations', () => {
     cy.visit('/#/about', {
       onBeforeLoad(win) {
         Object.defineProperty(win.navigator, 'language', {
+          configurable: true,
           value: 'zh-Hans'
         });
       }

--- a/packages/e2e/cypress/support/e2e.js
+++ b/packages/e2e/cypress/support/e2e.js
@@ -12,3 +12,14 @@ limitations under the License.
 */
 
 import './commands';
+
+beforeEach(() => {
+  cy.on('window:before:load', win => {
+    // we want to ensure the browser is using English as its language so tests
+    // that make assertions or locate elements by text content work as expected
+    Object.defineProperty(win.navigator, 'language', {
+      configurable: true,
+      value: 'en'
+    });
+  });
+});

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,6 +27,7 @@ module.exports = ({ mode }) => ({
       },
       {
         test: /\.js$/,
+        exclude: [path.resolve(__dirname, 'packages', 'e2e')],
         include: [
           path.resolve(__dirname, 'src'),
           path.resolve(__dirname, 'packages')


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
To ensure consistency and prevent issues with contributors running e2e tests on other platforms, configure the default language for all tests so that content-based assertions and locators work as expected.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
