### PR TITLE
Update About E2E to correctly save API response body

### DIFF
--- a/packages/e2e/cypress/e2e/common/about.cy.js
+++ b/packages/e2e/cypress/e2e/common/about.cy.js
@@ -13,9 +13,7 @@ limitations under the License.
 
 describe('About page', () => {
   before(() => {
-    cy.request('/v1/properties')
-      .then(({ body }) => body)
-      .as('installProperties');
+    cy.request('/v1/properties').its('body').as('installProperties');
   });
 
   it('should display install metadata', function () {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Use `its` to extract the response body. This behaviour appears to have changed in either Cypress v13, or v12, and was no longer returning just the body.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
