### PR TITLE
Fix missing translations for status filter dropdown control

### DIFF
--- a/packages/components/src/components/StatusFilterDropdown/StatusFilterDropdown.jsx
+++ b/packages/components/src/components/StatusFilterDropdown/StatusFilterDropdown.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 The Tekton Authors
+Copyright 2020-2023 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,10 @@ limitations under the License.
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { Dropdown } from 'carbon-components-react';
-import { statusFilterOrder } from '@tektoncd/dashboard-utils';
+import {
+  getTranslateWithId,
+  statusFilterOrder
+} from '@tektoncd/dashboard-utils';
 
 const StatusFilterDropdown = ({ id, initialSelectedStatus, onChange }) => {
   const intl = useIntl();
@@ -77,6 +80,7 @@ const StatusFilterDropdown = ({ id, initialSelectedStatus, onChange }) => {
         id: 'dashboard.filter.status.title',
         defaultMessage: 'Status:'
       })}
+      translateWithId={getTranslateWithId(intl)}
       type="inline"
     />
   );


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The dropdown component was missing the `translatedWithId` prop which meant that it was using the default English strings for icon tooltips and open / close states. Add the missing prop to ensure it uses the translations for the active locale.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
