### PR TITLE
Add new story showing all status icon variations together

### DIFF
--- a/packages/components/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/components/src/components/StatusIcon/StatusIcon.stories.js
@@ -11,7 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React from 'react';
+import {
+  Pending20 as DefaultStepIcon,
+  PendingFilled20 as DefaultTaskIcon,
+  UndefinedFilled20 as UndefinedIcon
+} from '@carbon/icons-react';
+
 import StatusIcon from './StatusIcon';
+
+import './StatusIcon.stories.scss';
 
 export default {
   component: StatusIcon,
@@ -20,6 +29,10 @@ export default {
     type: {
       control: {
         type: 'inline-radio'
+      },
+      if: {
+        arg: 'DefaultIcon',
+        exists: false
       },
       options: ['normal', 'inverse']
     }
@@ -80,4 +93,123 @@ export const Succeeded = {
 export const SucceededWithWarning = {
   args: { hasWarning: true, status: 'True' },
   name: 'Succeeded with warning'
+};
+
+export const DefaultTask = {
+  args: { DefaultIcon: DefaultTaskIcon },
+  name: 'Task default - no status received yet'
+};
+
+export const DefaultStep = {
+  args: { DefaultIcon: DefaultStepIcon },
+  name: 'Step default - no status received yet'
+};
+
+export const CustomRun = {
+  args: { DefaultIcon: UndefinedIcon },
+  name: 'CustomRun (unknown status)'
+};
+
+export const AllIcons = {
+  render() {
+    return (
+      <div className="status-icons-list">
+        <h3>PipelineRun</h3>
+        <ul>
+          <li>
+            <StatusIcon {...CancelledPipelineRun.args} />
+            <span>Cancelled</span>
+          </li>
+          <li>
+            <StatusIcon {...Failed.args} />
+            <span>Failed</span>
+          </li>
+          <li>
+            <StatusIcon {...Pending.args} />
+            <span>Pending</span>
+          </li>
+          <li>
+            <StatusIcon {...Queued.args} />
+            <span>Queued</span>
+          </li>
+          <li>
+            <StatusIcon {...Running.args} />
+            <span>Running</span>
+          </li>
+          <li>
+            <StatusIcon {...Succeeded.args} />
+            <span>Succeeded</span>
+          </li>
+          <li>
+            <StatusIcon {...SucceededWithWarning.args} />
+            <span>Succeeded with warning</span>
+          </li>
+        </ul>
+
+        <h3>TaskRun</h3>
+        <ul>
+          <li>
+            <StatusIcon {...CancelledPipelineRun.args} />
+            <span>Cancelled</span>
+          </li>
+          <li>
+            <StatusIcon {...Failed.args} />
+            <span>Failed</span>
+          </li>
+          <li>
+            <StatusIcon {...Pending.args} />
+            <span>Pending</span>
+          </li>
+          <li>
+            <StatusIcon {...Queued.args} />
+            <span>Queued</span>
+          </li>
+          <li>
+            <StatusIcon {...Running.args} />
+            <span>Running</span>
+          </li>
+          <li>
+            <StatusIcon {...Succeeded.args} />
+            <span>Succeeded</span>
+          </li>
+          <li>
+            <StatusIcon {...SucceededWithWarning.args} />
+            <span>Succeeded with warning</span>
+          </li>
+          <li>
+            <StatusIcon {...DefaultTask.args} />
+            <span>Default - no status received yet</span>
+          </li>
+          <li>
+            <StatusIcon {...CustomRun.args} />
+            <span>CustomRun - custom status</span>
+          </li>
+        </ul>
+
+        <h3>Step</h3>
+        <ul>
+          <li>
+            <StatusIcon {...Failed.args} type="inverse" />
+            <span>Failed</span>
+          </li>
+          <li>
+            <StatusIcon {...Running.args} type="inverse" />
+            <span>Running</span>
+          </li>
+          <li>
+            <StatusIcon {...Succeeded.args} type="inverse" />
+            <span>Succeeded</span>
+          </li>
+          <li>
+            <StatusIcon {...SucceededWithWarning.args} type="inverse" />
+            <span>Succeeded with warning</span>
+          </li>
+          <li>
+            <StatusIcon {...DefaultStep.args} />
+            <span>Default - no status received yet</span>
+          </li>
+        </ul>
+      </div>
+    );
+  }
 };

--- a/packages/components/src/components/StatusIcon/StatusIcon.stories.scss
+++ b/packages/components/src/components/StatusIcon/StatusIcon.stories.scss
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.status-icons-list {
+  h3 {
+    margin-bottom: 1rem;
+  }
+
+  ul {
+    margin-bottom: 2rem;
+  }
+
+  li {
+    margin-bottom: 0.25rem;
+  }
+  
+  .tkn--status-icon {
+    margin-right: 0.5rem;
+    vertical-align: middle;
+  }  
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2306, https://github.com/tektoncd/dashboard/issues/2293, and others

This will be very useful to us as we tackle our current use of icons with the design team to reconcile some of the inconsistencies, duplication, etc.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
