### PR TITLE
Update vitest to latest release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "vite": "^4.4.9",
         "vite-plugin-html": "^3.2.0",
         "vite-plugin-svgr": "^3.2.0",
-        "vitest": "^0.34.1"
+        "vitest": "^0.34.3"
       },
       "engines": {
         "node": "^18.17.0",
@@ -7363,13 +7363,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.1.tgz",
-      "integrity": "sha512-q2CD8+XIsQ+tHwypnoCk8Mnv5e6afLFvinVGCq3/BOT4kQdVQmY6rRfyKkwcg635lbliLPqbunXZr+L1ssUWiQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.3.tgz",
+      "integrity": "sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.34.1",
-        "@vitest/utils": "0.34.1",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "chai": "^4.3.7"
       },
       "funding": {
@@ -7377,12 +7377,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.1.tgz",
-      "integrity": "sha512-YfQMpYzDsYB7yqgmlxZ06NI4LurHWfrH7Wy3Pvf/z/vwUSgq1zLAb1lWcItCzQG+NVox+VvzlKQrYEXb47645g==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.3.tgz",
+      "integrity": "sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.34.1",
+        "@vitest/utils": "0.34.3",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.1"
       },
@@ -7418,9 +7418,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.1.tgz",
-      "integrity": "sha512-0O9LfLU0114OqdF8lENlrLsnn024Tb1CsS9UwG0YMWY2oGTQfPtkW+B/7ieyv0X9R2Oijhi3caB1xgGgEgclSQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.3.tgz",
+      "integrity": "sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.1",
@@ -7444,12 +7444,12 @@
       }
     },
     "node_modules/@vitest/snapshot/node_modules/pretty-format": {
-      "version": "29.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
-      "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7464,9 +7464,9 @@
       "dev": true
     },
     "node_modules/@vitest/spy": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.1.tgz",
-      "integrity": "sha512-UT4WcI3EAPUNO8n6y9QoEqynGGEPmmRxC+cLzneFFXpmacivjHZsNbiKD88KUScv5DCHVDgdBsLD7O7s1enFcQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.3.tgz",
+      "integrity": "sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.1"
@@ -7476,9 +7476,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.1.tgz",
-      "integrity": "sha512-/ql9dsFi4iuEbiNcjNHQWXBum7aL8pyhxvfnD9gNtbjR9fUKAjxhj4AA3yfLXg6gJpMGGecvtF8Au2G9y3q47Q==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.3.tgz",
+      "integrity": "sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.4.3",
@@ -7502,12 +7502,12 @@
       }
     },
     "node_modules/@vitest/utils/node_modules/pretty-format": {
-      "version": "29.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
-      "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -8643,9 +8643,9 @@
       "dev": true
     },
     "node_modules/chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
+      "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -10409,9 +10409,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -15558,15 +15558,15 @@
       "dev": true
     },
     "node_modules/mlly": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
-      "integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.1.tgz",
+      "integrity": "sha512-SCDs78Q2o09jiZiE2WziwVBEqXQ02XkGdUy45cbJf+BpYRIjArXRJ1Wbowxkb+NaM9DWvS3UC9GiO/6eqvQ/pg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.10.0",
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
-        "ufo": "^1.1.2"
+        "ufo": "^1.3.0"
       }
     },
     "node_modules/mlly/node_modules/acorn": {
@@ -19563,9 +19563,9 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/ufo": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.2.0.tgz",
-      "integrity": "sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
+      "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
       "dev": true
     },
     "node_modules/uglify-js": {
@@ -20016,9 +20016,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.1.tgz",
-      "integrity": "sha512-odAZAL9xFMuAg8aWd7nSPT+hU8u2r9gU3LRm9QKjxBEF2rRdWpMuqkrkjvyVQEdNFiBctqr2Gg4uJYizm5Le6w==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.3.tgz",
+      "integrity": "sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -20354,19 +20354,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.1.tgz",
-      "integrity": "sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.3.tgz",
+      "integrity": "sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.34.1",
-        "@vitest/runner": "0.34.1",
-        "@vitest/snapshot": "0.34.1",
-        "@vitest/spy": "0.34.1",
-        "@vitest/utils": "0.34.1",
+        "@vitest/expect": "0.34.3",
+        "@vitest/runner": "0.34.3",
+        "@vitest/snapshot": "0.34.3",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "acorn": "^8.9.0",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -20381,7 +20381,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.7.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.34.1",
+        "vite-node": "0.34.3",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -26054,23 +26054,23 @@
       }
     },
     "@vitest/expect": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.1.tgz",
-      "integrity": "sha512-q2CD8+XIsQ+tHwypnoCk8Mnv5e6afLFvinVGCq3/BOT4kQdVQmY6rRfyKkwcg635lbliLPqbunXZr+L1ssUWiQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.3.tgz",
+      "integrity": "sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "0.34.1",
-        "@vitest/utils": "0.34.1",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "chai": "^4.3.7"
       }
     },
     "@vitest/runner": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.1.tgz",
