### PR TITLE
Remove managedFields from display of Pod resource and events

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.js
@@ -211,8 +211,65 @@ export const WithPodDetails = () => {
       }}
       pipelineRun={pipelineRun}
       pod={{
-        events: '<Pod events go here>',
-        resource: '<Pod resource goes here>'
+        events: [
+          {
+            metadata: {
+              name: 'guarded-pr-vkm6w-check-file-pod.1721f00ca1846de4',
+              namespace: 'test',
+              uid: '0f4218f0-270a-408d-b5bd-56fc35dda853',
+              resourceVersion: '2047658',
+              creationTimestamp: '2022-10-27T13:27:54Z'
+            },
+            involvedObject: {
+              kind: 'Pod',
+              namespace: 'test',
+              name: 'guarded-pr-vkm6w-check-file-pod',
+              uid: '939a4823-2203-4b5a-8c00-6a2c9f15549d',
+              apiVersion: 'v1',
+              resourceVersion: '2047624'
+            },
+            reason: 'Scheduled',
+            message:
+              'Successfully assigned test/guarded-pr-vkm6w-check-file-pod to tekton-dashboard-control-plane',
+            '…': ''
+          },
+          {
+            metadata: {
+              name: 'guarded-pr-vkm6w-check-file-pod.1721f00cb6ef6ea7',
+              namespace: 'test',
+              uid: 'd1c8e367-66d1-4cd7-a04b-e49bdf9f322e',
+              resourceVersion: '2047664',
+              creationTimestamp: '2022-10-27T13:27:54Z'
+            },
+            involvedObject: {
+              kind: 'Pod',
+              namespace: 'test',
+              name: 'guarded-pr-vkm6w-check-file-pod',
+              uid: '939a4823-2203-4b5a-8c00-6a2c9f15549d',
+              apiVersion: 'v1',
+              resourceVersion: '2047657',
+              fieldPath: 'spec.initContainers{prepare}'
+            },
+            reason: 'Pulled',
+            message:
+              'Container image "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.40.0@sha256:ee6c81fa567c97b4dba0fb315fa038c671a0250ac3a5d43e6ccf8a91e86e6352" already present on machine',
+            '…': ''
+          }
+        ],
+        resource: {
+          kind: 'Pod',
+          apiVersion: 'v1',
+          metadata: {
+            name: 'some-pod-name',
+            namespace: 'test',
+            uid: '939a4823-2203-4b5a-8c00-6a2c9f15549d',
+            resourceVersion: '2047732',
+            creationTimestamp: '2022-10-27T13:27:49Z'
+          },
+          spec: {
+            '…': ''
+          }
+        }
       }}
       selectedStepId={selectedStepId}
       selectedTaskId={selectedTaskId}

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -98,6 +98,19 @@ const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view, showIO }) => {
   const [podContent, setPodContent] = useState();
   const hasEvents = pod?.events?.length > 0;
 
+  const podResource = { ...pod?.resource };
+  if (podResource?.metadata?.managedFields) {
+    delete podResource.metadata.managedFields;
+  }
+  let podEvents;
+  if (hasEvents) {
+    podEvents = pod.events.map(event => {
+      const filteredEvent = { ...event };
+      delete filteredEvent.metadata?.managedFields;
+      return filteredEvent;
+    });
+  }
+
   useEffect(() => {
     setPodContent('resource');
   }, [displayName, view]);
@@ -295,11 +308,11 @@ const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view, showIO }) => {
                 <ViewYAML
                   dark
                   enableSyntaxHighlighting
-                  resource={pod.resource}
+                  resource={podResource}
                 />
               ) : null}
               {hasEvents && podContent === 'events' ? (
-                <ViewYAML dark enableSyntaxHighlighting resource={pod.events} />
+                <ViewYAML dark enableSyntaxHighlighting resource={podEvents} />
               ) : null}
             </div>
           </Tab>

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 The Tekton Authors
+Copyright 2020-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -99,8 +99,65 @@ export const WithWarning = () => (
 export const Pod = () => (
   <TaskRunDetails
     pod={{
-      events: '<Pod events go here>',
-      resource: '<Pod resource goes here>'
+      events: [
+        {
+          metadata: {
+            name: 'guarded-pr-vkm6w-check-file-pod.1721f00ca1846de4',
+            namespace: 'test',
+            uid: '0f4218f0-270a-408d-b5bd-56fc35dda853',
+            resourceVersion: '2047658',
+            creationTimestamp: '2022-10-27T13:27:54Z'
+          },
+          involvedObject: {
+            kind: 'Pod',
+            namespace: 'test',
+            name: 'guarded-pr-vkm6w-check-file-pod',
+            uid: '939a4823-2203-4b5a-8c00-6a2c9f15549d',
+            apiVersion: 'v1',
+            resourceVersion: '2047624'
+          },
+          reason: 'Scheduled',
+          message:
+            'Successfully assigned test/guarded-pr-vkm6w-check-file-pod to tekton-dashboard-control-plane',
+          '…': ''
+        },
+        {
+          metadata: {
+            name: 'guarded-pr-vkm6w-check-file-pod.1721f00cb6ef6ea7',
+            namespace: 'test',
+            uid: 'd1c8e367-66d1-4cd7-a04b-e49bdf9f322e',
+            resourceVersion: '2047664',
+            creationTimestamp: '2022-10-27T13:27:54Z'
+          },
+          involvedObject: {
+            kind: 'Pod',
+            namespace: 'test',
+            name: 'guarded-pr-vkm6w-check-file-pod',
+            uid: '939a4823-2203-4b5a-8c00-6a2c9f15549d',
+            apiVersion: 'v1',
+            resourceVersion: '2047657',
+            fieldPath: 'spec.initContainers{prepare}'
+          },
+          reason: 'Pulled',
+          message:
+            'Container image "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.40.0@sha256:ee6c81fa567c97b4dba0fb315fa038c671a0250ac3a5d43e6ccf8a91e86e6352" already present on machine',
+          '…': ''
+        }
+      ],
+      resource: {
+        kind: 'Pod',
+        apiVersion: 'v1',
+        metadata: {
+          name: 'some-pod-name',
+          namespace: 'test',
+          uid: '939a4823-2203-4b5a-8c00-6a2c9f15549d',
+          resourceVersion: '2047732',
+          creationTimestamp: '2022-10-27T13:27:49Z'
+        },
+        spec: {
+          '…': ''
+        }
+      }
     }}
     taskRun={{
       metadata: { name: 'my-task' },

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -149,8 +149,16 @@ describe('TaskRunDetails', () => {
   });
 
   it('renders pod', () => {
-    const events = 'fake-events';
-    const pod = 'fake-pod';
+    const eventName = 'fake_event';
+    const podName = 'fake_pod';
+    const eventsManagedFields = 'fake_events_managedFields';
+    const podManagedFields = 'fake_pod_managedFields';
+    const events = [
+      { metadata: { name: eventName, managedFields: eventsManagedFields } }
+    ];
+    const pod = {
+      metadata: { name: podName, managedFields: podManagedFields }
+    };
     const taskRun = {
       metadata: { name: 'task-run-name' },
       spec: {},
@@ -172,14 +180,17 @@ describe('TaskRunDetails', () => {
     );
     expect(queryByText('Pod')).toBeTruthy();
     expect(queryByText('Resource')).toBeTruthy();
-    expect(queryByText(pod)).toBeTruthy();
+    expect(queryByText(podName)).toBeTruthy();
+    expect(queryByText(podManagedFields)).toBeFalsy();
     expect(queryByText('Events')).toBeTruthy();
     fireEvent.click(queryByText('Events'));
-    expect(queryByText(events)).toBeTruthy();
+    expect(queryByText(eventName)).toBeTruthy();
+    expect(queryByText(eventsManagedFields)).toBeFalsy();
   });
 
   it('renders pod with no events', () => {
-    const pod = 'fake-pod';
+    const podName = 'fake_pod';
+    const pod = { metadata: { name: podName } };
     const taskRun = {
       metadata: { name: 'task-run-name' },
       spec: {},
@@ -200,7 +211,7 @@ describe('TaskRunDetails', () => {
     );
     expect(queryByText('Pod')).toBeTruthy();
     expect(queryByText('Resource')).toBeFalsy();
-    expect(queryByText(pod)).toBeTruthy();
+    expect(queryByText(podName)).toBeTruthy();
     expect(queryByText('Events')).toBeFalsy();
   });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
`managedFields` clutters up the output and is not particularly useful to users of the Dashboard. Filter this out when displaying the Pod resource and associated events so users can focus on the more useful content provided in the other fields.

This filtering is already done on the ResourceDetails pages when in the YAML view for a single resource. Updating TaskRun details for consistency.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Filter out managedFields when displaying Pod resource and event details on the PipelineRun and TaskRun pages.
```
