### PR TITLE
Add support for disabling resource details links on extensions list pages

### DIFF
--- a/base/202-extension-crd.yaml
+++ b/base/202-extension-crd.yaml
@@ -47,7 +47,7 @@ spec:
           jsonPath: .spec.name
         - name: Display name
           type: string
-          jsonPath: .spec.displayname
+          jsonPath: .spec.displayName
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -41,12 +41,13 @@ See the [Example: Register a CronJob extension](#example-register-a-cronjob-exte
 
 #### ExtensionSpec
 
-| Variable Name | Type              | Required | Default | Description                                                      |
-|---------------|-------------------|----------|---------|------------------------------------------------------------------|
-| apiVersion    | string            | Yes      | -       | Extension resource group                                         |
-| name          | string            | Yes      | -       | Extension resource name                                          |
-| displayname   | string            | Yes      | -       | Display name in the Dashboard UI                                 |
-| namespaced    | boolean           | No       | true    | Specifies whether the Extension represents a namespaced resource |
+| Variable Name               | Type              | Required | Default | Description                                                      |
+|-----------------------------|-------------------|----------|---------|------------------------------------------------------------------|
+| apiVersion                  | string            | Yes      | -       | Extension resource group                                         |
+| name                        | string            | Yes      | -       | Extension resource name                                          |
+| disableResourceDetailsLinks | boolean           | No       | false   | Disable display of links to resource details pages               |
+| displayName                 | string            | Yes      | -       | Display name in the Dashboard UI                                 |
+| namespaced                  | boolean           | No       | true    | Specifies whether the Extension represents a namespaced resource |
 
 ### Example: Register a CronJob extension
 
@@ -61,7 +62,7 @@ metadata:
 spec:
   apiVersion: batch/v1
   name: cronjobs
-  displayname: k8s cronjobs
+  displayName: k8s cronjobs
 EOF
 ```
 

--- a/packages/e2e/cypress/e2e/common/extensions.cy.js
+++ b/packages/e2e/cypress/e2e/common/extensions.cy.js
@@ -37,7 +37,7 @@ metadata:
 spec:
   apiVersion: core/v1
   name: namespaces
-  displayname: Namespaces
+  displayName: Namespaces
 `);
 
     cy.contains(`.${carbonPrefix}--side-nav a`, 'Namespaces').click();

--- a/src/api/extensions.js
+++ b/src/api/extensions.js
@@ -25,12 +25,19 @@ export function useExtensions(params, queryConfig) {
   return {
     ...query,
     data: (data || []).map(({ spec }) => {
-      const { displayname: displayName, name, namespaced } = spec;
+      const {
+        disableResourceDetailsLinks,
+        displayname, // keep for backwards compatibility for a few releases
+        displayName,
+        name,
+        namespaced
+      } = spec;
       const [apiGroup, apiVersion] = spec.apiVersion.split('/');
       return {
         apiGroup,
         apiVersion,
-        displayName,
+        disableResourceDetailsLinks,
+        displayName: displayName || displayname,
         name,
         namespaced
       };

--- a/src/api/extensions.test.js
+++ b/src/api/extensions.test.js
@@ -22,6 +22,40 @@ it('useExtensions', () => {
   const displayName = 'fake_displayName';
   const namespaced = true;
   const query = {
+    data: [{ spec: { apiVersion, displayName, name, namespaced } }]
+  };
+  const params = { fake: 'params' };
+  vi.spyOn(utils, 'useCollection').mockImplementation(() => query);
+  const extensions = API.useExtensions(params);
+  expect(utils.useCollection).toHaveBeenCalledWith(
+    expect.objectContaining({
+      group: utils.dashboardAPIGroup,
+      kind: 'extensions',
+      params,
+      version: 'v1alpha1'
+    })
+  );
+  expect(extensions).toEqual({
+    data: [
+      {
+        apiGroup: group,
+        apiVersion: version,
+        displayName,
+        name,
+        namespaced
+      }
+    ]
+  });
+});
+
+it('useExtensions displayname backwards compatibility', () => {
+  const name = 'fake_name';
+  const group = 'fake_group';
+  const version = 'fake_version';
+  const apiVersion = `${group}/${version}`;
+  const displayName = 'fake_displayName';
+  const namespaced = true;
+  const query = {
     data: [{ spec: { apiVersion, displayname: displayName, name, namespaced } }]
   };
   const params = { fake: 'params' };


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/3381

Also rename the extension `displayname` field to `displayName`. Keep support for `displayname` for backwards compatibility. It is now deprecated and will be removed after a few releases.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
