### PR TITLE
Add optional prop to PipelineRuns component for react-router v5 compatibility

### DIFF
--- a/packages/components/src/components/PipelineRuns/PipelineRuns.jsx
+++ b/packages/components/src/components/PipelineRuns/PipelineRuns.jsx
@@ -115,6 +115,7 @@ const PipelineRuns = ({
   },
   getPipelineRunURL = urls.pipelineRuns.byName,
   getRunActions = () => [],
+  LinkComponent = Link,
   loading,
   pipelineRuns,
   selectedNamespace,
@@ -199,9 +200,9 @@ const PipelineRuns = ({
         <div>
           <span>
             {pipelineRunURL ? (
-              <Link to={pipelineRunURL} title={pipelineRunNameTooltip}>
+              <LinkComponent to={pipelineRunURL} title={pipelineRunNameTooltip}>
                 {pipelineRunName}
-              </Link>
+              </LinkComponent>
             ) : (
               pipelineRunName
             )}
@@ -219,9 +220,12 @@ const PipelineRuns = ({
           <span>
             {(pipelineRefName &&
               (pipelineRunsByPipelineURL ? (
-                <Link to={pipelineRunsByPipelineURL} title={pipelineRefName}>
+                <LinkComponent
+                  to={pipelineRunsByPipelineURL}
+                  title={pipelineRefName}
+                >
                   {pipelineRefName}
-                </Link>
+                </LinkComponent>
               ) : (
                 <span title={`Pipeline: ${pipelineRefName || '-'}`}>
                   {pipelineRefName}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Add an optional prop `LinkComponent` to the `PipelineRuns` component to provide backwards compatibility with consumers still using `react-router-dom@5.x`.

This can be provided to continue using `react-router-dom@5.x`'s `Link` component, or other custom links components as needed.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
