### PR TITLE
Escape origin header before logging

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -219,7 +219,10 @@ func checkUpgradeSameOrigin(req *http.Request) bool {
 func protectWebSocket(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if !checkUpgradeSameOrigin(req) {
-			logging.Log.Warnf("websocket: Connection upgrade blocked, Host: %s, Origin: %s", req.Host, req.Header.Get("Origin"))
+			origin := req.Header.Get("Origin")
+			origin = strings.Replace(origin, "\n", "", -1)
+			origin = strings.Replace(origin, "\r", "", -1)
+			logging.Log.Warnf("websocket: Connection upgrade blocked, Host: %s, Origin: %s", req.Host, origin)
 			http.Error(w, "websocket: request origin not allowed", http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Prevent spoofing of log entries via user-configurable Origin header by removing newlines (recommended by CodeQL)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
