### PR TITLE
Fix display of waiting string in pod resource tab

### DIFF
--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -98,7 +98,8 @@ const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view, showIO }) => {
   const [podContent, setPodContent] = useState();
   const hasEvents = pod?.events?.length > 0;
 
-  const podResource = { ...pod?.resource };
+  const podResource =
+    typeof pod?.resource === 'string' ? pod.resource : { ...pod?.resource };
   if (podResource?.metadata?.managedFields) {
     delete podResource.metadata.managedFields;
   }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -215,6 +215,31 @@ describe('TaskRunDetails', () => {
     expect(queryByText('Events')).toBeFalsy();
   });
 
+  it('renders pod waiting state', () => {
+    const waitingMessage = 'waiting for pod';
+    const taskRun = {
+      metadata: { name: 'task-run-name' },
+      spec: {},
+      status: {}
+    };
+    const { queryByText } = render(
+      <TaskRunDetails
+        pod={{
+          resource: waitingMessage
+        }}
+        task={{
+          metadata: 'task',
+          spec: {}
+        }}
+        taskRun={taskRun}
+        view="pod"
+      />
+    );
+    expect(queryByText('Pod')).toBeTruthy();
+    expect(queryByText('Resource')).toBeFalsy();
+    expect(queryByText(waitingMessage)).toBeTruthy();
+  });
+
   it('renders both input and output resources', () => {
     const inputResourceName = 'input-resource';
     const outputResourceName = 'output-resource';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Previous change to remove the managedFields from the pod resource tab inadvertently affected the display of the string in the waiting state, treating it as an array and displaying one character per line.

Update the code to correctly handle this case and display a string input as provided. Add test to cover this and prevent future regression.

![image](https://user-images.githubusercontent.com/2829095/206699785-12281891-81ed-4b86-bd5f-f33d589db345.png)

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix display of waiting state in pod resource tab so the message is displayed on a single line instead of one character per line
```
