### PR TITLE
Remove stale version comment from import resources pipeline

### DIFF
--- a/src/api/resources/import-resources-pipelinerun.yaml
+++ b/src/api/resources/import-resources-pipelinerun.yaml
@@ -57,7 +57,7 @@ spec:
             - name: repo
           steps:
             - name: clone
-              image: ghcr.io/wolfi-dev/git:alpine@sha256:c07caa1c1974bed9045fccd12a47ad4de1379341bec5287623a9897aa25c2978  # 2.45
+              image: ghcr.io/wolfi-dev/git:alpine@sha256:c07caa1c1974bed9045fccd12a47ad4de1379341bec5287623a9897aa25c2978
               env:
                 - name: PARAM_URL
                   value: $(params.repositoryURL)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Current version is 2.46.2. The version can be checked as follows:
```
$ docker run -it ghcr.io/wolfi-dev/git:alpine@sha256:97a6342c97dbdf38df0c83dbe623346846636931db0b698af50b1f757905e910 version
git version 2.46.2
```

/kind misc
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
