### PR TITLE
Update tests to remove references to deprecated bundles feature

### DIFF
--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -433,25 +433,24 @@ describe('getStepDefinition', () => {
     expect(definition).toBeNull();
   });
 
-  it('handles taskRun using tekton bundle', () => {
-    const selectedStepId = 'a-bundle-step';
-    const bundleStep = { name: selectedStepId };
+  it('handles TaskRun with spec in status.taskSpec', () => {
+    const selectedStepId = 'a-step';
+    const step = { name: selectedStepId };
     const task = {};
     const taskRun = {
       spec: {
         taskRef: {
-          bundle: 'index.docker.io/fake/dummybundle@0.1',
           name: 'dummy-task'
         }
       },
       status: {
         taskSpec: {
-          steps: [bundleStep]
+          steps: [step]
         }
       }
     };
     const definition = getStepDefinition({ selectedStepId, task, taskRun });
-    expect(definition).toEqual(bundleStep);
+    expect(definition).toEqual(step);
   });
 });
 
@@ -779,14 +778,13 @@ describe('getTaskRunsWithPlaceholders', () => {
     );
   });
 
-  it('handles pipeline using tekton bundle', () => {
-    const finallyTaskName = 'bundleFinallyTaskName';
-    const pipelineTaskName = 'bundlePipelineTaskName';
+  it('handles PipelineRuns with spec in status.pipelineSpec', () => {
+    const finallyTaskName = 'aFinallyTaskName';
+    const pipelineTaskName = 'aPipelineTaskName';
 
     const pipelineRun = {
       spec: {
         pipelineRef: {
-          bundle: 'index.docker.io/fake/dummybundle@0.1',
           name: 'dummy-pipeline'
         }
       },


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The bundles feature is deprecated, replaced by remote resolution. As part of this the `pipelineRef.bundle` and `taskRef.bundle` fields are deprecated.

These tests were originally added to handle the case of runs created from pipeline / task definitions loaded via bundles, but are not actually specific to that functionality and cover multiple cases where the pipeline / task definition is not available separately.

Rename the tests to make this clearer and remove the deprecated fields which didn't actually impact on the functionality at all.

These fields may be removed from Tekton Pipelines in any future release as the notice period has expired. See https://github.com/tektoncd/pipeline/blob/080ea1367aa342915fe86c8da583ee3401983946/docs/deprecations.md for details of the deprecation.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
