### PR TITLE
Switch Triggers resources to v1beta1

### DIFF
--- a/src/api/clusterTriggerBindings.js
+++ b/src/api/clusterTriggerBindings.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import {
 function getClusterTriggerBindingsAPI({ filters, isWebSocket, name }) {
   return getTektonAPI(
     'clustertriggerbindings',
-    { group: triggersAPIGroup, isWebSocket, version: 'v1alpha1' },
+    { group: triggersAPIGroup, isWebSocket, version: 'v1beta1' },
     getQueryParams({ filters, name })
   );
 }
@@ -37,7 +37,7 @@ export function getClusterTriggerBinding({ name }) {
   const uri = getTektonAPI('clustertriggerbindings', {
     group: triggersAPIGroup,
     name,
-    version: 'v1alpha1'
+    version: 'v1beta1'
   });
   return get(uri);
 }

--- a/src/api/eventListeners.js
+++ b/src/api/eventListeners.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import {
 function getEventListenersAPI({ filters, isWebSocket, name, namespace }) {
   return getTektonAPI(
     'eventlisteners',
-    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1beta1' },
     getQueryParams({ filters, name })
   );
 }
@@ -38,7 +38,7 @@ export function getEventListener({ name, namespace }) {
     group: triggersAPIGroup,
     name,
     namespace,
-    version: 'v1alpha1'
+    version: 'v1beta1'
   });
   return get(uri);
 }

--- a/src/api/triggerBindings.js
+++ b/src/api/triggerBindings.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import {
 function getTriggerBindingsAPI({ filters, isWebSocket, name, namespace }) {
   return getTektonAPI(
     'triggerbindings',
-    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1beta1' },
     getQueryParams({ filters, name })
   );
 }
@@ -38,7 +38,7 @@ export function getTriggerBinding({ name, namespace }) {
     group: triggersAPIGroup,
     name,
     namespace,
-    version: 'v1alpha1'
+    version: 'v1beta1'
   });
   return get(uri);
 }

--- a/src/api/triggerTemplates.js
+++ b/src/api/triggerTemplates.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import {
 function getTriggerTemplatesAPI({ filters, isWebSocket, name, namespace }) {
   return getTektonAPI(
     'triggertemplates',
-    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1beta1' },
     getQueryParams({ filters, name })
   );
 }
@@ -38,7 +38,7 @@ export function getTriggerTemplate({ name, namespace }) {
     group: triggersAPIGroup,
     name,
     namespace,
-    version: 'v1alpha1'
+    version: 'v1beta1'
   });
   return get(uri);
 }

--- a/src/api/triggers.js
+++ b/src/api/triggers.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2022 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import {
 function getTriggersAPI({ filters, isWebSocket, name, namespace }) {
   return getTektonAPI(
     'triggers',
-    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1alpha1' },
+    { group: triggersAPIGroup, isWebSocket, namespace, version: 'v1beta1' },
     getQueryParams({ filters, name })
   );
 }
@@ -38,7 +38,7 @@ export function getTrigger({ name, namespace }) {
     group: triggersAPIGroup,
     name,
     namespace,
-    version: 'v1alpha1'
+    version: 'v1beta1'
   });
   return get(uri);
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Update API calls for the following resources to use `v1beta1` instead of `v1alpha1`:
- `ClusterTriggerBinding`
- `EventListener`
- `Trigger`
- `TriggerBinding`
- `TriggerTemplate`

`v1beta1` has been supported since Triggers v0.15.0, and our current minimum supported version is v0.21.0.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Request v1beta1 version for supported Triggers resources, this includes: `ClusterTriggerBinding`, `EventListener`, `Trigger`, `TriggerBinding`, and `TriggerTemplate`
```
