### PR TITLE
Update walk-throughs and dev script to Kubernetes 1.25

### DIFF
--- a/docs/walkthrough/walkthrough-logs.md
+++ b/docs/walkthrough/walkthrough-logs.md
@@ -13,7 +13,9 @@ This guide walks you through installing a working Tekton Dashboard locally from 
 
 ## Before you begin
 
-**Note:** This walk-through requires Kubernetes 1.19 or newer.
+**Note:** This walk-through requires Kubernetes 1.19 or newer. See below for versions of the tools that have been tested.
+
+**Note:** [2022/11/08] Latest releases of the BanzaiCloud logging operator are currently not compatible with Kubernetes 1.25+ due to use of PodSecurityPolicy resources which have been removed in Kubernetes 1.25.
 
 Before you begin, make sure the following tools are installed:
 
@@ -31,7 +33,7 @@ Then, you will create a service to serve those logs and will plug the Tekton Das
 
 ## Installing a working Tekton Dashboard locally from scratch
 
-This walkthrough has been tested on Kind v0.14 with Kubernetes v1.21.
+This walk-through has been tested on Kind v0.15 with Kubernetes v1.21.
 
 If you didn't follow the [Tekton Dashboard walk-through with Kind](./walkthrough-kind.md) yet, start there to get a local cluster with a working Tekton Dashboard installed.
 

--- a/docs/walkthrough/walkthrough-oauth2-proxy.md
+++ b/docs/walkthrough/walkthrough-oauth2-proxy.md
@@ -35,7 +35,7 @@ The picture below illustrates the deployed components and interactions between t
 
 ## Installing a working Tekton Dashboard locally from scratch
 
-This walk-through has been tested on Kind v0.14 with Kubernetes v1.21.
+This walk-through has been tested on Kind v0.15 with Kubernetes v1.25.
 
 If you didn't follow the [Tekton Dashboard walk-through with Kind](./walkthrough-kind.md) yet, start there to get a local cluster with a working Tekton Dashboard installed.
 
@@ -47,7 +47,7 @@ Before installing `oauth2-proxy`, you will need to create a OAuth App on your Gi
 
 This OAuth App will be used to authenticate users using GitHub.
 
-To create the OAuth App on GitHub, browse https://github.com/settings/developers and click the `New OAuth App` button.
+To create the OAuth App on GitHub, browse https://github.com/settings/developers and click the `Register a new application` button.
 
 Fill in the form and click the `Register application` button:
 - `Application name`: the name of the application
@@ -56,15 +56,15 @@ Fill in the form and click the `Register application` button:
 
 ![Register OAuth application](./walkthrough-oauth2-proxy-register.png)
 
-Once the application is registered, you will obtain a `Client ID` and `Client Secret`.
+Once the application is registered, click the `Generate a new client secret` button.
 
-These will be needed to configure `oauth2-proxy` in the next step.
+Record the `Client ID` and `Client secret` somewhere secure, these will be needed to configure `oauth2-proxy` in the next step.
 
 ![Registered OAuth application](./walkthrough-oauth2-proxy-registered.png)
 
 ## Installing and configuring oauth2-proxy
 
-This walk-through has been tested with oauth2-proxy 7.2.1 (helm chart version 6.2.1). There is a known issue with the GitHub provider in oauth2-proxy 7.3.0.
+**Note:** [2022/11/08] This walk-through has been tested with oauth2-proxy 7.2.1 (helm chart version 6.3.0). There is a known issue with the GitHub provider in oauth2-proxy 7.3.0 and later.
 
 Now you have the OAuth application created on GitHub, you can deploy [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) in your cluster.
 

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -16,7 +16,7 @@ set -e
 CLUSTERNAME=tekton-dashboard
 DEFAULT_OPTIONS="--log-format console"
 ENABLE_INGRESS="false"
-KUBERNETES_NODE_IMAGE="kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98"
+KUBERNETES_NODE_IMAGE="kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
 
 create_cluster() {
 if [ "$ENABLE_INGRESS" == "false" ]; then


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
- Update the base and oauth2-proxy walk-throughs to work on Kubernetes 1.25
- Update the prepare-kind-cluster script to use Kubernetes 1.25
- Add note to the logs persistence walk-through about compatibility + versions

/kind documentation
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Update the base and oauth2-proxy walk-throughs to work with Kubernetes 1.25 and the latest Tekton Pipelines release (v0.41). Add a note to the logs walk-through referencing the known working combination of versions as this is not currently compatible with Kubernetes 1.25.
```
