### PR TITLE
Enable v1 API use by default

### DIFF
--- a/config_frontend/yaml.js
+++ b/config_frontend/yaml.js
@@ -11,7 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const crypto = require('crypto');
+const yaml = require('js-yaml');
+
 module.exports = {
-  metadata: {},
-  spec: {}
+  getCacheKey(sourceText, _sourcePath, _options) {
+    return crypto.createHash('md5').update(sourceText).digest('hex');
+  },
+  process(sourceText, _sourcePath, _options) {
+    const content = yaml.load(sourceText, { json: true });
+    return {
+      code: `module.exports = ${JSON.stringify(content, null, 2)};`
+    };
+  }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,6 @@ module.exports = {
       '<rootDir>/config_frontend/__mocks__/svgMock.js',
     '\\.(png|svg|woff|woff2)$':
       '<rootDir>/config_frontend/__mocks__/fileMock.js',
-    '\\.yaml$': '<rootDir>/config_frontend/__mocks__/resourceMock.js',
     '\\.(css|scss)$': '<rootDir>/config_frontend/__mocks__/styleMock.js'
   },
   restoreMocks: true,
@@ -45,5 +44,9 @@ module.exports = {
     '<rootDir>/src/**/*.test.js',
     '<rootDir>/packages/**/src/**/*.test.js'
   ],
+  transform: {
+    '\\.js$': 'babel-jest',
+    '\\.yaml$': '<rootDir>/config_frontend/yaml.js'
+  },
   transformIgnorePatterns: []
 };

