### PR TITLE
Remove the deprecated single namespace mode

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -35,7 +35,6 @@ var (
 	portNumber         = flag.Int("port", 8080, "Dashboard port number")
 	readOnly           = flag.Bool("read-only", true, "Enable or disable read-only mode")
 	logoutURL          = flag.String("logout-url", "", "If set, enables logout on the frontend and binds the logout button to this url")
-	tenantNamespace    = flag.String("namespace", "", "Deprecated: use --namespaces instead. If set, limits the scope of resources displayed to this namespace only")
 	tenantNamespaces   = flag.String("namespaces", "", "If set, limits the scope of resources displayed to this comma-separated list of namespaces only")
 	logLevel           = flag.String("log-level", "info", "Minimum log level output by the logger")
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
@@ -80,10 +79,6 @@ func main() {
 		logging.Log.Errorf("Error building k8s clientset: %s", err.Error())
 	}
 
-	if *tenantNamespace != "" {
-		logging.Log.Warn("DEPRECATION NOTICE: --namespace arg is deprecated, use --namespaces instead")
-	}
-
 	// use FieldsFunc instead of Split as Split returns an array containing an empty string
 	// instead of the desired empty array when there is no delimeter (i.e. empty string or single namespace)
 	splitByComma := func(c rune) bool {
@@ -95,7 +90,6 @@ func main() {
 		InstallNamespace:   installNamespace,
 		PipelinesNamespace: *pipelinesNamespace,
 		TriggersNamespace:  *triggersNamespace,
-		TenantNamespace:    *tenantNamespace,
 		TenantNamespaces:   tenants,
 		ReadOnly:           *readOnly,
 		LogoutURL:          *logoutURL,

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -104,14 +104,13 @@ These options are documented below:
 | `--port` | Dashboard port number | `int` | `8080` |
 | `--read-only` | Enable or disable read-only mode | `bool` | `true` |
 | `--logout-url` | If set, enables logout on the frontend and binds the logout button to this url | `string` | `""` |
-| `--namespace` | Deprecated: use --namespaces instead. If set, limits the scope of resources displayed to this namespace only | `string` | `""` |
 | `--namespaces` | If set, limits the scope of resources displayed to this comma-separated list of namespaces only | `string` | `""` |
 | `--log-level` | Minimum log level output by the logger | `string` | `"info"` |
 | `--log-format` | Format for log output (json or console) | `string` | `"json"` |
 
 Run `dashboard --help` to show the supported command line arguments and their default values directly from the `dashboard` binary.
 
-**Important note:** using `--namespace` or `--namespaces` provides this list of namespaces to the frontend, but does not limit actions that can be performed to just these namespaces. It's important when these flags are used that RBAC rules are setup accordingly.
+**Important note:** using `--namespaces` provides this list of namespaces to the frontend, but does not limit actions that can be performed to just these namespaces. It's important when this flag is used that RBAC rules are setup accordingly.
 
 ## Build and deploy with the installer script
 

--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -74,7 +74,6 @@ Accepted options:
         [--read-write]                          Will build manifests for a read/write deployment
         [--stream-logs false]                   Will disable log streaming and use polling instead
         [--tag <tag>]                           Tag used for the image produced by ko
-        [--tenant-namespace <namespace>]        [DEPRECATED: use tenant-namespaces instead] Will limit the visibility to the specified namespace only
         [--tenant-namespaces <namespaces>]      Will limit the visibility to the specified comma-separated namespaces only
         [--triggers-namespace <namespace>]      Override the namespace where Tekton Triggers is installed (defaults to Dashboard install namespace)
         [--version <version>]                   Will download manifests for specified version or build everything using kustomize/ko
@@ -131,16 +130,16 @@ To install the Dashboard add the `--read-write` option when calling the `install
 ./scripts/installer install --read-write
 ```
 
-### Installing for single namespace visibility
+### Installing for limited namespace visibility
 
-Single namespace visibility restricts the Tekton Dashboard actions scope and resources that can be seen to a single namespace in the cluster.
+Limited namespace visibility restricts the Tekton Dashboard actions scope and resources that can be seen to a subset of namespaces in the cluster.
 
-To install for single namespace visibility run the following command:
+To install for limited namespace visibility run the following command:
 
 ```bash
-TENANT_NAMESPACE=my-namespace
+TENANT_NAMESPACES=my-namespace1,my-namespace2
 
-./scripts/installer install --tenant-namespace $TENANT_NAMESPACE
+./scripts/installer install --tenant-namespaces $TENANT_NAMESPACES
 ```
 
 ### Install ingress

--- a/overlays/patches/installer/deployment-patch.yaml
+++ b/overlays/patches/installer/deployment-patch.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Tekton Authors
+# Copyright 2020-2024 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,10 +37,6 @@
   path: /spec/template/spec/containers/0/args/-
   value:
     --log-format=--log-format
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value:
-    --namespace=--tenant-namespace
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value:

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -30,7 +30,6 @@ type Properties struct {
 	PipelineVersion    string   `json:"pipelinesVersion"`
 	ReadOnly           bool     `json:"isReadOnly"`
 	StreamLogs         bool     `json:"streamLogs"`
-	TenantNamespace    string   `json:"tenantNamespace,omitempty"`
 	TenantNamespaces   []string `json:"tenantNamespaces,omitEmpty"`
 	TriggersNamespace  string   `json:"triggersNamespace,omitempty"`
 	TriggersVersion    string   `json:"triggersVersion,omitempty"`
@@ -52,7 +51,6 @@ func (r Resource) GetProperties(response http.ResponseWriter, _ *http.Request) {
 		PipelineVersion:    pipelineVersion,
 		ReadOnly:           r.Options.ReadOnly,
 		LogoutURL:          r.Options.LogoutURL,
-		TenantNamespace:    r.Options.TenantNamespace,
 		TenantNamespaces:   r.Options.TenantNamespaces,
 		StreamLogs:         r.Options.StreamLogs,
 	}

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,7 +23,6 @@ type Options struct {
 	InstallNamespace   string
 	PipelinesNamespace string
 	TriggersNamespace  string
-	TenantNamespace    string
 	TenantNamespaces   []string
 	ReadOnly           bool
 	LogoutURL          string

--- a/scripts/installer
+++ b/scripts/installer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021-2023 The Tekton Authors
+# Copyright 2021-2024 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -172,7 +172,6 @@ patch() {
   replace "--log-format=--log-format" "--log-format=$LOG_FORMAT"
   replace "--logout-url=--logout-url" "--logout-url=$LOGOUT_URL"
   replace "--read-only=--read-only" "--read-only=$READONLY"
-  replace "--namespace=--tenant-namespace" "--namespace="
   replace "--namespaces=--tenant-namespaces" "--namespaces=$TENANT_NAMESPACES"
   replace "--stream-logs=--stream-logs" "--stream-logs=$STREAM_LOGS"
   replace "--external-logs=--external-logs" "--external-logs=$EXTERNAL_LOGS"
@@ -406,7 +405,6 @@ help () {
   echo -e "\t[--read-write]\t\t\t\tWill build manifests for a read/write deployment"
   echo -e "\t[--stream-logs false]\t\t\tWill disable log streaming and use polling instead"
   echo -e "\t[--tag <tag>]\t\t\t\tTag used for the image produced by ko"
-  echo -e "\t[--tenant-namespace <namespace>]\t[DEPRECATED: use tenant-namespaces instead] Will limit the visibility to the specified namespace only"
   echo -e "\t[--tenant-namespaces <namespaces>]\tWill limit the visibility to the specified comma-separated namespaces only"
   echo -e "\t[--triggers-namespace <namespace>]\tOverride the namespace where Tekton Triggers is installed (defaults to Dashboard install namespace)"
   echo -e "\t[--version <version>]\t\t\tWill download manifests for specified version or build everything using kustomize/ko"
@@ -504,11 +502,6 @@ while [[ $# -gt 0 ]]; do
     '--triggers-namespace')
       shift
       OVERRIDE_TRIGGERS_NAMESPACE="${1}"
-      ;;
-    '--tenant-namespace')
-      warning "--tenant-namespace is deprecated, use --tenant-namespaces instead"
-      shift
-      TENANT_NAMESPACES="${1}"
       ;;
     '--tenant-namespaces')
       shift

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -338,11 +338,5 @@ export function useLogoutURL() {
 
 export function useTenantNamespaces() {
   const { data } = useProperties();
-  if (data.tenantNamespace) {
-    return [data.tenantNamespace];
-  }
-  if (data.tenantNamespaces) {
-    return data.tenantNamespaces;
-  }
-  return [];
+  return data.tenantNamespaces || [];
 }

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -516,7 +516,7 @@ it('other hooks that depend on useProperties', async () => {
     isReadOnly,
     logoutURL,
     streamLogs,
-    tenantNamespace,
+    tenantNamespaces: [tenantNamespace],
     triggersNamespace,
     triggersVersion
   };


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This was replaced in v0.39.0 with the ability to restrict the Dashboard to a list of namespaces instead of just a single one.

The single namespace mode was planned for removal after October 2023. There have been deprecation notices in the docs and warnings in the logs since the announcement with the v0.39.0 release so it is safe to remove in the next release.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Breaking change: The deprecated `--namespace` arg in the Dashboard deployment and associated `--tenant-namespace` option for the installer script are removed in this release. They have been deprecated since v0.39.0 and replaced with the `--namespaces` and `--tenant-namespaces` options respectively which support a comma-separated list of namespaces instead of a single namespace as provided by the previous options.
```
