### PR TITLE
Move remaining use of Tekton-produced images from gcr.io to ghcr.io

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ This guide explains how to install Tekton Dashboard. It covers the following top
 Choose the version of Tekton Dashboard you want to install. You have the following options:
 
 - **[Official](https://github.com/tektoncd/dashboard/releases)** - install this unless you have a specific reason to go for a different release.
-- **[Nightly](https://gcr.io/tekton-nightly)** - may contain bugs, install at your own risk.
+- **[Nightly](https://ghcr.io/tektoncd/dashboard)** - may contain bugs, install at your own risk.
 - **[`HEAD`]** - this is the bleeding edge. It contains unreleased code that may result in unpredictable behavior. To get started, see the [development guide](../DEVELOPMENT.md) instead of this page.
 
 ## Pre-requisites

--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/tekton-releases/dogfooding/dashboard-e2e-base:node20.18.0-chrome130@sha256:02918ee549ed9c8cb996e9b8da15069551f266b1df07c46acc36f0c4051f4a2d
+FROM ghcr.io/tektoncd/dashboard/dashboard-e2e-base:node20.18.0-chrome130@sha256:d1f3068cfb5ec95eb6e3e732788bf70e4c88c43d491a031d953b0c312e66c23d
 
 ENTRYPOINT ["npm", "run", "test:ci"]
 CMD ["--", "--browser", "chrome"]

--- a/packages/e2e/base-image/Dockerfile
+++ b/packages/e2e/base-image/Dockerfile
@@ -18,6 +18,11 @@ ARG NODE_VERSION='20.18.0'
 
 FROM cypress/factory@sha256:18e552026e3b2a33041a99417823d1ff2a016ff5ab3866cd9743d91410981797
 
+LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+LABEL org.opencontainers.image.source=https://github.com/tektoncd/dashboard
+LABEL org.opencontainers.image.description="Base image for Tekton Dashboard E2E tests"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates curl gpg &&\
     mkdir -p /etc/apt/keyrings &&\
     curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg &&\

--- a/packages/e2e/base-image/tekton/README.md
+++ b/packages/e2e/base-image/tekton/README.md
@@ -11,7 +11,7 @@ To create a release:
   kubectl create job --from=cronjob/image-build-cron-trigger-dashboard-e2e-base dashboard-e2e-base-$(date +"%Y%m%d-%H%M")
   ```
 - check the status of the [resulting `PipelineRun`](https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns?labelSelector=plumbing.tekton.dev%2Fimage%3Ddashboard-e2e-base)
-- confirm the image was [released and properly tagged](https://console.cloud.google.com/gcr/images/tekton-releases/global/dogfooding/dashboard-e2e-base)
+- confirm the image was [released and properly tagged](https://github.com/tektoncd/dashboard/pkgs/container/dashboard%2Fdashboard-e2e-base)
 - open a PR to update the [E2E test `Dockerfile`](../../Dockerfile) to reference the new image
 
 ## Future: automated releases

--- a/packages/e2e/base-image/tekton/cronjob.yaml
+++ b/packages/e2e/base-image/tekton/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
             - name: SINK_URL
               value: el-image-builder.default.svc.cluster.local:8080
             - name: TARGET_IMAGE
-              value: gcr.io/tekton-releases/dogfooding/dashboard-e2e-base
+              value: ghcr.io/tektoncd/dashboard/dashboard-e2e-base
             - name: CONTEXT_PATH
               value: packages/e2e/base-image
             - name: TAGS

--- a/releases.md
+++ b/releases.md
@@ -15,8 +15,14 @@ as follows:
     - Releases happen towards the middle of the month, between the 13th and the
       20th, depending on week-ends and readiness
 
-Tekton Dashboard produces nightly builds, publicly available on
-`gcr.io/tekton-nightly`. 
+Tekton Dashboard produces nightly builds, publicly available at:
+- [read-only](https://storage.googleapis.com/tekton-releases-nightly/dashboard/latest/release.yaml)
+- [read/write](https://storage.googleapis.com/tekton-releases-nightly/dashboard/latest/release-full.yaml)
+
+The images for Dashboard releases are published to `ghcr.io/tektoncd/dashboard`.
+
+Prior to 26th September 2024, nightly images were published to `gcr.io/tekton-nightly`.
+For release v0.50.x and earlier, release images were published to `gcr.io/tekton-releases`.
 
 ## Release Process
 

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -100,7 +100,7 @@ spec:
         cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
     - name: run-ko
-      image: gcr.io/tekton-releases/dogfooding/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
+      image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20241126-66f4b045c7@sha256:56d30d0c848067ca3ca3307a47f417964366cec33b37a39947adee0086e97550
       env:
         - name: KO_DOCKER_REPO
           value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -144,7 +144,7 @@ spec:
         ./scripts/installer build --debug              --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/release.yaml ${KO_EXTRA_ARGS}
         ./scripts/installer build --debug --read-write --platform $(params.platforms) --tag $(params.versionTag) --output $OUTPUT_RELEASE_DIR/release-full.yaml ${KO_EXTRA_ARGS}
     - name: koparse
-      image: gcr.io/tekton-releases/dogfooding/koparse:v20240923-1c3aa3eee7@sha256:ae363d70e3c2fb75e96aaeb561dcea20383c27a47f0266c8179bbb72b89c2430
+      image: ghcr.io/tektoncd/plumbing/koparse:v20241104-39ec1660b7@sha256:9179221325db56efbe2c7baea05b871454c3f01c6dba438455fb35fe95b772ce
       script: |
         set -ex
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Most images produced by Tekton projects, including tooling built from tektoncd/plumbing, are now consumed from ghcr.io.

The Dashboard E2E base image is now also published to ghcr.io. Update the Dockerfile to include the expected OCI labels. See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images for details.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
