### PR TITLE
Improve error handling in E2E script

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -82,19 +82,25 @@ function dump_extra_cluster_state() {
 }
 
 function wait_dashboard_backend() {
+  local ready=false
   # Wait until deployment is running before checking pods, stops timing error
   for i in {1..30}
   do
     wait=$(kubectl wait --namespace $DASHBOARD_NAMESPACE --for=condition=available deployments/tekton-dashboard --timeout=30s)
     echo "WAIT RESULT: $wait"
     if [ "$wait" = "deployment.apps/tekton-dashboard condition met" ]; then
+      ready=true
       break
     elif [ "$wait" = "deployment.extensions/tekton-dashboard condition met" ]; then
+      ready=true
       break
     else
       sleep 5
     fi
   done
+  if ! $ready; then
+    fail_test "Dashboard deployment not found"
+  fi
   # Wait for pods to be running in the namespaces we are deploying to
   wait_until_pods_running $DASHBOARD_NAMESPACE || fail_test "Dashboard backend did not come up"
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,10 +45,10 @@ test_dashboard() {
   header "Setting up environment ($@)"
   if [ "${USE_NIGHTLY_RELEASE}" == "true" ]; then
     echo "Installing nightly release"
-    $tekton_repo_dir/scripts/release-installer install --nightly latest $@
+    $tekton_repo_dir/scripts/release-installer install --nightly latest $@ || fail_test "Failed installing nightly release"
   else
     echo "Installing from HEAD"
-    $tekton_repo_dir/scripts/installer install $@
+    $tekton_repo_dir/scripts/installer install $@ || fail_test "Failed installing from HEAD"
   fi
 
   wait_dashboard_backend


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Fail early if the install script fails.
If the install script returns successfully, fail early if the Dashboard deployment isn't found after retries.

This prevents the tests waiting (as long as 5-10 minutes in some cases) for a condition that will never be met.

Spotted this while debugging issues with the nightly tests for Z and P on dogfooding.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
