### PR TITLE
Remove Node.js install from build tests

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -65,8 +65,6 @@ function post_build_tests() {
 
 function get_node() {
   echo "Installing Node.js"
-  apt-get update
-  apt-get install -y curl
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | bash
   export NVM_DIR="$HOME/.nvm"
   source "$NVM_DIR/nvm.sh"
@@ -75,6 +73,7 @@ function get_node() {
 
 function node_npm_install() {
   local failed=0
+  get_node
   echo "Configuring npm"
   mkdir ~/.npm-global
   npm config set prefix '~/.npm-global'
@@ -118,7 +117,6 @@ function pre_integration_tests() {
 
 function extra_initialization() {
   echo "Script is running as $(whoami) on $(hostname)"
-  get_node
 }
 
 function unit_tests() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The build tests script does not require Node.js so there's no need to install it during setup.

Remove the call to `get_node` from the `extra_initialization` function which is called for all tests types.

Add `get_node` to the function responsible for running npm install which is called for all tests types that require Node.js (unit + integration)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
