### PR TITLE
Update peerDependencies to allow react-router-dom v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17877,7 +17877,7 @@
         "react": "^16.14.0 || ^17.0.2",
         "react-dom": "^16.14.0 || ^17.0.2",
         "react-intl": "^6.4.1",
-        "react-router-dom": "^6.0.0"
+        "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
     "packages/e2e": {
@@ -17923,7 +17923,7 @@
         "npm": "^10.7.0"
       },
       "peerDependencies": {
-        "react-router-dom": "^6.0.0"
+        "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     }
   }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,7 +32,7 @@
     "react": "^16.14.0 || ^17.0.2",
     "react-dom": "^16.14.0 || ^17.0.2",
     "react-intl": "^6.4.1",
-    "react-router-dom": "^6.0.0"
+    "react-router-dom": "^5.0.0 || ^6.0.0"
   },
   "engines": {
     "node": "^20.14.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "scripts": {},
   "peerDependencies": {
-    "react-router-dom": "^6.0.0"
+    "react-router-dom": "^5.0.0 || ^6.0.0"
   },
   "engines": {
     "node": "^20.14.0",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/3531 to allow installation of the packages using react-router-dom v5 without `--force` or equivalent.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
