### PR TITLE
Remove unnecessary env files for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/dashboard
+        env:
+          DASHBOARD_MODE: ${{ matrix.dashboard-mode }}
         run: |
           ${{ github.workspace }}/scripts/hack/setup-kind.sh \
             --registry-url $(echo ${KO_DOCKER_REPO} | cut -d'/' -f 1) \
@@ -95,7 +97,7 @@ jobs:
             --nodes 3 \
             --k8s-version ${{ matrix.k8s-version }} \
             --e2e-script ./test/e2e-tests-prow.sh \
-            --e2e-env ./test/e2e-tests-kind-${{ matrix.dashboard-mode }}.env
+            --e2e-env ./test/e2e-tests-kind-prow.env
 
       - name: Upload test results
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/test/e2e-tests-kind-read-only.env
+++ b/test/e2e-tests-kind-read-only.env
@@ -1,3 +1,0 @@
-KO_DOCKER_REPO=registry.local:5000
-SKIP_INITIALIZE=true
-DASHBOARD_MODE=read-only

--- a/test/e2e-tests-kind-read-write.env
+++ b/test/e2e-tests-kind-read-write.env
@@ -1,3 +1,0 @@
-KO_DOCKER_REPO=registry.local:5000
-SKIP_INITIALIZE=true
-DASHBOARD_MODE=read-write


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Define the `DASHBOARD_MODE` env var directly in the workflow using the matrix context instead of indirectly via additional env files duplicating the base config.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
