### PR TITLE
Add toggle to settings UI to opt-in to Pipelines v1 resources

### DIFF
--- a/src/api/clusterTasks.js
+++ b/src/api/clusterTasks.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ import {
 function getClusterTasksAPI({ filters, isWebSocket, name }) {
   return getTektonAPI(
     'clustertasks',
-    { isWebSocket },
+    { isWebSocket, version: 'v1beta1' },
     getQueryParams({ filters, name })
   );
 }
@@ -33,12 +33,12 @@ export function getClusterTasks({ filters = [] } = {}) {
 }
 
 export function getClusterTask({ name }) {
-  const uri = getTektonAPI('clustertasks', { name });
+  const uri = getTektonAPI('clustertasks', { name, version: 'v1beta1' });
   return get(uri);
 }
 
 export function deleteClusterTask({ name }) {
-  const uri = getTektonAPI('clustertasks', { name });
+  const uri = getTektonAPI('clustertasks', { name, version: 'v1beta1' });
   return deleteRequest(uri);
 }
 

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -293,7 +293,12 @@ it('usePipelineRun', () => {
 
 it('rerunPipelineRun', () => {
   const originalPipelineRun = {
-    metadata: { name: 'fake_pipelineRun' },
+    metadata: {
+      labels: {
+        'tekton.dev/pipeline': 'foo'
+      },
+      name: 'fake_pipelineRun'
+    },
     spec: { status: 'fake_status' },
     status: 'fake_status'
   };

--- a/src/api/taskRuns.js
+++ b/src/api/taskRuns.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 The Tekton Authors
+Copyright 2019-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import { deleteRequest, get, patch, post } from './comms';
 import {
   getQueryParams,
   getTektonAPI,
+  getTektonPipelinesAPIVersion,
   useCollection,
   useResource
 } from './utils';
@@ -88,7 +89,7 @@ export function createTaskRun({
   timeout
 }) {
   const payload = {
-    apiVersion: 'tekton.dev/v1beta1',
+    apiVersion: `tekton.dev/${getTektonPipelinesAPIVersion()}`,
     kind: 'TaskRun',
     metadata: {
       name: taskRunName,
@@ -146,7 +147,8 @@ export function rerunTaskRun(taskRun) {
   const { annotations, labels, name, namespace } = taskRun.metadata;
 
   const payload = deepClone(taskRun);
-  payload.apiVersion = payload.apiVersion || 'tekton.dev/v1beta1';
+  payload.apiVersion =
+    payload.apiVersion || `tekton.dev/${getTektonPipelinesAPIVersion()}`;
   payload.kind = payload.kind || 'TaskRun';
   payload.metadata = {
     annotations,

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 The Tekton Authors
+Copyright 2019-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -97,6 +97,18 @@ export function getQueryParams({
   return '';
 }
 
+export function isPipelinesV1ResourcesEnabled() {
+  return localStorage.getItem('tkn-pipelines-v1-resources') === 'true';
+}
+
+export function setPipelinesV1ResourcesEnabled(enabled) {
+  localStorage.setItem('tkn-pipelines-v1-resources', enabled);
+}
+
+export function getTektonPipelinesAPIVersion() {
+  return isPipelinesV1ResourcesEnabled() ? 'v1' : 'v1beta1';
+}
+
 export function getTektonAPI(
   type,
   {
@@ -104,7 +116,7 @@ export function getTektonAPI(
     isWebSocket,
     name = '',
     namespace,
-    version = 'v1beta1'
+    version = getTektonPipelinesAPIVersion()
   } = {},
   queryParams
 ) {

--- a/src/containers/Settings/Settings.js
+++ b/src/containers/Settings/Settings.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021-2022 The Tekton Authors
+Copyright 2021-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -24,7 +24,9 @@ import {
 import { getTheme, setTheme } from '../../utils';
 import {
   isLogTimestampsEnabled,
-  setLogTimestampsEnabled
+  isPipelinesV1ResourcesEnabled,
+  setLogTimestampsEnabled,
+  setPipelinesV1ResourcesEnabled
 } from '../../api/utils';
 
 export function Settings() {
@@ -93,6 +95,24 @@ export function Settings() {
             defaultMessage: 'On'
           })}
           onToggle={checked => setLogTimestampsEnabled(checked)}
+        />
+
+        <Toggle
+          defaultToggled={isPipelinesV1ResourcesEnabled()}
+          id="tkn--pipelines-v1-resources-toggle"
+          labelText={intl.formatMessage({
+            id: 'dashboard.pipelines.v1Resources.label',
+            defaultMessage: 'Use Tekton Pipelines API version v1'
+          })}
+          labelA={intl.formatMessage({
+            id: 'dashboard.toggle.off',
+            defaultMessage: 'Off'
+          })}
+          labelB={intl.formatMessage({
+            id: 'dashboard.toggle.on',
+            defaultMessage: 'On'
+          })}
+          onToggle={checked => setPipelinesV1ResourcesEnabled(checked)}
         />
       </div>
     </div>

--- a/src/containers/Settings/Settings.scss
+++ b/src/containers/Settings/Settings.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,6 +16,10 @@ limitations under the License.
     .bx--tile-group {
       margin-bottom: 2rem;
       max-width: 400px;
+
+      legend {
+        margin-bottom: 1rem;
+      }
 
       .bx--tile {
         display: flex;
@@ -39,6 +43,10 @@ limitations under the License.
       .bx--tile:not(:last-child) {
         margin-bottom: 0.5rem;
       }
+    }
+
+    .bx--form-item + .bx--form-item {
+      margin-top: 2rem;
     }
   }
 }

--- a/src/containers/Settings/Settings.test.js
+++ b/src/containers/Settings/Settings.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2021-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, within } from '@testing-library/react';
 
 import { render } from '../../utils/test';
 import * as Utils from '../../utils';
@@ -45,9 +45,25 @@ describe('Settings', () => {
 
     const { getByLabelText, getByText } = render(<Settings />);
 
-    expect(getByText(/show log timestamps/i)).toBeTruthy();
-    expect(getByText(/on/i)).toBeTruthy();
+    const logTimestampToggle = getByText(/show log timestamps/i);
+    expect(logTimestampToggle).toBeTruthy();
+    expect(within(logTimestampToggle).getByText('On')).toBeTruthy();
     fireEvent.click(getByLabelText(/show log timestamps/i));
     expect(APIUtils.setLogTimestampsEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('should render the v1 API settings correctly', () => {
+    jest
+      .spyOn(APIUtils, 'isPipelinesV1ResourcesEnabled')
+      .mockImplementation(() => true);
+    jest.spyOn(APIUtils, 'setPipelinesV1ResourcesEnabled');
+
+    const { getByLabelText, getByText } = render(<Settings />);
+
+    const apiVersionToggle = getByText(/api version v1/i);
+    expect(apiVersionToggle).toBeTruthy();
+    expect(within(apiVersionToggle).getByText('On')).toBeTruthy();
+    fireEvent.click(getByLabelText(/api version v1/i));
+    expect(APIUtils.setPipelinesV1ResourcesEnabled).toHaveBeenCalledWith(false);
   });
 });

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "Schritt fehlgeschlagen",
     "dashboard.pipelineRuns.error": "Fehler beim Laden von PipelineRuns",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "Step failed",
     "dashboard.pipelineRuns.error": "Error loading PipelineRuns",
     "dashboard.pipelines.errorLoading": "Error loading Pipelines",
+    "dashboard.pipelines.v1Resources.label": "Use Tekton Pipelines API version v1",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "No Pipelines found",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "No Pipelines found in the ''{namespace}'' namespace",
     "dashboard.pipelinesDropdown.label": "Select Pipeline",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "Paso fallido",
     "dashboard.pipelineRuns.error": "Error al cargar PipelineRuns",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "Echec de l'étape",
     "dashboard.pipelineRuns.error": "Une erreur s'est produite lors du chargement des ressources PipelineRun",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "Passo non riuscito",
     "dashboard.pipelineRuns.error": "Errore nel caricamento delle esecuzioni pipeline",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "ステップが失敗しました",
     "dashboard.pipelineRuns.error": "PipelineRunのロード中にエラーが発生しました",
     "dashboard.pipelines.errorLoading": "Pipelineのロード中にエラーが発生しました",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "Pipelineが見つかりません",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "''{namespace}'' NamespaceにPipelineが見つかりません",
     "dashboard.pipelinesDropdown.label": "Pipelineを選択",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "단계 실패",
     "dashboard.pipelineRuns.error": "PipelineRun 로드 중 오류 발생",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "Etapa com falha",
     "dashboard.pipelineRuns.error": "Erro ao carregar os PipelineRuns",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "步骤失败",
     "dashboard.pipelineRuns.error": "加载 PipelineRun 时出错",
     "dashboard.pipelines.errorLoading": "加载 Pipelines 时出错",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "未找到 Pipelines",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "在Namespace ''{namespace}'' 中未找到 Pipelines",
     "dashboard.pipelinesDropdown.label": "选择 Pipeline",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -200,6 +200,7 @@
     "dashboard.pipelineRun.stepFailed": "步驟失敗",
     "dashboard.pipelineRuns.error": "載入 PipelineRuns 時發生錯誤",
     "dashboard.pipelines.errorLoading": "",
+    "dashboard.pipelines.v1Resources.label": "",
     "dashboard.pipelinesDropdown.empty.allNamespaces": "",
     "dashboard.pipelinesDropdown.empty.selectedNamespace": "",
     "dashboard.pipelinesDropdown.label": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2598

Add a toggle to the settings page allowing users to opt-in to requesting and managing v1 versions of the Pipelines CRDs: `Pipeline`, `PipelineRun`, `Task`, and `TaskRun`. This updates the API endpoints to use the corresponding version.

The toggle is off by default and will be included in the next release. Following that it will be on by default for one release, then removed.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add ability to opt-in to using v1 `Pipeline`, `PipelineRun`, `Task`, and `TaskRun` resources with a compatible Tekton Pipelines release (v0.43.0+). This will be enabled by default in a future release.
```
