### PR TITLE
Fix for nightly E2E on Power and Z

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -80,9 +80,11 @@ test_dashboard() {
   echo "Running browser E2E tests…"
 
   VIDEO_PATH=""
+  VIDEO_VOLUME=""
   CYPRESS_ENV=""
   if [ ! -z "$ARTIFACTS" ] && [ "$E2E_VIDEO" != "false" ]; then
     VIDEO_PATH=$ARTIFACTS/videos
+    VIDEO_VOLUME="-v $VIDEO_PATH:/home/node/cypress/videos"
     mkdir -p $VIDEO_PATH
     chmod -R 777 $VIDEO_PATH
     echo "Videos of failing tests will be stored at $VIDEO_PATH"
@@ -98,7 +100,7 @@ test_dashboard() {
     CYPRESS_SPEC='-- --spec cypress/e2e/common/**/*'
   fi
   chmod 644 ~/.kube/config
-  docker run --rm --network=host $CYPRESS_ENV -v ~/.kube/config:/home/node/.kube/config -v $VIDEO_PATH:/home/node/cypress/videos dashboard-e2e $CYPRESS_SPEC || fail_test "Browser E2E tests failed"
+  docker run --rm --network=host $CYPRESS_ENV -v ~/.kube/config:/home/node/.kube/config $VIDEO_VOLUME dashboard-e2e $CYPRESS_SPEC || fail_test "Browser E2E tests failed"
   # If we get here the tests passed, no need to upload artifacts
   if [ ! -z "$VIDEO_PATH" ]; then
     rm -rf $VIDEO_PATH


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Recent test image updates appear to have included a docker update that's now stricter on volume config passed to `docker run`.

Previously the empty mount was ignored but is now blocking the tests.

Ensure that when video is disabled, we don't attempt to mount the volume.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
