### PR TITLE
Remove the OpenShift release manifests and installer flag

### DIFF
--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -9,9 +9,8 @@ It covers the following topics:
 - [Install command](#install-command)
   - [Installing on Kubernetes](#installing-on-kubernetes)
   - [OpenShift with Tekton Pipelines and Triggers installed by OpenShift Pipelines Operator](#openshift-with-tekton-pipelines-and-triggers-installed-by-openshift-pipelines-operator)
-  - [OpenShift with Tekton Pipelines and Triggers installed manually using YAML manifests](#openshift-with-tekton-pipelines-and-triggers-installed-manually-using-yaml-manifests)
-  - [Read only install](#read-only-install)
   - [Installing in a custom namespace](#installing-in-a-custom-namespace)
+  - [Read only install](#read-only-install)
   - [Installing for single namespace visibility](#installing-for-single-namespace-visibility)
   - [Install ingress](#install-ingress)
 - [Uninstall command](#uninstall-command)
@@ -71,7 +70,6 @@ Accepted options:
         [--logout-url <logout-url>]             Will set up the logout URL
         [--namespace <namespace>]               Will override install namespace
         [--nightly]                             Will download manifests from the nightly releases channel
-        [--openshift]                           Will build manifests for openshift
         [--output <file>]                       Will output built manifests in the file instead of in the console
         [--pipelines-namespace <namespace>]     Override the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)
         [--platform <platform>]                 Override the platform to build for
@@ -87,14 +85,9 @@ Accepted options:
 
 The `install` command is used to install the Tekton Dashboard in a cluster. It supports both Kubernetes and OpenShift.
 
-Note that OpenShift supports two install methods:
-- Tekton Pipelines and Triggers installed by openshift pipelines operator
-- Tekton Pipelines and Triggers installed manually using YAML manifests
-
 Examples below illustrate the main `install` options:
 - [Installing on Kubernetes](#installing-on-kubernetes)
 - [OpenShift with Tekton Pipelines and Triggers installed by OpenShift Pipelines Operator](#openshift-with-tekton-pipelines-and-triggers-installed-by-openshift-pipelines-operator)
-- [OpenShift with Tekton Pipelines and Triggers installed manually using YAML manifests](#openshift-with-tekton-pipelines-and-triggers-installed-manually-using-yaml-manifests)
 - [Installing in a custom namespace](#installing-in-a-custom-namespace)
 - [Installing for single namespace visibility](#installing-for-single-namespace-visibility)
 - [Install ingress](#install-ingress)
@@ -114,35 +107,10 @@ This will install the Dashboard in the `tekton-pipelines` namespace and assumes 
 To install the Tekton Dashboard on OpenShift after installing Tekton Pipelines and Triggers using OpenShift Pipelines Operator, run the command:
 
 ```bash
-./scripts/installer install --openshift
+./scripts/installer install --namespace openshift-pipelines
 ```
 
-### OpenShift with Tekton Pipelines and Triggers installed manually using YAML manifests
-
-To install the Tekton Dashboard on OpenShift after installing Tekton Pipelines and Triggers manually using YAML manifests, you will need to override Tekton Pipelines and Triggers install namespaces.
-
-When installing from the manifests, Tekton Pipelines and Triggeers will be deployed in the `tekton-pipelines` namespace, whereas OpenShift Pipelines Operator uses the `openshift-pipelines` namespace.
-
-Therefore, you will need to add the `--pipelines-namespace tekton-pipelines` and `--triggers-namespace tekton-pipelines` options when calling the installer script:
-
-```bash
-./scripts/installer install --openshift --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines
-```
-
-### Read only install
-
-To install the Dashboard add the `--read-only` option when calling the `installer` script:
-
-```bash
-# for kubernetes
-./scripts/installer install --read-only
-
-# for openshift / openshift pipelines operator
-./scripts/installer install --openshift --read-only
-
-# for openshift / manifests
-./scripts/installer install --openshift --read-only --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines
-```
+Alternatively, take one of the official release manifests and replace any reference to the `tekton-pipelines` namespace with `openshift-pipelines` for the same result.
 
 ### Installing in a custom namespace
 
@@ -153,14 +121,15 @@ To tell the `installer` script the target namespace of your choice, add the `--n
 ```bash
 CUSTOM_NAMESPACE=my-namespace
 
-# for kubernetes
 ./scripts/installer install --namespace $CUSTOM_NAMESPACE
+```
 
-# for openshift / openshift pipelines operator
-./scripts/installer install --openshift --namespace $CUSTOM_NAMESPACE
+### Read only install
 
-# for openshift / manifests
-./scripts/installer install --openshift --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines --namespace $CUSTOM_NAMESPACE
+To install the Dashboard add the `--read-only` option when calling the `installer` script:
+
+```bash
+./scripts/installer install --read-only
 ```
 
 ### Installing for single namespace visibility
@@ -172,14 +141,7 @@ To install for single namespace visibility run the following command:
 ```bash
 TENANT_NAMESPACE=my-namespace
 
-# for kubernetes
 ./scripts/installer install --tenant-namespace $TENANT_NAMESPACE
-
-# for openshift / openshift pipelines operator
-./scripts/installer install --openshift --tenant-namespace $TENANT_NAMESPACE
-
-# for openshift / manifests
-./scripts/installer install --openshift --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines --tenant-namespace $TENANT_NAMESPACE
 ```
 
 ### Install ingress
@@ -203,14 +165,7 @@ To uninstall the Dashboard, use the `uninstall` instead of the `install` command
 The `installer` script can be used to build the Dashboard docker image and the YAML manifests (taking care of command line options) by using the `build` command when calling the script:
 
 ```bash
-# for kubernetes
 ./scripts/installer build
-
-# for openshift / openshift pipelines operator
-./scripts/installer build --openshift
-
-# for openshift / manifests
-./scripts/installer build --openshift --pipelines-namespace tekton-pipelines --triggers-namespace tekton-pipelines
 ```
 
 This will NOT deploy the resulting manifest in the target cluster but will build and push the Dashboard docker image to [whichever docker repo was configured](./README.md#build-and-deploy-with-kustomize-and-ko) for `ko` to work with and will display the YAML manifests in the console output.

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,7 +12,6 @@ This guide explains how to install Tekton Dashboard. It covers the following top
 - [Before you begin](#before-you-begin)
 - [Pre-requisites](#pre-requisites)
 - [Installing Tekton Dashboard on Kubernetes](#installing-tekton-dashboard-on-kubernetes)
-- [Installing Tekton Dashboard on OpenShift](#installing-tekton-dashboard-on-openshift)
 - [Installing with the installer script](#installing-with-the-installer-script)
 - [Accessing the Dashboard](#accessing-the-dashboard)
 - [Uninstalling the Dashboard on Kubernetes](#uninstalling-the-dashboard-on-kubernetes)
@@ -66,24 +65,6 @@ To install Tekton Dashboard on a Kubernetes cluster:
    **Note:** Hit CTRL+C to stop monitoring.
 
 Congratulations! You have successfully installed Tekton Dashboard on your Kubernetes cluster.
-
-## Installing Tekton Dashboard on OpenShift
-
-To install Tekton Dashboard on an OpenShift cluster:
-
-1. Install the Openshift Pipeline Operator from the operator hub.
-
-1. Assuming you want to install the Dashboard into the `openshift-pipelines` namespace, which is the default one:
-
-   ```bash
-   kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/openshift-tekton-dashboard-release.yaml --validate=false
-   ```
-
-Congratulations! You have successfully installed Tekton Dashboard on your OpenShift cluster.
-
-**Note for users installing Tekton Pipelines and Triggers outside the OpenShift Pipelines operator:**
-
-Tekton Dashboard on OpenShift works out of the box with the OpenShift Pipelines operator. If you installed Tekton Pipelines and Triggers without using the OpenShift Pipelines operator, you will need to change the following args `--pipelines-namespace=openshift-pipelines` and `--triggers-namespace=openshift-pipelines` and set their values to the namespace where Pipelines and Triggers were respectively deployed.
 
 ## Installing with the installer script
 

--- a/scripts/installer
+++ b/scripts/installer
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 # dashboard flavour
-OPENSHIFT="false"
 READONLY="false"
 
 # configuration default values
@@ -128,20 +127,14 @@ download() {
 setup() {
   if [ ! -z "$OVERRIDE_NAMESPACE" ]; then
     INSTALL_NAMESPACE="$OVERRIDE_NAMESPACE"
-  elif [ "$OPENSHIFT" == "true" ]; then
-    INSTALL_NAMESPACE="openshift-pipelines"
   fi
 
   if [ ! -z "$OVERRIDE_PIPELINES_NAMESPACE" ]; then
     PIPELINES_NAMESPACE="$OVERRIDE_PIPELINES_NAMESPACE"
-  elif [ "$OPENSHIFT" == "true" ]; then
-    PIPELINES_NAMESPACE="openshift-pipelines"
   fi
 
   if [ ! -z "$OVERRIDE_TRIGGERS_NAMESPACE" ]; then
     TRIGGERS_NAMESPACE="$OVERRIDE_TRIGGERS_NAMESPACE"
-  elif [ "$OPENSHIFT" == "true" ]; then
-    TRIGGERS_NAMESPACE="openshift-pipelines"
   fi
 }
 
@@ -423,7 +416,6 @@ help () {
   echo -e "\t[--logout-url <logout-url>]\t\tWill set up the logout URL"
   echo -e "\t[--namespace <namespace>]\t\tWill override install namespace"
   echo -e "\t[--nightly]\t\t\t\tWill download manifests from the nightly releases channel"
-  echo -e "\t[--openshift]\t\t\t\tWill build manifests for openshift"
   echo -e "\t[--output <file>]\t\t\tWill output built manifests in the file instead of in the console"
   echo -e "\t[--pipelines-namespace <namespace>]\tOverride the namespace where Tekton Pipelines is installed (defaults to tekton-pipelines)"
   echo -e "\t[--platform <platform>]\t\t\tOverride the platform to build for"
@@ -489,9 +481,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     '--nightly')
       BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases-nightly/dashboard"
-      ;;
-    '--openshift')
-      OPENSHIFT="true"
       ;;
     '--read-only')
       READONLY="true"

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -114,8 +114,6 @@ spec:
         # build pre configured manifests
         ./scripts/installer release --debug                         --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/tekton-dashboard-release.yaml
         ./scripts/installer release --debug --read-only             --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/tekton-dashboard-release-readonly.yaml
-        ./scripts/installer release --debug --openshift             --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/openshift-tekton-dashboard-release.yaml
-        ./scripts/installer release --debug --openshift --read-only --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/openshift-tekton-dashboard-release-readonly.yaml
 
     - name: koparse
       image: gcr.io/tekton-releases/dogfooding/koparse:latest

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -67,8 +67,6 @@ the dashboard repo, a terminal window and a text editor.
     commit-sha                                   6ea31d92a97420d4b7af94745c45b02447ceaa19
     tekton-dashboard-release                     https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.19.0/tekton-dashboard-release.yaml
     tekton-dashboard-release-readonly            https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.19.0/tekton-dashboard-release-readonly.yaml
-    tekton-dashboard-openshift-release           https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.19.0/openshift-tekton-dashboard-release.yaml
-    tekton-dashboard-openshift-release-readonly  https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.19.0/openshift-tekton-dashboard-release-readonly.yaml
 
     (...)
     ```
@@ -91,7 +89,7 @@ Creating the release announcement is currently a manual process but will be auto
 
 1. Add any upgrade and deprecation notices as required.
 
-1. Attach the release manifests to the release: `tekton-dashboard-*.yaml` and `openshift-tekton-dashboard-*.yaml`.
+1. Attach the release manifests to the release: `tekton-dashboard-*.yaml`.
 
 1. Once the release notes are ready, un-check the "This is a pre-release" checkbox since you're making a legit for-reals release!
 

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -44,12 +44,6 @@ spec:
     - name: release-file-readonly
       description: the URL of the release file
       value: $(tasks.report-bucket.results.release-readonly)
-    - name: release-file-openshift
-      description: the URL of the release file
-      value: $(tasks.report-bucket.results.release-openshift)
-    - name: release-file-openshift-readonly
-      description: the URL of the release file
-      value: $(tasks.report-bucket.results.release-openshift-readonly)
   tasks:
     - name: git-clone
       taskRef:
@@ -170,12 +164,6 @@ spec:
           - name: release-readonly
             description: The full URL of the release file (read-only) in the bucket
             type: string
-          - name: release-openshift
-            description: The full URL of the release file (OpenShift) in the bucket
-            type: string
-          - name: release-openshift-readonly
-            description: The full URL of the release file (OpenShift read-only) in the bucket
-            type: string
         steps:
           - name: create-results
             image: alpine
@@ -185,5 +173,3 @@ spec:
               BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
               echo "${BASE_URL}/tekton-dashboard-release.yaml" > $(results.release.path)
               echo "${BASE_URL}/tekton-dashboard-release-readonly.yaml" > $(results.release-readonly.path)
-              echo "${BASE_URL}/openshift-tekton-dashboard-release.yaml" > $(results.release-openshift.path)
-              echo "${BASE_URL}/openshift-tekton-dashboard-release-readonly.yaml" > $(results.release-openshift-readonly.path)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -206,10 +206,6 @@ if [ -z "$SKIP_BUILD_TEST" ]; then
 	$tekton_repo_dir/scripts/installer release                          || fail_test "Failed to build manifests for k8s"
 	echo "Building manifests for k8s --read-only"
 	$tekton_repo_dir/scripts/installer release --read-only              || fail_test "Failed to build manifests for k8s --read-only"
-	echo "Building manifests for openshift"
-	$tekton_repo_dir/scripts/installer release --openshift              || fail_test "Failed to build manifests for openshift"
-	echo "Building manifests for openshift --read-only"
-	$tekton_repo_dir/scripts/installer release --openshift --read-only  || fail_test "Failed to build manifests for openshift --read-only"
 fi
 
 header "Building browser E2E image"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
In the early days of the Dashboard project there were significant differences between the Dashboard releases on Kubernetes and OpenShift, including default provision of an `oauth-proxy` deployment, ingress, etc.

That is no longer the case since Tekton Dashboard v0.10.0 in September 2020, the only remaining difference between the release manifests is the namespace (`openshift-pipelines` vs. `tekton-pipelines`).

/misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove the OpenShift specific release manifests and the `--openshift` flag from the installer script. These existed for legacy reasons which are no longer relevant. The only remaining difference between the default and OpenShift manifests is the namespace used (`tekton-pipelines` vs. `openshift-pipelines`) and the installer script already provides a mechanism to customise this.

Action required: If you currently rely on one of the `openshift-*.yaml` release manifests, switch to the default manifests and replace references to the `tekton-pipelines` namespace with `openshift-pipelines`. Alternatively use the installer script with the `--namespace` flag to customise the value.
```
