### PR TITLE
Add support for configuring default namespace

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -34,12 +34,13 @@ var (
 	kubeConfigPath     = flag.String("kube-config", "", "Path to kube config file")
 	portNumber         = flag.Int("port", 8080, "Dashboard port number")
 	readOnly           = flag.Bool("read-only", true, "Enable or disable read-only mode")
-	logoutURL          = flag.String("logout-url", "", "If set, enables logout on the frontend and binds the logout button to this url")
+	logoutURL          = flag.String("logout-url", "", "If set, enables logout on the frontend and binds the logout button to this URL")
+	defaultNamespace   = flag.String("default-namespace", "", "If set, configures the default selected namespace to the provided namespace instead of 'All Namespaces'")
 	tenantNamespaces   = flag.String("namespaces", "", "If set, limits the scope of resources displayed to this comma-separated list of namespaces only")
 	logLevel           = flag.String("log-level", "info", "Minimum log level output by the logger")
 	logFormat          = flag.String("log-format", "json", "Format for log output (json or console)")
 	streamLogs         = flag.Bool("stream-logs", true, "Enable log streaming instead of polling")
-	externalLogs       = flag.String("external-logs", "", "External logs provider url")
+	externalLogs       = flag.String("external-logs", "", "External logs provider URL")
 	xFrameOptions      = flag.String("x-frame-options", "DENY", "Value for the X-Frame-Options response header, set '' to omit it")
 )
 
