### PR TITLE
Add support for optional pipeline prop in PipelineRun component

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -30,11 +30,12 @@ import StepDetails from '../StepDetails';
 import TaskRunDetails from '../TaskRunDetails';
 import TaskTree from '../TaskTree';
 
-function getPipelineTask({ pipelineRun, selectedTaskId, taskRun }) {
+function getPipelineTask({ pipeline, pipelineRun, selectedTaskId, taskRun }) {
   const memberOf = taskRun?.metadata?.labels?.[labelConstants.MEMBER_OF];
   const pipelineTask = (
     pipelineRun.spec?.pipelineSpec?.[memberOf] ||
-    pipelineRun.status?.pipelineSpec?.[memberOf]
+    pipelineRun.status?.pipelineSpec?.[memberOf] ||
+    pipeline?.spec?.[memberOf]
   )?.find(task => task.name === selectedTaskId);
 
   return pipelineTask;
@@ -141,7 +142,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
     selectedTaskId,
     taskRunName
   }) => {
-    const { handleTaskSelected, pipelineRun } = this.props;
+    const { handleTaskSelected, pipeline, pipelineRun } = this.props;
     const taskRuns = this.loadTaskRuns();
     const taskRun =
       taskRuns.find(
@@ -150,6 +151,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       ) || {};
 
     const pipelineTask = getPipelineTask({
+      pipeline,
       pipelineRun,
       selectedTaskId,
       taskRun
@@ -171,6 +173,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       loading,
       onRetryChange,
       onViewChange,
+      pipeline,
       pipelineRun,
       pod,
       runActions,
@@ -275,6 +278,7 @@ export /* istanbul ignore next */ class PipelineRunContainer extends Component {
       ) || {};
 
     const pipelineTask = getPipelineTask({
+      pipeline,
       pipelineRun,
       selectedTaskId,
       taskRun

--- a/packages/components/src/components/TaskTree/TaskTree.jsx
+++ b/packages/components/src/components/TaskTree/TaskTree.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -99,7 +99,7 @@ const TaskTree = ({
             selectedStepId={selectedStepId}
             steps={steps}
             succeeded={status}
-            taskRun={taskRun}
+            taskRun={taskRunToUse}
           />
         );
       })}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Some consumers of the PipelineRun component modify the PipelineRun resource (e.g. by removing `status.pipelineSpec`) to reduce message size and content duplication for very large pipeline definitions.

As a result, existing support for displaying matrix tasks on the PipelineRun details page was broken for PipelineRuns using a pipelineRef instead of inline pipelineSpec, preventing the user from selecting the second or subsequent TaskRuns for a given matrix task.

Add support for providing an optional `pipeline` prop which can be used as fallback in case neither `PipelineRun.spec.pipelineSpec` nor `PipelineRun.status.pipelineSpec` are available.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
