### PR TITLE
Display matrix TaskRuns on the PipelineRun details page

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.jsx
@@ -174,7 +174,10 @@ export const Default = () => {
   return (
     <PipelineRun
       fetchLogs={() => 'sample log output'}
-      handleTaskSelected={(taskId, stepId) => {
+      handleTaskSelected={({
+        selectedStepId: stepId,
+        selectedTaskId: taskId
+      }) => {
         setSelectedStepId(stepId);
         setSelectedTaskId(taskId);
       }}
@@ -193,7 +196,10 @@ export const WithMinimalStatus = () => {
   return (
     <PipelineRun
       fetchLogs={() => 'sample log output'}
-      handleTaskSelected={(taskId, stepId) => {
+      handleTaskSelected={({
+        selectedStepId: stepId,
+        selectedTaskId: taskId
+      }) => {
         setSelectedStepId(stepId);
         setSelectedTaskId(taskId);
       }}
@@ -212,7 +218,10 @@ export const WithPodDetails = () => {
   return (
     <PipelineRun
       fetchLogs={() => 'sample log output'}
-      handleTaskSelected={(taskId, stepId) => {
+      handleTaskSelected={({
+        selectedStepId: stepId,
+        selectedTaskId: taskId
+      }) => {
         setSelectedStepId(stepId);
         setSelectedTaskId(taskId);
       }}

--- a/packages/components/src/components/PipelineRun/PipelineRun.test.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.test.jsx
@@ -135,7 +135,7 @@ it('PipelineRunContainer handles init step failures for retry', async () => {
       selectedTaskId: null
     };
 
-    handleTaskSelected = (selectedTaskId, selectedStepId) => {
+    handleTaskSelected = ({ selectedStepId, selectedTaskId }) => {
       this.setState({ selectedStepId, selectedTaskId });
     };
 

--- a/packages/components/src/components/Task/Task.jsx
+++ b/packages/components/src/components/Task/Task.jsx
@@ -20,7 +20,6 @@ import {
 } from '@carbon/icons-react';
 import {
   getStepStatusReason,
-  getTranslateWithId,
   updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
@@ -74,9 +73,14 @@ class Task extends Component {
   }
 
   handleClick = () => {
-    const { id, selectedRetry } = this.props;
+    const { id, selectedRetry, taskRun } = this.props;
     const { selectedStepId } = this.state;
-    this.props.onSelect(id, selectedStepId, selectedRetry);
+    this.props.onSelect({
+      selectedRetry,
+      selectedStepId,
+      selectedTaskId: id,
+      taskRunName: taskRun.metadata?.name
+    });
   };
 
   handleStepSelected = selectedStepId => {

--- a/packages/components/src/components/Task/Task.stories.jsx
+++ b/packages/components/src/components/Task/Task.stories.jsx
@@ -56,7 +56,7 @@ export const Expanded = args => {
     <Task
       {...args}
       expanded
-      onSelect={(_, stepId) => setSelectedStepId(stepId)}
+      onSelect={({ selectedStepId: stepId }) => setSelectedStepId(stepId)}
       reason="Running"
       selectedStepId={selectedStepId}
       steps={[

--- a/packages/components/src/components/Task/Task.test.jsx
+++ b/packages/components/src/components/Task/Task.test.jsx
@@ -60,7 +60,12 @@ describe('Task', () => {
       />
     );
 
-    expect(onSelect).toHaveBeenCalledWith(props.id, firstStepName, undefined);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry: undefined,
+      selectedStepId: firstStepName,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 
   it('automatically selects first error step in expanded Task', () => {
@@ -82,7 +87,12 @@ describe('Task', () => {
       />
     );
 
-    expect(onSelect).toHaveBeenCalledWith(props.id, errorStepName, undefined);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry: undefined,
+      selectedStepId: errorStepName,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 
   it('handles no steps', () => {
@@ -98,7 +108,12 @@ describe('Task', () => {
       />
     );
 
-    expect(onSelect).toHaveBeenCalledWith(props.id, undefined, undefined);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry: undefined,
+      selectedStepId: undefined,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 
   it('renders completed steps in expanded state', () => {
@@ -167,7 +182,12 @@ describe('Task', () => {
     expect(onSelect).not.toHaveBeenCalled();
     fireEvent.click(getByText(props.displayName));
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith(props.id, null, undefined);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry: undefined,
+      selectedStepId: null,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 
   it('handles click event with retries', () => {
@@ -179,7 +199,12 @@ describe('Task', () => {
     expect(onSelect).not.toHaveBeenCalled();
     fireEvent.click(getByText(`${props.displayName} (retry ${selectedRetry})`));
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith(props.id, null, selectedRetry);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry,
+      selectedStepId: null,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 
   it('handles click event on Step', () => {
@@ -192,7 +217,12 @@ describe('Task', () => {
     expect(onSelect).not.toHaveBeenCalled();
     fireEvent.click(getByText(stepName));
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith(props.id, stepName, undefined);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry: undefined,
+      selectedStepId: stepName,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 
   it('handles click event on Step with retries', () => {
@@ -212,6 +242,11 @@ describe('Task', () => {
     expect(onSelect).not.toHaveBeenCalled();
     fireEvent.click(getByText(stepName));
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith(props.id, stepName, selectedRetry);
+    expect(onSelect).toHaveBeenCalledWith({
+      selectedRetry,
+      selectedStepId: stepName,
+      selectedTaskId: props.id,
+      taskRunName: undefined
+    });
   });
 });

--- a/packages/components/src/components/TaskTree/TaskTree.stories.jsx
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.jsx
@@ -86,7 +86,7 @@ export const Default = {
     return (
       <TaskTree
         {...args}
-        onSelect={(taskId, stepId) => {
+        onSelect={({ selectedStepId: stepId, selectedTaskId: taskId }) => {
           setSelectedStepId(stepId);
           setSelectedTaskId(taskId);
         }}

--- a/packages/utils/src/utils/constants.js
+++ b/packages/utils/src/utils/constants.js
@@ -16,6 +16,7 @@ export const labels = {
   DASHBOARD_DESCRIPTION: 'dashboard.tekton.dev/description',
   DASHBOARD_DISPLAY_NAME: 'dashboard.tekton.dev/displayName',
   DASHBOARD_IMPORT: 'dashboard.tekton.dev/import',
+  MEMBER_OF: 'tekton.dev/memberOf',
   PIPELINE: 'tekton.dev/pipeline',
   PIPELINE_RUN: 'tekton.dev/pipelineRun',
   PIPELINE_TASK: 'tekton.dev/pipelineTask',
@@ -35,6 +36,7 @@ export const queryParams = {
   RETRY: 'retry',
   STEP: 'step',
   TASK_RUN_DETAILS: 'taskRunDetails',
+  TASK_RUN_NAME: 'taskRunName',
   VIEW: 'view'
 };
 

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -494,19 +494,24 @@ export function getTaskRunsWithPlaceholders({
 
   const taskRunsToDisplay = [];
   pipelineTasks.forEach(pipelineTask => {
-    const realTaskRun = taskRuns.find(
+    const realTaskRuns = taskRuns.filter(
       taskRun =>
         taskRun.metadata.labels?.[labelConstants.PIPELINE_TASK] ===
         pipelineTask.name
     );
 
-    const taskRunToDisplay =
-      realTaskRun ||
-      getPlaceholderTaskRun({ clusterTasks, pipelineTask, tasks });
+    realTaskRuns.forEach(taskRun => {
+      taskRunsToDisplay.push(addDashboardLabels({ pipelineTask, taskRun }));
+    });
 
-    taskRunsToDisplay.push(
-      addDashboardLabels({ pipelineTask, taskRun: taskRunToDisplay })
-    );
+    if (!realTaskRuns.length) {
+      taskRunsToDisplay.push(
+        addDashboardLabels({
+          pipelineTask,
+          taskRun: getPlaceholderTaskRun({ clusterTasks, pipelineTask, tasks })
+        })
+      );
+    }
   });
 
   return taskRunsToDisplay;

--- a/src/containers/TaskRun/TaskRun.jsx
+++ b/src/containers/TaskRun/TaskRun.jsx
@@ -191,7 +191,7 @@ export function TaskRunContainer() {
     navigate(browserURL);
   }
 
-  function handleTaskSelected(_, newSelectedStepId, retry) {
+  function handleTaskSelected({ selectedStepId: newSelectedStepId }) {
     if (newSelectedStepId) {
       queryParams.set(STEP, newSelectedStepId);
       queryParams.delete(TASK_RUN_DETAILS);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2410

Add support for displaying all TaskRuns produced by a matrix task on the PipelineRun details page.

Future updates will improve the display of the matrix information making it easier to differentiate between them on the left task/step nav, and making it clearer which params are provided from the matrix.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for displaying TaskRuns for a matrix task on the PipelineRun details page.
This allows users to access logs, status, and other details of the matrix-generated TaskRuns that were not previously available on the PipelineRun details page. Future releases will improve the display of this information.
```
