### PR TITLE
Fix typo in container registry auth step

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -43,7 +43,7 @@ spec:
     env:
       - name: "PROJECT_ROOT"
         value: "$(workspaces.source.path)"
-      - name: CONTAINER_REGISTY_CREDENTIALS
+      - name: CONTAINER_REGISTRY_CREDENTIALS
         value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
       - name: CONTAINER_REGISTRY
         value: "$(params.imageRegistry)/$(params.imageRegistryPath)"
@@ -56,14 +56,14 @@ spec:
     # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
     - name: IMAGES
   steps:
-    - name: container-registy-auth
+    - name: container-registry-auth
       image: gcr.io/go-containerregistry/crane:debug
       script: |
         #!/busybox/sh
         set -ex
 
         # Login to the container registry
-        DOCKER_CONFIG=$(cat ${CONTAINER_REGISTY_CREDENTIALS} | \
+        DOCKER_CONFIG=$(cat ${CONTAINER_REGISTRY_CREDENTIALS} | \
           crane auth login -u _json_key --password-stdin $(params.imageRegistry) 2>&1 | \
           sed 's,^.*logged in via \(.*\)$,\1,g')
 
@@ -71,7 +71,7 @@ spec:
         for region in ${REGIONS}
         do
           HOSTNAME=${region}.$(params.imageRegistry)
-          cat ${CONTAINER_REGISTY_CREDENTIALS} | crane auth login -u _json_key --password-stdin ${HOSTNAME}
+          cat ${CONTAINER_REGISTRY_CREDENTIALS} | crane auth login -u _json_key --password-stdin ${HOSTNAME}
         done
         cp ${DOCKER_CONFIG} /workspace/docker-config.json
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Same fix in https://github.com/tektoncd/pipeline/pull/7648
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
