### PR TITLE
Switch functional components to `useIntl` hook

### DIFF
--- a/packages/components/src/components/DeleteModal/DeleteModal.js
+++ b/packages/components/src/components/DeleteModal/DeleteModal.js
@@ -13,74 +13,76 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Modal } from 'carbon-components-react';
 import { Table } from '..';
 
 const DeleteModal = ({
   onClose,
   onSubmit,
-  intl,
   kind,
   resources,
   showNamespace = true
-}) => (
-  <Modal
-    className="tkn--delete-modal"
-    open
-    primaryButtonText={intl.formatMessage({
-      id: 'dashboard.actions.deleteButton',
-      defaultMessage: 'Delete'
-    })}
-    secondaryButtonText={intl.formatMessage({
-      id: 'dashboard.modal.cancelButton',
-      defaultMessage: 'Cancel'
-    })}
-    modalHeading={intl.formatMessage(
-      {
-        id: 'dashboard.deleteResources.heading',
-        defaultMessage: 'Delete {kind}'
-      },
-      { kind }
-    )}
-    onSecondarySubmit={onClose}
-    onRequestSubmit={onSubmit}
-    onRequestClose={onClose}
-    danger
-  >
-    <p>
-      {intl.formatMessage(
+}) => {
+  const intl = useIntl();
+  return (
+    <Modal
+      className="tkn--delete-modal"
+      open
+      primaryButtonText={intl.formatMessage({
+        id: 'dashboard.actions.deleteButton',
+        defaultMessage: 'Delete'
+      })}
+      secondaryButtonText={intl.formatMessage({
+        id: 'dashboard.modal.cancelButton',
+        defaultMessage: 'Cancel'
+      })}
+      modalHeading={intl.formatMessage(
         {
-          id: 'dashboard.deleteResources.confirm',
-          defaultMessage: 'Are you sure you want to delete these {kind}?'
+          id: 'dashboard.deleteResources.heading',
+          defaultMessage: 'Delete {kind}'
         },
         { kind }
       )}
-    </p>
-    <Table
-      headers={[
-        {
-          key: 'name',
-          header: intl.formatMessage({
-            id: 'dashboard.tableHeader.name',
-            defaultMessage: 'Name'
-          })
-        },
-        showNamespace
-          ? {
-              key: 'namespace',
-              header: 'Namespace'
-            }
-          : null
-      ].filter(Boolean)}
-      rows={resources.map(resource => ({
-        id: resource.metadata.uid,
-        name: resource.metadata.name,
-        namespace: resource.metadata.namespace
-      }))}
-      size="sm"
-    />
-  </Modal>
-);
+      onSecondarySubmit={onClose}
+      onRequestSubmit={onSubmit}
+      onRequestClose={onClose}
+      danger
+    >
+      <p>
+        {intl.formatMessage(
+          {
+            id: 'dashboard.deleteResources.confirm',
+            defaultMessage: 'Are you sure you want to delete these {kind}?'
+          },
+          { kind }
+        )}
+      </p>
+      <Table
+        headers={[
+          {
+            key: 'name',
+            header: intl.formatMessage({
+              id: 'dashboard.tableHeader.name',
+              defaultMessage: 'Name'
+            })
+          },
+          showNamespace
+            ? {
+                key: 'namespace',
+                header: 'Namespace'
+              }
+            : null
+        ].filter(Boolean)}
+        rows={resources.map(resource => ({
+          id: resource.metadata.uid,
+          name: resource.metadata.name,
+          namespace: resource.metadata.namespace
+        }))}
+        size="sm"
+      />
+    </Modal>
+  );
+};
 
-export default injectIntl(DeleteModal);
+export default DeleteModal;

--- a/packages/components/src/components/FormattedDate/FormattedDate.js
+++ b/packages/components/src/components/FormattedDate/FormattedDate.js
@@ -12,14 +12,15 @@ limitations under the License.
 */
 
 import React from 'react';
