### PR TITLE
Add support for updated resourceTemplates field in future Triggers release

### DIFF
--- a/packages/components/src/components/Trigger/Trigger.test.jsx
+++ b/packages/components/src/components/Trigger/Trigger.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -284,7 +284,7 @@ describe('Trigger', () => {
     expect(queryByText(/TriggerBindings/i)).toBeFalsy();
   });
 
-  it('handles embedded template spec', () => {
+  it('handles embedded template spec - resourcetemplates', () => {
     const props = {
       namespace: 'tekton-pipelines',
       trigger: {
@@ -293,6 +293,36 @@ describe('Trigger', () => {
           spec: {
             params: [{ name: 'foo' }],
             resourcetemplates: [
+              {
+                apiVersion: 'tekton.dev/v1beta1',
+                kind: 'TaskRun',
+                metadata: {
+                  generateName: 'pr-run-'
+                },
+                spec: {
+                  taskSpec: {
+                    steps: [{ image: 'ubuntu', script: 'echo "hello there"' }]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+    const { getByText } = renderWithRouter(<Trigger {...props} />);
+    expect(getByText(/hello there/)).toBeTruthy();
+  });
+
+  it('handles embedded template spec - resourceTemplates', () => {
+    const props = {
+      namespace: 'tekton-pipelines',
+      trigger: {
+        ...fakeTrigger,
+        template: {
+          spec: {
+            params: [{ name: 'foo' }],
+            resourceTemplates: [
               {
                 apiVersion: 'tekton.dev/v1beta1',
                 kind: 'TaskRun',

--- a/src/containers/TriggerTemplate/TriggerTemplate.jsx
+++ b/src/containers/TriggerTemplate/TriggerTemplate.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -73,7 +73,12 @@ export /* istanbul ignore next */ function TriggerTemplateContainer() {
       return null;
     }
 
-    const { params, resourcetemplates } = triggerTemplate.spec;
+    const {
+      params,
+      resourceTemplates: newResourceTemplates,
+      resourcetemplates: oldResourceTemplates
+    } = triggerTemplate.spec;
+    const resourceTemplates = oldResourceTemplates || newResourceTemplates;
 
     const headersForParameters = [
       {
@@ -130,12 +135,12 @@ export /* istanbul ignore next */ function TriggerTemplateContainer() {
           emptyTextAllNamespaces={emptyTextMessage}
           emptyTextSelectedNamespace={emptyTextMessage}
         />
-        {resourcetemplates && (
+        {resourceTemplates && (
           // This is a very customised expandable table so intentionally not the one used elsewhere
           // although it should look the same
           <div className="tkn--table">
             <DataTable
-              rows={resourcetemplates.map((item, index) => ({
+              rows={resourceTemplates.map((item, index) => ({
                 id: `${index}|${
                   item.metadata.name || item.metadata.generateName
                 }`,
@@ -191,9 +196,7 @@ export /* istanbul ignore next */ function TriggerTemplateContainer() {
                           {row.isExpanded && (
                             <TableExpandedRow colSpan={headers.length + 1}>
                               <ViewYAML
-                                resource={
-                                  triggerTemplate.spec.resourcetemplates[index]
-                                }
+                                resource={resourceTemplates[index]}
                                 dark
                               />
                             </TableExpandedRow>

--- a/src/containers/TriggerTemplate/TriggerTemplate.test.jsx
+++ b/src/containers/TriggerTemplate/TriggerTemplate.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -115,7 +115,7 @@ const fakeTriggerTemplateWithLabels = {
       },
       { description: 'The Content-Type of the event', name: 'contenttype' }
     ],
-    resourcetemplates: [
+    resourceTemplates: [
       resourceTemplate1Details,
       {
         apiVersion: 'tekton.dev/v1alpha1',


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Triggers v0.26.0 attempted to rename `resourcetemplates` to `resourceTemplates` but it was done in a backwards incompatible way and reverted in v0.26.1.

This change will be reintroduced in a backwards compatible way in a future release.

Update the Dashboard code to handle both variants, including ensuring we have test coverage for both.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
