### PR TITLE
Send start and completion time to external logs proxy

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -182,12 +182,25 @@ export function useEvents(
 }
 
 export function getExternalLogURL({
+  completionTime,
   container,
   externalLogsURL,
   namespace,
-  podName
+  podName,
+  startTime
 }) {
-  return `${externalLogsURL}/${namespace}/${podName}/${container}`;
+  const queryParams = new URLSearchParams();
+  if (startTime) {
+    queryParams.set('startTime', startTime);
+  }
+  if (completionTime) {
+    queryParams.set('completionTime', completionTime);
+  }
+  let queryString = queryParams.toString(); // returns the properly encoded string, or '' if no params
+  if (queryString) {
+    queryString = `?${queryString}`;
+  }
+  return `${externalLogsURL}/${namespace}/${podName}/${container}${queryString}`;
 }
 
 export function getPodLogURL({ container, name, namespace, follow }) {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -225,6 +225,52 @@ it('getExternalLogURL', () => {
   const externalLogsURL = 'fake_externalLogsURL';
   const namespace = 'fake_namespace';
   const podName = 'fake_podName';
+  const startTime = '2000-01-02T03:04:05Z';
+  const completionTime = '2006-07-08T09:10:11Z';
+  expect(
+    API.getExternalLogURL({
+      completionTime,
+      container,
+      externalLogsURL,
+      namespace,
+      podName,
+      startTime
+    })
+  ).toEqual(
+    `${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
+      ':',
+      '%3A'
+    )}&completionTime=${completionTime.replaceAll(':', '%3A')}`
+  );
+});
+
+it('getExternalLogURL with empty completionTime', () => {
+  const container = 'fake_container';
+  const externalLogsURL = 'fake_externalLogsURL';
+  const namespace = 'fake_namespace';
+  const podName = 'fake_podName';
+  const startTime = '2000-01-02T03:04:05Z';
+  expect(
+    API.getExternalLogURL({
+      container,
+      externalLogsURL,
+      namespace,
+      podName,
+      startTime
+    })
+  ).toEqual(
+    `${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
+      ':',
+      '%3A'
+    )}`
+  );
+});
+
+it('getExternalLogURL with empty startTime and completionTime', () => {
+  const container = 'fake_container';
+  const externalLogsURL = 'fake_externalLogsURL';
+  const namespace = 'fake_namespace';
+  const podName = 'fake_podName';
   expect(
     API.getExternalLogURL({ container, externalLogsURL, namespace, podName })
   ).toEqual(`${externalLogsURL}/${namespace}/${podName}/${container}`);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -98,10 +98,17 @@ export function fetchLogsFallback(externalLogsURL) {
 
   return (stepName, stepStatus, taskRun) => {
     const { namespace } = taskRun.metadata;
-    const { podName } = taskRun.status || {};
+    const { podName, startTime, completionTime } = taskRun.status || {};
     const { container } = stepStatus;
     return get(
-      getExternalLogURL({ container, externalLogsURL, namespace, podName }),
+      getExternalLogURL({
+        container,
+        externalLogsURL,
+        namespace,
+        podName,
+        startTime,
+        completionTime
+      }),
       {
         Accept: 'text/plain'
       }

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -140,6 +140,32 @@ describe('fetchLogsFallback', () => {
     const namespace = 'fake_namespace';
     const podName = 'fake_podName';
     const stepName = 'fake_stepName';
+    const startTime = '2000-01-02T03:04:05Z';
+    const completionTime = '2006-07-08T09:10:11Z';
+    const stepStatus = { container };
+    const taskRun = {
+      metadata: { namespace },
+      status: { podName, startTime, completionTime }
+    };
+    jest.spyOn(comms, 'get').mockImplementation(() => {});
+
+    const fallback = fetchLogsFallback(externalLogsURL);
+    fallback(stepName, stepStatus, taskRun);
+    expect(comms.get).toHaveBeenCalledWith(
+      `${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
+        ':',
+        '%3A'
+      )}&completionTime=${completionTime.replaceAll(':', '%3A')}`,
+      { Accept: 'text/plain' }
+    );
+  });
+
+  it('should handle a missing startTime and completionTime', () => {
+    const container = 'fake_container';
+    const externalLogsURL = 'fake_url';
+    const namespace = 'fake_namespace';
+    const podName = 'fake_podName';
+    const stepName = 'fake_stepName';
     const stepStatus = { container };
     const taskRun = { metadata: { namespace }, status: { podName } };
     jest.spyOn(comms, 'get').mockImplementation(() => {});


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Fixes https://github.com/tektoncd/dashboard/issues/2908

Include the `startTime` and `completionTime` of the TaskRun when calling out to the external logs proxy so that queries against the long-term log storage can be optimised to search a targeted timeframe if possible.

These are included as query parameters to allow for backwards-compatibility with existing route handling logic that might be being used. 

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
	- No existing docs for external-logs aside from the walkthrough. This change doesn't cause a change to those docs.
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Include the TaskRun's `startTime` and `completionTime` as query parameters when making requests to the external-logs proxy.
```
