### PR TITLE
Switch chainguard images to alternative Alpine-based images

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7
+defaultBaseImage: ghcr.io/wolfi-dev/static:alpine@sha256:2a0e1651c779fd24cea09a5ec6a0437117ff5d1fbe5fafe78020dfb8cc757018

--- a/src/api/resources/import-resources-pipelinerun.yaml
+++ b/src/api/resources/import-resources-pipelinerun.yaml
@@ -57,7 +57,7 @@ spec:
             - name: repo
           steps:
             - name: clone
-              image: cgr.dev/chainguard/git:latest@sha256:2c70afb3b34ca5feab37c5826c32dae6e0c48549486fdf6be93faf928b658efe  # 2.41
+              image: ghcr.io/wolfi-dev/git:alpine@sha256:3a118879b998f146812c11630805863f8a769587460938cbcc1daca874d9b57c  # 2.45
               env:
                 - name: PARAM_URL
                   value: $(params.repositoryURL)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
On July 15, 2024, Chainguard will be changing their base images to be based on their own custom Wolfi base. This means they will be dropping support for a number of platforms, keeping only linux/arm64 and linux/amd64.

Switch to their alternative Alpine-based images to maintain support for other platforms such as linux/s390x and linux/ppc64le.

See https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images-2 for more details.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
