### PR TITLE
Replace remaining use of useState in stories with useArgs

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.jsx
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useState } from 'react';
+import { useArgs } from '@storybook/preview-api';
 import { labels as labelConstants } from '@tektoncd/dashboard-utils';
 
 import PipelineRun from '.';
@@ -163,79 +163,72 @@ const pipelineRunWithMinimalStatus = {
 };
 
 export default {
+  args: {
+    selectedStepId: undefined,
+    selectedTaskId: undefined,
+    view: undefined
+  },
   component: PipelineRun,
   decorators: [Story => <Story />],
   title: 'PipelineRun'
 };
 
-export const Default = () => {
-  const [selectedStepId, setSelectedStepId] = useState();
-  const [selectedTaskId, setSelectedTaskId] = useState();
-  const [view, setView] = useState();
+export const Default = args => {
+  const [, updateArgs] = useArgs();
 
   return (
     <PipelineRun
+      {...args}
       fetchLogs={() => 'sample log output'}
       handleTaskSelected={({
         selectedStepId: stepId,
         selectedTaskId: taskId
       }) => {
-        setSelectedStepId(stepId);
-        setSelectedTaskId(taskId);
+        updateArgs({ selectedStepId: stepId, selectedTaskId: taskId });
       }}
-      onViewChange={selectedView => setView(selectedView)}
+      onViewChange={selectedView => updateArgs({ view: selectedView })}
       pipelineRun={pipelineRun}
-      selectedStepId={selectedStepId}
-      selectedTaskId={selectedTaskId}
       taskRuns={[taskRun, taskRunWithWarning]}
       tasks={[task]}
-      view={view}
     />
   );
 };
 
-export const WithMinimalStatus = () => {
-  const [selectedStepId, setSelectedStepId] = useState();
-  const [selectedTaskId, setSelectedTaskId] = useState();
-  const [view, setView] = useState();
+export const WithMinimalStatus = args => {
+  const [, updateArgs] = useArgs();
 
   return (
     <PipelineRun
+      {...args}
       fetchLogs={() => 'sample log output'}
       handleTaskSelected={({
         selectedStepId: stepId,
         selectedTaskId: taskId
       }) => {
-        setSelectedStepId(stepId);
-        setSelectedTaskId(taskId);
+        updateArgs({ selectedStepId: stepId, selectedTaskId: taskId });
       }}
-      onViewChange={selectedView => setView(selectedView)}
+      onViewChange={selectedView => updateArgs({ view: selectedView })}
       pipelineRun={pipelineRunWithMinimalStatus}
-      selectedStepId={selectedStepId}
-      selectedTaskId={selectedTaskId}
       taskRuns={[taskRun, taskRunWithWarning]}
       tasks={[task]}
-      view={view}
     />
   );
 };
 
-export const WithPodDetails = () => {
-  const [selectedStepId, setSelectedStepId] = useState();
-  const [selectedTaskId, setSelectedTaskId] = useState();
-  const [view, setView] = useState();
+export const WithPodDetails = args => {
+  const [, updateArgs] = useArgs();
 
   return (
     <PipelineRun
+      {...args}
       fetchLogs={() => 'sample log output'}
       handleTaskSelected={({
         selectedStepId: stepId,
         selectedTaskId: taskId
       }) => {
-        setSelectedStepId(stepId);
-        setSelectedTaskId(taskId);
+        updateArgs({ selectedStepId: stepId, selectedTaskId: taskId });
       }}
-      onViewChange={selectedView => setView(selectedView)}
+      onViewChange={selectedView => updateArgs({ view: selectedView })}
       pipelineRun={pipelineRun}
       pod={{
         events: [
@@ -298,11 +291,8 @@ export const WithPodDetails = () => {
           }
         }
       }}
-      selectedStepId={selectedStepId}
-      selectedTaskId={selectedTaskId}
       taskRuns={[taskRun]}
       tasks={[task]}
-      view={view}
     />
   );
 };

--- a/packages/components/src/components/Task/Task.stories.jsx
+++ b/packages/components/src/components/Task/Task.stories.jsx
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/preview-api';
 
 import Task from './Task';
 
@@ -20,6 +20,7 @@ export default {
   args: {
     displayName: 'A Task',
     onSelect: action('selected'),
+    selectedStepId: undefined,
     taskRun: {}
   },
   component: Task,
@@ -51,14 +52,16 @@ export const Pending = { args: { ...Unknown.args, reason: 'Pending' } };
 export const Running = { args: { ...Unknown.args, reason: 'Running' } };
 
 export const Expanded = args => {
-  const [selectedStepId, setSelectedStepId] = useState();
+  const [, updateArgs] = useArgs();
+
   return (
     <Task
       {...args}
       expanded
-      onSelect={({ selectedStepId: stepId }) => setSelectedStepId(stepId)}
+      onSelect={({ selectedStepId: stepId }) =>
+        updateArgs({ selectedStepId: stepId })
+      }
       reason="Running"
-      selectedStepId={selectedStepId}
       steps={[
         { name: 'lint', terminated: { exitCode: 0, reason: 'Completed' } },
         { name: 'test', terminated: { exitCode: 1, reason: 'Completed' } },

--- a/packages/components/src/components/TaskTree/TaskTree.stories.jsx
+++ b/packages/components/src/components/TaskTree/TaskTree.stories.jsx
@@ -11,12 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useState } from 'react';
+import { useArgs } from '@storybook/preview-api';
 
 import TaskTree from './TaskTree';
 
 export default {
   args: {
+    selectedStepId: undefined,
+    selectedTaskId: undefined,
     taskRuns: [
       {
         metadata: {
@@ -80,18 +82,14 @@ export default {
 
 export const Default = {
   render: args => {
-    const [selectedStepId, setSelectedStepId] = useState();
-    const [selectedTaskId, setSelectedTaskId] = useState();
+    const [, updateArgs] = useArgs();
 
     return (
       <TaskTree
         {...args}
         onSelect={({ selectedStepId: stepId, selectedTaskId: taskId }) => {
-          setSelectedStepId(stepId);
-          setSelectedTaskId(taskId);
+          updateArgs({ selectedStepId: stepId, selectedTaskId: taskId });
         }}
-        selectedStepId={selectedStepId}
-        selectedTaskId={selectedTaskId}
       />
     );
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This means we can expose the props in the story's args, making them available in the Controls tab in Storybook and helps with documenting use of the components.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
