### PR TITLE
Fix style issues in Storybook production build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -47,7 +47,9 @@ export default defineConfig(({ mode }) => ({
     target: 'es2022'
   },
   plugins: [
-    createHtmlPlugin({}),
+    // disable CSS minification since we don't use it ourselves and it causes
+    // problems with use of CSS nesting in Storybook production build
+    createHtmlPlugin({ minify: { minifyCSS: false } }),
     react({ devTarget: 'es2022' }),
     svgr(),
     yaml(),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The Storybook production build injects some CSS into the iframe used to render the stories. This uses nesting, which while well supported in browsers, causes issues with some build tooling which is not expecting it.

The `vite-plugin-html` minifies the CSS in any `style` tags by default, but this minification process does not account for nested CSS. The net result of this is that some of the styles which are expected to be scoped to `.sb-errordisplay` end up applying globally instead.

The most obvious manifestation of this was on the PipelineRun details story where there was an additional gap between each Task in the TaskTree caused by an unexpected `li+li` rule.

> [!NOTE]
> This only affected display in the Storybook

Disable CSS minification in the HTML plugin since we don't need this for Storybook, and don't make use of `style` tags as part of the template for the Dashboard application itself.

/kind misc

Before:
![image](https://github.com/user-attachments/assets/86cbed99-61ae-4cf8-9cb3-57f8f3e32187)

After:
![image](https://github.com/user-attachments/assets/0ebc4417-09c6-4093-b343-eeb39d708005)


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
