### PR TITLE
Add Dockerfile for e2e base image

### DIFF
--- a/packages/e2e/base-image/Dockerfile
+++ b/packages/e2e/base-image/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2024 The Tekton Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The exact version must be used for these, no wildcards or shorthands are supported.
+# https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
+# https://nodejs.org/en/about/previous-releases
+
+ARG CHROME_VERSION='121.0.6167.139-1'
+ARG NODE_VERSION='20.11.0'
+
+FROM cypress/factory
+
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates curl gpg &&\
+    mkdir -p /etc/apt/keyrings &&\
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg &&\
+    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list &&\
+    apt-get update && apt-get install -y kubectl &&\
+    rm -rf /var/lib/apt/lists/*
+USER node
+WORKDIR /home/node
+ENV CI=true
+ENV NO_COLOR=true


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/pull/3283

Add a Dockerfile which will be used to create the base images used for running the e2e tests. This allows us direct control over the Chrome and Node.js versions used instead of waiting for Cypress to release a new image which happens very infrequently.

Move the kubectl install and much of the other config into this Dockerfile so that the one used to package the tests is more focused and doesn't have to duplicate the foundations each time the tests run.

Pipeline definitions and related config to build and publish the image will follow separately.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
