### PR TITLE
Remove reference to resolvers.yaml from prepare-kind-cluster script

### DIFF
--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -74,7 +74,6 @@ install_ingress_nginx() {
 install_pipelines() {
   header 'Installing Tekton Pipelines'
   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/resolvers.yaml
   sleep 10
   kubectl wait -n tekton-pipelines --for=condition=ready pod --selector=app.kubernetes.io/part-of=tekton-pipelines,app.kubernetes.io/component=controller --timeout=90s
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Pipelines v0.41.0 removes the separate resolver.yaml file as it's now included in release.yaml

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
