### PR TITLE
Update tutorial to include RoleBinding for default namespace

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -117,6 +117,48 @@ kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097
 
 You can now open the Dashboard in your browser at http://localhost:9097
 
+## Grant required permissions
+
+The import must be executed using a ServiceAccount with permissions to create the resources being imported.
+
+For this tutorial we will create a ClusterRole granting permission to create a number of Tekton resources, and a RoleBinding configuring this for the `default` ServiceAccount in the `default` namespace.
+
+```bash
+kubectl apply -f - <<EOF
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-tutorial
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-tutorial
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-tutorial
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+EOF
+```
+
 ## Import some Tekton resources using the Tekton Dashboard
 
 We will import [two simple Tasks and a Pipeline definition](https://github.com/tektoncd/dashboard/tree/main/docs/tutorial) to demonstrate some of the features of the Dashboard.
@@ -127,7 +169,8 @@ We will import [two simple Tasks and a Pipeline definition](https://github.com/t
    - Repository path: `docs/tutorial`
    - Target namespace: `default`
 1. Expand the 'Advanced configuration' section and fill in the following:
-   - Service Account: `tekton-dashboard`
+   - Namespace: `default`
+   - Service Account: `default`
 1. Leave the default values for the rest of the fields
 1. Click the `Import and Apply` button
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Recent Tekton Pipelines releases include stricter policies on the `tekton-pipelines` namespace meaning that created pods must satisfy additional requirements to be able to run.

Since the `tekton-pipelines` namespace is reserved for Tekton controllers we shouldn't be running the import pipeline there anyway.

Update the tutorial to use the `default` namespace and provide a ClusterRole and RoleBinding granting the required permissions to create the tutorial resources.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