-import { FormattedDate, FormattedRelativeTime, injectIntl } from 'react-intl';
+import { FormattedDate, FormattedRelativeTime, useIntl } from 'react-intl';
 
 const FormattedDateWrapper = ({
   date,
   formatTooltip = formattedDate => formattedDate,
-  intl,
   relative
 }) => {
+  const intl = useIntl();
+
   if (!date) {
     return null;
   }
@@ -62,4 +63,4 @@ const FormattedDateWrapper = ({
   return <span title={formatTooltip(formattedDate)}>{content}</span>;
 };
 
-export default injectIntl(FormattedDateWrapper);
+export default FormattedDateWrapper;

--- a/packages/components/src/components/Header/Header.js
+++ b/packages/components/src/components/Header/Header.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   Header as CarbonHeader,
   HeaderGlobalBar,
@@ -31,10 +31,10 @@ function skipToContentClick(event) {
 function Header({
   children,
   headerNameProps,
-  intl,
   isSideNavExpanded,
   onHeaderMenuButtonClick
 }) {
+  const intl = useIntl();
   return (
     <CarbonHeader aria-label="Tekton Dashboard" className="tkn--header">
       <SkipToContent href="#" onClick={skipToContentClick}>
@@ -68,4 +68,4 @@ function Header({
   );
 }
 
-export default injectIntl(Header);
+export default Header;

--- a/packages/components/src/components/KeyValueList/KeyValueList.js
+++ b/packages/components/src/components/KeyValueList/KeyValueList.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,13 +12,13 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Button, TextInput } from 'carbon-components-react';
 import { AddAlt24 as Add, SubtractAlt16 as Remove } from '@carbon/icons-react';
 
 const KeyValueList = props => {
+  const intl = useIntl();
   const {
-    intl,
     invalidFields,
     invalidText,
     keyValues,
@@ -109,4 +109,4 @@ KeyValueList.defaultProps = {
   minKeyValues: 0
 };
 
-export default injectIntl(KeyValueList);
+export default KeyValueList;

--- a/packages/components/src/components/LoadingShell/LoadingShell.js
+++ b/packages/components/src/components/LoadingShell/LoadingShell.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   SkeletonText as CarbonSkeletonText,
   Content,
@@ -29,7 +29,8 @@ const SkeletonText = ({ heading, paragraph }) => (
   <CarbonSkeletonText heading={heading} paragraph={paragraph} width="80%" />
 );
 
-const LoadingShell = ({ intl }) => {
+const LoadingShell = () => {
+  const intl = useIntl();
   const loadingMessage = intl.formatMessage({
     id: 'dashboard.loading.config',
     defaultMessage: 'Loading configuration…'
@@ -86,4 +87,4 @@ const LoadingShell = ({ intl }) => {
   );
 };
 
-export default injectIntl(LoadingShell);
+export default LoadingShell;

--- a/packages/components/src/components/LogsToolbar/LogsToolbar.js
+++ b/packages/components/src/components/LogsToolbar/LogsToolbar.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   Download16,
   Launch16,
@@ -20,57 +20,64 @@ import {
   Minimize16
 } from '@carbon/icons-react';
 
-const LogsToolbar = ({ intl, isMaximized, name, toggleMaximized, url }) => (
-  <div className="bx--btn-set">
-    {toggleMaximized ? (
-      <button className="bx--copy-btn" onClick={toggleMaximized} type="button">
-        {isMaximized ? (
-          <Minimize16>
-            <title>
-              {intl.formatMessage({
-                id: 'dashboard.logs.restore',
-                defaultMessage: 'Return to default'
-              })}
-            </title>
-          </Minimize16>
-        ) : (
-          <Maximize16>
-            <title>
-              {intl.formatMessage({
-                id: 'dashboard.logs.maximize',
-                defaultMessage: 'Maximize'
-              })}
-            </title>
-          </Maximize16>
-        )}
-      </button>
-    ) : null}
-    <a
-      className="bx--copy-btn"
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <Launch16>
-        <title>
-          {intl.formatMessage({
-            id: 'dashboard.logs.launchButtonTooltip',
-            defaultMessage: 'Open logs in a new window'
-          })}
-        </title>
-      </Launch16>
-    </a>
-    <a className="bx--copy-btn" download={name} href={url}>
-      <Download16>
-        <title>
-          {intl.formatMessage({
-            id: 'dashboard.logs.downloadButtonTooltip',
-            defaultMessage: 'Download logs'
-          })}
-        </title>
-      </Download16>
-    </a>
-  </div>
-);
+const LogsToolbar = ({ isMaximized, name, toggleMaximized, url }) => {
+  const intl = useIntl();
+  return (
+    <div className="bx--btn-set">
+      {toggleMaximized ? (
+        <button
+          className="bx--copy-btn"
+          onClick={toggleMaximized}
+          type="button"
+        >
+          {isMaximized ? (
+            <Minimize16>
+              <title>
+                {intl.formatMessage({
+                  id: 'dashboard.logs.restore',
+                  defaultMessage: 'Return to default'
+                })}
+              </title>
+            </Minimize16>
+          ) : (
+            <Maximize16>
+              <title>
+                {intl.formatMessage({
+                  id: 'dashboard.logs.maximize',
+                  defaultMessage: 'Maximize'
+                })}
+              </title>
+            </Maximize16>
+          )}
+        </button>
+      ) : null}
+      <a
+        className="bx--copy-btn"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Launch16>
+          <title>
+            {intl.formatMessage({
+              id: 'dashboard.logs.launchButtonTooltip',
+              defaultMessage: 'Open logs in a new window'
+            })}
+          </title>
+        </Launch16>
+      </a>
+      <a className="bx--copy-btn" download={name} href={url}>
+        <Download16>
+          <title>
+            {intl.formatMessage({
+              id: 'dashboard.logs.downloadButtonTooltip',
+              defaultMessage: 'Download logs'
+            })}
+          </title>
+        </Download16>
+      </a>
+    </div>
+  );
+};
 
-export default injectIntl(LogsToolbar);
+export default LogsToolbar;

--- a/packages/components/src/components/Modal/Modal.js
+++ b/packages/components/src/components/Modal/Modal.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,17 +13,20 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Modal as CarbonModal } from 'carbon-components-react';
 
-const Modal = ({ intl, ...rest }) => (
-  <CarbonModal
-    iconDescription={intl.formatMessage({
-      id: 'dashboard.modal.close',
-      defaultMessage: 'Close'
-    })}
-    {...rest}
-  />
-);
+const Modal = props => {
+  const intl = useIntl();
+  return (
+    <CarbonModal
+      iconDescription={intl.formatMessage({
+        id: 'dashboard.modal.close',
+        defaultMessage: 'Close'
+      })}
+      {...props}
+    />
+  );
+};
 
-export default injectIntl(Modal);
+export default Modal;

--- a/packages/components/src/components/PageErrorBoundary/PageErrorBoundary.js
+++ b/packages/components/src/components/PageErrorBoundary/PageErrorBoundary.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,12 +12,13 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 
 import { ErrorBoundary } from '..';
 
-const PageErrorBoundary = ({ children, intl }) => {
+const PageErrorBoundary = ({ children }) => {
+  const intl = useIntl();
   const location = useLocation();
   const message = intl.formatMessage({
     id: 'dashboard.errorBoundary.pageError',
@@ -31,4 +32,4 @@ const PageErrorBoundary = ({ children, intl }) => {
   );
 };
 
-export default injectIntl(PageErrorBoundary);
+export default PageErrorBoundary;

--- a/packages/components/src/components/PipelineResources/PipelineResources.js
+++ b/packages/components/src/components/PipelineResources/PipelineResources.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { urls } from '@tektoncd/dashboard-utils';
 import { Link as CustomLink } from '@tektoncd/dashboard-components';
@@ -24,12 +24,12 @@ const PipelineResources = ({
   createPipelineResourcesURL = urls.pipelineResources.byName,
   createPipelineResourceDisplayName = ({ pipelineResourceMetadata }) =>
     pipelineResourceMetadata.name,
-  intl,
   loading,
   pipelineResources,
   selectedNamespace,
   toolbarButtons
 }) => {
+  const intl = useIntl();
   const headers = [
     {
       key: 'name',
@@ -115,4 +115,4 @@ const PipelineResources = ({
   );
 };
 
-export default injectIntl(PipelineResources);
+export default PipelineResources;

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { getStatus, urls } from '@tektoncd/dashboard-utils';
 import {
@@ -115,13 +115,13 @@ const PipelineRuns = ({
   },
   getPipelineRunURL = urls.pipelineRuns.byName,
   getRunActions = () => [],
-  intl,
   loading,
   pipelineRuns,
   selectedNamespace,
   skeletonRowCount,
   toolbarButtons
 }) => {
+  const intl = useIntl();
   let hasRunActions = false;
   const defaultHeaders = {
     pipeline: intl.formatMessage({
@@ -325,4 +325,4 @@ const PipelineRuns = ({
   );
 };
 
-export default injectIntl(PipelineRuns);
+export default PipelineRuns;

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { InlineNotification, SkeletonText, Tag } from 'carbon-components-react';
 import { formatLabels, getErrorMessage } from '@tektoncd/dashboard-utils';
 import { FormattedDate, Tab, Tabs, ViewYAML } from '..';
@@ -25,12 +25,12 @@ const ResourceDetails = ({
   additionalMetadata,
   children,
   error,
-  intl,
   loading,
   onViewChange,
   resource: originalResource,
   view
 }) => {
+  const intl = useIntl();
   if (loading) {
     return <SkeletonText heading width="60%" />;
   }
@@ -169,4 +169,4 @@ ResourceDetails.propTypes = {
   view: PropTypes.string
 };
 
-export default injectIntl(ResourceDetails);
+export default ResourceDetails;

--- a/packages/components/src/components/StatusFilterDropdown/StatusFilterDropdown.js
+++ b/packages/components/src/components/StatusFilterDropdown/StatusFilterDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,16 +12,12 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Dropdown } from 'carbon-components-react';
 import { statusFilterOrder } from '@tektoncd/dashboard-utils';
 
-const StatusFilterDropdown = ({
-  id,
-  initialSelectedStatus,
-  intl,
-  onChange
-}) => {
+const StatusFilterDropdown = ({ id, initialSelectedStatus, onChange }) => {
+  const intl = useIntl();
   const allItem = {
     id: '',
     text: intl.formatMessage({
@@ -86,4 +82,4 @@ const StatusFilterDropdown = ({
   );
 };
 
-export default injectIntl(StatusFilterDropdown);
+export default StatusFilterDropdown;

--- a/packages/components/src/components/StepDetails/StepDetails.js
+++ b/packages/components/src/components/StepDetails/StepDetails.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getStatus, getStepStatusReason } from '@tektoncd/dashboard-utils';
 
 import { DetailsHeader, StepDefinition, Tab, Tabs } from '..';
@@ -21,9 +21,9 @@ import { DetailsHeader, StepDefinition, Tab, Tabs } from '..';
 const tabs = ['logs', 'details'];
 
 const StepDetails = props => {
+  const intl = useIntl();
   const {
     definition,
-    intl,
     logContainer,
     onViewChange,
     stepName,
@@ -91,4 +91,4 @@ StepDetails.defaultProps = {
   taskRun: {}
 };
 
-export default injectIntl(StepDetails);
+export default StepDetails;

--- a/packages/components/src/components/Table/Table.js
+++ b/packages/components/src/components/Table/Table.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
@@ -111,6 +111,7 @@ function getTranslateWithId(intl) {
 }
 
 const Table = props => {
+  const intl = useIntl();
   const {
     batchActionButtons,
     className,
@@ -120,7 +121,6 @@ const Table = props => {
     hasDetails,
     headers: dataHeaders,
     id,
-    intl,
     isSortable,
     loading,
     rows: dataRows,
@@ -300,4 +300,4 @@ Table.propTypes = {
   toolbarButtons: PropTypes.arrayOf(PropTypes.object)
 };
 
-export default injectIntl(Table);
+export default Table;

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   getParams,
   getResources,
@@ -87,15 +87,8 @@ function resourceTable(title, namespace, resources, intl) {
   );
 }
 
-const TaskRunDetails = ({
-  intl,
-  onViewChange,
-  pod,
-  task,
-  taskRun,
-  view,
-  showIO
-}) => {
+const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view, showIO }) => {
+  const intl = useIntl();
   const displayName = taskRun.metadata.name;
   const taskSpec = task?.spec || taskRun.spec.taskSpec;
 
@@ -330,4 +323,4 @@ TaskRunDetails.defaultProps = {
   showIO: false
 };
 
-export default injectIntl(TaskRunDetails);
+export default TaskRunDetails;

--- a/packages/components/src/components/TaskRuns/TaskRuns.js
+++ b/packages/components/src/components/TaskRuns/TaskRuns.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import {
   Calendar16 as CalendarIcon,
@@ -94,12 +94,12 @@ const TaskRuns = ({
     );
   },
   getTaskRunURL = urls.taskRuns.byName,
-  intl,
   loading,
   selectedNamespace,
   taskRuns,
   toolbarButtons
 }) => {
+  const intl = useIntl();
   let hasRunActions = false;
   const headers = [
     {
@@ -287,4 +287,4 @@ const TaskRuns = ({
   );
 };
 
-export default injectIntl(TaskRuns);
+export default TaskRuns;

--- a/packages/components/src/components/TooltipDropdown/TooltipDropdown.js
+++ b/packages/components/src/components/TooltipDropdown/TooltipDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ComboBox, DropdownSkeleton } from 'carbon-components-react';
 import { getTranslateWithId } from '@tektoncd/dashboard-utils';
 
@@ -32,7 +32,6 @@ const TooltipDropdown = ({
   emptyText,
   id,
   inline,
-  intl,
   items,
   label,
   light,
@@ -42,6 +41,7 @@ const TooltipDropdown = ({
   titleText,
   ...rest
 }) => {
+  const intl = useIntl();
   if (loading) {
     return (
       <div className="bx--list-box__wrapper">
@@ -88,4 +88,4 @@ TooltipDropdown.defaultProps = {
   loading: false
 };
 
-export default injectIntl(TooltipDropdown);
+export default TooltipDropdown;

--- a/packages/components/src/components/Trigger/Trigger.js
+++ b/packages/components/src/components/Trigger/Trigger.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import {
   Accordion,
@@ -23,7 +23,8 @@ import {
 import { urls } from '@tektoncd/dashboard-utils';
 import { Link as CustomLink, Table, ViewYAML } from '..';
 
-const Trigger = ({ intl, namespace, trigger }) => {
+const Trigger = ({ namespace, trigger }) => {
+  const intl = useIntl();
   const tableHeaders = [
     {
       key: 'name',
@@ -357,4 +358,4 @@ const Trigger = ({ intl, namespace, trigger }) => {
   );
 };
 
-export default injectIntl(Trigger);
+export default Trigger;

--- a/src/containers/About/About.js
+++ b/src/containers/About/About.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { Fragment } from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   ClickableTile as CarbonClickableTile,
   InlineNotification,
@@ -40,7 +40,8 @@ function ClickableTile(props) {
   );
 }
 
-export function About({ intl }) {
+export function About() {
+  const intl = useIntl();
   useTitleSync({
     page: intl.formatMessage({
       id: 'dashboard.about.title',
@@ -280,4 +281,4 @@ export function About({ intl }) {
   );
 }
 
-export default injectIntl(About);
+export default About;

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -22,7 +22,7 @@ import {
   Switch
 } from 'react-router-dom';
 
-import { injectIntl, IntlProvider } from 'react-intl';
+import { IntlProvider, useIntl } from 'react-intl';
 import { Content, InlineNotification } from 'carbon-components-react';
 
 import {
@@ -95,7 +95,8 @@ import '../../scss/App.scss';
 const { default: defaultLocale, supported: supportedLocales } = config.locales;
 
 /* istanbul ignore next */
-const ConfigErrorComponent = ({ intl, loadingConfigError }) => {
+const ConfigErrorComponent = ({ loadingConfigError }) => {
+  const intl = useIntl();
   if (!loadingConfigError) {
     return null;
   }
@@ -113,7 +114,7 @@ const ConfigErrorComponent = ({ intl, loadingConfigError }) => {
   );
 };
 
-const ConfigError = injectIntl(ConfigErrorComponent);
+const ConfigError = ConfigErrorComponent;
 
 async function loadMessages(lang) {
   const isSupportedLocale = supportedLocales.includes(lang);

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.js
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -48,7 +48,8 @@ function getFormattedResources(resources) {
   }));
 }
 
-function ClusterInterceptors({ intl }) {
+function ClusterInterceptors() {
+  const intl = useIntl();
   const location = useLocation();
   const filters = getFilters(location);
 
@@ -126,4 +127,4 @@ function ClusterInterceptors({ intl }) {
   );
 }
 
-export default injectIntl(ClusterInterceptors);
+export default ClusterInterceptors;

--- a/src/containers/ClusterTasks/ClusterTasks.js
+++ b/src/containers/ClusterTasks/ClusterTasks.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
   Link as CustomLink,
@@ -122,7 +122,8 @@ function getFormattedResources({
   }));
 }
 
-function ClusterTasksContainer({ intl }) {
+function ClusterTasksContainer() {
+  const intl = useIntl();
   const location = useLocation();
   const [cancelSelection, setCancelSelection] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
@@ -281,4 +282,4 @@ function ClusterTasksContainer({ intl }) {
   );
 }
 
-export default injectIntl(ClusterTasksContainer);
+export default ClusterTasksContainer;

--- a/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.js
+++ b/src/containers/ClusterTasksDropdown/ClusterTasksDropdown.js
@@ -12,12 +12,13 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import { useClusterTasks } from '../../api';
 
-function ClusterTasksDropdown({ disabled, intl, label, ...rest }) {
+function ClusterTasksDropdown({ disabled, label, ...rest }) {
+  const intl = useIntl();
   const { data: clusterTasks = [], isFetching } = useClusterTasks({});
 
   const items = clusterTasks.map(clusterTask => clusterTask.metadata.name);
@@ -50,4 +51,4 @@ ClusterTasksDropdown.defaultProps = {
   titleText: 'ClusterTask'
 };
 
-export default injectIntl(ClusterTasksDropdown);
+export default ClusterTasksDropdown;

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,13 +14,14 @@ limitations under the License.
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { useClusterTriggerBinding } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export function ClusterTriggerBindingContainer({ intl }) {
+export function ClusterTriggerBindingContainer() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -92,4 +93,4 @@ export function ClusterTriggerBindingContainer({ intl }) {
   );
 }
 
-export default injectIntl(ClusterTriggerBindingContainer);
+export default ClusterTriggerBindingContainer;

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -42,7 +42,8 @@ function getFormattedResources(resources) {
   }));
 }
 
-function ClusterTriggerBindings({ intl }) {
+function ClusterTriggerBindings() {
+  const intl = useIntl();
   const location = useLocation();
   const filters = getFilters(location);
 
@@ -111,4 +112,4 @@ function ClusterTriggerBindings({ intl }) {
   );
 }
 
-export default injectIntl(ClusterTriggerBindings);
+export default ClusterTriggerBindings;

--- a/src/containers/CreatePipelineResource/CreatePipelineResource.js
+++ b/src/containers/CreatePipelineResource/CreatePipelineResource.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Button, InlineNotification } from 'carbon-components-react';
 import {
   ALL_NAMESPACES,
@@ -51,7 +51,8 @@ function validateInputs(value, id) {
   return true;
 }
 
-export /* istanbul ignore next */ function CreatePipelineResource({ intl }) {
+export /* istanbul ignore next */ function CreatePipelineResource() {
+  const intl = useIntl();
   const history = useHistory();
   const { selectedNamespace: defaultNamespace } = useSelectedNamespace();
   const [creating, setCreating] = useState(false);
@@ -304,4 +305,4 @@ export /* istanbul ignore next */ function CreatePipelineResource({ intl }) {
   );
 }
 
-export default injectIntl(CreatePipelineResource);
+export default CreatePipelineResource;

--- a/src/containers/CreatePipelineResource/GitResourceFields.js
+++ b/src/containers/CreatePipelineResource/GitResourceFields.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,10 +13,14 @@ limitations under the License.
 
 import React from 'react';
 import { TextInput } from 'carbon-components-react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 
-const GitResourceFields = props => {
-  const { revision, handleChangeTextInput, invalidFields, intl } = props;
+const GitResourceFields = ({
+  revision,
+  handleChangeTextInput,
+  invalidFields
+}) => {
+  const intl = useIntl();
 
   return (
     <TextInput
@@ -41,4 +45,4 @@ const GitResourceFields = props => {
   );
 };
 
-export default injectIntl(GitResourceFields);
+export default GitResourceFields;

--- a/src/containers/CreatePipelineResource/UniversalFields.js
+++ b/src/containers/CreatePipelineResource/UniversalFields.js
@@ -13,25 +13,24 @@ limitations under the License.
 
 import React from 'react';
 import { Dropdown, TextInput } from 'carbon-components-react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getTranslateWithId } from '@tektoncd/dashboard-utils';
 
 import NamespacesDropdown from '../NamespacesDropdown';
 
 const itemToString = ({ text }) => text;
 
-const UniversalFields = props => {
-  const {
-    name,
-    handleChangeTextInput,
-    handleChangeNamespace,
-    selectedNamespace,
-    type,
-    handleChangeType,
-    url,
-    invalidFields,
-    intl
-  } = props;
+const UniversalFields = ({
+  name,
+  handleChangeTextInput,
+  handleChangeNamespace,
+  selectedNamespace,
+  type,
+  handleChangeType,
+  url,
+  invalidFields
+}) => {
+  const intl = useIntl();
 
   return (
     <>
@@ -113,4 +112,4 @@ const UniversalFields = props => {
   );
 };
 
-export default injectIntl(UniversalFields);
+export default UniversalFields;

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.js
@@ -31,7 +31,7 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import { KeyValueList } from '@tektoncd/dashboard-components';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   NamespacesDropdown,
   PipelineResourcesDropdown,
@@ -90,7 +90,8 @@ const initialResourcesState = resourceSpecs => {
   return resourceSpecs.reduce(resourcesReducer, {});
 };
 
-function CreatePipelineRun({ intl }) {
+function CreatePipelineRun() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const { selectedNamespace: defaultNamespace } = useSelectedNamespace();
@@ -768,4 +769,4 @@ function CreatePipelineRun({ intl }) {
   );
 }
 
-export default injectIntl(CreatePipelineRun);
+export default CreatePipelineRun;

--- a/src/containers/CreateTaskRun/CreateTaskRun.js
+++ b/src/containers/CreateTaskRun/CreateTaskRun.js
@@ -32,7 +32,7 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import { KeyValueList } from '@tektoncd/dashboard-components';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   ClusterTasksDropdown,
   NamespacesDropdown,
@@ -103,7 +103,8 @@ const initialResourcesState = resourceSpecs => {
 
 const itemToString = ({ text }) => text;
 
-function CreateTaskRun({ intl }) {
+function CreateTaskRun() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const { selectedNamespace: defaultNamespace } = useSelectedNamespace();
@@ -830,4 +831,4 @@ function CreateTaskRun({ intl }) {
   );
 }
 
-export default injectIntl(CreateTaskRun);
+export default CreateTaskRun;

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,6 @@ limitations under the License.
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
 
@@ -75,4 +74,4 @@ function CustomResourceDefinition() {
   );
 }
 
-export default injectIntl(CustomResourceDefinition);
+export default CustomResourceDefinition;

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -25,7 +25,8 @@ import {
 import { useEventListener } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export function EventListenerContainer({ intl }) {
+export function EventListenerContainer() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -145,4 +146,4 @@ export function EventListenerContainer({ intl }) {
   );
 }
 
-export default injectIntl(EventListenerContainer);
+export default EventListenerContainer;

--- a/src/containers/EventListeners/EventListeners.js
+++ b/src/containers/EventListeners/EventListeners.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -44,7 +44,8 @@ function getFormattedResources(resources) {
   }));
 }
 
-function EventListeners({ intl }) {
+function EventListeners() {
+  const intl = useIntl();
   const location = useLocation();
   const params = useParams();
   const filters = getFilters(location);
@@ -126,4 +127,4 @@ function EventListeners({ intl }) {
   );
 }
 
-export default injectIntl(EventListeners);
+export default EventListeners;

--- a/src/containers/Extension/Extension.js
+++ b/src/containers/Extension/Extension.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,14 +13,15 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { Suspense, useState } from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ErrorBoundary } from '@tektoncd/dashboard-components';
 import { paths, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 
 // TODO: restore this when adding support for custom UI extensions
 // import './globals';
 
-function Extension({ displayName: resourceName, intl, source }) {
+function Extension({ displayName: resourceName, source }) {
+  const intl = useIntl();
   const [ExtensionComponent] = useState(() =>
     React.lazy(() => import(/* webpackIgnore: true */ source))
   );
@@ -53,4 +54,4 @@ function Extension({ displayName: resourceName, intl, source }) {
   );
 }
 
-export default injectIntl(Extension);
+export default Extension;

--- a/src/containers/Extensions/Extensions.js
+++ b/src/containers/Extensions/Extensions.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { InlineNotification } from 'carbon-components-react';
 import {
@@ -26,7 +26,8 @@ import { Link as CustomLink, Table } from '@tektoncd/dashboard-components';
 
 import { useExtensions, useTenantNamespace } from '../../api';
 
-function Extensions({ intl }) {
+function Extensions() {
+  const intl = useIntl();
   useTitleSync({
     page: intl.formatMessage({
       id: 'dashboard.extensions.title',
@@ -106,4 +107,4 @@ function Extensions({ intl }) {
   );
 }
 
-export default injectIntl(Extensions);
+export default Extensions;

--- a/src/containers/ImportResources/ImportResources.js
+++ b/src/containers/ImportResources/ImportResources.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React, { useState } from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   Accordion,
   AccordionItem,
@@ -63,7 +63,8 @@ const HelpIcon = ({ title }) => (
   </TooltipIcon>
 );
 
-export function ImportResources({ intl }) {
+export function ImportResources() {
+  const intl = useIntl();
   const { selectedNamespace: navNamespace } = useSelectedNamespace();
   const dashboardNamespace = useDashboardNamespace();
 
@@ -433,4 +434,4 @@ export function ImportResources({ intl }) {
   );
 }
 
-export default injectIntl(ImportResources);
+export default ImportResources;

--- a/src/containers/ListPageLayout/ListPageLayout.js
+++ b/src/containers/ListPageLayout/ListPageLayout.js
@@ -14,7 +14,7 @@ limitations under the License.
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory, useLocation } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { InlineNotification, Pagination } from 'carbon-components-react';
 import { getErrorMessage } from '@tektoncd/dashboard-utils';
 
@@ -24,10 +24,10 @@ export const ListPageLayout = ({
   children,
   error,
   filters,
-  intl,
   resources = [],
   title
 }) => {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
 
@@ -106,7 +106,7 @@ export const ListPageLayout = ({
   );
 };
 
-export default injectIntl(ListPageLayout);
+export default ListPageLayout;
 
 ListPageLayout.propTypes = {
   children: PropTypes.func.isRequired

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.js
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
@@ -23,13 +23,13 @@ const NamespacesDropdown = ({
   children,
   dispatch,
   emptyText,
-  intl,
   isSideNavExpanded,
   label,
   selectedItem: originalSelectedItem,
   showAllNamespaces,
   ...rest
 }) => {
+  const intl = useIntl();
   const labelString =
     label ||
     intl.formatMessage({
@@ -85,4 +85,4 @@ NamespacesDropdown.defaultProps = {
   titleText: 'Namespace'
 };
 
-export default injectIntl(NamespacesDropdown);
+export default NamespacesDropdown;

--- a/src/containers/NotFound/NotFound.js
+++ b/src/containers/NotFound/NotFound.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { Column, Grid, Row } from 'carbon-components-react';
 import { Link as CustomLink } from '@tektoncd/dashboard-components';
@@ -26,7 +26,8 @@ const smallConfig = { offset: 1, span: 2 };
 const mediumConfig = { offset: 2, span: 4 };
 const largeConfig = { offset: 5, span: 6 };
 
-function NotFound({ intl, suggestions = [] }) {
+function NotFound({ suggestions = [] }) {
+  const intl = useIntl();
   const { selectedNamespace: namespace } = useSelectedNamespace();
 
   return (
@@ -114,4 +115,4 @@ function NotFound({ intl, suggestions = [] }) {
   );
 }
 
-export default injectIntl(NotFound);
+export default NotFound;

--- a/src/containers/PipelineResource/PipelineResource.js
+++ b/src/containers/PipelineResource/PipelineResource.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { DataTable } from 'carbon-components-react';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
@@ -32,7 +32,8 @@ const {
 } = DataTable;
 
 /* istanbul ignore next */
-function PipelineResource({ intl }) {
+function PipelineResource() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const { namespace, pipelineResourceName: resourceName } = useParams();
@@ -196,4 +197,4 @@ function PipelineResource({ intl }) {
   );
 }
 
-export default injectIntl(PipelineResource);
+export default PipelineResource;

--- a/src/containers/PipelineResources/PipelineResources.js
+++ b/src/containers/PipelineResources/PipelineResources.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
   ALL_NAMESPACES,
@@ -36,7 +36,8 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function PipelineResources({ intl }) {
+export function PipelineResources() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -177,4 +178,4 @@ export function PipelineResources({ intl }) {
   );
 }
 
-export default injectIntl(PipelineResources);
+export default PipelineResources;

--- a/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
+++ b/src/containers/PipelineResourcesDropdown/PipelineResourcesDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,19 +12,19 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import { usePipelineResources, useSelectedNamespace } from '../../api';
 
 function PipelineResourcesDropdown({
-  intl,
   label,
   namespace: namespaceProp,
   type,
   ...rest
 }) {
+  const intl = useIntl();
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceProp || selectedNamespace;
 
@@ -93,4 +93,4 @@ PipelineResourcesDropdown.defaultProps = {
   titleText: 'PipelineResource'
 };
 
-export default injectIntl(PipelineResourcesDropdown);
+export default PipelineResourcesDropdown;

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -30,7 +30,7 @@ import {
   TileGroup
 } from 'carbon-components-react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import {
   cancelPipelineRun,
@@ -57,7 +57,8 @@ import { NotFound } from '..';
 
 const { PIPELINE_TASK, RETRY, STEP, VIEW } = queryParamConstants;
 
-export /* istanbul ignore next */ function PipelineRunContainer({ intl }) {
+export /* istanbul ignore next */ function PipelineRunContainer() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -565,4 +566,4 @@ export /* istanbul ignore next */ function PipelineRunContainer({ intl }) {
   );
 }
 
-export default injectIntl(PipelineRunContainer);
+export default PipelineRunContainer;

--- a/src/containers/PipelineRuns/PipelineRuns.js
+++ b/src/containers/PipelineRuns/PipelineRuns.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import { RadioTile, TileGroup } from 'carbon-components-react';
 import {
@@ -51,7 +51,8 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function PipelineRuns({ intl }) {
+export function PipelineRuns() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -418,4 +419,4 @@ export function PipelineRuns({ intl }) {
   );
 }
 
-export default injectIntl(PipelineRuns);
+export default PipelineRuns;

--- a/src/containers/Pipelines/Pipelines.js
+++ b/src/containers/Pipelines/Pipelines.js
@@ -19,7 +19,7 @@ import {
   PlayOutline16 as RunIcon,
   Playlist16 as RunsIcon
 } from '@carbon/icons-react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import { Button } from 'carbon-components-react';
 import {
@@ -135,7 +135,8 @@ function getFormattedResources({
   }));
 }
 
-export function Pipelines({ intl }) {
+export function Pipelines() {
+  const intl = useIntl();
   const location = useLocation();
   const params = useParams();
   const filters = getFilters(location);
@@ -310,4 +311,4 @@ export function Pipelines({ intl }) {
   );
 }
 
-export default injectIntl(Pipelines);
+export default Pipelines;

--- a/src/containers/PipelinesDropdown/PipelinesDropdown.js
+++ b/src/containers/PipelinesDropdown/PipelinesDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
@@ -20,11 +20,11 @@ import { usePipelines, useSelectedNamespace } from '../../api';
 
 function PipelinesDropdown({
   disabled,
-  intl,
   label,
   namespace: namespaceProp,
   ...rest
 }) {
+  const intl = useIntl();
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceProp || selectedNamespace;
 
@@ -74,4 +74,4 @@ PipelinesDropdown.defaultProps = {
   titleText: 'Pipeline'
 };
 
-export default injectIntl(PipelinesDropdown);
+export default PipelinesDropdown;

--- a/src/containers/ResourceList/ResourceList.js
+++ b/src/containers/ResourceList/ResourceList.js
@@ -12,7 +12,7 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
@@ -28,7 +28,8 @@ import {
   useSelectedNamespace
 } from '../../api';
 
-export function ResourceListContainer({ intl }) {
+export function ResourceListContainer() {
+  const intl = useIntl();
   const location = useLocation();
   const { group, namespace: namespaceParam, version, type } = useParams();
 
@@ -164,4 +165,4 @@ export function ResourceListContainer({ intl }) {
   );
 }
 
-export default injectIntl(ResourceListContainer);
+export default ResourceListContainer;

--- a/src/containers/Run/Run.js
+++ b/src/containers/Run/Run.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { UndefinedFilled20 as UndefinedIcon } from '@carbon/icons-react';
 import {
   Actions,
@@ -83,7 +83,8 @@ function getRunStatusTooltip(run) {
   return `${reason} - ${message}`;
 }
 
-function Run({ intl }) {
+function Run() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const { namespace, runName: resourceName } = useParams();
@@ -373,4 +374,4 @@ function Run({ intl }) {
   );
 }
 
-export default injectIntl(Run);
+export default Run;

--- a/src/containers/Runs/Runs.js
+++ b/src/containers/Runs/Runs.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
   ALL_NAMESPACES,
@@ -104,7 +104,8 @@ function getRunStatusTooltip(run) {
   return `${reason}: ${message}`;
 }
 
-function Runs({ intl }) {
+function Runs() {
+  const intl = useIntl();
   const location = useLocation();
   const params = useParams();
   const filters = getFilters(location);
@@ -515,4 +516,4 @@ function Runs({ intl }) {
   );
 }
 
-export default injectIntl(Runs);
+export default Runs;

--- a/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
+++ b/src/containers/ServiceAccountsDropdown/ServiceAccountsDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
@@ -20,11 +20,11 @@ import { useSelectedNamespace, useServiceAccounts } from '../../api';
 
 function ServiceAccountsDropdown({
   disabled,
-  intl,
   label,
   namespace: namespaceProp,
   ...rest
 }) {
+  const intl = useIntl();
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceProp || selectedNamespace;
 
@@ -76,4 +76,4 @@ ServiceAccountsDropdown.defaultProps = {
   titleText: 'ServiceAccount'
 };
 
-export default injectIntl(ServiceAccountsDropdown);
+export default ServiceAccountsDropdown;

--- a/src/containers/Settings/Settings.js
+++ b/src/containers/Settings/Settings.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { RadioTile, TileGroup, Toggle } from 'carbon-components-react';
 import {
@@ -27,7 +27,8 @@ import {
   setLogTimestampsEnabled
 } from '../../api/utils';
 
-export function Settings({ intl }) {
+export function Settings() {
+  const intl = useIntl();
   useTitleSync({
     page: intl.formatMessage({
       id: 'dashboard.settings.title',
@@ -98,4 +99,4 @@ export function Settings({ intl }) {
   );
 }
 
-export default injectIntl(Settings);
+export default Settings;

--- a/src/containers/SideNav/SideNav.js
+++ b/src/containers/SideNav/SideNav.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { matchPath, NavLink, useLocation } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   SideNav as CarbonSideNav,
   SideNavItems,
@@ -40,7 +40,8 @@ import {
 import { ReactComponent as KubernetesIcon } from '../../images/kubernetes.svg';
 import { ReactComponent as TektonIcon } from '../../images/tekton-logo-20x20.svg';
 
-function SideNav({ expanded, intl, showKubernetesResources }) {
+function SideNav({ expanded, showKubernetesResources }) {
+  const intl = useIntl();
   if (!expanded) {
     return null;
   }
@@ -254,4 +255,4 @@ SideNav.defaultProps = {
   showKubernetesResources: false
 };
 
-export default injectIntl(SideNav);
+export default SideNav;

--- a/src/containers/TaskRun/TaskRun.js
+++ b/src/containers/TaskRun/TaskRun.js
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import React, { useRef, useState } from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { InlineNotification, SkeletonText } from 'carbon-components-react';
 import {
@@ -57,7 +57,8 @@ import { NotFound } from '..';
 
 const { STEP, TASK_RUN_DETAILS, VIEW } = queryParamConstants;
 
-export function TaskRunContainer({ intl }) {
+export function TaskRunContainer() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -450,4 +451,4 @@ export function TaskRunContainer({ intl }) {
   );
 }
 
-export default injectIntl(TaskRunContainer);
+export default TaskRunContainer;

--- a/src/containers/TaskRuns/TaskRuns.js
+++ b/src/containers/TaskRuns/TaskRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
   DeleteModal,
@@ -49,7 +49,8 @@ import {
 const { CLUSTER_TASK, TASK } = labels;
 
 /* istanbul ignore next */
-function TaskRuns({ intl }) {
+function TaskRuns() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -327,4 +328,4 @@ function TaskRuns({ intl }) {
   );
 }
 
-export default injectIntl(TaskRuns);
+export default TaskRuns;

--- a/src/containers/Tasks/Tasks.js
+++ b/src/containers/Tasks/Tasks.js
@@ -14,7 +14,7 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import { Button } from 'carbon-components-react';
 import {
@@ -136,7 +136,8 @@ function getFormattedResources({
   }));
 }
 
-function Tasks({ intl }) {
+function Tasks() {
+  const intl = useIntl();
   const location = useLocation();
   const params = useParams();
 
@@ -308,4 +309,4 @@ function Tasks({ intl }) {
   );
 }
 
-export default injectIntl(Tasks);
+export default Tasks;

--- a/src/containers/TasksDropdown/TasksDropdown.js
+++ b/src/containers/TasksDropdown/TasksDropdown.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,13 +12,14 @@ limitations under the License.
 */
 
 import React from 'react';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
 import { useSelectedNamespace, useTasks } from '../../api';
 
-function TasksDropdown({ intl, label, namespace: namespaceProp, ...rest }) {
+function TasksDropdown({ label, namespace: namespaceProp, ...rest }) {
+  const intl = useIntl();
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceProp || selectedNamespace;
 
@@ -62,4 +63,4 @@ TasksDropdown.defaultProps = {
   titleText: 'Task'
 };
 
-export default injectIntl(TasksDropdown);
+export default TasksDropdown;

--- a/src/containers/Trigger/Trigger.js
+++ b/src/containers/Trigger/Trigger.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,6 @@ limitations under the License.
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
 
@@ -60,4 +59,4 @@ export function TriggerContainer() {
   );
 }
 
-export default injectIntl(TriggerContainer);
+export default TriggerContainer;

--- a/src/containers/TriggerBinding/TriggerBinding.js
+++ b/src/containers/TriggerBinding/TriggerBinding.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,14 +13,15 @@ limitations under the License.
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 
 import { useSelectedNamespace, useTriggerBinding } from '../../api';
 import { getViewChangeHandler } from '../../utils';
 
-export function TriggerBindingContainer({ intl }) {
+export function TriggerBindingContainer() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
@@ -99,4 +100,4 @@ export function TriggerBindingContainer({ intl }) {
   );
 }
 
-export default injectIntl(TriggerBindingContainer);
+export default TriggerBindingContainer;

--- a/src/containers/TriggerBindings/TriggerBindings.js
+++ b/src/containers/TriggerBindings/TriggerBindings.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -44,7 +44,8 @@ function getFormattedResources(resources) {
   }));
 }
 
-export function TriggerBindings({ intl }) {
+export function TriggerBindings() {
+  const intl = useIntl();
   const location = useLocation();
   const params = useParams();
   const filters = getFilters(location);
@@ -126,4 +127,4 @@ export function TriggerBindings({ intl }) {
   );
 }
 
-export default injectIntl(TriggerBindings);
+export default TriggerBindings;

--- a/src/containers/TriggerTemplate/TriggerTemplate.js
+++ b/src/containers/TriggerTemplate/TriggerTemplate.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { DataTable } from 'carbon-components-react';
 import {
   Table as DashboardTable,
@@ -38,7 +38,8 @@ const {
   TableRow
 } = DataTable;
 
-export /* istanbul ignore next */ function TriggerTemplateContainer({ intl }) {
+export /* istanbul ignore next */ function TriggerTemplateContainer() {
+  const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
   const { namespace, triggerTemplateName: resourceName } = useParams();
@@ -220,4 +221,4 @@ export /* istanbul ignore next */ function TriggerTemplateContainer({ intl }) {
   );
 }
 
-export default injectIntl(TriggerTemplateContainer);
+export default TriggerTemplateContainer;

--- a/src/containers/TriggerTemplates/TriggerTemplates.js
+++ b/src/containers/TriggerTemplates/TriggerTemplates.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -44,7 +44,8 @@ function getFormattedResources(resources) {
   }));
 }
 
-function TriggerTemplates({ intl }) {
+function TriggerTemplates() {
+  const intl = useIntl();
   useTitleSync({ page: 'TriggerTemplates' });
 
   const location = useLocation();
@@ -122,4 +123,4 @@ function TriggerTemplates({ intl }) {
   );
 }
 
-export default injectIntl(TriggerTemplates);
+export default TriggerTemplates;

--- a/src/containers/Triggers/Triggers.js
+++ b/src/containers/Triggers/Triggers.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import {
   Link as CustomLink,
@@ -46,7 +46,8 @@ function getFormattedResources(resources) {
   }));
 }
 
-function Triggers({ intl }) {
+function Triggers() {
+  const intl = useIntl();
   useTitleSync({ page: 'Triggers' });
 
   const location = useLocation();
@@ -136,4 +137,4 @@ function Triggers({ intl }) {
   );
 }
 
-export default injectIntl(Triggers);
+export default Triggers;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Reduce the number of HOC used in the component tree and prepare for future React improvements by switching all function-based component to use the `useIntl` hook provided by react-intl instead of the `injectIntl` HOC.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
