### PR TITLE
Update E2E tests to use Node.js 20 and Chrome 121

### DIFF
--- a/packages/e2e/.dockerignore
+++ b/packages/e2e/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+base-image

--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 The Tekton Authors
+# Copyright 2022-2024 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,17 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM cypress/browsers:node18.12.0-chrome107
-RUN apt-get update && apt-get install -y gpg &&\
-    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --dearmor -o /usr/share/keyrings/kubernetes-apt-keyring.gpg &&\
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list &&\
-    apt-get update && apt-get install -y \
-    kubectl \
-    && rm -rf /var/lib/apt/lists/*
-USER node
-WORKDIR /home/node
-ENV CI=true
-ENV NO_COLOR=true
+FROM gcr.io/tekton-releases/dogfooding/dashboard-e2e-base:node20.11.0-chrome121
+
 ENTRYPOINT ["npm", "run", "test:ci"]
 CMD ["--", "--browser", "chrome"]
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This resolves an error with previous version of the image where
Chrome install failed due to missing public key used for signing
Chrome releases:

```
\#6 2.433 W: GPG error: https://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY E88979FB9B30ACF2
\#6 2.433 E: The repository 'https://dl.google.com/linux/chrome/deb stable InRelease' is not signed.
```

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
