### PR TITLE
Revert Carbon to 1.65 due to regression introduced in 1.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "packages/e2e"
       ],
       "dependencies": {
-        "@carbon/react": "^1.66.0",
+        "@carbon/react": "^1.65.0",
         "@codemirror/legacy-modes": "^6.4.1",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.36.1",
@@ -524,16 +524,16 @@
       }
     },
     "node_modules/@carbon/react": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-1.66.0.tgz",
-      "integrity": "sha512-zbTheHe500QpLBpZdrbASKV2N6ddKVcoQpBJjLiXMaLH7YbwOmz4y+6Q7S71JFJgQWndkSbfolC8zG04N1a7LA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-1.65.0.tgz",
+      "integrity": "sha512-xjxSpAymOvlWheZYaytdsIQ/cnoPdqKhCroxP1/lKiqbVOD9eBGQ2OAs1RErlMretHqQKpx8Cow8YqjSpQkZ8A==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@carbon/feature-flags": "^0.22.0",
-        "@carbon/icons-react": "^11.49.0",
-        "@carbon/layout": "^11.26.0",
-        "@carbon/styles": "^1.65.0",
+        "@carbon/icons-react": "^11.48.0",
+        "@carbon/layout": "^11.25.0",
+        "@carbon/styles": "^1.64.0",
         "@floating-ui/react": "^0.26.0",
         "@ibm/telemetry-js": "^1.5.0",
         "classnames": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@carbon/react": "^1.66.0",
+    "@carbon/react": "^1.65.0",
     "@codemirror/legacy-modes": "^6.4.1",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to `https://github.com/carbon-design-system/carbon/issues/17450`

`@carbon/react@1.66.0` introduced a regression related to the `autoAlign` prop on a number of components. This results in the tooltip being positioned off screen or rendered too small for its content.

Revert to the previous release until the fix is available.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
