### PR TITLE
Fix global namespaces dropdown loading styles

### DIFF
--- a/packages/components/src/components/TooltipDropdown/TooltipDropdown.jsx
+++ b/packages/components/src/components/TooltipDropdown/TooltipDropdown.jsx
@@ -35,12 +35,12 @@ const TooltipDropdown = ({
   disabled,
   emptyText,
   id,
-  inline,
   items = defaults.items,
   label,
   loading = false,
   onChange,
   selectedItem,
+  size = 'md',
   titleText,
   ...rest
 }) => {
@@ -55,9 +55,9 @@ const TooltipDropdown = ({
           <span className={`${carbonPrefix}--label`}>{titleText}</span>
         )}
         <DropdownSkeleton
-          className={`${carbonPrefix}--combo-box ${className || ''}`}
+          className={`${carbonPrefix}--combo-box ${carbonPrefix}--list-box ${carbonPrefix}--list-box--${size} ${className || ''}`}
+          hideLabel
           id={id}
-          inline={inline}
         />
       </div>
     );
@@ -87,13 +87,13 @@ const TooltipDropdown = ({
         }
       })}
       id={id}
-      inline={inline}
       items={options}
       itemToString={itemToString}
       key={key}
       onChange={onChange}
       placeholder={options.length === 0 ? emptyString : label}
       selectedItem={selectedItem}
+      size={size}
       titleText={titleText}
       translateWithId={getTranslateWithId(intl)}
       {...rest}

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -95,6 +95,10 @@ body {
   margin-inline-start: 16rem;
 }
 
+.#{$prefix}--header .#{$prefix}--list-box__wrapper:has(.#{$prefix}--list-box.#{$prefix}--skeleton) {
+  inline-size: 245px;
+}
+
 .#{$prefix}--modal-header,
 .#{$prefix}--modal-content {
   inline-size: 100%;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
With the move to Carbon 11 the ComboBox and Dropdown skeleton states have changes, and the component props are slightly different.

Remove the obsolete `inline` prop, and update the styles to account for the updated components to prevent the loading styles overflowing the header and causing a layout shift on other pages too.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
