### PR TITLE
Increase timeout for the import resources E2E test

### DIFF
--- a/packages/e2e/cypress/e2e/import/import-resources.cy.js
+++ b/packages/e2e/cypress/e2e/import/import-resources.cy.js
@@ -69,7 +69,7 @@ subjects:
     cy.contains('a', 'View status of this run').click();
 
     cy.get('header[class="tkn--pipeline-run-header"]')
-      .find('span[class="tkn--status-label"]', { timeout: 30000 })
+      .find('span[class="tkn--status-label"]', { timeout: 60000 })
       .should('have.text', 'Succeeded');
 
     cy.visit(`/#/namespaces/${namespace}/pipelines`);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This test is intermittently failing due to timeout when running the nightly tests against Z and P installs of the Dashboard.

Increase the timeout to stabilise the tests.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
