### PR TITLE
Remove installer script release tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -108,14 +108,6 @@ test_dashboard() {
   $tekton_repo_dir/scripts/installer uninstall $@
 }
 
-if [ -z "$SKIP_BUILD_TEST" ]; then
-	header "Validating that we can build the release manifests"
-	echo "Building manifests for k8s"
-	$tekton_repo_dir/scripts/installer release                          || fail_test "Failed to build manifests for k8s"
-	echo "Building manifests for k8s --read-write"
-	$tekton_repo_dir/scripts/installer release --read-write              || fail_test "Failed to build manifests for k8s --read-write"
-fi
-
 header "Building browser E2E image"
 docker build -t dashboard-e2e packages/e2e
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The tests for the `release` target used to provide value but now all they're doing is testing features of `ko`. Remove them as the main functionality of the installer script is already tested elsewhere.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
