### PR TITLE
Downgrade `react-router-dom-v5-compat` due to breaking change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-hot-loader": "^4.13.1",
         "react-intl": "^6.2.5",
         "react-router-dom": "^5.3.4",
-        "react-router-dom-v5-compat": "^6.6.1",
+        "react-router-dom-v5-compat": "^6.4.5",
         "reconnecting-websocket": "^4.4.0"
       },
       "devDependencies": {
@@ -4519,9 +4519,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.2.1.tgz",
-      "integrity": "sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5.tgz",
+      "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==",
       "engines": {
         "node": ">=14"
       }
@@ -29593,12 +29593,12 @@
       }
     },
     "node_modules/react-router-dom-v5-compat": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.6.1.tgz",
-      "integrity": "sha512-5zbA0/cl7tgJSQfqiTmIgUJPTYtrOQKqOgFgri74+bMTlLH9bYL8iBDS9ZMlq8kSbeSkSxBcU/XwvIS3ieZfvg==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.4.5.tgz",
+      "integrity": "sha512-+Ld5n7yP5zAYU1mmtr3yAysl2N4D/FxSDJPVLqA084WgbpjIsacAhzymuMBtySCg0O+LGVh0meORBmJnuIlIRQ==",
       "dependencies": {
         "history": "^5.3.0",
-        "react-router": "6.6.1"
+        "react-router": "6.4.5"
       },
       "engines": {
         "node": ">=14"
@@ -29610,11 +29610,11 @@
       }
     },
     "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.6.1.tgz",
-      "integrity": "sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.5.tgz",
+      "integrity": "sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==",
       "dependencies": {
-        "@remix-run/router": "1.2.1"
+        "@remix-run/router": "1.0.5"
       },
       "engines": {
         "node": ">=14"
@@ -38214,9 +38214,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.2.1.tgz",
-      "integrity": "sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5.tgz",
+      "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug=="
     },
     "@sinclair/typebox": {
       "version": "0.24.38",
@@ -57468,20 +57468,20 @@
       }
     },
     "react-router-dom-v5-compat": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.6.1.tgz",
-      "integrity": "sha512-5zbA0/cl7tgJSQfqiTmIgUJPTYtrOQKqOgFgri74+bMTlLH9bYL8iBDS9ZMlq8kSbeSkSxBcU/XwvIS3ieZfvg==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.4.5.tgz",
+      "integrity": "sha512-+Ld5n7yP5zAYU1mmtr3yAysl2N4D/FxSDJPVLqA084WgbpjIsacAhzymuMBtySCg0O+LGVh0meORBmJnuIlIRQ==",
       "requires": {
         "history": "^5.3.0",
-        "react-router": "6.6.1"
+        "react-router": "6.4.5"
       },
       "dependencies": {
         "react-router": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.6.1.tgz",
-          "integrity": "sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==",
+          "version": "6.4.5",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.5.tgz",
+          "integrity": "sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==",
           "requires": {
-            "@remix-run/router": "1.2.1"
+            "@remix-run/router": "1.0.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-hot-loader": "^4.13.1",
     "react-intl": "^6.2.5",
     "react-router-dom": "^5.3.4",
-    "react-router-dom-v5-compat": "^6.6.1",
+    "react-router-dom-v5-compat": "^6.4.5",
     "reconnecting-websocket": "^4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/pull/2647

`react-router-dom-v5-compat@6.5.0` introduces a breaking change that affects behaviour of `generatePath`. The presence of the `?` in the URL now triggers the new 'optional route segments' behaviour, and the `?` is given special meaning. This results in broken URLs as named placeholders in the query string are no longer replaced, e.g. `:pipelineName` is output as-is in the URL instead of being replaced with the value of the provided `pipelineName` param.

Updating the Dashboard to support this new behaviour will take some time as it's core to how the routes and URLs used for filtering are implemented. Rolling back the update for now to unblock other changes.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
