### PR TITLE
Reduce flakiness in create and edit E2E tests

### DIFF
--- a/packages/e2e/cypress/e2e/run/pipelinerun-create.cy.js
+++ b/packages/e2e/cypress/e2e/run/pipelinerun-create.cy.js
@@ -45,6 +45,8 @@ spec:
     cy.visit(
       `/#/pipelineruns/create?namespace=${namespace}&pipelineName=${pipelineName}`
     );
+    cy.contains('h1', 'Create PipelineRun');
+
     cy.get('[id=create-pipelinerun--namespaces-dropdown]').should(
       'have.value',
       namespace
@@ -58,10 +60,13 @@ spec:
 
     cy.contains('h1', 'PipelineRuns');
     cy.contains('a', `${pipelineName}-run`).click();
+    cy.contains('h1', `${pipelineName}-run`);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
@@ -92,6 +97,8 @@ spec:
     cy.visit(
       `/#/pipelineruns/create?namespace=${namespace}&pipelineName=${pipelineName}`
     );
+    cy.contains('h1', 'Create PipelineRun');
+
     cy.get('[id=create-pipelinerun--namespaces-dropdown]').should(
       'have.value',
       namespace
@@ -116,10 +123,13 @@ spec:
 
     cy.contains('h1', 'PipelineRuns');
     cy.contains('a', pipelineRunName).click();
+    cy.contains('h1', pipelineRunName);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
@@ -158,10 +168,13 @@ spec:
 
     cy.contains('h1', 'PipelineRuns');
     cy.get(`[title=${pipelineRunName}]`).click();
+    cy.contains('h1', pipelineRunName);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
@@ -201,6 +214,8 @@ spec:
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');

--- a/packages/e2e/cypress/e2e/run/pipelinerun-edit.cy.js
+++ b/packages/e2e/cypress/e2e/run/pipelinerun-edit.cy.js
@@ -46,6 +46,8 @@ spec:
     cy.visit(
       `/#/pipelineruns/create?namespace=${namespace}&pipelineName=${pipelineName}`
     );
+    cy.contains('h1', 'Create PipelineRun');
+
     cy.get('[id=create-pipelinerun--namespaces-dropdown]').should(
       'have.value',
       namespace

--- a/packages/e2e/cypress/e2e/run/taskrun-create.cy.js
+++ b/packages/e2e/cypress/e2e/run/taskrun-create.cy.js
@@ -40,6 +40,8 @@ spec:
     `;
     cy.applyResource(task);
     cy.visit(`/#/taskruns/create?namespace=${namespace}&taskName=${taskName}`);
+    cy.contains('h1', 'Create TaskRun');
+
     cy.get('[id=create-taskrun--namespaces-dropdown]').should(
       'have.value',
       namespace
@@ -53,10 +55,13 @@ spec:
 
     cy.contains('h1', 'TaskRuns');
     cy.contains('a', `${taskName}-run`).click();
+    cy.contains('h1', `${taskName}-run`);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
@@ -82,6 +87,7 @@ spec:
       `;
     cy.applyResource(task);
     cy.visit(`/#/taskruns/create?namespace=${namespace}&taskName=${taskName}`);
+    cy.contains('h1', 'Create TaskRun');
     cy.get('[id=create-taskrun--namespaces-dropdown]').should(
       'have.value',
       namespace
@@ -106,10 +112,13 @@ spec:
 
     cy.contains('h1', 'TaskRuns');
     cy.contains('a', taskRunName).click();
+    cy.contains('h1', taskRunName);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
@@ -145,10 +154,13 @@ spec:
 
     cy.contains('h1', 'TaskRuns');
     cy.get(`[title=${taskRunName}]`).click();
+    cy.contains('h1', taskRunName);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
@@ -181,10 +193,13 @@ spec:
 
     cy.contains('h1', 'TaskRuns');
     cy.get(`[title=${taskRunName}]`).click();
+    cy.contains('h1', taskRunName);
 
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
+
+    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');

--- a/packages/e2e/cypress/e2e/run/taskrun-edit.cy.js
+++ b/packages/e2e/cypress/e2e/run/taskrun-edit.cy.js
@@ -41,6 +41,7 @@ spec:
     `;
     cy.applyResource(task);
     cy.visit(`/#/taskruns/create?namespace=${namespace}&taskName=${taskName}`);
+    cy.contains('h1', 'Create TaskRun');
     cy.get('[id=create-taskrun--namespaces-dropdown]').should(
       'have.value',
       namespace


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Reduce the incidents of flakiness encountered when running the E2E tests locally on some machines. We have not encountered this flakiness in CI, but the changes should have no negative impact.

- Wait for new page header after navigation. This helps to reduce the likelihood of timeouts when attempting to interact with controls on the destination page
- Ensure the step details are loaded before making assertions based on the log content

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
