### PR TITLE
Add missing API root for external logs requests

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -153,7 +153,7 @@ export function getExternalLogURL({
   if (queryString) {
     queryString = `?${queryString}`;
   }
-  return `${externalLogsURL}/${namespace}/${podName}/${container}${queryString}`;
+  return `${getAPIRoot({ isDashboardAPI: true })}${externalLogsURL}/${namespace}/${podName}/${container}${queryString}`;
 }
 
 export function getPodLogURL({ container, name, namespace, follow }) {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -156,7 +156,7 @@ it('useEvents', async () => {
 
 it('getExternalLogURL', () => {
   const container = 'fake_container';
-  const externalLogsURL = 'fake_externalLogsURL';
+  const externalLogsURL = '/fake_externalLogsURL';
   const namespace = 'fake_namespace';
   const podName = 'fake_podName';
   const startTime = '2000-01-02T03:04:05Z';
@@ -171,7 +171,7 @@ it('getExternalLogURL', () => {
       startTime
     })
   ).toEqual(
-    `${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
+    `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
       ':',
       '%3A'
     )}&completionTime=${completionTime.replaceAll(':', '%3A')}`
@@ -180,7 +180,7 @@ it('getExternalLogURL', () => {
 
 it('getExternalLogURL with empty completionTime', () => {
   const container = 'fake_container';
-  const externalLogsURL = 'fake_externalLogsURL';
+  const externalLogsURL = '/fake_externalLogsURL';
   const namespace = 'fake_namespace';
   const podName = 'fake_podName';
   const startTime = '2000-01-02T03:04:05Z';
@@ -193,7 +193,7 @@ it('getExternalLogURL with empty completionTime', () => {
       startTime
     })
   ).toEqual(
-    `${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
+    `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
       ':',
       '%3A'
     )}`
@@ -202,12 +202,14 @@ it('getExternalLogURL with empty completionTime', () => {
 
 it('getExternalLogURL with empty startTime and completionTime', () => {
   const container = 'fake_container';
-  const externalLogsURL = 'fake_externalLogsURL';
+  const externalLogsURL = '/fake_externalLogsURL';
   const namespace = 'fake_namespace';
   const podName = 'fake_podName';
   expect(
     API.getExternalLogURL({ container, externalLogsURL, namespace, podName })
-  ).toEqual(`${externalLogsURL}/${namespace}/${podName}/${container}`);
+  ).toEqual(
+    `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}`
+  );
 });
 
 it('getPodLog', () => {

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -133,7 +133,7 @@ describe('fetchLogsFallback', () => {
 
   it('should return a function to retrieve logs from the external provider', () => {
     const container = 'fake_container';
-    const externalLogsURL = 'fake_url';
+    const externalLogsURL = '/fake_url';
     const namespace = 'fake_namespace';
     const podName = 'fake_podName';
     const stepName = 'fake_stepName';
@@ -149,7 +149,7 @@ describe('fetchLogsFallback', () => {
     const fallback = fetchLogsFallback(externalLogsURL);
     fallback(stepName, stepStatus, taskRun);
     expect(comms.get).toHaveBeenCalledWith(
-      `${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
+      `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}?startTime=${startTime.replaceAll(
         ':',
         '%3A'
       )}&completionTime=${completionTime.replaceAll(':', '%3A')}`,
@@ -159,7 +159,7 @@ describe('fetchLogsFallback', () => {
 
   it('should handle a missing startTime and completionTime', () => {
     const container = 'fake_container';
-    const externalLogsURL = 'fake_url';
+    const externalLogsURL = '/fake_url';
     const namespace = 'fake_namespace';
     const podName = 'fake_podName';
     const stepName = 'fake_stepName';
@@ -170,7 +170,7 @@ describe('fetchLogsFallback', () => {
     const fallback = fetchLogsFallback(externalLogsURL);
     fallback(stepName, stepStatus, taskRun);
     expect(comms.get).toHaveBeenCalledWith(
-      `${externalLogsURL}/${namespace}/${podName}/${container}`,
+      `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}`,
       { Accept: 'text/plain' }
     );
   });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/3606
Replaces https://github.com/tektoncd/dashboard/pull/3607

Somehow the external logs APIs in the client never used the API root when constructing the URL. This means that if the Dashboard is deployed at a non-root path, the requests never made it to the logs proxy.

Update the external logs URL util to include the API root in the same manner as we already do for all other APIs.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
