### PR TITLE
Rename default stories

### DIFF
--- a/packages/components/src/components/Actions/Actions.stories.js
+++ b/packages/components/src/components/Actions/Actions.stories.js
@@ -63,7 +63,7 @@ const props = {
   ]
 };
 
-export const Base = {
+export const Default = {
   args: {
     ...props
   }

--- a/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
+++ b/packages/components/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
@@ -54,4 +54,4 @@ export default {
   title: 'DataTableSkeleton'
 };
 
-export const Base = {};
+export const Default = {};

--- a/packages/components/src/components/DeleteModal/DeleteModal.stories.js
+++ b/packages/components/src/components/DeleteModal/DeleteModal.stories.js
@@ -25,7 +25,7 @@ export default {
   title: 'DeleteModal'
 };
 
-export const Base = {
+export const Default = {
   args: {
     kind: 'Pipelines',
     onClose: action('onClose'),

--- a/packages/components/src/components/DotSpinner/DotSpinner.stories.js
+++ b/packages/components/src/components/DotSpinner/DotSpinner.stories.js
@@ -18,4 +18,4 @@ export default {
   title: 'DotSpinner'
 };
 
-export const Base = {};
+export const Default = {};

--- a/packages/components/src/components/Header/Header.stories.js
+++ b/packages/components/src/components/Header/Header.stories.js
@@ -21,7 +21,7 @@ export default {
   title: 'Header'
 };
 
-export const Base = {};
+export const Default = {};
 
 export const WithLogout = {
   args: {

--- a/packages/components/src/components/KeyValueList/KeyValueList.stories.js
+++ b/packages/components/src/components/KeyValueList/KeyValueList.stories.js
@@ -23,7 +23,7 @@ export default {
   title: 'KeyValueList'
 };
 
-export const Base = {
+export const Default = {
   args: {
     invalidFields: { '2-key': true, '3-value': true },
     invalidText: 'There are invalid KeyValue entries.',

--- a/packages/components/src/components/LabelFilter/LabelFilter.stories.js
+++ b/packages/components/src/components/LabelFilter/LabelFilter.stories.js
@@ -20,7 +20,7 @@ export default {
   title: 'LabelFilter'
 };
 
-export const Base = {
+export const Default = {
   args: {
     filters: ['tekton.dev/pipeline=output-pipeline'],
     handleAddFilter: action('handleAddFilter'),

--- a/packages/components/src/components/LoadingShell/LoadingShell.stories.js
+++ b/packages/components/src/components/LoadingShell/LoadingShell.stories.js
@@ -18,4 +18,4 @@ export default {
   title: 'LoadingShell'
 };
 
-export const Base = {};
+export const Default = {};

--- a/packages/components/src/components/LogsToolbar/LogsToolbar.stories.js
+++ b/packages/components/src/components/LogsToolbar/LogsToolbar.stories.js
@@ -18,7 +18,7 @@ export default {
   title: 'LogsToolbar'
 };
 
-export const Base = {
+export const Default = {
   args: {
     name: 'some_filename.txt',
     url: '/some/logs/url'

--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.js
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.js
@@ -156,7 +156,7 @@ export default {
   title: 'PipelineRun'
 };
 
-export const Base = () => {
+export const Default = () => {
   const [selectedStepId, setSelectedStepId] = useState();
   const [selectedTaskId, setSelectedTaskId] = useState();
   return (

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.stories.js
@@ -39,7 +39,7 @@ export default {
   title: 'PipelineRuns'
 };
 
-export const Base = () => (
+export const Default = () => (
   <PipelineRuns
     getPipelineRunURL={({ namespace, pipelineRunName }) =>
       namespace ? `to-pipelineRun-${namespace}/${pipelineRunName}` : null

--- a/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.stories.js
@@ -46,11 +46,11 @@ export const Error = { args: { error: 'A helpful error message' } };
 
 export const Loading = { args: { loading: true } };
 
-export const Base = { args: { resource } };
+export const Default = { args: { resource } };
 
 export const WithAdditionalContent = {
   args: {
-    ...Base.args,
+    ...Default.args,
     additionalMetadata: (
       <li>
         <span>Custom Field:</span>some additional metadata

--- a/packages/components/src/components/RunHeader/RunHeader.stories.js
+++ b/packages/components/src/components/RunHeader/RunHeader.stories.js
@@ -26,7 +26,7 @@ export default {
   title: 'RunHeader'
 };
 
-export const Base = {};
+export const Default = {};
 
 export const Running = {
   args: {

--- a/packages/components/src/components/Spinner/Spinner.stories.js
+++ b/packages/components/src/components/Spinner/Spinner.stories.js
@@ -18,4 +18,4 @@ export default {
   title: 'Spinner'
 };
 
-export const Base = {};
+export const Default = {};

--- a/packages/components/src/components/Step/Step.stories.js
+++ b/packages/components/src/components/Step/Step.stories.js
@@ -30,7 +30,7 @@ export default {
   title: 'Step'
 };
 
-export const Base = {};
+export const Default = {};
 export const Selected = { args: { selected: true } };
 export const Waiting = { args: { status: 'waiting' } };
 export const Running = { args: { status: 'running' } };

--- a/packages/components/src/components/StepDefinition/StepDefinition.stories.js
+++ b/packages/components/src/components/StepDefinition/StepDefinition.stories.js
@@ -18,7 +18,7 @@ export default {
   title: 'StepDefinition'
 };
 
-export const Base = {};
+export const Default = {};
 
 export const WithContent = {
   args: {

--- a/packages/components/src/components/StepDetails/StepDetails.stories.js
+++ b/packages/components/src/components/StepDetails/StepDetails.stories.js
@@ -44,7 +44,7 @@ export default {
   title: 'StepDetails'
 };
 
-export const Base = {
+export const Default = {
   args: {
     logContainer: getLogContainer(),
     stepStatus: getStepStatus()

--- a/packages/components/src/components/Tabs/Tabs.stories.js
+++ b/packages/components/src/components/Tabs/Tabs.stories.js
@@ -26,7 +26,7 @@ export default {
   title: 'Tabs'
 };
 
-export const Base = () => (
+export const Default = () => (
   <Tabs>
     <Tab label="label for tab1">content of tab 1</Tab>
     <Tab label="tab 2">content of tab 2</Tab>

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.stories.js
@@ -33,7 +33,7 @@ export default {
   title: 'TaskRunDetails'
 };
 
-export const Base = {
+export const Default = {
   args: {
     taskRun: {
       metadata: { name: 'my-task', namespace: 'my-namespace' },

--- a/packages/components/src/components/TaskTree/TaskTree.stories.js
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.js
@@ -78,7 +78,7 @@ export default {
   title: 'TaskTree'
 };
 
-export const Base = {
+export const Default = {
   render: args => {
     const [selectedStepId, setSelectedStepId] = useState();
     const [selectedTaskId, setSelectedTaskId] = useState();

--- a/packages/components/src/components/TextInput/TextInput.stories.js
+++ b/packages/components/src/components/TextInput/TextInput.stories.js
@@ -25,7 +25,7 @@ export default {
   title: 'TextInput'
 };
 
-export const Base = {
+export const Default = {
   args: {
     labelText: 'foo',
     helperText: 'this is a description of input foo',

--- a/packages/components/src/components/TooltipDropdown/TooltipDropdown.stories.js
+++ b/packages/components/src/components/TooltipDropdown/TooltipDropdown.stories.js
@@ -34,7 +34,7 @@ export default {
   title: 'TooltipDropdown'
 };
 
-export const Base = {};
+export const Default = {};
 
 export const Loading = {
   args: { loading: true }

--- a/packages/components/src/components/Trigger/Trigger.stories.js
+++ b/packages/components/src/components/Trigger/Trigger.stories.js
@@ -85,7 +85,7 @@ export default {
   title: 'Trigger'
 };
 
-export const Base = { args: props };
+export const Default = { args: props };
 
 export const NoName = {
   args: {

--- a/packages/components/src/components/ViewYAML/ViewYAML.stories.js
+++ b/packages/components/src/components/ViewYAML/ViewYAML.stories.js
@@ -41,7 +41,7 @@ export default {
   title: 'ViewYAML'
 };
 
-export const Base = {};
+export const Default = {};
 
 export const SyntaxHighlighter = {
   args: {

--- a/packages/graph/src/components/Graph.stories.js
+++ b/packages/graph/src/components/Graph.stories.js
@@ -25,4 +25,4 @@ export default {
   title: 'legacy/Graph'
 };
 
-export const Base = { args: { graph } };
+export const Default = { args: { graph } };

--- a/packages/graph/src/components/PipelineGraph.stories.js
+++ b/packages/graph/src/components/PipelineGraph.stories.js
@@ -30,7 +30,7 @@ export default {
   title: 'legacy/PipelineGraph'
 };
 
-export const Base = () => (
+export const Default = () => (
   <PipelineGraph
     onClickStep={action('onClickStep')}
     onClickTask={action('onClickTask')}

--- a/packages/graph/src/components/ZoomablePipelineGraph.stories.js
+++ b/packages/graph/src/components/ZoomablePipelineGraph.stories.js
@@ -30,7 +30,7 @@ export default {
   title: 'legacy/ZoomablePipelineGraph'
 };
 
-export const Base = () => (
+export const Default = () => (
   <ZoomablePipelineGraph
     onClickStep={action('onClickStep')}
     onClickTask={action('onClickTask')}

--- a/src/containers/EventListener/EventListener.stories.js
+++ b/src/containers/EventListener/EventListener.stories.js
@@ -149,7 +149,7 @@ export default {
   title: 'EventListener'
 };
 
-export const Base = {
+export const Default = {
   render: () => <EventListenerContainer {...props} />,
 
   decorators: [

--- a/src/containers/ListPageLayout/ListPageLayout.stories.js
+++ b/src/containers/ListPageLayout/ListPageLayout.stories.js
@@ -58,7 +58,7 @@ export default {
   title: 'ListPageLayout'
 };
 
-export const Base = {
+export const Default = {
   render: args => (
     <ListPageLayoutContainer {...args}>
       {() => <span>page content goes here</span>}

--- a/src/containers/NotFound/NotFound.stories.js
+++ b/src/containers/NotFound/NotFound.stories.js
@@ -34,7 +34,7 @@ export default {
   title: 'NotFound'
 };
 
-export const Base = {};
+export const Default = {};
 
 export const CustomSuggestions = {
   args: {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
A previous version of storybook had an issue with stories called 'Default', that's now resolved so rename them back to their expected names.

This is a common name used in many Storybooks for the most common or simplest usage of a component.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
