### PR TITLE
Simplify API utils for constructing URLs

### DIFF
--- a/src/api/extensions.js
+++ b/src/api/extensions.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,15 +12,14 @@ limitations under the License.
 */
 
 import { get } from './comms';
-import { dashboardAPIGroup, getResourcesAPI, useCollection } from './utils';
+import { dashboardAPIGroup, getKubeAPI, useCollection } from './utils';
 
 function getExtensionsAPI({ isWebSocket, namespace }) {
-  return getResourcesAPI({
+  return getKubeAPI({
     group: dashboardAPIGroup,
-    isWebSocket,
-    version: 'v1alpha1',
-    type: 'extensions',
-    namespace
+    kind: 'extensions',
+    params: { isWebSocket, namespace },
+    version: 'v1alpha1'
   });
 }
 

--- a/src/api/serviceAccounts.js
+++ b/src/api/serviceAccounts.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,14 +15,24 @@ import { get } from './comms';
 import { getKubeAPI, useCollection } from './utils';
 
 export function getServiceAccounts({ namespace } = {}) {
-  const uri = getKubeAPI('serviceaccounts', { namespace });
+  const uri = getKubeAPI({
+    group: 'core',
+    kind: 'serviceaccounts',
+    params: { namespace },
+    version: 'v1'
+  });
   return get(uri);
 }
 
 export function useServiceAccounts(params, queryConfig) {
-  const webSocketURL = getKubeAPI('serviceaccounts', {
-    ...params,
-    isWebSocket: true
+  const webSocketURL = getKubeAPI({
+    group: 'core',
+    kind: 'serviceaccounts',
+    params: {
+      ...params,
+      isWebSocket: true
+    },
+    version: 'v1'
   });
   return useCollection({
     api: getServiceAccounts,

--- a/src/api/utils.test.js
+++ b/src/api/utils.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2023 The Tekton Authors
+Copyright 2019-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -55,67 +55,6 @@ describe('getTektonAPI', () => {
     expect(uri).toContain('clustertasks');
     expect(uri).toContain('somename');
     expect(uri).not.toContain('namespaces');
-  });
-});
-
-describe('getResourcesAPI', () => {
-  it('returns a URI containing the given type', () => {
-    const uri = utils.getResourcesAPI({
-      group: 'test.dev',
-      version: 'testversion',
-      type: 'testtype'
-    });
-    expect(uri).toContain('test.dev');
-    expect(uri).toContain('testversion');
-    expect(uri).toContain('testtype');
-  });
-
-  it('returns a URI containing the given type and name without namespace', () => {
-    const uri = utils.getResourcesAPI({
-      group: 'test.dev',
-      version: 'testversion',
-      type: 'testtype',
-      name: 'testname'
-    });
-    expect(uri).toContain('test.dev');
-    expect(uri).toContain('testversion');
-    expect(uri).toContain('testtype');
-    expect(uri).toContain('testname');
-    expect(uri).not.toContain('namespaces');
-  });
-
-  it('returns a URI containing the given type, name and namespace', () => {
-    const uri = utils.getResourcesAPI({
-      group: 'test.dev',
-      version: 'testversion',
-      type: 'testtype',
-      namespace: 'testnamespace',
-      name: 'testname'
-    });
-    expect(uri).toContain('test.dev');
-    expect(uri).toContain('testversion');
-    expect(uri).toContain('testtype');
-    expect(uri).toContain('testname');
-    expect(uri).toContain('namespaces');
-    expect(uri).toContain('testnamespace');
-  });
-
-  it('handles the core group correctly', () => {
-    const uri = utils.getResourcesAPI({
-      group: 'core',
-      version: 'testversion',
-      type: 'testtype',
-      namespace: 'testnamespace',
-      name: 'testname'
-    });
-    expect(uri).not.toContain('core');
-    expect(uri).toContain('api');
-    expect(uri).not.toContain('apis');
-    expect(uri).toContain('testversion');
-    expect(uri).toContain('testtype');
-    expect(uri).toContain('testname');
-    expect(uri).toContain('namespaces');
-    expect(uri).toContain('testnamespace');
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2452 and https://github.com/tektoncd/dashboard/issues/3381

There's no longer a need for multiple utils to build Kube API URLs. This is an artifact of an earlier approach which is no longer used.

Combine the various URL builders into a single util and replace usage as appropriate.

`getTektonAPI` will be removed in a future change.

This simplification will be core to the planned updates for React Router 6, providing a single common approach to handling all Kube resources in the app.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
