### PR TITLE
Sort matrix TaskRuns by display name on the PipelineRun details page

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -511,8 +511,9 @@ export function getTaskRunsWithPlaceholders({
       }
       return acc;
     }, {});
+    const taskRunsToSort = [];
     realTaskRuns.forEach(taskRun => {
-      taskRunsToDisplay.push(
+      taskRunsToSort.push(
         addDashboardLabels({
           displayName: displayNames[taskRun.metadata.name],
           pipelineTask,
@@ -520,8 +521,24 @@ export function getTaskRunsWithPlaceholders({
         })
       );
     });
-
-    if (!realTaskRuns.length) {
+    if (taskRunsToSort.length) {
+      // sort by display name to provide a stable order in the UI
+      // if there's no display name stick with the source order
+      if (
+        taskRunsToSort[0].metadata.labels[labelConstants.DASHBOARD_DISPLAY_NAME]
+      ) {
+        // sort only if at least one of the TaskRuns has a display name,
+        // it's likely they all do in that case (e.g. matrix TaskRuns)
+        taskRunsToSort.sort((taskRunA, taskRunB) => {
+          const displayNameA =
+            taskRunA.metadata.labels[labelConstants.DASHBOARD_DISPLAY_NAME];
+          const displayNameB =
+            taskRunB.metadata.labels[labelConstants.DASHBOARD_DISPLAY_NAME];
+          return displayNameA.localeCompare(displayNameB);
+        });
+      }
+      taskRunsToDisplay.push(...taskRunsToSort);
+    } else {
       taskRunsToDisplay.push(
         addDashboardLabels({
           pipelineTask,

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -849,6 +849,11 @@ describe('getTaskRunsWithPlaceholders', () => {
     const displayName = 'aDisplayName';
     const pipelineTaskName = 'aPipelineTaskName';
     const taskRunName = 'aTaskRunName';
+    const matrixPipelineTaskName = 'aMatrixPipelineTaskName';
+    const matrixTaskRunName1 = 'matrixTaskRun1';
+    const matrixTaskRunName2 = 'matrixTaskRun2';
+    const matrixTaskRunDisplayName1 = 'matrixRunDisplayName1';
+    const matrixTaskRunDisplayName2 = 'matrixRunDisplayName2';
 
     const pipelineRun = {
       spec: {
@@ -859,15 +864,28 @@ describe('getTaskRunsWithPlaceholders', () => {
       status: {
         childReferences: [
           {
+            displayName: matrixTaskRunDisplayName2,
+            name: matrixTaskRunName2,
+            pipelineTaskName: matrixPipelineTaskName
+          },
+          {
             displayName,
             name: taskRunName,
             pipelineTaskName
+          },
+          {
+            displayName: matrixTaskRunDisplayName1,
+            name: matrixTaskRunName1,
+            pipelineTaskName: matrixPipelineTaskName
           }
         ],
         pipelineSpec: {
           tasks: [
             {
               name: pipelineTaskName
+            },
+            {
+              name: matrixPipelineTaskName
             }
           ]
         }
@@ -881,12 +899,36 @@ describe('getTaskRunsWithPlaceholders', () => {
         name: taskRunName
       }
     };
+    const matrixTaskRun1 = {
+      metadata: {
+        labels: {
+          [labels.PIPELINE_TASK]: matrixPipelineTaskName
+        },
+        name: matrixTaskRunName1
+      }
+    };
+    const matrixTaskRun2 = {
+      metadata: {
+        labels: {
+          [labels.PIPELINE_TASK]: matrixPipelineTaskName
+        },
+        name: matrixTaskRunName2
+      }
+    };
+
     const runs = getTaskRunsWithPlaceholders({
       pipelineRun,
-      taskRuns: [taskRun]
+      taskRuns: [matrixTaskRun2, taskRun, matrixTaskRun1]
     });
+    // sorts matrix TaskRuns by display name
     expect(runs[0].metadata.labels[labels.DASHBOARD_DISPLAY_NAME]).toEqual(
       displayName
+    );
+    expect(runs[1].metadata.labels[labels.DASHBOARD_DISPLAY_NAME]).toEqual(
+      matrixTaskRunDisplayName1
+    );
+    expect(runs[2].metadata.labels[labels.DASHBOARD_DISPLAY_NAME]).toEqual(
+      matrixTaskRunDisplayName2
     );
   });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/3613

To ensure a stable order when showing the matrix TaskRuns in the UI, sort by display name. This should also work for custom tasks that produce multiple TaskRuns.

If there is no display name we maintain the source order, so there is no change to the user experience in that case.
/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Use TaskRun display names to provide a stable sort order when displaying matrixed TaskRuns on the PipelineRun details page.
```
