### PR TITLE
Fix permission denied while running docker-in-docker CI builds

### DIFF
--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -10,8 +10,6 @@
 # limitations under the License.
 
 FROM cypress/browsers:node16.14.2-slim-chrome103-ff102
-USER node
-WORKDIR /home/node
 ENV CI=true
 ENV NO_COLOR=true
 ENTRYPOINT ["npm", "run", "test:ci"]

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -170,7 +170,7 @@ test_dashboard() {
   echo "Videos of failing tests will be stored at $VIDEO_PATH"
   # In case of failure we'll upload videos of the failing tests
   # Our Cypress config will delete videos of passing tests before exiting
-  docker run --rm --network=host -v $VIDEO_PATH:/home/node/cypress/videos dashboard-e2e || fail_test "Browser E2E tests failed"
+  docker run --rm --network=host -v $VIDEO_PATH:/root/cypress/videos dashboard-e2e || fail_test "Browser E2E tests failed"
 
   # If we get here the tests passed, no need to upload artifacts
   rm -rf $VIDEO_PATH


### PR DESCRIPTION
# Changes
CI builds are failed with permission denied while running browser e2e testcase. This commit will remove node user and use default user.
https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns/tekton-dashboard-s390x-nightly-run-np27x?pipelineTask=e2e-test-dashboard&step=run-e2e-tests&retry=0
 



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
