### PR TITLE
Update E2E to use new base image with Node.js 20.17 and Chrome 129

### DIFF
--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/tekton-releases/dogfooding/dashboard-e2e-base:node20.14.0-chrome126
+FROM gcr.io/tekton-releases/dogfooding/dashboard-e2e-base:node20.17.0-chrome129@sha256:823219d58f96726fa25d79571ec236c4bf672ceec961c79ded77b1eeafd858a3
 
 ENTRYPOINT ["npm", "run", "test:ci"]
 CMD ["--", "--browser", "chrome"]

--- a/packages/e2e/base-image/Dockerfile
+++ b/packages/e2e/base-image/Dockerfile
@@ -16,7 +16,7 @@
 ARG CHROME_VERSION='129.0.6668.58-1'
 ARG NODE_VERSION='20.17.0'
 
-FROM cypress/factory
+FROM cypress/factory@sha256:2fd35ba020a43beefb3de43c1dfc56d36b2dd3ebb261955f4185d28737957a3f
 
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates curl gpg &&\
     mkdir -p /etc/apt/keyrings &&\


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/3632 now that the new E2E base image has been published.

Also pin the image version using the image digest

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
