### PR TITLE
Update obsolete link in kind walk-through

### DIFF
--- a/docs/walkthrough/walkthrough-kind.md
+++ b/docs/walkthrough/walkthrough-kind.md
@@ -181,7 +181,7 @@ kubectl wait -n tekton-pipelines \
 
 The Tekton Dashboard can import resources directly from a GitHub repository.
 
-The following steps demonstrate how to import a set of resources from a file hosted in a GitHub repository and view the resulting `PipelineRun`. The example contains some `Tasks`, a `Pipeline` that uses them, and a `PipelineRun` to execute it. To learn more about what the example does, take a look at the [example file](https://github.com/tektoncd/pipeline/blob/main/examples/v1beta1/pipelineruns/output-pipelinerun.yaml) we'll be using.
+The following steps demonstrate how to import a set of resources from files hosted in a GitHub repository and view the resulting `PipelineRun`. The example contains some `Tasks` and a `Pipeline` that uses them. To learn more about what the example does, take a look at the [example files](https://github.com/tektoncd/dashboard/blob/main/docs/tutorial) we'll be using.
 
 Create a new namespace and grant the ServiceAccount permissions to create Tekton resources:
 


### PR DESCRIPTION
# Changes

The link to an example file was broken in the kind walkthrough as those files were removed in: https://github.com/tektoncd/pipeline/pull/6150. (Note: the tektoncd/pipeline examples doc still refers to the missing files also: https://github.com/tektoncd/pipeline/blob/main/examples/README.md?plain=1#L26)

Update the link to match the example that is now being used: https://github.com/tektoncd/dashboard/blob/main/docs/tutorial

Also update the example images to match the newer example

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
