### PR TITLE
Remove whatwg-fetch polyfill

### DIFF
--- a/config_frontend/jsdom.js
+++ b/config_frontend/jsdom.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+export default class CustomJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(config, context) {
+    super(config, context);
+
+    // use Node.js native fetch
+    this.global.fetch = fetch;
+    this.global.Headers = Headers;
+    this.global.Request = Request;
+    this.global.Response = Response;
+  }
+}

--- a/config_frontend/setupTests.js
+++ b/config_frontend/setupTests.js
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import 'whatwg-fetch';
 import { TextDecoder, TextEncoder } from 'util';
 
 import { server } from './msw';

--- a/jest.config.js
+++ b/jest.config.js
@@ -40,7 +40,7 @@ module.exports = {
   },
   restoreMocks: true,
   setupFilesAfterEnv: ['<rootDir>/config_frontend/setupTests.js'],
-  testEnvironment: 'jsdom',
+  testEnvironment: '<rootDir>/config_frontend/jsdom.js',
   testMatch: [
     '<rootDir>/src/**/*.test.js',
     '<rootDir>/packages/**/src/**/*.test.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,6 @@
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.11.1",
         "webpack-merge": "^5.8.0",
-        "whatwg-fetch": "^3.6.2",
         "yaml-loader": "^0.8.0"
       },
       "engines": {
@@ -25241,12 +25240,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -44438,12 +44431,6 @@
           }
         }
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1",
     "webpack-merge": "^5.8.0",
-    "whatwg-fetch": "^3.6.2",
     "yaml-loader": "^0.8.0"
   },
   "engines": {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Instead of using a global polyfill for fetch we can provide a custom jest test environment based on jest-environment-jsdom with the missing APIs added by using the Node.js native fetch.

This means fewer dependencies to maintain, and should benefit directly from any future improvements to the Node.js native fetch implementation as we update Node.js versions.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
