### PR TITLE
Relax the Carbon version requirement for the components package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14770,7 +14770,7 @@
         "npm": "^10.7.0"
       },
       "peerDependencies": {
-        "@carbon/react": "^1.68.0",
+        "@carbon/react": "^1.65.0",
         "react": "^16.14.0 || ^17.0.2",
         "react-dom": "^16.14.0 || ^17.0.2",
         "react-intl": "^6.4.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
     "tlds": "^1.255.0"
   },
   "peerDependencies": {
-    "@carbon/react": "^1.68.0",
+    "@carbon/react": "^1.65.0",
     "react": "^16.14.0 || ^17.0.2",
     "react-dom": "^16.14.0 || ^17.0.2",
     "react-intl": "^6.4.1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
There are a number of significant changes to the ComboBox component between v1.65 and v1.68. Relax the requirement so consumers of the Dashboard components package can continue using an older Carbon release until they've updated to account for these changes.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
