### PR TITLE
Ensure getInstallProperties always returns a value

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -107,6 +107,10 @@ export async function getInstallProperties() {
     data = await get(uri);
   } catch (error) {
     if (error?.response?.status === 404) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Install properties not found, setting client-mode defaults'
+      );
       data = {
         dashboardNamespace: 'N/A',
         dashboardVersion: 'kubectl-proxy-client',
@@ -116,6 +120,13 @@ export async function getInstallProperties() {
         triggersNamespace: 'Unknown',
         triggersVersion: 'Unknown'
       };
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Failed loading install properties, setting read-only default',
+        error
+      );
+      data = { isReadOnly: true };
     }
   }
   return data;

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -483,7 +483,7 @@ describe('getInstallProperties', () => {
       http.get(/\/properties$/, () => new HttpResponse(null, { status: 500 }))
     );
     const properties = await API.getInstallProperties();
-    expect(properties).toBeUndefined();
+    expect(properties).toEqual({ isReadOnly: true });
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
With React Query 4+ a query function must always either return a value or throw an error. The install properties getter was previously returning undefined which meant React Query 3 would keep using the placeholder data. That's no longer the case so we have to return the default in this case.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
