### PR TITLE
Resolve a11y warning on tabs

### DIFF
--- a/packages/components/src/components/ResourceDetails/ResourceDetails.jsx
+++ b/packages/components/src/components/ResourceDetails/ResourceDetails.jsx
@@ -83,14 +83,16 @@ const ResourceDetails = ({
         {actions}
       </div>
       <Tabs
-        aria-label={intl.formatMessage({
-          id: 'dashboard.resourceDetails.ariaLabel',
-          defaultMessage: 'Resource details'
-        })}
         onChange={event => onViewChange(tabs[event.selectedIndex])}
         selectedIndex={selectedTabIndex}
       >
-        <TabList activation="manual">
+        <TabList
+          activation="manual"
+          aria-label={intl.formatMessage({
+            id: 'dashboard.resourceDetails.ariaLabel',
+            defaultMessage: 'Resource details'
+          })}
+        >
           <Tab>
             {intl.formatMessage({
               id: 'dashboard.resource.overviewTab',

--- a/packages/components/src/components/StepDetails/StepDetails.jsx
+++ b/packages/components/src/components/StepDetails/StepDetails.jsx
@@ -59,11 +59,10 @@ const StepDetails = ({
         taskRun={taskRun}
       />
       <Tabs
-        aria-label="Step details"
         onChange={event => onViewChange(tabs[event.selectedIndex])}
         selectedIndex={selectedTabIndex}
       >
-        <TabList activation="manual">
+        <TabList activation="manual" aria-label="Step details">
           <Tab>
             {intl.formatMessage({
               id: 'dashboard.taskRun.logs',

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
@@ -278,11 +278,12 @@ const TaskRunDetails = ({
         type="taskRun"
       />
       <Tabs
-        aria-label="TaskRun details"
         onChange={event => onViewChange(tabs[event.selectedIndex])}
         selectedIndex={selectedTabIndex}
       >
-        <TabList activation="manual">{tabList}</TabList>
+        <TabList activation="manual" aria-label="TaskRun details">
+          {tabList}
+        </TabList>
         <TabPanels>{tabPanels}</TabPanels>
       </Tabs>
     </div>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This was missed as part of the Carbon 11 migration.

The `aria-label` prop should be applied to the `TabList` in Carbon 11, where it was on the `Tabs` components previously in Carbon 10.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
