### PR TITLE
Update to Cypress 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16984,9 +16984,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
+      "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -17037,7 +17037,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -34934,7 +34934,7 @@
       "version": "0.31.0-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "cypress": "^11.2.0"
+        "cypress": "^12.0.2"
       },
       "engines": {
         "node": "^16.18.1",
@@ -43699,7 +43699,7 @@
     "@tektoncd/dashboard-e2e": {
       "version": "file:packages/e2e",
       "requires": {
-        "cypress": "^11.2.0"
+        "cypress": "12.0.2"
       }
     },
     "@tektoncd/dashboard-graph": {
@@ -47845,9 +47845,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
+      "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/packages/e2e/cypress.config.js
+++ b/packages/e2e/cypress.config.js
@@ -20,7 +20,6 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8000',
     experimentalRunAllSpecs: true,
-    // experimentalSessionAndOrigin: true, // default is false
     experimentalStudio: true,
     setupNodeEvents(on, _config) {
       on('after:spec', (spec, results) => {

--- a/packages/e2e/cypress/e2e/common/read-permissions.cy.js
+++ b/packages/e2e/cypress/e2e/common/read-permissions.cy.js
@@ -13,7 +13,7 @@ limitations under the License.
 
 import kinds from '../../fixtures/kinds.json';
 
-describe('Read permissions', () => {
+describe('Read permissions', { testIsolation: false }, () => {
   before(() => {
     cy.visit('/');
     cy.hash().should('equal', '#/about');

--- a/packages/e2e/cypress/e2e/run/create-pipelinerun.cy.js
+++ b/packages/e2e/cypress/e2e/run/create-pipelinerun.cy.js
@@ -18,7 +18,7 @@ function preserveIndentation(input) {
     .join('\n');
 }
 
-const namespace = 'e2e';
+const namespace = 'tekton-dashboard-e2e';
 describe('Create Pipeline Run', () => {
   before(() => {
     cy.exec('kubectl version --client');

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -17,7 +17,7 @@
     "test:ci": "cypress run"
   },
   "devDependencies": {
-    "cypress": "^11.2.0"
+    "cypress": "^12.0.2"
   },
   "engines": {
     "node": "^16.18.1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The Session and Origin experiment is now GA which means that the flag in the config is not required to enable it, and also that test isolation is now enabled by default.

Test isolation causes Cypress to navigate to `about:blank` between tests, so update the read permissions test to disable this as we only want to navigate to the app once then iterate over all of the side nav links. Without this change the `before` would need to be changed to a `beforeEach` and the tests would take significantly longer without any real additional benefit.

Also swith the namespace used for the 'create' tests to something less likely to cause conflicts, especially important as we delete the namespace at the end of the tests.

/kind misc
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Update to Cypress 12
```
