### PR TITLE
docs: fix logs persistence walkthrough broken url

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -108,7 +108,7 @@ For example:
     bash -s -- install latest --read-write --external-logs <logs-provider-url>
   ```
 
-  See [Tekton Dashboard walk-through - Logs persistence](/docs/walkthrough/walkthrough-logs.md) for details
+  See [Tekton Dashboard walk-through - Logs persistence](./walkthrough/walkthrough-logs.md) for details
 
 ## Accessing the Dashboard
 


### PR DESCRIPTION
# What

I was reading the [Tekton Dashboard installation guide](https://tekton.dev/docs/dashboard/install/) and noticed that the link reference for logs persistence was broken.

<img width="563" alt="Screenshot 2024-07-25 at 11 06 50" src="https://github.com/user-attachments/assets/42590869-b12c-47c6-9c9a-2d635c89961c">



# Changes

Added the path correctly to walkthrough markdown.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
docs: fix logs persistence walkthrough broken url
```
