### PR TITLE
Move param and result descriptions to tooltip icon

### DIFF
--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.js
@@ -15,9 +15,33 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { getParams, taskRunHasWarning } from '@tektoncd/dashboard-utils';
-import { ContentSwitcher, Switch } from 'carbon-components-react';
+import { ContentSwitcher, Switch, Tooltip } from 'carbon-components-react';
+import { Information16 } from '@carbon/icons-react';
 
 import { DetailsHeader, Param, Tab, Table, Tabs, ViewYAML } from '..';
+
+function HelpIcon({ title }) {
+  const intl = useIntl();
+
+  if (!title) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      align="end"
+      direction="top"
+      iconDescription={intl.formatMessage({
+        id: 'dashboard.resourceDetails.description',
+        defaultMessage: 'Description'
+      })}
+      renderIcon={Information16}
+      showIcon
+    >
+      {title}
+    </Tooltip>
+  );
+}
 
 function getDescriptions(array) {
   if (!array) {
@@ -75,11 +99,8 @@ const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view }) => {
       })
     },
     {
-      key: 'description',
-      header: intl.formatMessage({
-        id: 'dashboard.resourceDetails.description',
-        defaultMessage: 'Description'
-      })
+      key: 'actions',
+      header: ''
     }
   ];
 
@@ -91,7 +112,7 @@ const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view }) => {
       rows={params.map(({ name, value }) => ({
         id: name,
         name,
-        description: paramsDescriptions[name],
+        actions: <HelpIcon title={paramsDescriptions[name]} />,
         value: (
           <span title={value}>
             <Param>{value}</Param>
@@ -109,7 +130,7 @@ const TaskRunDetails = ({ onViewChange, pod, task, taskRun, view }) => {
       rows={results.map(({ name, value }) => ({
         id: name,
         name,
-        description: resultsDescriptions[name],
+        actions: <HelpIcon title={resultsDescriptions[name]} />,
         value: (
           <span title={value}>
             <Param>{value}</Param>

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.scss
@@ -21,4 +21,13 @@ limitations under the License.
   .bx--content-switcher {
     margin-bottom: 1rem;
   }
+
+  /*
+    Allow columns in the params and results tables to grow to better fit their content
+  */
+  .bx--data-table td {
+    &:not(.cell-actions):not(.bx--table-column-checkbox) {
+      max-width: none;
+    }
+  }
 }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
@@ -23,6 +23,7 @@ const params = [
     value: paramValue
   }
 ];
+const taskResults = [{ name: 'message', value: 'hello' }];
 
 export default {
   component: TaskRunDetails,
@@ -39,13 +40,27 @@ export const Base = () => (
     taskRun={{
       metadata: { name: 'my-task', namespace: 'my-namespace' },
       spec: {
-        params
+        params,
+        taskSpec: {
+          params: [
+            {
+              name: params[0].name,
+              description: 'A useful description of the param…'
+            }
+          ],
+          results: [
+            {
+              name: taskResults[0].name,
+              description: 'A useful description of the result…'
+            }
+          ]
+        }
       },
       status: {
         completionTime: '2021-03-03T15:25:34Z',
         podName: 'my-task-h7d6j-pod-pdtb7',
         startTime: '2021-03-03T15:25:27Z',
-        taskResults: [{ name: 'message', value: 'hello' }]
+        taskResults
       }
     }}
   />
@@ -77,7 +92,7 @@ export const WithWarning = () => (
           }
         ],
         startTime: '2021-03-03T15:25:27Z',
-        taskResults: [{ name: 'message', value: 'hello' }]
+        taskResults
       }
     }}
   />

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.test.js
@@ -38,7 +38,7 @@ describe('TaskRunDetails', () => {
     const paramValue = 'v';
     const params = [{ name: paramKey, value: paramValue }];
     const description = 'param_description';
-    const { queryByText } = render(
+    const { queryByLabelText, queryByText } = render(
       <TaskRunDetails
         task={{
           metadata: 'task',
@@ -51,6 +51,7 @@ describe('TaskRunDetails', () => {
     expect(queryByText(taskRunName)).toBeTruthy();
     expect(queryByText(paramKey)).toBeTruthy();
     expect(queryByText(paramValue)).toBeTruthy();
+    fireEvent.click(queryByLabelText('Description'));
     expect(queryByText(description)).toBeTruthy();
   });
 
@@ -61,7 +62,7 @@ describe('TaskRunDetails', () => {
     const paramValue = 'v';
     const params = [{ name: paramKey, value: paramValue }];
     const description = 'param_description';
-    const { queryByText } = render(
+    const { queryByLabelText, queryByText } = render(
       <TaskRunDetails
         taskRun={{
           metadata: { name: taskRunName },
@@ -76,6 +77,7 @@ describe('TaskRunDetails', () => {
 
     expect(queryByText(paramKey)).toBeTruthy();
     expect(queryByText(paramValue)).toBeTruthy();
+    fireEvent.click(queryByLabelText('Description'));
     expect(queryByText(description)).toBeTruthy();
   });
 
@@ -115,7 +117,7 @@ describe('TaskRunDetails', () => {
       spec: {},
       status: { taskResults: [{ name: resultName, value: 'hello' }] }
     };
-    const { queryByText } = render(
+    const { queryByLabelText, queryByText } = render(
       <TaskRunDetails
         task={{
           metadata: 'task',
@@ -128,6 +130,7 @@ describe('TaskRunDetails', () => {
     expect(queryByText(/results/i)).toBeTruthy();
     expect(queryByText(/message/)).toBeTruthy();
     expect(queryByText(/hello/)).toBeTruthy();
+    fireEvent.click(queryByLabelText('Description'));
     expect(queryByText(description)).toBeTruthy();
   });
 
@@ -141,9 +144,10 @@ describe('TaskRunDetails', () => {
       },
       status: { taskResults: [{ name: resultName, value: 'hello' }] }
     };
-    const { queryByText } = render(
+    const { queryByLabelText, queryByText } = render(
       <TaskRunDetails taskRun={taskRun} view="results" />
     );
+    fireEvent.click(queryByLabelText('Description'));
     expect(queryByText(description)).toBeTruthy();
   });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Based on feedback from users, move the description of params and results displayed on the TaskRun details to a tooltip. It does not need to be permanently visible and can be placed in a tooltip for easy discovery if/when needed.

Before:
![image](https://user-images.githubusercontent.com/2829095/234367033-275294c1-8758-43bd-9810-ababfca890c1.png)

After:
![image](https://user-images.githubusercontent.com/2829095/234367064-29efff59-5f7f-4afa-8c3a-84621e6d2330.png)

The name and value columns will adjust to accommodate their content as they're no longer constrained to 10vw.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
