### PR TITLE
Fix storybook production build

### DIFF
--- a/packages/components/src/components/LogFormat/LogFormat.jsx
+++ b/packages/components/src/components/LogFormat/LogFormat.jsx
@@ -109,11 +109,13 @@ const LogFormat = ({ children }) => {
   };
 
   const enableTextStyle = flag => {
-    properties.classes[`tkn--ansi--text--${flag}`] = true;
+    const className = `tkn--ansi--text--${flag}`;
+    properties.classes[className] = true;
   };
 
   const disableTextStyle = flag => {
-    properties.classes[`tkn--ansi--text--${flag}`] = false;
+    const className = `tkn--ansi--text--${flag}`;
+    properties.classes[className] = false;
   };
 
   const setFGColor = color => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
react-docgen has issues parsing use of template literals as keys for accessing an object. Separate it out so the template literal is evaluated before attempting to use it as a key.

This limitation was likely exposed by recent updates to @babel/traverse.

Prior to this change, running `npm run storybook:build` would result in an error:

```
ERROR  [storybook:react-docgen-plugin] Argument must be Identifier, Literal, QualifiedTypeIdentifier or TSQualifiedName. Received 'TemplateLiteral'
file: /workspace/github.com/tektoncd/dashboard/packages/components/src/components/LogFormat/LogFormat.jsx


=> Failed to build the preview
TypeError: Argument must be Identifier, Literal, QualifiedTypeIdentifier or TSQualifiedName. Received 'TemplateLiteral'
    at getNameOrValue (./node_modules/react-docgen/dist/utils/getNameOrValue.js:48:9)
    at Object.enter (./node_modules/react-docgen/dist/utils/getMemberExpressionValuePath.js:83:100)
    at NodePath._call (./node_modules/@babel/traverse/lib/path/context.js:46:20)
    at NodePath.call (./node_modules/@babel/traverse/lib/path/context.js:36:17)
    at NodePath.visit (./node_modules/@babel/traverse/lib/path/context.js:82:31)
    at TraversalContext.visitQueue (./node_modules/@babel/traverse/lib/context.js:86:16)
    at TraversalContext.visitSingle (./node_modules/@babel/traverse/lib/context.js:65:19)
    at TraversalContext.visit (./node_modules/@babel/traverse/lib/context.js:109:19)
    at traverseNode (./node_modules/@babel/traverse/lib/traverse-node.js:22:17)
    at NodePath.visit (./node_modules/@babel/traverse/lib/path/context.js:88:52)
    at TraversalContext.visitQueue (./node_modules/@babel/traverse/lib/context.js:86:16)
    at TraversalContext.visitMultiple (./node_modules/@babel/traverse/lib/context.js:61:17)
    at TraversalContext.visit (./node_modules/@babel/traverse/lib/context.js:107:19)
    at traverseNode (./node_modules/@babel/traverse/lib/traverse-node.js:22:17)
    at NodePath.visit (./node_modules/@babel/traverse/lib/path/context.js:88:52)
    at TraversalContext.visitQueue (./node_modules/@babel/traverse/lib/context.js:86:16)
    at TraversalContext.visitSingle (./node_modules/@babel/traverse/lib/context.js:65:19)
    at TraversalContext.visit (./node_modules/@babel/traverse/lib/context.js:109:19)
…
```

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
