### PR TITLE
Handle missing steps gracefully

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -155,9 +155,9 @@ export function getStepDefinition({ selectedStepId, task, taskRun }) {
   // unnamed step numbering skips named steps, so we could have for example:
   // ['unnamed-2', 'unnamed-4']
   // but the order will be consistent with unnamed steps in the definition
-  const statusSteps = taskRun.status.steps.filter(({ name }) =>
-    name.startsWith('unnamed-')
-  );
+  const statusSteps =
+    taskRun.status.steps?.filter(({ name }) => name.startsWith('unnamed-')) ||
+    [];
   const unnamedSteps = stepDefinitions.filter(({ name }) => !name);
 
   const index = statusSteps.findIndex(({ name }) => name === selectedStepId);

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -408,6 +408,21 @@ describe('getStepDefinition', () => {
     expect(definition).toEqual(step);
   });
 
+  it('handles unnamed steps when steps not yet available', () => {
+    const selectedStepId = 'unnamed-1';
+    const step = { name: '' };
+    const task = {
+      spec: {
+        steps: [{ name: 'a-step' }, step]
+      }
+    };
+    const taskRun = {
+      status: {}
+    };
+    const definition = getStepDefinition({ selectedStepId, task, taskRun });
+    expect(definition).toBeUndefined();
+  });
+
   it('handles deleted Task spec', () => {
     const selectedStepId = 'unnamed-1';
     const task = {};


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/3062

There's a timing issue where steps may not be available in the retry status before the UI re-renders. Guard against this and return undefined instead of throwing an error in this case so the remaining code can continue to process the task tree.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
