### PR TITLE
Check for the wrong start date

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.jsx
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.jsx
@@ -28,7 +28,7 @@ class DetailsHeader extends Component {
         stepStatus.terminated || {});
     }
 
-    if (!startTime || !endTime) {
+    if (!startTime || !endTime || new Date(startTime).getTime() == 0) {
       return null;
     }
 


### PR DESCRIPTION
Add wrongDateChecker to catch the wrong start date which is causing the wrong duration for PipelineRuns and TaskRuns

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This will prevent to show the wrong duration for the users.
Related issue: https://github.ibm.com/one-pipeline/adoption-issues/issues/1374

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
