### PR TITLE
Pass AbortSignal to fetch to allow for cancelling in-flight requests on navigation

### DIFF
--- a/src/api/comms.js
+++ b/src/api/comms.js
@@ -122,7 +122,8 @@ export function get(uri, headers, options = {}) {
     uri,
     {
       method: 'GET',
-      headers: getHeaders(headers)
+      headers: getHeaders(headers),
+      signal: options.signal
     },
     options.stream
   );

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -83,10 +83,10 @@ export function getKubeAPI({
   ].join('');
 }
 
-export async function defaultQueryFn({ queryKey }) {
+export async function defaultQueryFn({ queryKey, signal }) {
   const [group, version, kind, params] = queryKey;
   const url = getKubeAPI({ group, kind, params, version });
-  const response = await get(url);
+  const response = await get(url, undefined, { signal });
   if (typeof response === 'undefined') {
     return null;
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/3465
Related to https://github.com/tektoncd/dashboard/issues/2452

TanStack Query provides an `AbortSignal` instance to the query function which can in turn be provided to `fetch` to cancel in-flight requests when the response is no longer required, e.g. incomplete API calls in progress when the user navigates to a different page.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
