### PR TITLE
Delete .ko.yaml

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,0 @@
-defaultBaseImage: gcr.io/distroless/base-debian11:nonroot


### PR DESCRIPTION
The default base image for `ko` since v0.12.0 is `cgr.dev/chainguard/static` This is a very lightweight base image with just the bare minimum required to run static binaries. It also runs as nonroot by default so matches the previous image.

Comparison of base image sizes (output from `docker images`):

```
cgr.dev/chainguard/static        latest      90320c6851cc  6 weeks ago    3.06 MB
gcr.io/distroless/base-debian11  nonroot     053d24ed112e  4 seconds ago  19.3 MB
```

Comparison of built Dashboard image (using installer script with default settings):

```
root@tekton-dashboard-control-plane:/# crictl images | grep dashboard
kind.local/dashboard-9623576a202fe86c8b7d1bc489905f86                  latest
921213af83dc0       23.2MB
kind.local/dashboard-9623576a202fe86c8b7d1bc489905f86
94370ac46698f930b2b8366a1f6d2a9ca3f24080c20a440106bc1599d8decc76   921213af83dc0       23.2MB
kind.local/dashboard-9623576a202fe86c8b7d1bc489905f86
ecc31e47e5b7e50c1b9c92805d3c4b69d6425f9757677fdaa800b008d198487c   e5e5e2f4101d1       31.3MB
```

This gives an over 25% reduction in the final image size.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
