### PR TITLE
Replace the deprecated `element` prop with `as` in Carbon components

### DIFF
--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -131,7 +131,7 @@ function Root() {
         render={({ isSideNavExpanded, onClickSideNavExpand }) => (
           <Header
             headerNameProps={{
-              element: HeaderNameLink
+              as: HeaderNameLink
             }}
             isSideNavExpanded={isSideNavExpanded}
             onHeaderMenuButtonClick={onClickSideNavExpand}

--- a/src/containers/SideNav/SideNav.jsx
+++ b/src/containers/SideNav/SideNav.jsx
@@ -59,7 +59,7 @@ function SideNav({ expanded, showKubernetesResources = false }) {
 
   function getMenuItemProps(to) {
     return {
-      element: NavLink,
+      as: NavLink,
       isActive: !!matchPath(
         {
           path: to


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
