### PR TITLE
Fix the Storybook production build

### DIFF
--- a/packages/graph/src/components/newGraph.scss
+++ b/packages/graph/src/components/newGraph.scss
@@ -14,7 +14,7 @@ limitations under the License.
 @use '@carbon/react/scss/config' as *;
 @use '@carbon/react/scss/theme' as *;
 
-@import '@carbon/charts-react/styles.css';
+@import '@carbon/charts-react/styles';
 
 .#{$prefix}--cc--card-node {
   &.card-status-success {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
For some reason `@carbon/charts-react/styles.css` isn't bundled correctly in the production Storybook build, even though the entry in the package's package.json point to the same location as `@carbon/charts-react/styles`. Drop the extension so the production build loads as expected.

The dev build was unaffected and continues to load the same content.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
