### PR TITLE
Increase timeout for flaky tests

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.test.jsx
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.test.jsx
@@ -70,20 +70,24 @@ const serviceAccount = {
 
 describe('CreatePipelineRun', () => {
   beforeEach(() => {
-    vi.spyOn(ServiceAccountsAPI, 'useServiceAccounts')
-      .mockImplementation(() => ({ data: [serviceAccount] }));
-    vi.spyOn(PipelinesAPI, 'usePipelines')
-      .mockImplementation(() => ({ data: pipelines }));
-    vi.spyOn(PipelineRunsAPI, 'usePipelineRuns')
-      .mockImplementation(() => ({ data: [] }));
+    vi.spyOn(ServiceAccountsAPI, 'useServiceAccounts').mockImplementation(
+      () => ({ data: [serviceAccount] })
+    );
+    vi.spyOn(PipelinesAPI, 'usePipelines').mockImplementation(() => ({
+      data: pipelines
+    }));
+    vi.spyOn(PipelineRunsAPI, 'usePipelineRuns').mockImplementation(() => ({
+      data: []
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [
         { metadata: { name: 'namespace-1' } },
         { metadata: { name: 'namespace-2' } }
       ]
     }));
-    vi.spyOn(APIUtils, 'useSelectedNamespace')
-      .mockImplementation(() => ({ selectedNamespace: 'namespace-1' }));
+    vi.spyOn(APIUtils, 'useSelectedNamespace').mockImplementation(() => ({
+      selectedNamespace: 'namespace-1'
+    }));
   });
 
   it('renders labels', () => {
@@ -187,16 +191,29 @@ describe('CreatePipelineRun yaml mode', () => {
   });
 
   it('renders with namespace', async () => {
-    vi.spyOn(PipelineRunsAPI, 'createPipelineRunRaw')
-      .mockImplementation(() => Promise.resolve({ data: {} }));
-    vi.spyOn(PipelineRunsAPI, 'usePipelineRun')
-      .mockImplementation(() => ({ data: pipelineRunRawGenerateName }));
+    vi.spyOn(PipelineRunsAPI, 'createPipelineRunRaw').mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    vi.spyOn(PipelineRunsAPI, 'usePipelineRun').mockImplementation(() => ({
+      data: pipelineRunRawGenerateName
+    }));
 
-    const { getByRole, queryAllByText } = renderWithRouter(<CreatePipelineRun />, {
-      path: '/pipelineruns/create',
-      route: '/pipelineruns/create?mode=yaml&namespace=test-namespace'
-    });
+    const { getByRole, queryAllByText } = renderWithRouter(
+      <CreatePipelineRun />,
+      {
+        path: '/pipelineruns/create',
+        route: '/pipelineruns/create?mode=yaml&namespace=test-namespace'
+      }
+    );
 
+    await waitFor(
+      () => {
+        expect(queryAllByText(/Loading/).length).toBe(0);
+      },
+      {
+        timeout: 3000
+      }
+    );
     await waitFor(() => {
       expect(queryAllByText(/Loading/).length).toBe(0);
     });
@@ -209,10 +226,12 @@ describe('CreatePipelineRun yaml mode', () => {
   });
 
   it('handle submit with pipelinerun and namespace', async () => {
-    vi.spyOn(PipelineRunsAPI, 'createPipelineRunRaw')
-      .mockImplementation(() => Promise.resolve({ data: {} }));
-    vi.spyOn(PipelineRunsAPI, 'usePipelineRun')
-      .mockImplementation(() => ({ data: pipelineRunRawGenerateName }));
+    vi.spyOn(PipelineRunsAPI, 'createPipelineRunRaw').mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    vi.spyOn(PipelineRunsAPI, 'usePipelineRun').mockImplementation(() => ({
+      data: pipelineRunRawGenerateName
+    }));
 
     const { queryAllByText } = renderWithRouter(<CreatePipelineRun />, {
       path: '/pipelineruns/create',
@@ -220,9 +239,12 @@ describe('CreatePipelineRun yaml mode', () => {
         '/pipelineruns/create?mode=yaml&pipelineRunName=test-pipeline-run-name&namespace=test-namespace'
     });
 
-    await waitFor(() => {
-      expect(queryAllByText(/Loading/).length).toBe(0);
-    });
+    await waitFor(
+      () => {
+        expect(queryAllByText(/Loading/).length).toBe(0);
+      },
+      { timeout: 3000 }
+    );
     expect(submitButton(queryAllByText)).toBeTruthy();
 
     fireEvent.click(submitButton(queryAllByText));


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Some of the CreatePipelineRun tests are failing in CI due to timeouts loading the YAMLEditor. The default timeout for `waitFor` is 1000ms, but locally on my machine at least this step is completing in ~50ms. Increase the timeout for the two affected tests to see if this resolves the flakiness in CI.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
