### PR TITLE
Update to React Router 6

### DIFF
--- a/.storybook/Container.jsx
+++ b/.storybook/Container.jsx
@@ -13,9 +13,7 @@ limitations under the License.
 
 import { StrictMode } from 'react';
 import { IntlProvider } from 'react-intl';
-import { createMemoryHistory } from 'history';
-import { Router, Switch } from 'react-router-dom';
-import { CompatRoute, CompatRouter } from 'react-router-dom-v5-compat';
+import { Route, MemoryRouter as Router, Routes } from 'react-router-dom';
 
 import messages from '../src/nls/messages_en.json';
 
@@ -31,16 +29,17 @@ export default function Container({
     <IntlProvider locale="en" defaultLocale="en" messages={messages['en']}>
       {notes && <p>{notes}</p>}
       <div data-floating-menu-container role="main">
-        <Router history={createMemoryHistory({ initialEntries: [route] })}>
-          <CompatRouter>
-            <Switch>
-              <CompatRoute path={path}>
+        <Router initialEntries={[route]}>
+          <Routes>
+            <Route
+              path={path}
+              element={
                 <StrictMode>
                   <Story />
                 </StrictMode>
-              </CompatRoute>
-            </Switch>
-          </CompatRouter>
+              }
+            />
+          </Routes>
         </Router>
       </div>
     </IntlProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,7 @@
         "react-dom": "^17.0.2",
         "react-hot-loader": "^4.13.1",
         "react-intl": "^6.6.6",
-        "react-router-dom": "^5.3.4",
-        "react-router-dom-v5-compat": "^6.23.0",
+        "react-router-dom": "^6.23.1",
         "reconnecting-websocket": "^4.4.0"
       },
       "devDependencies": {
@@ -66,7 +65,6 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-storybook": "^0.8.0",
-        "history": "^5.3.0",
         "jsdom": "^24.0.0",
         "lodash.difference": "^4.5.0",
         "lodash.omit": "^4.5.0",
@@ -3727,9 +3725,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
-      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -12056,14 +12054,6 @@
       "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
       "dev": true
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -15896,65 +15886,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom-v5-compat": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.23.0.tgz",
-      "integrity": "sha512-ffDaOI5UuahWs+n8qFj0S3N8L6VsUjU9RX2WMQWQPyoGRUxaBeaXjEngZDXhz5nsbyF+N5YAY21SmGC/8DlPug==",
-      "dependencies": {
-        "@remix-run/router": "1.16.0",
-        "history": "^5.3.0",
-        "react-router": "6.23.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "react-router-dom": "4 || 5"
-      }
-    },
-    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
-      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
-      "dependencies": {
-        "@remix-run/router": "1.16.0"
+        "@remix-run/router": "1.16.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15963,49 +15899,21 @@
         "react": ">=16.8"
       }
     },
-    "node_modules/react-router-dom/node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-window": {
       "version": "1.8.10",
@@ -16393,11 +16301,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -17831,12 +17734,8 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.5.1",
@@ -18498,11 +18397,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/varint": {
       "version": "6.0.0",
@@ -19379,7 +19273,7 @@
         "react": "^16.14.0 || ^17.0.1",
         "react-dom": "^16.14.0 || ^17.0.1",
         "react-intl": "^6.4.1",
-        "react-router-dom": "^5.0.0"
+        "react-router-dom": "^6.0.0"
       }
     },
     "packages/e2e": {
@@ -19428,7 +19322,7 @@
         "npm": "^10.2.4"
       },
       "peerDependencies": {
-        "react-router-dom": "^5.0.0"
+        "react-router-dom": "^6.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "react-dom": "^17.0.2",
     "react-hot-loader": "^4.13.1",
     "react-intl": "^6.6.6",
-    "react-router-dom": "^5.3.4",
-    "react-router-dom-v5-compat": "^6.23.0",
+    "react-router-dom": "^6.23.1",
     "reconnecting-websocket": "^4.4.0"
   },
   "devDependencies": {
@@ -75,7 +74,6 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-storybook": "^0.8.0",
-    "history": "^5.3.0",
     "jsdom": "^24.0.0",
     "lodash.difference": "^4.5.0",
     "lodash.omit": "^4.5.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
     "react": "^16.14.0 || ^17.0.1",
     "react-dom": "^16.14.0 || ^17.0.1",
     "react-intl": "^6.4.1",
-    "react-router-dom": "^5.0.0"
+    "react-router-dom": "^6.0.0"
   },
   "engines": {
     "node": "^20.11.0",

--- a/packages/components/src/components/Link/Link.jsx
+++ b/packages/components/src/components/Link/Link.jsx
@@ -12,8 +12,34 @@ limitations under the License.
 */
 /* istanbul ignore file */
 
+import { forwardRef } from 'react';
+import { useHref, useLinkClickHandler } from 'react-router-dom';
 import { Link as CarbonLink } from 'carbon-components-react';
 
-export default function Link({ navigate, ...rest }) {
-  return <CarbonLink {...rest} />;
-}
+const Link = forwardRef(
+  ({ onClick, replace = false, state, target, to, ...rest }, ref) => {
+    const href = useHref(to);
+    const handleClick = useLinkClickHandler(to, {
+      replace,
+      state,
+      target
+    });
+
+    return (
+      <CarbonLink
+        {...rest}
+        href={href}
+        onClick={event => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            handleClick(event);
+          }
+        }}
+        ref={ref}
+        target={target}
+      />
+    );
+  }
+);
+
+export default Link;

