### PR TITLE
Update import resources to specify version v1beta1

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 The Tekton Authors
+Copyright 2019-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -359,7 +359,10 @@ export function importResources({
     payload.spec.serviceAccountName = serviceAccount;
   }
 
-  const uri = getTektonAPI('pipelineruns', { namespace: importerNamespace });
+  const uri = getTektonAPI('pipelineruns', {
+    namespace: importerNamespace,
+    version: 'v1beta1'
+  });
   return post(uri, payload).then(({ body }) => body);
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/2649

Stick with v1beta1 API version for the import resources API call (create PipelineRun) as we currently rely on PipelineResources which are no longer available in v1.

We'll be switching to using the resolvers included since Tekton Pipelines v0.40 instead, but pin the version for now to prevent issues when users enable the v1 toggle on the settings page.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
