### PR TITLE
Add v0.41.x to releases doc and remove v0.30 and v0.40

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -35,13 +35,13 @@ Further documentation available:
 
 ## Releases
 
-### v0.40
+### v0.41 (LTS)
 
-- **Latest Release**: [v0.40.1][v0-40-1] (2023-09-28) ([docs][v0-40-1-docs])
-- **Initial Release**: [v0.40.0][v0-40-0] (2023-09-25)
-- **End of Life**: 2023-10-24
-- **Patch Releases**: [v0.40.0][v0-40-0] [v0.40.1][v0-40-1]
-- **Supported Pipelines Releases**: v0.47.x LTS, v0.50.x LTS, v0.52.x
+- **Latest Release**: [v0.41.0][v0-41-0] (2023-11-01) ([docs][v0-41-0-docs])
+- **Initial Release**: [v0.41.0][v0-41-0] (2023-11-01)
+- **End of Life**: 2024-10-31
+- **Patch Releases**: [v0.41.0][v0-41-0]
+- **Supported Pipelines Releases**: v0.50.x LTS, v0.53.x LTS
 - **Supported Triggers Releases**: v0.24.x LTS, v0.25.x
 
 ### v0.38 (LTS)
@@ -71,15 +71,6 @@ Further documentation available:
 - **Supported Pipelines Releases**: v0.41.x LTS - v0.44.x LTS
 - **Supported Triggers Releases**: v0.22.x
 
-### v0.30 (LTS)
-
-- **Latest Release**: [v0.30.1][v0-30-1] (2023-05-31) ([docs][v0-30-1-docs])
-- **Initial Release**: [v0.30.0][v0-30-0] (2022-11-01)
-- **End of Life**: 2023-10-31
-- **Patch Releases**: [v0.30.0][v0-30-0], [v0.30.1][v0-30-1]
-- **Supported Pipelines Releases**: v0.38.x - v0.41.x LTS
-- **Supported Triggers Releases**: v0.21.x
-
 ## End of Life Releases
 
 Older releases are EOL and available on [GitHub][tekton-dashboard-releases].
@@ -95,22 +86,16 @@ Older releases are EOL and available on [GitHub][tekton-dashboard-releases].
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 
-[v0-40-1]: https://github.com/tektoncd/dashboard/releases/tag/v0.40.1
-[v0-40-0]: https://github.com/tektoncd/dashboard/releases/tag/v0.40.0
+[v0-41-0]: https://github.com/tektoncd/dashboard/releases/tag/v0.41.0
 [v0-38-0]: https://github.com/tektoncd/dashboard/releases/tag/v0.38.0
 [v0-35-1]: https://github.com/tektoncd/dashboard/releases/tag/v0.35.1
 [v0-35-0]: https://github.com/tektoncd/dashboard/releases/tag/v0.35.0
 [v0-32-1]: https://github.com/tektoncd/dashboard/releases/tag/v0.32.1
 [v0-32-0]: https://github.com/tektoncd/dashboard/releases/tag/v0.32.0
-[v0-30-1]: https://github.com/tektoncd/dashboard/releases/tag/v0.30.1
-[v0-30-0]: https://github.com/tektoncd/dashboard/releases/tag/v0.30.0
 
-[v0-40-1-docs]: https://github.com/tektoncd/dashboard/tree/v0.40.1/docs#tekton-dashboard
-[v0-40-0-docs]: https://github.com/tektoncd/dashboard/tree/v0.40.0/docs#tekton-dashboard
+[v0-41-0-docs]: https://github.com/tektoncd/dashboard/tree/v0.41.0/docs#tekton-dashboard
 [v0-38-0-docs]: https://github.com/tektoncd/dashboard/tree/v0.38.0/docs#tekton-dashboard
 [v0-35-1-docs]: https://github.com/tektoncd/dashboard/tree/v0.35.1/docs#tekton-dashboard
 [v0-35-0-docs]: https://github.com/tektoncd/dashboard/tree/v0.35.0/docs#tekton-dashboard
 [v0-32-1-docs]: https://github.com/tektoncd/dashboard/tree/v0.32.1/docs#tekton-dashboard
 [v0-32-0-docs]: https://github.com/tektoncd/dashboard/tree/v0.32.0/docs#tekton-dashboard
-[v0-30-1-docs]: https://github.com/tektoncd/dashboard/tree/v0.30.1/docs#tekton-dashboard
-[v0-30-0-docs]: https://github.com/tektoncd/dashboard/tree/v0.30.0/docs#tekton-dashboard


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
v0.30 and v0.40 are both EOL, remove them from the doc.

v0.30 is our first LTS release to reach EOL.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