--- a/packages/components/src/components/PageErrorBoundary/PageErrorBoundary.jsx
+++ b/packages/components/src/components/PageErrorBoundary/PageErrorBoundary.jsx
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 
 import ErrorBoundary from '../ErrorBoundary';
 

--- a/packages/components/src/components/PipelineRuns/PipelineRuns.jsx
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.jsx
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
 import { getStatus, urls } from '@tektoncd/dashboard-utils';
 import {
   Calendar16 as CalendarIcon,
@@ -22,9 +21,9 @@ import {
 } from '@carbon/icons-react';
 
 import Actions from '../Actions';
-import CustomLink from '../Link';
 import FormattedDate from '../FormattedDate';
 import FormattedDuration from '../FormattedDuration';
+import Link from '../Link';
 import StatusIcon from '../StatusIcon';
 import Table from '../Table';
 
@@ -196,11 +195,7 @@ const PipelineRuns = ({
         <div>
           <span>
             {pipelineRunURL ? (
-              <Link
-                component={CustomLink}
-                to={pipelineRunURL}
-                title={pipelineRunNameTooltip}
-              >
+              <Link to={pipelineRunURL} title={pipelineRunNameTooltip}>
                 {pipelineRunName}
               </Link>
             ) : (
@@ -220,11 +215,7 @@ const PipelineRuns = ({
           <span>
             {(pipelineRefName &&
               (pipelineRunsByPipelineURL ? (
-                <Link
-                  component={CustomLink}
-                  to={pipelineRunsByPipelineURL}
-                  title={pipelineRefName}
-                >
+                <Link to={pipelineRunsByPipelineURL} title={pipelineRefName}>
                   {pipelineRefName}
                 </Link>
               ) : (

--- a/packages/components/src/components/TaskRuns/TaskRuns.jsx
+++ b/packages/components/src/components/TaskRuns/TaskRuns.jsx
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
 import {
   Calendar16 as CalendarIcon,
   Time16 as TimeIcon,
@@ -21,9 +20,9 @@ import {
 import { getStatus, taskRunHasWarning, urls } from '@tektoncd/dashboard-utils';
 
 import Actions from '../Actions';
-import CustomLink from '../Link';
 import FormattedDate from '../FormattedDate';
 import FormattedDuration from '../FormattedDuration';
+import Link from '../Link';
 import StatusIcon from '../StatusIcon';
 import Table from '../Table';
 
@@ -172,7 +171,7 @@ const TaskRuns = ({
         <div>
           <span>
             {taskRunURL ? (
-              <Link component={CustomLink} to={taskRunURL} title={taskRunName}>
+              <Link to={taskRunURL} title={taskRunName}>
                 {taskRunName}
               </Link>
             ) : (
@@ -188,7 +187,7 @@ const TaskRuns = ({
         <div>
           <span>
             {taskRefName ? (
-              <Link component={CustomLink} to={taskRunsURL} title={taskRefName}>
+              <Link to={taskRunsURL} title={taskRefName}>
                 {taskRefName}
               </Link>
             ) : (

--- a/packages/components/src/components/Trigger/Trigger.jsx
+++ b/packages/components/src/components/Trigger/Trigger.jsx
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
 import {
   Accordion,
   AccordionItem,
@@ -21,7 +20,7 @@ import {
 } from 'carbon-components-react';
 import { getCarbonPrefix, urls } from '@tektoncd/dashboard-utils';
 
-import CustomLink from '../Link';
+import Link from '../Link';
 import Table from '../Table';
 import ViewYAML from '../ViewYAML';
 
@@ -71,7 +70,6 @@ const Trigger = ({ namespace, trigger }) => {
                   {binding.ref ? (
                     <Link
                       className="tkn--trigger-resourcelink"
-                      component={CustomLink}
                       to={
                         binding.kind === 'ClusterTriggerBinding'
                           ? urls.clusterTriggerBindings.byName({
@@ -106,7 +104,6 @@ const Trigger = ({ namespace, trigger }) => {
           ) : (
             <Link
               className="tkn--trigger-resourcelink"
-              component={CustomLink}
               to={urls.triggerTemplates.byName({
                 namespace,
                 triggerTemplateName
@@ -326,7 +323,6 @@ const Trigger = ({ namespace, trigger }) => {
                 const clusterInterceptorName = interceptor.ref.name;
                 content = (
                   <Link
-                    component={CustomLink}
                     to={urls.clusterInterceptors.byName({
                       clusterInterceptorName
                     })}

--- a/packages/components/src/utils/test.jsx
+++ b/packages/components/src/utils/test.jsx
@@ -12,23 +12,23 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import { Fragment } from 'react';
-import { BrowserRouter, Switch } from 'react-router-dom';
-import { CompatRoute, CompatRouter } from 'react-router-dom-v5-compat';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { render as baseRender } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
 function RouterWrapper({ children, path }) {
   return (
     <BrowserRouter>
-      <CompatRouter>
-        <Switch>
-          <CompatRoute path={path}>
+      <Routes>
+        <Route
+          path={path}
+          element={
             <IntlProvider locale="en" defaultLocale="en" messages={{}}>
               {children}
             </IntlProvider>
-          </CompatRoute>
-        </Switch>
-      </CompatRouter>
+          }
+        />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "scripts": {},
   "peerDependencies": {
-    "react-router-dom": "^5.0.0"
+    "react-router-dom": "^6.0.0"
   },
   "engines": {
     "node": "^20.11.0",

--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { generatePath } from 'react-router-dom-v5-compat';
+import { generatePath } from 'react-router-dom';
 import { labels } from './constants';
 
 function byNamespace({ path = '' } = {}) {

--- a/packages/utils/src/utils/router.test.js
+++ b/packages/utils/src/utils/router.test.js
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { generatePath } from 'react-router-dom-v5-compat';
+import { generatePath } from 'react-router-dom';
 import { paths, urls } from './router';
 import { labels } from './constants';
 

--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -14,13 +14,13 @@ limitations under the License.
 import { useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { hot } from 'react-hot-loader/root';
-import { Link, Redirect, HashRouter as Router, Switch } from 'react-router-dom';
 import {
-  CompatRoute,
-  CompatRouter,
+  Link,
+  Navigate,
   Route,
+  HashRouter as Router,
   Routes
-} from 'react-router-dom-v5-compat';
+} from 'react-router-dom';
 import { IntlProvider, useIntl } from 'react-intl';
 import { Content, InlineNotification } from 'carbon-components-react';
 import {
@@ -227,264 +227,345 @@ export function App({ lang }) {
         {showLoadingState && <LoadingShell />}
         {!showLoadingState && (
           <Router>
-            <CompatRouter>
-              <>
-                <Routes>
-                  <Route
-                    path={paths.byNamespace({ path: '/*' })}
-                    element={header}
-                  />
-                  <Route path="*" element={header} />
-                </Routes>
-                <SideNav expanded={isSideNavExpanded} />
+            <>
+              <Routes>
+                <Route
+                  path={paths.byNamespace({ path: '/*' })}
+                  element={header}
+                />
+                <Route path="*" element={header} />
+              </Routes>
+              <SideNav expanded={isSideNavExpanded} />
 
-                <Content
-                  id="main-content"
-                  className="tkn--main-content"
-                  aria-labelledby="main-content-header"
-                  tabIndex="0"
-                >
-                  <ConfigError loadingConfigError={loadingConfigError} />
-                  <PageErrorBoundary>
-                    <Switch>
-                      <CompatRoute path="/" exact>
+              <Content
+                id="main-content"
+                className="tkn--main-content"
+                aria-labelledby="main-content-header"
+                tabIndex="0"
+              >
+                <ConfigError loadingConfigError={loadingConfigError} />
+                <PageErrorBoundary>
+                  <Routes>
+                    <Route
+                      path="/"
+                      element={
                         <>
                           <HandleDefaultNamespace />
-                          <Redirect to={urls.about()} />
+                          <Navigate replace to={urls.about()} />
                         </>
-                      </CompatRoute>
-                      <CompatRoute path={paths.pipelines.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.pipelines.all()}
+                      element={
                         <NamespacedRoute>
                           <Pipelines />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.pipelines.byNamespace()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.pipelines.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <Pipelines />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.pipelineRuns.create()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.pipelineRuns.create()}
+                      element={
                         <ReadWriteRoute>
                           <CreatePipelineRun />
                         </ReadWriteRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.pipelineRuns.byName()}>
+                      }
+                    />
+                    <Route
+                      path={paths.pipelineRuns.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <PipelineRun />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.pipelineRuns.all()}>
+                      }
+                    />
+                    <Route
+                      path={paths.pipelineRuns.all()}
+                      element={
                         <NamespacedRoute>
                           <PipelineRuns />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.pipelineRuns.byNamespace()}>
+                      }
+                    />
+                    <Route
+                      path={paths.pipelineRuns.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <PipelineRuns />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.tasks.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.tasks.all()}
+                      element={
                         <NamespacedRoute>
                           <Tasks />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.tasks.byNamespace()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.tasks.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <Tasks />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.taskRuns.create()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.taskRuns.create()}
+                      element={
                         <ReadWriteRoute>
                           <CreateTaskRun />
                         </ReadWriteRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.taskRuns.byName()}>
+                      }
+                    />
+                    <Route
+                      path={paths.taskRuns.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <TaskRun />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.taskRuns.all()}>
+                      }
+                    />
+                    <Route
+                      path={paths.taskRuns.all()}
+                      element={
                         <NamespacedRoute>
                           <TaskRuns />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.taskRuns.byNamespace()}>
+                      }
+                    />
+                    <Route
+                      path={paths.taskRuns.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <TaskRuns />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.customRuns.create()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.customRuns.create()}
+                      element={
                         <ReadWriteRoute>
                           <CreateCustomRun />
                         </ReadWriteRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.customRuns.all()}>
+                      }
+                    />
+                    <Route
+                      path={paths.customRuns.all()}
+                      element={
                         <NamespacedRoute>
                           <CustomRuns />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.customRuns.byNamespace()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.customRuns.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <CustomRuns />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.customRuns.byName()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.customRuns.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <CustomRun />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.clusterTasks.all()} exact>
-                        <ClusterTasks />
-                      </CompatRoute>
-                      <CompatRoute path={paths.about()}>
-                        <About />
-                      </CompatRoute>
-                      <CompatRoute path={paths.settings()}>
-                        <Settings />
-                      </CompatRoute>
-                      <CompatRoute path={paths.importResources()}>
+                      }
+                    />
+                    <Route
+                      path={paths.clusterTasks.all()}
+                      element={<ClusterTasks />}
+                    />
+                    <Route path={paths.about()} element={<About />} />
+                    <Route path={paths.settings()} element={<Settings />} />
+                    <Route
+                      path={paths.importResources()}
+                      element={
                         <ReadWriteRoute>
                           <ImportResources />
                         </ReadWriteRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.eventListeners.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.eventListeners.all()}
+                      element={
                         <NamespacedRoute>
                           <EventListeners />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.eventListeners.byNamespace()}
-                        exact
-                      >
+                      }
+                    />
+                    <Route
+                      path={paths.eventListeners.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <EventListeners />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.eventListeners.byName()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.eventListeners.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <EventListener />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggers.byName()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.triggers.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <Trigger />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggers.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.triggers.all()}
+                      element={
                         <NamespacedRoute>
                           <Triggers />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggers.byNamespace()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.triggers.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <Triggers />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggerBindings.byName()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.triggerBindings.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <TriggerBinding />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggerBindings.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.triggerBindings.all()}
+                      element={
                         <NamespacedRoute>
                           <TriggerBindings />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.triggerBindings.byNamespace()}
-                        exact
-                      >
+                      }
+                    />
+                    <Route
+                      path={paths.triggerBindings.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <TriggerBindings />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.clusterTriggerBindings.byName()}
-                        exact
-                      >
-                        <ClusterTriggerBinding />
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.clusterTriggerBindings.all()}
-                        exact
-                      >
-                        <ClusterTriggerBindings />
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggerTemplates.byName()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.clusterTriggerBindings.byName()}
+                      element={<ClusterTriggerBinding />}
+                    />
+                    <Route
+                      path={paths.clusterTriggerBindings.all()}
+                      element={<ClusterTriggerBindings />}
+                    />
+                    <Route
+                      path={paths.triggerTemplates.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <TriggerTemplate />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.triggerTemplates.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.triggerTemplates.all()}
+                      element={
                         <NamespacedRoute>
                           <TriggerTemplates />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.triggerTemplates.byNamespace()}
-                        exact
-                      >
+                      }
+                    />
+                    <Route
+                      path={paths.triggerTemplates.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <TriggerTemplates />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.interceptors.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.interceptors.all()}
+                      element={
                         <NamespacedRoute>
                           <Interceptors />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.interceptors.byNamespace()}
-                        exact
-                      >
+                      }
+                    />
+                    <Route
+                      path={paths.interceptors.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <Interceptors />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.clusterInterceptors.all()} exact>
-                        <ClusterInterceptors />
-                      </CompatRoute>
-                      <CompatRoute path={paths.rawCRD.byNamespace()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.clusterInterceptors.all()}
+                      element={<ClusterInterceptors />}
+                    />
+                    <Route
+                      path={paths.rawCRD.byNamespace()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <CustomResourceDefinition />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute path={paths.rawCRD.cluster()} exact>
-                        <CustomResourceDefinition />
-                      </CompatRoute>
-                      <CompatRoute path={paths.kubernetesResources.all()} exact>
+                      }
+                    />
+                    <Route
+                      path={paths.rawCRD.cluster()}
+                      element={<CustomResourceDefinition />}
+                    />
+                    <Route
+                      path={paths.kubernetesResources.all()}
+                      element={
                         <NamespacedRoute>
                           <ResourceList />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.kubernetesResources.byNamespace()}
-                        exact
-                      >
+                      }
+                    />
+                    <Route
+                      path={paths.kubernetesResources.byNamespace()}
+                      element={
                         <NamespacedRoute>
                           <ResourceList />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.kubernetesResources.byName()}
-                        exact
-                      >
+                      }
+                    />
+                    <Route
+                      path={paths.kubernetesResources.byName()}
+                      element={
                         <NamespacedRoute isResourceDetails>
                           <CustomResourceDefinition />
                         </NamespacedRoute>
-                      </CompatRoute>
-                      <CompatRoute
-                        path={paths.kubernetesResources.cluster()}
-                        exact
-                      >
-                        <CustomResourceDefinition />
-                      </CompatRoute>
-                      <NotFound />
-                    </Switch>
-                  </PageErrorBoundary>
-                </Content>
-              </>
-            </CompatRouter>
+                      }
+                    />
+                    <Route
+                      path={paths.kubernetesResources.cluster()}
+                      element={<CustomResourceDefinition />}
+                    />
+                    <Route path="*" element={<NotFound />} />
+                  </Routes>
+                </PageErrorBoundary>
+              </Content>
+            </>
           </Router>
         )}
       </IntlProvider>

--- a/src/containers/ClusterInterceptors/ClusterInterceptors.jsx
+++ b/src/containers/ClusterInterceptors/ClusterInterceptors.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useClusterInterceptors } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: clusterInterceptor.metadata.uid,
     name: (
       <Link
-        component={CustomLink}
         to={urls.rawCRD.cluster({
           name: clusterInterceptor.metadata.name,
           type: 'clusterinterceptors'

--- a/src/containers/ClusterTasks/ClusterTasks.jsx
+++ b/src/containers/ClusterTasks/ClusterTasks.jsx
@@ -13,14 +13,13 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
-  Link as CustomLink,
   DeleteModal,
   FormattedDate,
+  Link,
   Table
 } from '@tektoncd/dashboard-components';
 import { Button } from 'carbon-components-react';
@@ -44,7 +43,6 @@ function getFormattedResources({
     id: clusterTask.metadata.uid,
     name: (
       <Link
-        component={CustomLink}
         to={urls.rawCRD.cluster({
           type: 'clustertasks',
           name: clusterTask.metadata.name

--- a/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.jsx
+++ b/src/containers/ClusterTriggerBinding/ClusterTriggerBinding.jsx
@@ -12,11 +12,7 @@ limitations under the License.
 */
 /* istanbul ignore file */
 
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';

--- a/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.jsx
+++ b/src/containers/ClusterTriggerBindings/ClusterTriggerBindings.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useClusterTriggerBindings } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: `${binding.metadata.name}`,
     name: (
       <Link
-        component={CustomLink}
         to={urls.clusterTriggerBindings.byName({
           clusterTriggerBindingName: binding.metadata.name
         })}

--- a/src/containers/CreateCustomRun/CreateCustomRun.jsx
+++ b/src/containers/CreateCustomRun/CreateCustomRun.jsx
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { lazy, Suspense } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom';
 import yaml from 'js-yaml';
 import { ALL_NAMESPACES, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { Loading } from '@tektoncd/dashboard-components';

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.jsx
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.jsx
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { lazy, Suspense, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom';
 import keyBy from 'lodash.keyby';
 import yaml from 'js-yaml';
 import {

--- a/src/containers/CreateTaskRun/CreateTaskRun.jsx
+++ b/src/containers/CreateTaskRun/CreateTaskRun.jsx
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { lazy, Suspense, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom';
 import keyBy from 'lodash.keyby';
 import yaml from 'js-yaml';
 import {

--- a/src/containers/CustomResourceDefinition/CustomResourceDefinition.jsx
+++ b/src/containers/CustomResourceDefinition/CustomResourceDefinition.jsx
@@ -12,11 +12,7 @@ limitations under the License.
 */
 /* istanbul ignore file */
 
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails } from '@tektoncd/dashboard-components';
 

--- a/src/containers/CustomRun/CustomRun.jsx
+++ b/src/containers/CustomRun/CustomRun.jsx
@@ -13,12 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { UndefinedFilled20 as UndefinedIcon } from '@carbon/icons-react';
 import {

--- a/src/containers/CustomRuns/CustomRuns.jsx
+++ b/src/containers/CustomRuns/CustomRuns.jsx
@@ -13,12 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {
@@ -30,10 +25,10 @@ import {
 } from '@tektoncd/dashboard-utils';
 import {
   Actions,
-  Link as CustomLink,
   DeleteModal,
   FormattedDate,
   FormattedDuration,
+  Link,
   StatusIcon,
   Table
 } from '@tektoncd/dashboard-components';
@@ -441,7 +436,6 @@ function CustomRuns() {
               <div>
                 <span>
                   <Link
-                    component={CustomLink}
                     to={urls.customRuns.byName({
                       namespace: run.metadata.namespace,
                       runName: run.metadata.name

--- a/src/containers/EventListener/EventListener.jsx
+++ b/src/containers/EventListener/EventListener.jsx
@@ -12,19 +12,10 @@ limitations under the License.
 */
 /* istanbul ignore file */
 
-import { Link } from 'react-router-dom';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  ResourceDetails,
-  Trigger
-} from '@tektoncd/dashboard-components';
+import { Link, ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
 
 import { useEventListener } from '../../api';
 import { getViewChangeHandler } from '../../utils';
@@ -117,7 +108,6 @@ export function EventListenerContainer() {
               <div className="tkn--trigger-resourcelinks">
                 <span>Trigger:</span>
                 <Link
-                  component={CustomLink}
                   to={urls.triggers.byName({
                     namespace,
                     triggerName: trigger.triggerRef

--- a/src/containers/EventListeners/EventListeners.jsx
+++ b/src/containers/EventListeners/EventListeners.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useEventListeners, useSelectedNamespace } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: `${listener.metadata.namespace}:${listener.metadata.name}`,
     name: (
       <Link
-        component={CustomLink}
         to={urls.eventListeners.byName({
           namespace: listener.metadata.namespace,
           eventListenerName: listener.metadata.name

--- a/src/containers/HeaderBarContent/HeaderBarContent.jsx
+++ b/src/containers/HeaderBarContent/HeaderBarContent.jsx
@@ -16,7 +16,7 @@ import {
   useLocation,
   useNavigate,
   useParams
-} from 'react-router-dom-v5-compat';
+} from 'react-router-dom';
 import { ALL_NAMESPACES, paths, urls } from '@tektoncd/dashboard-utils';
 
 import NamespacesDropdown from '../NamespacesDropdown';

--- a/src/containers/HeaderBarContent/HeaderBarContent.test.jsx
+++ b/src/containers/HeaderBarContent/HeaderBarContent.test.jsx
@@ -46,16 +46,13 @@ describe('HeaderBarContent', () => {
       selectedNamespace: ALL_NAMESPACES,
       selectNamespace: () => {}
     }));
-    vi.spyOn(window.history, 'pushState');
     const { getByText, getByDisplayValue } = renderWithRouter(
       <HeaderBarContent />,
       { path, route: path }
     );
     fireEvent.click(getByDisplayValue(/All Namespaces/i));
     fireEvent.click(getByText(otherNamespace));
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      expect.anything(),
-      null,
+    expect(window.location.pathname).toEqual(
       `/namespaces/${otherNamespace}${path}`
     );
   });
@@ -76,7 +73,6 @@ describe('HeaderBarContent', () => {
       selectNamespace: () => {}
     }));
     const selectNamespace = vi.fn();
-    vi.spyOn(window.history, 'pushState');
     const { getByText, getByDisplayValue } = renderWithRouter(
       <HeaderBarContent />,
       { path, route: `/namespaces/${namespace}/fake/path` }
@@ -84,9 +80,7 @@ describe('HeaderBarContent', () => {
     fireEvent.click(getByDisplayValue(namespace));
     fireEvent.click(getByText(otherNamespace));
     expect(selectNamespace).not.toHaveBeenCalled();
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      expect.anything(),
-      null,
+    expect(window.location.pathname).toEqual(
       `/namespaces/${otherNamespace}/fake/path`
     );
   });
@@ -103,7 +97,6 @@ describe('HeaderBarContent', () => {
       selectedNamespace: namespace,
       selectNamespace
     }));
-    vi.spyOn(window.history, 'pushState');
     const { getByText, getByDisplayValue } = renderWithRouter(
       <HeaderBarContent />,
       {
@@ -114,11 +107,7 @@ describe('HeaderBarContent', () => {
     fireEvent.click(getByDisplayValue(namespace));
     fireEvent.click(getByText(/All Namespaces/i));
     expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      expect.anything(),
-      null,
-      '/fake/path'
-    );
+    expect(window.location.pathname).toEqual('/fake/path');
   });
 
   it('removes namespace from URL when clearing selection', async () => {
@@ -133,18 +122,13 @@ describe('HeaderBarContent', () => {
       selectedNamespace: namespace,
       selectNamespace
     }));
-    vi.spyOn(window.history, 'pushState');
     const { getByTitle } = renderWithRouter(<HeaderBarContent />, {
       path,
       route: `/namespaces/${namespace}/fake/path`
     });
     fireEvent.click(getByTitle(/clear selected item/i));
     expect(selectNamespace).toHaveBeenCalledWith(ALL_NAMESPACES);
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      expect.anything(),
-      null,
-      '/fake/path'
-    );
+    expect(window.location.pathname).toEqual('/fake/path');
   });
 
   it('selects first namespace when clearing selection in tenant namespace visibility mode', async () => {
@@ -161,7 +145,6 @@ describe('HeaderBarContent', () => {
       selectedNamespace: tenantNamespace2,
       selectNamespace
     }));
-    vi.spyOn(window.history, 'pushState');
     const { getByDisplayValue, getByTitle } = renderWithRouter(
       <HeaderBarContent />,
       {
@@ -172,9 +155,7 @@ describe('HeaderBarContent', () => {
     await waitFor(() => getByDisplayValue(tenantNamespace2));
     fireEvent.click(getByTitle(/clear selected item/i));
     expect(selectNamespace).toHaveBeenCalledWith(tenantNamespace1);
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      expect.anything(),
-      null,
+    expect(window.location.pathname).toEqual(
       `/namespaces/${tenantNamespace1}/fake/path`
     );
   });

--- a/src/containers/Interceptors/Interceptors.jsx
+++ b/src/containers/Interceptors/Interceptors.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useInterceptors, useSelectedNamespace } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: `${interceptor.metadata.namespace}:${interceptor.metadata.name}`,
     name: (
       <Link
-        component={CustomLink}
         to={urls.interceptors.byName({
           namespace: interceptor.metadata.namespace,
           interceptorName: interceptor.metadata.name

--- a/src/containers/ListPageLayout/ListPageLayout.jsx
+++ b/src/containers/ListPageLayout/ListPageLayout.jsx
@@ -13,7 +13,7 @@ limitations under the License.
 
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { InlineNotification, Pagination } from 'carbon-components-react';
 import { getErrorMessage } from '@tektoncd/dashboard-utils';

--- a/src/containers/NamespacedRoute/NamespacedRoute.js
+++ b/src/containers/NamespacedRoute/NamespacedRoute.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Tekton Authors
+Copyright 2022-2024 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { useContext, useEffect } from 'react';
 import {
   UNSAFE_RouteContext, // eslint-disable-line camelcase
   useParams
-} from 'react-router-dom-v5-compat';
+} from 'react-router-dom';
 
 import { useSelectedNamespace } from '../../api';
 

--- a/src/containers/NotFound/NotFound.jsx
+++ b/src/containers/NotFound/NotFound.jsx
@@ -13,9 +13,8 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
 import { Column, Grid, Row } from 'carbon-components-react';
-import { Link as CustomLink } from '@tektoncd/dashboard-components';
+import { Link } from '@tektoncd/dashboard-components';
 import { ALL_NAMESPACES, urls } from '@tektoncd/dashboard-utils';
 
 import { useSelectedNamespace } from '../../api';
@@ -66,13 +65,11 @@ function NotFound({ suggestions = [] }) {
           <ul>
             {suggestions.map(({ text, to }) => (
               <li key={text}>
-                <Link component={CustomLink} to={to}>
-                  {text}
-                </Link>
+                <Link to={to}>{text}</Link>
               </li>
             ))}
             <li>
-              <Link component={CustomLink} to="/">
+              <Link to="/">
                 {intl.formatMessage({
                   id: 'dashboard.home.title',
                   defaultMessage: 'Home'
@@ -83,7 +80,6 @@ function NotFound({ suggestions = [] }) {
               <>
                 <li>
                   <Link
-                    component={CustomLink}
                     to={
                       namespace !== ALL_NAMESPACES
                         ? urls.pipelineRuns.byNamespace({ namespace })
@@ -95,7 +91,6 @@ function NotFound({ suggestions = [] }) {
                 </li>
                 <li>
                   <Link
-                    component={CustomLink}
                     to={
                       namespace !== ALL_NAMESPACES
                         ? urls.taskRuns.byNamespace({ namespace })

--- a/src/containers/PipelineRun/PipelineRun.jsx
+++ b/src/containers/PipelineRun/PipelineRun.jsx
@@ -31,12 +31,7 @@ import {
   TileGroup
 } from 'carbon-components-react';
 
-import { Link } from 'react-router-dom';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 
 import {

--- a/src/containers/PipelineRuns/PipelineRuns.jsx
+++ b/src/containers/PipelineRuns/PipelineRuns.jsx
@@ -13,11 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useEffect, useState } from 'react';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import { RadioTile, TileGroup } from 'carbon-components-react';

--- a/src/containers/Pipelines/Pipelines.jsx
+++ b/src/containers/Pipelines/Pipelines.jsx
@@ -13,8 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import {
   TrashCan16 as DeleteIcon,
   PlayOutline16 as RunIcon,
@@ -30,9 +29,9 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import {
-  Link as CustomLink,
   DeleteModal,
   FormattedDate,
+  Link,
   Table
 } from '@tektoncd/dashboard-components';
 
@@ -54,7 +53,6 @@ function getFormattedResources({
     id: pipeline.metadata.uid,
     name: (
       <Link
-        component={CustomLink}
         to={urls.rawCRD.byNamespace({
           namespace: pipeline.metadata.namespace,
           type: 'pipelines',

--- a/src/containers/ResourceList/ResourceList.jsx
+++ b/src/containers/ResourceList/ResourceList.jsx
@@ -12,14 +12,9 @@ limitations under the License.
 */
 /* istanbul ignore file */
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import {
@@ -130,7 +125,6 @@ export function ResourceListContainer() {
               id: uid,
               name: (
                 <Link
-                  component={CustomLink}
                   to={
                     resourceNamespace
                       ? urls.kubernetesResources.byName({

--- a/src/containers/SideNav/SideNav.jsx
+++ b/src/containers/SideNav/SideNav.jsx
@@ -11,8 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { matchPath } from 'react-router-dom';
-import { NavLink, useLocation } from 'react-router-dom-v5-compat';
+import { matchPath, NavLink, useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import {
   SideNav as CarbonSideNav,
@@ -60,9 +59,12 @@ function SideNav({ expanded, showKubernetesResources = false }) {
   function getMenuItemProps(to) {
     return {
       element: NavLink,
-      isActive: !!matchPath(location.pathname, {
-        path: to
-      }),
+      isActive: !!matchPath(
+        {
+          path: to
+        },
+        location.pathname
+      ),
       to
     };
   }

--- a/src/containers/TaskRun/TaskRun.jsx
+++ b/src/containers/TaskRun/TaskRun.jsx
@@ -14,12 +14,7 @@ limitations under the License.
 
 import { Fragment, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { InlineNotification, SkeletonText } from 'carbon-components-react';
 import {
   Actions,

--- a/src/containers/TaskRuns/TaskRuns.jsx
+++ b/src/containers/TaskRuns/TaskRuns.jsx
@@ -12,11 +12,7 @@ limitations under the License.
 */
 
 import { useEffect, useState } from 'react';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import {

--- a/src/containers/Tasks/Tasks.jsx
+++ b/src/containers/Tasks/Tasks.jsx
@@ -13,8 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import keyBy from 'lodash.keyby';
 import { Button } from 'carbon-components-react';
@@ -25,9 +24,9 @@ import {
   useTitleSync
 } from '@tektoncd/dashboard-utils';
 import {
-  Link as CustomLink,
   DeleteModal,
   FormattedDate,
+  Link,
   Table
 } from '@tektoncd/dashboard-components';
 import {
@@ -54,7 +53,6 @@ function getFormattedResources({
     id: task.metadata.uid,
     name: (
       <Link
-        component={CustomLink}
         to={urls.rawCRD.byNamespace({
           namespace: task.metadata.namespace,
           type: 'tasks',

--- a/src/containers/Trigger/Trigger.jsx
+++ b/src/containers/Trigger/Trigger.jsx
@@ -11,11 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { ResourceDetails, Trigger } from '@tektoncd/dashboard-components';
 

--- a/src/containers/TriggerBinding/TriggerBinding.jsx
+++ b/src/containers/TriggerBinding/TriggerBinding.jsx
@@ -11,11 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { ResourceDetails, Table } from '@tektoncd/dashboard-components';
 import { useTitleSync } from '@tektoncd/dashboard-utils';

--- a/src/containers/TriggerBindings/TriggerBindings.jsx
+++ b/src/containers/TriggerBindings/TriggerBindings.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useSelectedNamespace, useTriggerBindings } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: `${binding.metadata.namespace}:${binding.metadata.name}`,
     name: (
       <Link
-        component={CustomLink}
         to={urls.triggerBindings.byName({
           namespace: binding.metadata.namespace,
           triggerBindingName: binding.metadata.name

--- a/src/containers/TriggerTemplate/TriggerTemplate.jsx
+++ b/src/containers/TriggerTemplate/TriggerTemplate.jsx
@@ -12,11 +12,7 @@ limitations under the License.
 */
 
 import { Fragment } from 'react';
-import {
-  useLocation,
-  useNavigate,
-  useParams
-} from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { DataTable } from 'carbon-components-react';
 import {

--- a/src/containers/TriggerTemplates/TriggerTemplates.jsx
+++ b/src/containers/TriggerTemplates/TriggerTemplates.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useSelectedNamespace, useTriggerTemplates } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: `${template.metadata.namespace}:${template.metadata.name}`,
     name: (
       <Link
-        component={CustomLink}
         to={urls.triggerTemplates.byName({
           namespace: template.metadata.namespace,
           triggerTemplateName: template.metadata.name

--- a/src/containers/Triggers/Triggers.jsx
+++ b/src/containers/Triggers/Triggers.jsx
@@ -11,15 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Link } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { getFilters, urls, useTitleSync } from '@tektoncd/dashboard-utils';
-import {
-  Link as CustomLink,
-  FormattedDate,
-  Table
-} from '@tektoncd/dashboard-components';
+import { FormattedDate, Link, Table } from '@tektoncd/dashboard-components';
 
 import ListPageLayout from '../ListPageLayout';
 import { useSelectedNamespace, useTriggers } from '../../api';
@@ -29,7 +24,6 @@ function getFormattedResources(resources) {
     id: trigger.metadata.uid,
     name: (
       <Link
-        component={CustomLink}
         to={urls.triggers.byName({
           namespace: trigger.metadata.namespace,
           triggerName: trigger.metadata.name


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/issues/2452

Follow the remaining steps in the migration guide to replace the compat layer with actual use of React Router 6 directly. This includes:
- move `Route` children into the `element` prop
- refactor use of the `Link`'s `component` prop to the new approach
- update tests to avoid relying on `history`
- and more

While this does update us to React Router 6 there is still more to be done to take advantage of the new features, such as the `handle` prop on `Route`s to avoid the need for our custom `NamespacedRoute` component etc. This will be tackled in the near future and will dramatically simplify the code, allowing for a more uniform approach to handling Kube resources without the current overhead of custom containers per kind etc.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