@@ -91,6 +92,7 @@ func main() {
 		PipelinesNamespace: *pipelinesNamespace,
 		TriggersNamespace:  *triggersNamespace,
 		TenantNamespaces:   tenants,
+		DefaultNamespace:   *defaultNamespace,
 		ReadOnly:           *readOnly,
 		LogoutURL:          *logoutURL,
 		StreamLogs:         *streamLogs,

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -103,7 +103,8 @@ These options are documented below:
 | `--triggers-namespace` | Namespace where Tekton triggers is installed (assumes same namespace as dashboard if not set) | `string` | `""` |
 | `--port` | Dashboard port number | `int` | `8080` |
 | `--read-only` | Enable or disable read-only mode | `bool` | `true` |
-| `--logout-url` | If set, enables logout on the frontend and binds the logout button to this url | `string` | `""` |
+| `--logout-url` | If set, enables logout on the frontend and binds the logout button to this URL | `string` | `""` |
+| `--default-namespace` | If set, configures the default selected namespace to the provided namespace instead of 'All Namespaces' | `string` | `""` |
 | `--namespaces` | If set, limits the scope of resources displayed to this comma-separated list of namespaces only | `string` | `""` |
 | `--log-level` | Minimum log level output by the logger | `string` | `"info"` |
 | `--log-format` | Format for log output (json or console) | `string` | `"json"` |

--- a/overlays/patches/installer/deployment-patch.yaml
+++ b/overlays/patches/installer/deployment-patch.yaml
@@ -40,6 +40,10 @@
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value:
+    --default-namespace=--default-namespace
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
     --namespaces=--tenant-namespaces
 - op: add
   path: /spec/template/spec/containers/0/args/-

--- a/pkg/endpoints/cluster.go
+++ b/pkg/endpoints/cluster.go
@@ -24,13 +24,14 @@ import (
 type Properties struct {
 	DashboardNamespace string   `json:"dashboardNamespace"`
 	DashboardVersion   string   `json:"dashboardVersion"`
+	DefaultNamespace   string   `json:"defaultNamespace,omitempty"`
 	ExternalLogsURL    string   `json:"externalLogsURL"`
 	LogoutURL          string   `json:"logoutURL,omitempty"`
 	PipelineNamespace  string   `json:"pipelinesNamespace"`
 	PipelineVersion    string   `json:"pipelinesVersion"`
 	ReadOnly           bool     `json:"isReadOnly"`
 	StreamLogs         bool     `json:"streamLogs"`
-	TenantNamespaces   []string `json:"tenantNamespaces,omitEmpty"`
+	TenantNamespaces   []string `json:"tenantNamespaces,omitempty"`
 	TriggersNamespace  string   `json:"triggersNamespace,omitempty"`
 	TriggersVersion    string   `json:"triggersVersion,omitempty"`
 }
@@ -47,6 +48,7 @@ func (r Resource) GetProperties(response http.ResponseWriter, _ *http.Request) {
 	properties := Properties{
 		DashboardNamespace: r.Options.InstallNamespace,
 		DashboardVersion:   dashboardVersion,
+		DefaultNamespace:   r.Options.DefaultNamespace,
 		PipelineNamespace:  pipelineNamespace,
 		PipelineVersion:    pipelineVersion,
 		ReadOnly:           r.Options.ReadOnly,

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -24,6 +24,7 @@ type Options struct {
 	PipelinesNamespace string
 	TriggersNamespace  string
 	TenantNamespaces   []string
+	DefaultNamespace   string
 	ReadOnly           bool
 	LogoutURL          string
 	StreamLogs         bool

--- a/scripts/installer
+++ b/scripts/installer
@@ -23,6 +23,7 @@ EXTENSIONS_RBAC="false"
 LOGOUT_URL=""
 LOG_LEVEL="info"
 LOG_FORMAT="json"
+DEFAULT_NAMESPACE=""
 TENANT_NAMESPACES=""
 STREAM_LOGS="true"
 EXTERNAL_LOGS=""
@@ -172,6 +173,7 @@ patch() {
   replace "--log-format=--log-format" "--log-format=$LOG_FORMAT"
   replace "--logout-url=--logout-url" "--logout-url=$LOGOUT_URL"
   replace "--read-only=--read-only" "--read-only=$READONLY"
+  replace "--default-namespace=--default-namespace" "--default-namespace=$DEFAULT_NAMESPACE"
   replace "--namespaces=--tenant-namespaces" "--namespaces=$TENANT_NAMESPACES"
   replace "--stream-logs=--stream-logs" "--stream-logs=$STREAM_LOGS"
   replace "--external-logs=--external-logs" "--external-logs=$EXTERNAL_LOGS"
@@ -502,6 +504,10 @@ while [[ $# -gt 0 ]]; do
     '--triggers-namespace')
       shift
       OVERRIDE_TRIGGERS_NAMESPACE="${1}"
+      ;;
+    '--default-namespace')
+      shift
+      DEFAULT_NAMESPACE="${1}"
       ;;
     '--tenant-namespaces')
       shift

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -340,3 +340,8 @@ export function useTenantNamespaces() {
   const { data } = useProperties();
   return data.tenantNamespaces || [];
 }
+
+export function useDefaultNamespace() {
+  const { data } = useProperties();
+  return data.defaultNamespace;
+}

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -601,3 +601,26 @@ it('useTenantNamespaces', async () => {
   );
   expect(tenantNamespacesResult.current).toEqual(tenantNamespaces);
 });
+
+it('useDefaultNamespace', async () => {
+  const queryClient = getQueryClient();
+
+  const defaultNamespace = 'fake_defaultNamespace';
+
+  const properties = { defaultNamespace };
+  server.use(http.get(/\/properties$/, () => HttpResponse.json(properties)));
+  const { result, waitFor } = renderHook(() => API.useProperties(), {
+    wrapper: getAPIWrapper({ queryClient })
+  });
+  await waitFor(() => result.current.isFetching);
+  await waitFor(() => !result.current.isFetching);
+  expect(result.current.data).toEqual(properties);
+
+  const { result: defaultNamespacesResult } = renderHook(
+    () => API.useDefaultNamespace(),
+    {
+      wrapper: getAPIWrapper({ queryClient })
+    }
+  );
+  expect(defaultNamespacesResult.current).toEqual(defaultNamespace);
+});

--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -78,6 +78,7 @@ import {
 
 import {
   NamespaceContext,
+  useDefaultNamespace,
   useExtensions,
   useLogoutURL,
   useNamespaces,
@@ -145,6 +146,7 @@ export function App({ lang }) {
   } = useProperties();
   const logoutURL = useLogoutURL();
   const tenantNamespaces = useTenantNamespaces();
+  const defaultNamespace = useDefaultNamespace();
 
   const [isSideNavExpanded, setIsSideNavExpanded] = useState(true);
   const [selectedNamespace, setSelectedNamespace] = useState(
@@ -210,6 +212,13 @@ export function App({ lang }) {
     </Header>
   );
 
+  function HandleDefaultNamespace() {
+    if (defaultNamespace) {
+      setTimeout(() => setSelectedNamespace(defaultNamespace), 0);
+    }
+    return null;
+  }
+
   return (
     <NamespaceContext.Provider value={namespaceContext}>
       <IntlProvider
@@ -241,7 +250,10 @@ export function App({ lang }) {
                   <PageErrorBoundary>
                     <Switch>
                       <CompatRoute path="/" exact>
-                        <Redirect to={urls.about()} />
+                        <>
+                          <HandleDefaultNamespace />
+                          <Redirect to={urls.about()} />
+                        </>
                       </CompatRoute>
                       <CompatRoute path={paths.pipelines.all()} exact>
                         <NamespacedRoute>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/3297

When the Dashboard deployment's `--default-namespace` arg is set, this configures teh default namespace selected when loading the application instead of 'All Namespaces' being selected.

This behaviour will only be triggered when the Dashboard is loaded with no path on the URL, i.e. only for the root (which automatically redirects to the About page).

The reason for this limitation is that handling the default namespace configuration as part of the normal namespace processing would break the ability to select 'All Namespaces' from the namespace filter dropdown, as well as causing issues with URL consistency. It would also be impossible to differentiate between a user attempting to visit a namespaced page (e.g. PipelineRuns) with 'All Namespaces' selected, vs. with no selection which would be expected to use the default namespace instead.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add the ability to configure the default namespace selected in the UI instead of 'All Namespaces' when the user visits the application root (i.e. `/`).
```