--- a/packages/e2e/cypress/e2e/run/pipelinerun-create.cy.js
+++ b/packages/e2e/cypress/e2e/run/pipelinerun-create.cy.js
@@ -25,7 +25,7 @@ describe('Create PipelineRun', () => {
     const uniqueNumber = Date.now();
 
     const pipelineName = `simple-pipeline-${uniqueNumber}`;
-    const pipeline = `apiVersion: tekton.dev/v1beta1
+    const pipeline = `apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: ${pipelineName}
@@ -69,7 +69,7 @@ spec:
 
     const pipelineName = `simple-pipeline-${uniqueNumber}`;
     const pipelineRunName = `run-${uniqueNumber}`;
-    const pipeline = `apiVersion: tekton.dev/v1beta1
+    const pipeline = `apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: ${pipelineName}
@@ -123,7 +123,7 @@ spec:
     const uniqueNumber = Date.now();
 
     const pipelineRunName = `yaml-mode-${uniqueNumber}`;
-    const pipelineRun = `apiVersion: tekton.dev/v1beta1
+    const pipelineRun = `apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: ${pipelineRunName}
@@ -162,7 +162,7 @@ spec:
     const uniqueNumber = Date.now();
 
     const pipelineRunName = `yaml-mode-${uniqueNumber}`;
-    const pipelineRun = `apiVersion: tekton.dev/v1beta1
+    const pipelineRun = `apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: ${pipelineRunName}

--- a/packages/e2e/cypress/e2e/run/pipelinerun-edit.cy.js
+++ b/packages/e2e/cypress/e2e/run/pipelinerun-edit.cy.js
@@ -24,7 +24,7 @@ describe('Edit and run PipelineRun', () => {
   it('should create PipelineRun on edit and run', function () {
     const uniqueNumber = Date.now();
     const pipelineName = `sp-${uniqueNumber}`;
-    const pipeline = `apiVersion: tekton.dev/v1beta1
+    const pipeline = `apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: ${pipelineName}

--- a/packages/e2e/cypress/e2e/run/taskrun-create.cy.js
+++ b/packages/e2e/cypress/e2e/run/taskrun-create.cy.js
@@ -25,7 +25,7 @@ describe('Create TaskRun', () => {
     const uniqueNumber = Date.now();
 
     const taskName = `simple-task-${uniqueNumber}`;
-    const task = `apiVersion: tekton.dev/v1beta1
+    const task = `apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: ${taskName}
@@ -64,7 +64,7 @@ spec:
 
     const taskName = `simple-task-${uniqueNumber}`;
     const taskRunName = `run-${uniqueNumber}`;
-    const task = `apiVersion: tekton.dev/v1beta1
+    const task = `apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: ${taskName}
@@ -113,7 +113,7 @@ spec:
     const uniqueNumber = Date.now();
 
     const taskRunName = `yaml-mode-${uniqueNumber}`;
-    const taskRun = `apiVersion: tekton.dev/v1beta1
+    const taskRun = `apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: ${taskRunName}
@@ -149,7 +149,7 @@ spec:
     const uniqueNumber = Date.now();
 
     const taskRunName = `yaml-mode-${uniqueNumber}`;
-    const taskRun = `apiVersion: tekton.dev/v1beta1
+    const taskRun = `apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: ${taskRunName}

--- a/packages/e2e/cypress/e2e/run/taskrun-edit.cy.js
+++ b/packages/e2e/cypress/e2e/run/taskrun-edit.cy.js
@@ -24,7 +24,7 @@ describe('Edit and run TaskRun', () => {
   it('should create TaskRun on edit and run', function () {
     const uniqueNumber = Date.now();
     const taskName = `sp-${uniqueNumber}`;
-    const task = `apiVersion: tekton.dev/v1beta1
+    const task = `apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: ${taskName}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -250,13 +250,16 @@ export function importResources({
     { name: 'target-namespace', value: namespace }
   ];
 
+  if (pipelinesAPIVersion === 'v1beta1') {
+    pipelineRun.spec.podTemplate = {
+      ...pipelineRun.spec.taskRunTemplate.podTemplate
+    };
+    delete pipelineRun.spec.taskRunTemplate.podTemplate;
+  }
+
   if (serviceAccount) {
     if (pipelinesAPIVersion === 'v1') {
-      pipelineRun.spec.taskRunTemplate = {
-        podTemplate: { ...pipelineRun.spec.podTemplate },
-        serviceAccountName: serviceAccount
-      };
-      delete pipelineRun.spec.podTemplate;
+      pipelineRun.spec.taskRunTemplate.serviceAccountName = serviceAccount;
     } else {
       pipelineRun.spec.taskRunSpecs = [
         {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -337,6 +337,8 @@ describe('importResources', () => {
       expect(comms.post).toHaveBeenCalledWith(
         fakeAPI,
         expect.objectContaining({
+          apiVersion: 'tekton.dev/v1',
+          kind: 'PipelineRun',
           metadata: expect.objectContaining({
             name: 'import-resources-fake-timestamp',
             labels: {
@@ -351,16 +353,14 @@ describe('importResources', () => {
               { name: 'revision', value: undefined },
               { name: 'target-namespace', value: namespace }
             ]),
-            taskRunSpecs: [
-              {
-                pipelineTaskName: 'fetch-repo',
-                taskServiceAccountName: serviceAccount
-              },
-              {
-                pipelineTaskName: 'import-resources',
-                taskServiceAccountName: serviceAccount
-              }
-            ]
+            pipelineSpec: expect.objectContaining({}),
+            taskRunTemplate: {
+              podTemplate: expect.objectContaining({
+                securityContext: expect.objectContaining({})
+              }),
+              serviceAccountName: serviceAccount
+            },
+            workspaces: expect.objectContaining({})
           })
         })
       );

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -59,7 +59,7 @@ describe('createPipelineRun', () => {
       timeoutsPipeline: timeout
     };
     const data = {
-      apiVersion: 'tekton.dev/v1beta1',
+      apiVersion: 'tekton.dev/v1',
       kind: 'PipelineRun',
       metadata: {
         name: `${pipelineName}-run-${Date.now()}`
@@ -108,7 +108,7 @@ describe('createPipelineRun', () => {
       }
     };
     const data = {
-      apiVersion: 'tekton.dev/v1beta1',
+      apiVersion: 'tekton.dev/v1',
       kind: 'PipelineRun',
       metadata: {
         name: `${pipelineName}-run-${Date.now()}`
@@ -285,7 +285,7 @@ it('rerunPipelineRun', () => {
     .mockImplementation((uri, body) => Promise.resolve(body));
 
   const rerun = {
-    apiVersion: 'tekton.dev/v1beta1',
+    apiVersion: 'tekton.dev/v1',
     kind: 'PipelineRun',
     metadata: {
       annotations: {},

--- a/src/api/resources/import-resources-pipelinerun.yaml
+++ b/src/api/resources/import-resources-pipelinerun.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # version may be replaced in the API layer if the user has opted in to v1 resources
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   # name will be replaced in the API layer
@@ -22,13 +22,6 @@ metadata:
     # additional labels will be added in the API layer
     dashboard.tekton.dev/import: 'true'
 spec:
-  podTemplate:
-    securityContext:
-      runAsUser: 65532
-      runAsGroup: 65532
-      runAsNonRoot: true
-      seccompProfile:
-        type: RuntimeDefault
   pipelineSpec:
     params:
       - name: method
@@ -149,6 +142,14 @@ spec:
       value: ''
     - name: target-namespace
       value: ''
+  taskRunTemplate:
+    podTemplate:
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
   workspaces:
     - name: repo
       volumeClaimTemplate:

--- a/src/api/taskRuns.test.js
+++ b/src/api/taskRuns.test.js
@@ -41,7 +41,7 @@ describe('createTaskRun', () => {
     return API.createTaskRun({}).then(() => {
       expect(comms.post).toHaveBeenCalled();
       const sentBody = comms.post.mock.lastCall[1];
-      expect(sentBody.apiVersion).toEqual('tekton.dev/v1beta1');
+      expect(sentBody.apiVersion).toEqual('tekton.dev/v1');
       expect(sentBody.kind).toEqual('TaskRun');
       expect(sentBody).toHaveProperty('metadata');
       expect(sentBody).toHaveProperty('spec');
@@ -282,7 +282,7 @@ it('rerunTaskRun', () => {
     .mockImplementation((uri, body) => Promise.resolve(body));
 
   const rerun = {
-    apiVersion: 'tekton.dev/v1beta1',
+    apiVersion: 'tekton.dev/v1',
     kind: 'TaskRun',
     metadata: {
       annotations: {},

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -98,7 +98,7 @@ export function getQueryParams({
 }
 
 export function isPipelinesV1ResourcesEnabled() {
-  return localStorage.getItem('tkn-pipelines-v1-resources') === 'true';
+  return localStorage.getItem('tkn-pipelines-v1-resources') !== 'false';
 }
 
 export function setPipelinesV1ResourcesEnabled(enabled) {

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.js
@@ -156,7 +156,7 @@ const pipelineRunRawGenerateName = {
   }
 };
 
-const expectedPipelineRun = `apiVersion: tekton.dev/v1beta1
+const expectedPipelineRun = `apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: run-1111111111


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Flip the default value of the v1 API toggle on the settings page. Tekton Pipelines v0.44 serves v1 and is the minimum supported Pipelines release for the latest Dashboard release so it is now safe to enable this by default.

A future release will remove the toggle entirely, but that won't be until some time after Pipelines have deprecated and removed the v1beta1 resources.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Switch the default value of the v1 CRD toggle on the settings page from off to on. This means that the Dashboard will request and display v1 resources from Tekton Pipelines by default unless the user has previously changed this setting.
Action required: If you wish to opt-out of this change, you can turn off the toggle on the settings page. Note: a future Dashboard release will remove this toggle but this won't happen until some time after Tekton Pipelines have deprecated and removed the v1beta1 resources.
```
