### PR TITLE
Add support for displayName from childReferences

### DIFF
--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -843,6 +843,51 @@ describe('getTaskRunsWithPlaceholders', () => {
     ];
     const runs = getTaskRunsWithPlaceholders({ pipelineRun, taskRuns });
     expect(runs).toEqual([taskRun, finallyTaskRun]);
+  });
+
+  it('handles displayName in childReferences', () => {
+    const displayName = 'aDisplayName';
+    const pipelineTaskName = 'aPipelineTaskName';
+    const taskRunName = 'aTaskRunName';
+
+    const pipelineRun = {
+      spec: {
+        pipelineRef: {
+          name: 'dummy-pipeline'
+        }
+      },
+      status: {
+        childReferences: [
+          {
+            displayName,
+            name: taskRunName,
+            pipelineTaskName
+          }
+        ],
+        pipelineSpec: {
+          tasks: [
+            {
+              name: pipelineTaskName
+            }
+          ]
+        }
+      }
+    };
+    const taskRun = {
+      metadata: {
+        labels: {
+          [labels.PIPELINE_TASK]: pipelineTaskName
+        },
+        name: taskRunName
+      }
+    };
+    const runs = getTaskRunsWithPlaceholders({
+      pipelineRun,
+      taskRuns: [taskRun]
+    });
+    expect(runs[0].metadata.labels[labels.DASHBOARD_DISPLAY_NAME]).toEqual(
+      displayName
+    );
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/2410
Depends on https://github.com/tektoncd/pipeline/pull/7683

Update utils to support pulling the pipeline task `displayName` from the run's `status.childReferences`. This adds support for dynamic matrix display names, and provides a consistent location to retrieve the resolve display name value after param substitution etc. has taken place.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for matrix task display names. When a `displayName` is set on a matrix task, the Dashboard will now retrieve that value from the PipelineRun status if present and display it in the task tree instead of the pipeline task name which would be the same for all instances of that matrix task. This makes it easier for users to differentiate between instances of the task without having to inspect the params or logs.

This feature requires Pipelines v0.58.0 or newer.
```
