### PR TITLE
Fail E2E early if docker build fails

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -109,7 +109,7 @@ test_dashboard() {
 }
 
 header "Building browser E2E image"
-docker build -t dashboard-e2e packages/e2e
+docker build -t dashboard-e2e packages/e2e || fail_test "Failed building browser E2E image"
 
 if [ -z "$PIPELINES_VERSION" ]; then
   export PIPELINES_VERSION=v0.46.0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Spotted this on a recent nightly build on Z: https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns/tekton-dashboard-s390x-nightly-run-7nnxz?pipelineTask=e2e-test-dashboard&retry=1&step=run-e2e-tests

<details>
<summary>Logs excerpt</summary>

```
====================================
==== BUILDING BROWSER E2E IMAGE ====
====================================
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon   47.1kB

Step 1/12 : FROM cypress/browsers:node18.12.0-chrome107
Get "https://registry-1.docker.io/v2/": net/http: TLS handshake timeout
===========================================
==== INSTALLING PIPELINES AND TRIGGERS ====
===========================================
>> Deploying Tekton Pipelines (v0.46.0)
namespace/tekton-pipelines unchanged
clusterrole.rbac.authorization.k8s.io/tekton-pipelines-controller-cluster-access unchanged
clusterrole.rbac.authorization.k8s.io/tekton-pipelines-controller-tenant-access unchanged
clusterrole.rbac.authorization.k8s.io/tekton-pipelines-webhook-cluster-access unchanged

… (a few hundred lines removed) …

===========================================
==== RUNNING THE E2E TESTS (--PLATFORM ====
===========================================
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   532  100   532    0     0   1597      0 --:--:-- --:--:-- --:--:--  1592
Dashboard ready
Running browser E2E testsâ€¦
Skipping recording videos
Unable to find image 'dashboard-e2e:latest' locally
docker: Error response from daemon: pull access denied for dashboard-e2e, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
ERROR: Browser E2E tests failed
==================================
==== INTEGRATION TESTS FAILED ====
==================================
```

</details>

Currently the script continues if the docker build fails, however with recent changes there's no point in continuing as all of the tests now rely on this image.

Exit on failure with a custom error message.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
