### PR TITLE
Pin images used for the release pipeline

### DIFF
--- a/tekton/build.yaml
+++ b/tekton/build.yaml
@@ -22,7 +22,7 @@ spec:
     - name: source
   steps:
     - name: build-static
-      image: docker.io/library/node:20.14-slim
+      image: docker.io/library/node:20.17.0-slim@sha256:df85129996d6b7a4ec702ebf2142cfa683f28b1d33446faec12168d122d3410d
       workingDir: $(workspaces.source.path)
       env:
         - name: CI

--- a/tekton/prerelease-checks.yaml
+++ b/tekton/prerelease-checks.yaml
@@ -32,7 +32,7 @@ spec:
       description: The workspace where the repo has been cloned
   steps:
     - name: check-git-tag
-      image: docker.io/alpine/git
+      image: docker.io/alpine/git:2.45.2@sha256:7d612867d6b2f12be0827bc70833bac7204791871c80d7c852a336479ba99104
       script: |
         echo "Checking git tag"
         # Look for the tag in the list of tags
@@ -53,7 +53,7 @@ spec:
           exit 1
         fi
     - name: check-github-release
-      image: docker.io/library/python:3.6-alpine3.9
+      image: docker.io/library/python:3.6-alpine3.9@sha256:368f69f11e002a63d587791bb9652009dbb19a85f015698eac40d687e6f4ab19
       script: |
         echo "Checking GitHub release"
         PACKAGE=$(echo $(params.package) | cut -d/ -f2,3)
@@ -65,7 +65,7 @@ spec:
         echo "Release $(params.versionTag) already exists for $(params.package)"
         exit 1
     - name: success-confirmation
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
       script: |
         echo "All pre-release checks for $(params.package) @ $(params.versionTag) were successful"
         echo "Happy releasing 😺"

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -71,7 +71,7 @@ spec:
     - name: IMAGES
   steps:
     - name: container-registry-auth
-      image: gcr.io/go-containerregistry/crane:debug
+      image: gcr.io/go-containerregistry/crane:debug@sha256:ff0e08eeae8097d28b2381c7f7123bf542757abc68d11bff58fb882b72843785
       script: |
         #!/busybox/sh
         set -ex
@@ -90,7 +90,7 @@ spec:
         cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
     - name: run-ko
-      image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+      image: gcr.io/tekton-releases/dogfooding/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
       env:
         - name: KO_DOCKER_REPO
           value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -130,7 +130,7 @@ spec:
         ./scripts/installer release --debug --read-write --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/release-full.yaml
 
     - name: koparse
-      image: gcr.io/tekton-releases/dogfooding/koparse:latest
+      image: gcr.io/tekton-releases/dogfooding/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
       script: |
         set -ex
 
@@ -147,7 +147,7 @@ spec:
           --base ${IMAGES_PATH} --images ${IMAGES} > /workspace/built_images
 
     - name: tag-images
-      image: gcr.io/go-containerregistry/crane:debug
+      image: gcr.io/go-containerregistry/crane:debug@sha256:ff0e08eeae8097d28b2381c7f7123bf542757abc68d11bff58fb882b72843785
       script: |
         #!/busybox/sh
         set -ex

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -180,7 +180,7 @@ spec:
             type: string
         steps:
           - name: create-results
-            image: docker.io/library/alpine
+            image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
             script: |
               BASE_URL=$(echo "$(params.releaseBucket)/previous/$(params.versionTag)")
               # If the bucket is in the gs:// return the corresponding public https URL


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/plumbing/issues/2197

All images used in the release pipeline (including for nightly releases) should be pinned by specifying the digest to use.

Update Node.js to 20.17 as part of this change.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
