### PR TITLE
Remove remaining references to Conditions

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.js
@@ -161,18 +161,12 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     }, []);
 
     return taskRuns.map(taskRun => {
-      const { labels, name: taskRunName, uid } = taskRun.metadata;
+      const { name: taskRunName, uid } = taskRun.metadata;
 
-      let pipelineTaskName;
-      const conditionCheck = labels[labelConstants.CONDITION_CHECK];
-      if (conditionCheck) {
-        pipelineTaskName = conditionCheck;
-      } else {
-        pipelineTaskName = getPipelineTaskName({
-          pipelineRun,
-          taskRunName
-        });
-      }
+      let pipelineTaskName = getPipelineTaskName({
+        pipelineRun,
+        taskRunName
+      });
 
       const { podName } = taskRun.status || {};
 

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
@@ -16,24 +16,24 @@ import React from 'react';
 import ResourceDetails from '.';
 
 const resource = {
-  apiVersion: 'tekton.dev/v1alpha1',
-  kind: 'Condition',
+  apiVersion: 'tekton.dev/v1',
+  kind: 'Task',
   metadata: {
     creationTimestamp: '2020-05-19T16:49:30Z',
     labels: {
       'label-key': 'label-value'
     },
-    name: 'file-exists',
+    name: 'test',
     namespace: 'tekton-pipelines'
   },
   spec: {
-    check: {
-      image: 'alpine',
-      script: 'test -f $(resources.workspace.path)/$(params.path)'
-    },
-    description: 'Checks if a file exists at the specified path',
-    params: [{ name: 'path' }],
-    resources: [{ name: 'workspace', type: 'git' }]
+    steps: [
+      {
+        name: 'test',
+        image: 'alpine',
+        script: 'echo hello'
+      }
+    ]
   }
 };
 

--- a/packages/utils/src/utils/constants.js
+++ b/packages/utils/src/utils/constants.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 The Tekton Authors
+Copyright 2020-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,8 +13,6 @@ limitations under the License.
 
 export const labels = {
   CLUSTER_TASK: 'tekton.dev/clusterTask',
-  CONDITION_CHECK: 'tekton.dev/conditionCheck',
-  CONDITION_NAME: 'tekton.dev/conditionName',
   DASHBOARD_IMPORT: 'dashboard.tekton.dev/import',
   DASHBOARD_RETRY_NAME: 'dashboard.tekton.dev/retryName',
   PIPELINE: 'tekton.dev/pipeline',

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -419,31 +419,19 @@ export function getTaskSpecFromTaskRef({ clusterTasks, pipelineTask, tasks }) {
   return definition?.spec || {};
 }
 
-export function getPlaceholderTaskRun({
-  clusterTasks,
-  condition,
-  pipelineTask,
-  tasks
-}) {
+export function getPlaceholderTaskRun({ clusterTasks, pipelineTask, tasks }) {
   const { name: pipelineTaskName, taskSpec } = pipelineTask;
   const specToDisplay =
     taskSpec || getTaskSpecFromTaskRef({ clusterTasks, pipelineTask, tasks });
   const { steps = [] } = specToDisplay;
 
-  const displayName =
-    pipelineTaskName + (condition ? `-${condition.conditionRef}` : '');
-
   return {
     metadata: {
-      name: displayName,
+      name: pipelineTaskName,
       labels: {
-        [labelConstants.PIPELINE_TASK]: pipelineTaskName,
-        ...(condition && {
-          [labelConstants.CONDITION_CHECK]: displayName,
-          [labelConstants.CONDITION_NAME]: condition.conditionRef
-        })
+        [labelConstants.PIPELINE_TASK]: pipelineTaskName
       },
-      uid: `_placeholder_${displayName}`
+      uid: `_placeholder_${pipelineTaskName}`
     },
     spec: {
       taskSpec: specToDisplay
@@ -483,26 +471,10 @@ export function getTaskRunsWithPlaceholders({
 
   const taskRunsToDisplay = [];
   pipelineTasks.forEach(pipelineTask => {
-    if (pipelineTask.conditions) {
-      pipelineTask.conditions.forEach(condition => {
-        const conditionTaskRun = taskRuns.find(
-          taskRun =>
-            taskRun.metadata.labels?.[labelConstants.PIPELINE_TASK] ===
-              pipelineTask.name &&
-            taskRun.metadata.labels?.[labelConstants.CONDITION_NAME] ===
-              condition.conditionRef
-        );
-        taskRunsToDisplay.push(
-          conditionTaskRun || getPlaceholderTaskRun({ pipelineTask, condition })
-        );
-      });
-    }
-
     const realTaskRun = taskRuns.find(
       taskRun =>
         taskRun.metadata.labels?.[labelConstants.PIPELINE_TASK] ===
-          pipelineTask.name &&
-        !taskRun.metadata.labels?.[labelConstants.CONDITION_CHECK]
+        pipelineTask.name
     );
 
     taskRunsToDisplay.push(

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -620,48 +620,17 @@ describe('getPlaceholderTaskRun', () => {
       pipelineTask.name
     );
   });
-
-  it('handles conditions', () => {
-    const condition = {
-      conditionRef: 'someCondition'
-    };
-    const name = 'someTaskName';
-    const task = {
-      metadata: {
-        name
-      },
-      spec: {
-        fake: 'spec'
-      }
-    };
-    const pipelineTask = {
-      name: 'somePipelineTask',
-      taskRef: {
-        name
-      }
-    };
-    const taskRun = getPlaceholderTaskRun({
-      condition,
-      pipelineTask,
-      tasks: [task]
-    });
-    expect(taskRun.spec.taskSpec).toEqual(task.spec);
-    expect(taskRun.metadata.labels[labels.CONDITION_CHECK]).toBeTruthy();
-    expect(taskRun.metadata.labels[labels.CONDITION_NAME]).toBeTruthy();
-  });
 });
 
 describe('getTaskRunsWithPlaceholders', () => {
   it('handles pipeline', () => {
-    const conditionRef = 'someCondition';
     const finallyTaskName = 'someFinallyTaskName';
     const pipelineTaskName = 'somePipelineTaskName';
     const pipeline = {
       spec: {
         tasks: [
           {
-            name: pipelineTaskName,
-            conditions: [{ conditionRef }]
+            name: pipelineTaskName
           }
         ],
         finally: [
@@ -687,22 +656,13 @@ describe('getTaskRunsWithPlaceholders', () => {
         name: 'someFinallyTaskRun'
       }
     };
-    const conditionTaskRun = {
-      metadata: {
-        labels: {
-          [labels.PIPELINE_TASK]: pipelineTaskName,
-          [labels.CONDITION_NAME]: conditionRef
-        }
-      }
-    };
     const taskRuns = [
       finallyTaskRun,
       { metadata: { labels: {}, name: 'junk' } },
-      taskRun,
-      conditionTaskRun
+      taskRun
     ];
     const runs = getTaskRunsWithPlaceholders({ pipeline, taskRuns });
-    expect(runs).toEqual([conditionTaskRun, taskRun, finallyTaskRun]);
+    expect(runs).toEqual([taskRun, finallyTaskRun]);
   });
 
   it('handles inline spec', () => {
@@ -750,15 +710,13 @@ describe('getTaskRunsWithPlaceholders', () => {
   });
 
   it('handles missing TaskRuns', () => {
-    const conditionRef = 'someCondition';
     const finallyTaskName = 'someFinallyTaskName';
     const pipelineTaskName = 'somePipelineTaskName';
     const pipeline = {
       spec: {
         tasks: [
           {
-            name: pipelineTaskName,
-            conditions: [{ conditionRef }]
+            name: pipelineTaskName
           }
         ],
         finally: [
@@ -768,18 +726,13 @@ describe('getTaskRunsWithPlaceholders', () => {
         ]
       }
     };
-    const [conditionTaskRun, taskRun, finallyTaskRun] =
-      getTaskRunsWithPlaceholders({ pipeline, taskRuns: [] });
-    expect(conditionTaskRun.metadata.labels[labels.PIPELINE_TASK]).toEqual(
-      pipelineTaskName
-    );
-    expect(conditionTaskRun.metadata.labels[labels.CONDITION_NAME]).toEqual(
-      conditionRef
-    );
+    const [taskRun, finallyTaskRun] = getTaskRunsWithPlaceholders({
+      pipeline,
+      taskRuns: []
+    });
     expect(taskRun.metadata.labels[labels.PIPELINE_TASK]).toEqual(
       pipelineTaskName
     );
-    expect(taskRun.metadata.labels[labels.CONDITION_NAME]).toBeUndefined();
     expect(finallyTaskRun.metadata.labels[labels.PIPELINE_TASK]).toEqual(
       finallyTaskName
     );

--- a/src/containers/PipelineRun/PipelineRun.js
+++ b/src/containers/PipelineRun/PipelineRun.js
@@ -147,15 +147,7 @@ export /* istanbul ignore next */ function PipelineRunContainer() {
   function getSelectedTaskId(pipelineTaskName, retry) {
     const taskRun = taskRuns.find(
       ({ metadata }) =>
-        metadata.labels &&
-        ((metadata.labels[labelConstants.CONDITION_CHECK] &&
-          metadata.labels[labelConstants.CONDITION_CHECK] ===
-            pipelineTaskName) ||
-          // the `pipelineTask` label is present on both TaskRuns (the owning
-          // TaskRun and the TaskRun created for the condition check), ensure
-          // we only match on the owning TaskRun here and not another condition
-          (!metadata.labels[labelConstants.CONDITION_CHECK] &&
-            metadata.labels[labelConstants.PIPELINE_TASK] === pipelineTaskName))
+        metadata.labels?.[labelConstants.PIPELINE_TASK] === pipelineTaskName
     );
 
     if (!taskRun) {
@@ -174,10 +166,7 @@ export /* istanbul ignore next */ function PipelineRunContainer() {
   function getSelectedTaskRun(selectedTaskId) {
     const lookup = taskRuns.reduce((acc, taskRun) => {
       const { labels, uid } = taskRun.metadata;
-      const pipelineTaskName =
-        labels &&
-        (labels[labelConstants.CONDITION_CHECK] ||
-          labels[labelConstants.PIPELINE_TASK]);
+      const pipelineTaskName = labels?.[labelConstants.PIPELINE_TASK];
       const { podName, retriesStatus } = taskRun.status || {};
       acc[uid + podName] = {
         pipelineTaskName,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/1445

Since support for displaying the Condition CRD was removed in a previous release and Tekton Pipelines has removed support for the CRD, we should now remove the remaining code handling this on the PipelineRun details page.

This simplifies the logic for displaying placeholders and tracking the selected item in the pipeline task list, and should make future changes related to retries and when expressions easier to implement.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove support for displaying Condition checks on the PipelineRun details page. The list and details pages for displaying the Condition CRD were removed in Tekton Dashboard v0.28.0 and support for using these resources was removed in Tekton Pipelines v0.37.0.
```
