### PR TITLE
Add retest slash command

### DIFF
--- a/.github/workflows/chatops-retest.yml
+++ b/.github/workflows/chatops-retest.yml
@@ -1,0 +1,9 @@
+name: Rerun Failed Actions
+on:
+  repository_dispatch:
+    types: [retest-command]
+
+jobs:
+  retest:
+    name: Rerun Failed Actions
+    uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@b3abc99873185dfb1d74064e4aa851478d6aaa7c

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -1,0 +1,8 @@
+name: Slash Command Routing
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_comments:
+    uses: tektoncd/plumbing/.github/workflows/_slash.yml@b3abc99873185dfb1d74064e4aa851478d6aaa7c


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Depends on https://github.com/tektoncd/plumbing/pull/2334

Add workflows to enable the retest slash command defined in `tektoncd/plumbing` to allow users to rerun failed jobs on PRs.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
