### PR TITLE
Fix glob ignore patterns for extractMessages script

### DIFF
--- a/scripts/i18n/extractMessages.js
+++ b/scripts/i18n/extractMessages.js
@@ -75,7 +75,7 @@ babelConfig.plugins.push([
 log('Extracting messages\n');
 
 globSync('./@(src|packages)/**/!(*.cy|*.stories|*.test).js', {
-  ignore: ['./**/node_modules/**/*.js', './packages/e2e/**/*.js']
+  ignore: ['packages/**/node_modules/**', 'packages/e2e/**']
 }).forEach(filePath => {
   babel.transformFileSync(path.normalize(filePath), babelConfig);
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
It appears that behaviour of the ignore field has also changed in the latest major glob release, this means that we've been unnecessarily processing files in the node_modules folders of our packages, as well as processing the e2e test files.

Update the ignore pattern strings to match the new behaviour.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
