### PR TITLE
Update error handling for application loading state

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -225,11 +225,9 @@ export function App({ lang }) {
     <NamespaceContext.Provider value={namespaceContext}>
       <IntlProvider
         defaultLocale={defaultLocale}
-        locale={messages[lang] ? lang : defaultLocale}
-        messages={messages[lang]}
+        locale={messages?.[lang] ? lang : defaultLocale}
+        messages={messages?.[lang]}
       >
-        <ConfigError loadingConfigError={loadingConfigError} />
-
         {showLoadingState && <LoadingShell />}
         {!showLoadingState && (
           <Router>
@@ -250,6 +248,7 @@ export function App({ lang }) {
                   aria-labelledby="main-content-header"
                   tabIndex="0"
                 >
+                  <ConfigError loadingConfigError={loadingConfigError} />
                   <PageErrorBoundary>
                     <Switch>
                       <CompatRoute path="/" exact>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
If the request for the messages bundle is blocked at the network level (not a 404 or other 'normal' error, request rejected / dropped somewhere before response reaches client), this causes the main app component to fall over. This was discovered in the nightly tests for the Z (s390x) platform running on dogfooding.

Update the processing of the messages bundle to handle this more gracefully and fallback to the default locale.

Move the display of the error notification inside the `Content` component so that it's fully visible on screen.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
