### PR TITLE
Update E2E to use new base image with Node.js 20.18 and Chrome 130

### DIFF
--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/tekton-releases/dogfooding/dashboard-e2e-base:node20.17.0-chrome129@sha256:823219d58f96726fa25d79571ec236c4bf672ceec961c79ded77b1eeafd858a3
+FROM gcr.io/tekton-releases/dogfooding/dashboard-e2e-base:node20.18.0-chrome130@sha256:02918ee549ed9c8cb996e9b8da15069551f266b1df07c46acc36f0c4051f4a2d
 
 ENTRYPOINT ["npm", "run", "test:ci"]
 CMD ["--", "--browser", "chrome"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/3719 now that the new base image is published.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
