### PR TITLE
Add support for new environment variable to skip recording videos in e2e tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -166,13 +166,13 @@ test_dashboard() {
 
   VIDEO_PATH=""
   CYPRESS_ENV=""
-  if [ ! -z "$ARTIFACTS" ]; then
+  if [ ! -z "$ARTIFACTS" ] && [ "$E2E_VIDEO" != "false" ]; then
     VIDEO_PATH=$ARTIFACTS/videos
     mkdir -p $VIDEO_PATH
     chmod -R 777 $VIDEO_PATH
     echo "Videos of failing tests will be stored at $VIDEO_PATH"
   else
-    echo "ARTIFACTS environment variable not set, skipping recording videos"
+    echo "Skipping recording videos"
     CYPRESS_ENV="-e CYPRESS_video=false"
   fi
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
One of the scripts in tektoncd/plumbing sets an ARTIFACTS environment variable to a new temp directory if not already set. This means the previous attempt to use the presence of the variable to enable recording videos does not work as expected. Add a new environment variable `E2E_VIDEO` to allow consumers to explicitly disable video recording.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

_See [the contribution guide](https://github.com/tektoncd/dashboard/blob/main/CONTRIBUTING.md)
for more details._