-      "integrity": "sha512-YfQMpYzDsYB7yqgmlxZ06NI4LurHWfrH7Wy3Pvf/z/vwUSgq1zLAb1lWcItCzQG+NVox+VvzlKQrYEXb47645g==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.3.tgz",
+      "integrity": "sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "0.34.1",
+        "@vitest/utils": "0.34.3",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.1"
       },
@@ -26093,9 +26093,9 @@
       }
     },
     "@vitest/snapshot": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.1.tgz",
-      "integrity": "sha512-0O9LfLU0114OqdF8lENlrLsnn024Tb1CsS9UwG0YMWY2oGTQfPtkW+B/7ieyv0X9R2Oijhi3caB1xgGgEgclSQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.3.tgz",
+      "integrity": "sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==",
       "dev": true,
       "requires": {
         "magic-string": "^0.30.1",
@@ -26110,12 +26110,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
-          "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+          "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -26129,18 +26129,18 @@
       }
     },
     "@vitest/spy": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.1.tgz",
-      "integrity": "sha512-UT4WcI3EAPUNO8n6y9QoEqynGGEPmmRxC+cLzneFFXpmacivjHZsNbiKD88KUScv5DCHVDgdBsLD7O7s1enFcQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.3.tgz",
+      "integrity": "sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==",
       "dev": true,
       "requires": {
         "tinyspy": "^2.1.1"
       }
     },
     "@vitest/utils": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.1.tgz",
-      "integrity": "sha512-/ql9dsFi4iuEbiNcjNHQWXBum7aL8pyhxvfnD9gNtbjR9fUKAjxhj4AA3yfLXg6gJpMGGecvtF8Au2G9y3q47Q==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.3.tgz",
+      "integrity": "sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==",
       "dev": true,
       "requires": {
         "diff-sequences": "^29.4.3",
@@ -26155,12 +26155,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
-          "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+          "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -27023,9 +27023,9 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
+      "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -28360,9 +28360,9 @@
       }
     },
     "diff-sequences": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
     },
     "dir-glob": {
@@ -32210,15 +32210,15 @@
       "dev": true
     },
     "mlly": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
-      "integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.1.tgz",
+      "integrity": "sha512-SCDs78Q2o09jiZiE2WziwVBEqXQ02XkGdUy45cbJf+BpYRIjArXRJ1Wbowxkb+NaM9DWvS3UC9GiO/6eqvQ/pg==",
       "dev": true,
       "requires": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.10.0",
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
-        "ufo": "^1.1.2"
+        "ufo": "^1.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -35226,9 +35226,9 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "ufo": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.2.0.tgz",
-      "integrity": "sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
+      "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
       "dev": true
     },
     "uglify-js": {
@@ -35524,9 +35524,9 @@
       }
     },
     "vite-node": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.1.tgz",
-      "integrity": "sha512-odAZAL9xFMuAg8aWd7nSPT+hU8u2r9gU3LRm9QKjxBEF2rRdWpMuqkrkjvyVQEdNFiBctqr2Gg4uJYizm5Le6w==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.3.tgz",
+      "integrity": "sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -35730,19 +35730,19 @@
       }
     },
     "vitest": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.1.tgz",
-      "integrity": "sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.3.tgz",
+      "integrity": "sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.34.1",
-        "@vitest/runner": "0.34.1",
-        "@vitest/snapshot": "0.34.1",
-        "@vitest/spy": "0.34.1",
-        "@vitest/utils": "0.34.1",
+        "@vitest/expect": "0.34.3",
+        "@vitest/runner": "0.34.3",
+        "@vitest/snapshot": "0.34.3",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "acorn": "^8.9.0",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -35757,7 +35757,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.7.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.34.1",
+        "vite-node": "0.34.3",
         "why-is-node-running": "^2.2.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "vite": "^4.4.9",
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-svgr": "^3.2.0",
-    "vitest": "^0.34.1"
+    "vitest": "^0.34.3"
   },
   "engines": {
     "node": "^18.17.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,7 @@ const proxyConfig = {
   target: customAPIDomain || 'http://localhost:9097'
 };
 
-export default defineConfig(({ _mode }) => ({
+export default defineConfig(({ mode }) => ({
   root: './',
   base: './',
   build: {
@@ -54,7 +54,7 @@ export default defineConfig(({ _mode }) => ({
       'Content-Security-Policy':
         "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; connect-src 'self' wss: ws:; font-src 'self' https://1.www.s81c.com;"
     },
-    open: true,
+    open: mode !== 'test',
     port: process.env.PORT || 8000,
     proxy: {
       '/v1': proxyConfig,
@@ -63,7 +63,7 @@ export default defineConfig(({ _mode }) => ({
         ws: true
       }
     },
-    strictPort: true
+    strictPort: mode !== 'test'
   },
   test: {
     clearMocks: true,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Replaces https://github.com/tektoncd/dashboard/pull/3087

Update port config to avoid conflict with dev server in latest vitest release (0.34.3)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
