### PR TITLE
Update kustomization.yaml files to replace deprecated fields

### DIFF
--- a/overlays/installer/base/kustomization.yaml
+++ b/overlays/installer/base/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2020-2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,25 +16,25 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../base/200-clusterrole-backend.yaml
-  - ../../../base/200-clusterrole-tenant.yaml
-  - ../../../base/200-role.yaml
-  - ../../../base/201-clusterrolebinding-backend.yaml
-  - ../../../base/201-rolebinding.yaml
-  - ../../../base/202-extension-crd.yaml
-  - ../../../base/203-serviceaccount.yaml
-  - ../../../base/300-deployment.yaml
-  - ../../../base/300-service.yaml
-  - ../../../base/300-config-info.yaml
+- ../../../base/200-clusterrole-backend.yaml
+- ../../../base/200-clusterrole-tenant.yaml
+- ../../../base/200-role.yaml
+- ../../../base/201-clusterrolebinding-backend.yaml
+- ../../../base/201-rolebinding.yaml
+- ../../../base/202-extension-crd.yaml
+- ../../../base/203-serviceaccount.yaml
+- ../../../base/300-deployment.yaml
+- ../../../base/300-service.yaml
+- ../../../base/300-config-info.yaml
 images:
-  - name: dashboardImage
-    newName: ko://github.com/tektoncd/dashboard/cmd/dashboard
-patchesJson6902:
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: tekton-dashboard
-      namespace: tekton-pipelines
-    path: ../../patches/installer/deployment-patch.yaml
+- name: dashboardImage
+  newName: ko://github.com/tektoncd/dashboard/cmd/dashboard
 namespace: tekton-dashboard
+patches:
+- path: ../../patches/installer/deployment-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-dashboard
+    namespace: tekton-pipelines
+    version: v1

--- a/overlays/installer/read-only/kustomization.yaml
+++ b/overlays/installer/read-only/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2020-2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+- ../base

--- a/overlays/installer/read-write/kustomization.yaml
+++ b/overlays/installer/read-write/kustomization.yaml
@@ -16,18 +16,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
-  - 100-namespace.yaml
-patchesJson6902:
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRole
-      name: tekton-dashboard-backend
-    path: ../../patches/read-write/clusterrole-backend-patch.yaml
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRole
-      name: tekton-dashboard-tenant
-    path: ../../patches/read-write/clusterrole-tenant-patch.yaml
+- ../base
+- 100-namespace.yaml
+patches:
+- path: ../../patches/read-write/clusterrole-backend-patch.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-dashboard-backend
+    version: v1
+- path: ../../patches/read-write/clusterrole-tenant-patch.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-dashboard-tenant
+    version: v1

--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Run `kustomize edit fix` on each of our kustomization.yaml files to replace use of `patchesJson6902` with `patches` since it has been deprecated in kustomize v5 and will be removed in a future release when switching to the `kustomize.config.k8s.io/v1` API

The only significant change was renaming `patchesJson6902` to `patches`, the rest is just the tool reordering the fields and whitespace changes.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
