### PR TITLE
Update E2E tests script to provide option for using nightly releases

### DIFF
--- a/scripts/release-installer
+++ b/scripts/release-installer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 The Tekton Authors
+# Copyright 2020-2023 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,6 +12,14 @@
 # limitations under the License.
 
 BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard"
+
+download() {
+  if type "curl" > /dev/null 2>&1; then
+    curl -sL $@
+  else
+    wget -q $@
+  fi
+}
 
 verifySupported() {
   if ! type "curl" > /dev/null 2>&1 && ! type "wget" > /dev/null 2>&1; then
@@ -31,39 +39,23 @@ getReleaseURL() {
 
 build() {
   local VERSION=$1
-  if type "curl" > /dev/null 2>&1; then
-    curl -sL $(getReleaseURL $VERSION)/installer | bash -s -- build --version $@
-  elif type "wget" > /dev/null 2>&1; then
-    wget -q $(getReleaseURL $VERSION)/installer | bash -s -- build --version $@
-  fi
+  download $(getReleaseURL $VERSION)/installer | bash -s -- build --version $@
 }
 
 install() {
   local VERSION=$1
-  if type "curl" > /dev/null 2>&1; then
-    curl -sL $(getReleaseURL $VERSION)/installer | bash -s -- install --version $@
-  elif type "wget" > /dev/null 2>&1; then
-    wget -q $(getReleaseURL $VERSION)/installer | bash -s -- install --version $@
-  fi
+  download $(getReleaseURL $VERSION)/installer | bash -s -- install --version $@
 }
 
 uninstall() {
   local VERSION=$1
-  if type "curl" > /dev/null 2>&1; then
-    curl -sL $(getReleaseURL $VERSION)/installer | bash -s -- uninstall --version $@
-  elif type "wget" > /dev/null 2>&1; then
-    wget -q $(getReleaseURL $VERSION)/installer | bash -s -- uninstall --version $@
-  fi
+  download $(getReleaseURL $VERSION)/installer | bash -s -- uninstall --version $@
 }
 
 # help provides possible cli installation arguments
 help () {
   local VERSION=$1
-  if type "curl" > /dev/null 2>&1; then
-    curl -sL $(getReleaseURL $VERSION)/installer | bash -s -- "help"
-  elif type "wget" > /dev/null 2>&1; then
-    wget -q $(getReleaseURL $VERSION)/installer | bash -s -- "help"
-  fi
+  download $(getReleaseURL $VERSION)/installer | bash -s -- "help"
 }
 
 set -e

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -108,11 +108,15 @@ function pre_unit_tests() {
 }
 
 function pre_integration_tests() {
-    local failed=0
+  local failed=0
+  if [ "${USE_NIGHTLY_RELEASE}" == "true" ]; then
+    echo "Using nightly release, skipping npm install and frontend build"
+  else
     node_npm_install || failed=1
     echo "Running frontend build"
     npm run build || failed=1
-    return ${failed}
+  fi
+  return ${failed}
 }
 
 function extra_initialization() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Depends on https://github.com/tektoncd/dashboard/pull/2854

Some automated tests just need to run the integration tests / browser
E2E tests against a specific release version. They do not need to
build the application from scratch.

Add support for an environment variable `USE_NIGHTLY_RELEASE` which
bypasses the normal `npm install`, webpack build, ko build, etc. and
instead deploys the latest nightly release to the target environment.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
