### PR TITLE
Fix default selected namespace when using limited namespace visibility

### DIFF
--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { hot } from 'react-hot-loader/root';
 import { Link, Redirect, HashRouter as Router, Switch } from 'react-router-dom';
@@ -180,12 +180,6 @@ export function App({ lang }) {
     () => queryClient.invalidateQueries(),
     isWebSocketConnected
   );
-
-  useEffect(() => {
-    if (!isFetchingConfig && tenantNamespaces.length) {
-      setSelectedNamespace(tenantNamespaces[0]);
-    }
-  }, [isFetchingConfig, JSON.stringify(tenantNamespaces)]);
 
   const logoutButton = <LogoutButton getLogoutURL={() => logoutURL} />;
 

--- a/src/containers/HeaderBarContent/HeaderBarContent.jsx
+++ b/src/containers/HeaderBarContent/HeaderBarContent.jsx
@@ -37,8 +37,10 @@ export default function HeaderBarContent({ isFetchingConfig, logoutButton }) {
   useEffect(() => {
     if (params.namespace) {
       selectNamespace(params.namespace);
+    } else if (tenantNamespaces.length) {
+      selectNamespace(tenantNamespaces[0]);
     }
-  }, [params.namespace]);
+  }, [params.namespace, JSON.stringify(tenantNamespaces)]);
 
   function setPath(path, { dropQueryParams } = {}) {
     navigate(`${path}${dropQueryParams ? '' : location.search}`);

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.jsx
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.jsx
@@ -56,7 +56,7 @@ const NamespacesDropdown = ({
     disableWebSocket: true
   });
 
-  let selectedItem = { ...originalSelectedItem };
+  const selectedItem = { ...originalSelectedItem };
   if (selectedItem && selectedItem.id === ALL_NAMESPACES) {
     selectedItem.text = allNamespacesString;
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/3135

When the `--namespaces` arg is set to restrict namespace visibility, the Dashboard was incorrectly defaulting to the first namespace in the list on page load instead of using the namespace specified in the URL.

Move the logic to select the default namespace from the top-level app component into the header where we're already checking for the selected namespace from the URL.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
