### PR TITLE
Update git image to use digest

### DIFF
--- a/src/api/resources/import-resources-pipelinerun.yaml
+++ b/src/api/resources/import-resources-pipelinerun.yaml
@@ -64,7 +64,7 @@ spec:
             - name: repo
           steps:
             - name: clone
-              image: cgr.dev/chainguard/git:2.40
+              image: cgr.dev/chainguard/git:latest@sha256:2c70afb3b34ca5feab37c5826c32dae6e0c48549486fdf6be93faf928b658efe # 2.41
               env:
                 - name: PARAM_URL
                   value: $(params.repositoryURL)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/2977

Chainguard are making changes to their registry to restrict access to non-latest tags for public users.

Switch to using digest, updating to use the current latest version.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
