### PR TITLE
Fix path to cypress for code completion

### DIFF
--- a/packages/e2e/jsconfig.json
+++ b/packages/e2e/jsconfig.json
@@ -1,3 +1,3 @@
 {
-  "include": ["./node_modules/cypress", "cypress/**/*.js"]
+  "include": ["../../node_modules/cypress", "cypress/**/*.js"]
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Enable code completion in supported editors (e.g. VS Code) by fixing the path to the cypress package specified in jsconfig

Base on Cypress docs at https://docs.cypress.io/guides/tooling/IDE-integration#Reference-type-declarations-via-jsconfig

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
