### PR TITLE
Add debug log to E2E tests when run in CI

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -14,7 +14,7 @@
   "private": true,
   "scripts": {
     "test": "cypress open --e2e --browser chrome",
-    "test:ci": "cypress run"
+    "test:ci": "node -e \"console.log('process.arch:', process.arch)\" && cypress run"
   },
   "devDependencies": {
     "cypress": "^12.8.1"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Output the value returned by `process.arch` in the logs before running the tests. This is useful for debugging issues with the E2E docker image etc.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
