### PR TITLE
Fix invalid dom nesting

### DIFF
--- a/packages/components/src/components/ResourceDetails/ResourceDetails.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 The Tekton Authors
+Copyright 2020-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -83,8 +83,8 @@ const ResourceDetails = ({
           })}
         >
           <div className="tkn--details">
-            <div className="tkn--resourcedetails-metadata">
-              <p>
+            <ul className="tkn--resourcedetails-metadata">
+              <li>
                 <span>
                   {intl.formatMessage({
                     id: 'dashboard.metadata.dateCreated',
@@ -95,8 +95,8 @@ const ResourceDetails = ({
                   date={resource.metadata.creationTimestamp}
                   relative
                 />
-              </p>
-              <p>
+              </li>
+              <li>
                 <span>
                   {intl.formatMessage({
                     id: 'dashboard.metadata.labels',
@@ -113,9 +113,9 @@ const ResourceDetails = ({
                         {label}
                       </Tag>
                     ))}
-              </p>
+              </li>
               {resource.metadata.namespace && (
-                <p>
+                <li>
                   <span>
                     {intl.formatMessage({
                       id: 'dashboard.metadata.namespace',
@@ -123,10 +123,10 @@ const ResourceDetails = ({
                     })}
                   </span>
                   {resource.metadata.namespace}
-                </p>
+                </li>
               )}
               {resource.spec?.description && (
-                <p>
+                <li>
                   <span>
                     {intl.formatMessage({
                       id: 'dashboard.resourceDetails.description',
@@ -134,10 +134,10 @@ const ResourceDetails = ({
                     })}
                   </span>
                   {resource.spec.description}
-                </p>
+                </li>
               )}
               {additionalMetadata}
-            </div>
+            </ul>
             {children}
           </div>
         </Tab>

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2020-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -52,9 +52,9 @@ export const WithAdditionalContent = () => (
   <ResourceDetails
     resource={resource}
     additionalMetadata={
-      <p>
+      <li>
         <span>Custom Field:</span>some additional metadata
-      </p>
+      </li>
     }
   >
     <p>some additional content</p>

--- a/src/containers/EventListener/EventListener.js
+++ b/src/containers/EventListener/EventListener.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 The Tekton Authors
+Copyright 2019-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -64,7 +64,7 @@ export function EventListenerContainer() {
     return (
       <>
         {serviceAccountName && (
-          <p>
+          <li>
             <span>
               {intl.formatMessage({
                 id: 'dashboard.eventListener.serviceAccount',
@@ -72,10 +72,10 @@ export function EventListenerContainer() {
               })}
             </span>
             {serviceAccountName}
-          </p>
+          </li>
         )}
         {serviceType && (
-          <p>
+          <li>
             <span>
               {intl.formatMessage({
                 id: 'dashboard.eventListener.serviceType',
@@ -83,10 +83,10 @@ export function EventListenerContainer() {
               })}
             </span>
             {serviceType}
-          </p>
+          </li>
         )}
         {namespaceSelector?.matchNames?.length ? (
-          <p>
+          <li>
             <span>
               {intl.formatMessage({
                 id: 'dashboard.eventListener.namespaceSelector',
@@ -94,7 +94,7 @@ export function EventListenerContainer() {
               })}
             </span>
             {namespaceSelector.matchNames.join(', ')}
-          </p>
+          </li>
         ) : null}
       </>
     );

--- a/src/containers/Run/Run.js
+++ b/src/containers/Run/Run.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Tekton Authors
+Copyright 2022-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -296,7 +296,7 @@ function Run() {
         }
         additionalMetadata={
           <>
-            <p>
+            <li>
               <span>
                 {intl.formatMessage({
                   id: 'dashboard.run.duration.label',
@@ -304,8 +304,8 @@ function Run() {
                 })}
               </span>
               {getRunDuration(run)}
-            </p>
-            <p>
+            </li>
+            <li>
               <span>
                 {intl.formatMessage({
                   id: 'dashboard.filter.status.title',
@@ -314,7 +314,7 @@ function Run() {
               </span>
               {getRunStatusIcon(run)}
               {getRunStatusTooltip(run)}
-            </p>
+            </li>
           </>
         }
         error={error}

--- a/src/scss/Triggers.scss
+++ b/src/scss/Triggers.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 The Tekton Authors
+Copyright 2019-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,7 +21,8 @@ limitations under the License.
     }
   }
   .tkn--details {
-    p:not(:empty) {
+    li:not(:empty), p:not(:empty) {
+      @include type-style('body-short-02');
       margin-top: $spacing-03;
       span:first-child {
         font-weight: bold;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
When rendering the `Tag` Carbon component on the `ResourceDetails` the browser produces an 'invalid DOM nesting' error due to use of a `<div>` element for the `Tag` which we render inside a `<p>`.

Switch to an unordered list (semantically valid here) to avoid the invalid nesting issue and clean up our logs (both browser and test).

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
