### PR TITLE
Replace git-init image in import resources

### DIFF
--- a/src/api/resources/import-resources-pipelinerun.yaml
+++ b/src/api/resources/import-resources-pipelinerun.yaml
@@ -64,7 +64,7 @@ spec:
             - name: repo
           steps:
             - name: clone
-              image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.41.0
+              image: cgr.dev/chainguard/git:2.40
               env:
                 - name: PARAM_URL
                   value: $(params.repositoryURL)
@@ -80,11 +80,14 @@ spec:
               script: |
                 #!/usr/bin/env sh
                 set -eu
+                git config --global init.defaultBranch main
                 git config --global --add safe.directory "${WORKSPACE_PATH}"
-                /ko-app/git-init \
-                  -url="${PARAM_URL}" \
-                  -revision="${PARAM_REVISION}" \
-                  -path=${WORKSPACE_PATH}
+                cd "${WORKSPACE_PATH}"
+                git init
+                git remote add origin "${PARAM_URL}"
+                git fetch --depth=1 --recurse-submodules=yes origin "${PARAM_REVISION}"
+                git reset --hard FETCH_HEAD
+                git submodule update --init --recursive
         params:
           - name: repositoryURL
             value: $(params.repositoryURL)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The `git-init` image is no longer published as part of the Pipelines release (it was part of the git PipelineResource support which has been removed).

Switch to `cgr.dev/chainguard/git` which provides the git client and is regularly updated for security fixes etc.

Implement the same functionality we previously had using pure git commands.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
