### PR TITLE
update e2e tests to use latest triggers version

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -220,7 +220,7 @@ if [ -z "$PIPELINES_VERSION" ]; then
 fi
 
 if [ -z "$TRIGGERS_VERSION" ]; then
-  export TRIGGERS_VERSION=v0.21.0
+  export TRIGGERS_VERSION=v0.22.0
 fi
 
 header "Installing Pipelines and Triggers"


### PR DESCRIPTION
# Changes
update e2e tests to use latest triggers version. i.e. v0.22.0
 -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
