### PR TITLE
feat: Tekton Results integration DEMO

### DIFF
--- a/base/200-clusterrole-backend.yaml
+++ b/base/200-clusterrole-backend.yaml
@@ -54,3 +54,7 @@ rules:
       - get
       - list
       - watch
+  # Dashboard needs to be able to query existing results.
+  - apiGroups: ["results.tekton.dev"]
+    resources: ["logs", "results", "records"]
+    verbs: ["get", "list"]

--- a/base/300-deployment.yaml
+++ b/base/300-deployment.yaml
@@ -80,3 +80,5 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          # empty volumeMounts is needed for resultsAPI cert mount
+          volumeMounts: []

--- a/docs/dev/results.md
+++ b/docs/dev/results.md
@@ -1,0 +1,16 @@
+# Tekton Dashboard - [Tekton Results](https://github.com/tektoncd/results) API support
+
+Tekton Results aims to help users logically group CI/CD workload history and separate out long term result storage away
+from the Pipeline controller. For more info information, please
+see [Tekton Results](https://github.com/tektoncd/results)
+
+Note: Dashboard for [Tekton Results](https://github.com/tektoncd/results) API support is still at early stage.
+
+## [Tekton Results](https://github.com/tektoncd/results) supporting set-up
+
+1. follow Tekton Results [installation instructions](https://github.com/tektoncd/results/blob/main/docs/install.md)
+2. append `--enable-results` arguments to install, note that `--enable-results` override `--read-write`.
+
+```bash
+./scripts/installer install --enable-results
+```

--- a/overlays/installer/results/kustomization.yaml
+++ b/overlays/installer/results/kustomization.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020-2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../read-only
+patches:
+- path: ../../patches/results/deployment-tls-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-dashboard
+    namespace: tekton-pipelines
+    version: v1

--- a/overlays/patches/results/deployment-tls-patch.yaml
+++ b/overlays/patches/results/deployment-tls-patch.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020-2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: tls
+    secret:
+      secretName: tekton-results-tls
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: tls
+    mountPath: "/etc/tls"
+    readOnly: true
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --enable-results-tls=1
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --results-tls-cert-path=/etc/tls/tls.crt

--- a/packages/components/src/components/TaskRuns/TaskRuns.jsx
+++ b/packages/components/src/components/TaskRuns/TaskRuns.jsx
@@ -138,7 +138,8 @@ const TaskRuns = ({
     const statusIcon = getTaskRunStatusIcon(taskRun);
     const taskRunURL = getTaskRunURL({
       name: taskRunName,
-      namespace
+      namespace,
+      taskRun
     });
 
     const taskRunsURL =

--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -198,11 +198,11 @@ export const paths = {
       return byNamespace({ path: '/triggertemplates' });
     }
   },
-  results: {
-    taskRunsAll() {
+  taskRunsByResults: {
+    all() {
       return '/results/taskruns';
     },
-    taskRunsByNamespace() {
+    byNamespace() {
       return byNamespace({ path: '/results/taskruns' });
     }
   }

--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -204,6 +204,9 @@ export const paths = {
     },
     byNamespace() {
       return byNamespace({ path: '/results/taskruns' });
+    },
+    byUID() {
+      return byNamespace({ path: '/results/taskruns/:resultuid/:recorduid' });
     }
   }
 };

--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -197,6 +197,14 @@ export const paths = {
     byNamespace() {
       return byNamespace({ path: '/triggertemplates' });
     }
+  },
+  results: {
+    taskRunsAll() {
+      return '/results/taskruns';
+    },
+    taskRunsByNamespace() {
+      return byNamespace({ path: '/results/taskruns' });
+    }
   }
 };
 

--- a/pkg/endpoints/types.go
+++ b/pkg/endpoints/types.go
@@ -54,7 +54,8 @@ func (o Options) GetTriggersNamespace() string {
 
 // Resource is a wrapper around all necessary clients and config used for endpoints
 type Resource struct {
-	Config    *rest.Config
-	K8sClient k8sclientset.Interface
-	Options   Options
+	Config        *rest.Config
+	K8sClient     k8sclientset.Interface
+	Options       Options
+	ResultsConfig *rest.Config
 }

--- a/scripts/installer
+++ b/scripts/installer
@@ -13,6 +13,7 @@
 
 # dashboard flavour
 READONLY="true"
+RESULTS_SUPPORT="false"
 
 # configuration default values
 DEBUG="false"
@@ -105,7 +106,9 @@ debug() {
 compile() {
   local overlay="overlays/installer"
 
-  if [ "$READONLY" == "true" ]; then
+  if [ "$RESULTS_SUPPORT" == "true" ]; then
+    overlay="$overlay/results"
+  elif [ "$READONLY" == "true" ]; then
     overlay="$overlay/read-only"
   else
     overlay="$overlay/read-write"
@@ -409,6 +412,7 @@ help () {
   echo -e "\t[--tenant-namespaces <namespaces>]\tWill limit the visibility to the specified comma-separated namespaces only"
   echo -e "\t[--triggers-namespace <namespace>]\tOverride the namespace where Tekton Triggers is installed (defaults to Dashboard install namespace)"
   echo -e "\t[--version <version>]\t\t\tWill download manifests for specified version or build everything using kustomize/ko"
+  echo -e "\t[--enable-results]\t\t\tWill build manifests that enable Tekton Results support"
 }
 
 # cleanup temporary files
@@ -535,6 +539,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     '--preserve-import-paths')
       KO_RESOLVE_OPTIONS="$KO_RESOLVE_OPTIONS --preserve-import-paths"
+      ;;
+    '--enable-results')
+      RESULTS_SUPPORT="true"
       ;;
     *)
       echo "ERROR: Unknown option $1"

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -173,6 +173,7 @@ export function getPodLogURL({ container, name, namespace, follow }) {
   return uri;
 }
 
+// TODO(xinnjie) 获取log的地方
 export function getPodLog({ container, name, namespace, stream }) {
   const uri = getPodLogURL({ container, name, namespace, follow: stream });
   return get(uri, { Accept: 'text/plain,*/*' }, { stream });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -21,6 +21,7 @@ import { get, getAPIRoot, post } from './comms';
 import {
   apiRoot,
   getKubeAPI,
+  getLogAPI,
   getTektonPipelinesAPIVersion,
   isLogTimestampsEnabled,
   tektonAPIGroup,
@@ -173,10 +174,14 @@ export function getPodLogURL({ container, name, namespace, follow }) {
   return uri;
 }
 
-// TODO(xinnjie) 获取log的地方
 export function getPodLog({ container, name, namespace, stream }) {
   const uri = getPodLogURL({ container, name, namespace, follow: stream });
   return get(uri, { Accept: 'text/plain,*/*' }, { stream });
+}
+
+export function getLogByResultsAPI({ namespace, resultUID, recordUID }) {
+  const uri = getLogAPI({ namespace, resultUID, recordUID });
+  return get(uri, { Accept: 'text/plain,*/*' }, { stream: false });
 }
 
 export function importResources({

--- a/src/api/taskRunsByResultsAPI.js
+++ b/src/api/taskRunsByResultsAPI.js
@@ -28,7 +28,6 @@ export function useTaskRunsByResultsAPI(namespace, queryConfig) {
         result: '-',
         filters: 'data_type==TASK_RUN'
       });
-      console.debug("Querying TaskRuns by ResultsAPI, uri:", uri);
       const resp = await fetch(uri, {
         method: 'GET',
         headers: {
@@ -52,12 +51,6 @@ export function useTaskRunsByResultsAPI(namespace, queryConfig) {
     staleTime: 0,
     ...queryConfig
   });
-  if (query.data) {
-    console.debug(
-      'records queried for TaskRuns, response: ',
-      JSON.parse(JSON.stringify(query.data))
-    );
-  }
   return {
     ...query,
     data: query.data?.records || []
@@ -82,7 +75,6 @@ export function useTaskRunByResultsAPI(
         resultUID,
         recordUID
       });
-      console.debug('Querying TaskRun by ResultsAPI, uri:', uri);
       const resp = await fetch(uri, {
         method: 'GET',
         headers: {
@@ -104,11 +96,5 @@ export function useTaskRunByResultsAPI(
     },
     ...queryConfig
   });
-  if (query.data) {
-    console.debug(
-      'TaskRun queried by ResultsAPI, record:',
-      JSON.parse(JSON.stringify(query.data))
-    );
-  }
   return query;
 }

--- a/src/api/taskRunsByResultsAPI.js
+++ b/src/api/taskRunsByResultsAPI.js
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useQuery } from '@tanstack/react-query';
+import { getRecordsAPI } from './utils';
+
+// useTaskRunsByResultsAPI list all TaskRuns by ResultsAPI
+export function useTaskRunsByResultsAPI(namespace, queryConfig) {
+  const query = useQuery({
+    queryKey: ['resultsAPI', 'taskruns', namespace],
+    queryFn: async () => {
+      const uri = getRecordsAPI({
+        group: 'results.tekton.dev',
+        version: 'v1alpha2',
+        namespace,
+        result: '-',
+        filters: 'data_type==TASK_RUN'
+      });
+      return fetch(uri, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization:
+            'Bearer ' +
+            'eyJhbGciOiJSUzI1NiIsImtpZCI6IlU5OFJkVEQ3ZVV2T3puNjFheklxM3RUc2xSWGdDNFdHTjlfQWN4b1RGc3cifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJrM3MiXSwiZXhwIjoxNzM0Njg2MTcwLCJpYXQiOjE3MzQ2ODI1NzAsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwianRpIjoiNGViNTMzMDktMmQ2Yy00NzZiLWFlZDktZjJkMTE1MzAyMmYyIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ0ZWt0b24tcGlwZWxpbmVzIiwic2VydmljZWFjY291bnQiOnsibmFtZSI6InRla3Rvbi1yZXN1bHRzLWRlYnVnIiwidWlkIjoiZTc5MGQwZTctZDJhYy00Njg3LWJiZjgtYjlkYmJhZTY5OTFkIn19LCJuYmYiOjE3MzQ2ODI1NzAsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDp0ZWt0b24tcGlwZWxpbmVzOnRla3Rvbi1yZXN1bHRzLWRlYnVnIn0.VWzhu-bw3Ng-7erF4rZl3CkJVrLssabULWa_QTePWqT0AxSDf9ZR9vzaP1pstJyFL_S8HU4jsKTzpqxlzb5Tpk4IinJ19cMXx7GfrFzRt4YJdVar-DKQqn1ohV0J5qauP2lSEcI0OEkfJsufCvrfvKJMbAhvB-AeLrQmPFuFBxCgYdHHIje1SxCINmlJuqjTxNETyX_pf1d_CFfpN7j9a3S2hUyA5umAn8ezE7xQ4X33fu21KXWkSNKWEuYMaqzx71YXONAdpMQb0FXXdFS8moN-Adl4-eyJhbGciOiJSUzI1NiIsImtpZCI6IlU5OFJkVEQ3ZVV2T3puNjFheklxM3RUc2xSWGdDNFdHTjlfQWN4b1RGc3cifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJrM3MiXSwiZXhwIjoxNzM0NzA1MDk5LCJpYXQiOjE3MzQ3MDE0OTksImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwianRpIjoiMDMxZWI5ZGMtMGQ2MC00YjAzLWEwNWItMzQyZjI3Mzk0NDhjIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ0ZWt0b24tcGlwZWxpbmVzIiwic2VydmljZWFjY291bnQiOnsibmFtZSI6InRla3Rvbi1yZXN1bHRzLWRlYnVnIiwidWlkIjoiZTc5MGQwZTctZDJhYy00Njg3LWJiZjgtYjlkYmJhZTY5OTFkIn19LCJuYmYiOjE3MzQ3MDE0OTksInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDp0ZWt0b24tcGlwZWxpbmVzOnRla3Rvbi1yZXN1bHRzLWRlYnVnIn0.lVbJogflHSjZtrmC79dA9kKdEooLY4OGH2DVje5W9oXRlJHyihn-TD_P4qs1w9yYrRwgnzsvTl7Y0eT0CMcliIkQdvb3rva3ZkoTml809jzvSiA_bQVtfdAtlwWPPSpUO_f0AI8iMRL1YP8XgYC2qJvce0Z8A998hh-ma7SoxQWwrVNuVDKXI1nRbzQrZY4rupjonqtoOC8DuSt7zzWEAcVZESNDActLih5vs-muCZ3bgtAyNnMMcNTJr1_t9BIONyp8MKZ960K7JKriOvZBwTIzmiX4rJbZ_JMpko4_0me3zye3Wyh6d9UABUkj74rqM_9oVtJjVNsjmQAFRkaZiQ'
+        }
+      });
+    },
+    staleTime: 0,
+    ...queryConfig
+  });
+  if (query.data?.records) {
+    query.data.records.forEach(record => {
+      return {
+        ...record,
+        data: {
+          type: record.data.type,
+          value: JSON.parse(atob(record.data.value))
+        }
+      };
+    });
+  }
+  return query;
+}

--- a/src/api/taskRunsByResultsAPI.js
+++ b/src/api/taskRunsByResultsAPI.js
@@ -13,11 +13,11 @@ limitations under the License.
 
 import { useQuery } from '@tanstack/react-query';
 import { getRecordsAPI } from './utils';
-
+import { checkStatus } from './comms';
 // useTaskRunsByResultsAPI list all TaskRuns by ResultsAPI
 export function useTaskRunsByResultsAPI(namespace, queryConfig) {
   const query = useQuery({
-    queryKey: ['resultsAPI', 'taskruns', namespace],
+    queryKey: ['results', 'taskruns', namespace],
     queryFn: async () => {
       const uri = getRecordsAPI({
         group: 'results.tekton.dev',
@@ -26,29 +26,38 @@ export function useTaskRunsByResultsAPI(namespace, queryConfig) {
         result: '-',
         filters: 'data_type==TASK_RUN'
       });
-      return fetch(uri, {
+      console.debug("Querying TaskRuns by ResultsAPI, uri:", uri);
+      const resp = await fetch(uri, {
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization:
-            'Bearer ' +
-            'eyJhbGciOiJSUzI1NiIsImtpZCI6IlU5OFJkVEQ3ZVV2T3puNjFheklxM3RUc2xSWGdDNFdHTjlfQWN4b1RGc3cifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJrM3MiXSwiZXhwIjoxNzM0Njg2MTcwLCJpYXQiOjE3MzQ2ODI1NzAsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwianRpIjoiNGViNTMzMDktMmQ2Yy00NzZiLWFlZDktZjJkMTE1MzAyMmYyIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ0ZWt0b24tcGlwZWxpbmVzIiwic2VydmljZWFjY291bnQiOnsibmFtZSI6InRla3Rvbi1yZXN1bHRzLWRlYnVnIiwidWlkIjoiZTc5MGQwZTctZDJhYy00Njg3LWJiZjgtYjlkYmJhZTY5OTFkIn19LCJuYmYiOjE3MzQ2ODI1NzAsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDp0ZWt0b24tcGlwZWxpbmVzOnRla3Rvbi1yZXN1bHRzLWRlYnVnIn0.VWzhu-bw3Ng-7erF4rZl3CkJVrLssabULWa_QTePWqT0AxSDf9ZR9vzaP1pstJyFL_S8HU4jsKTzpqxlzb5Tpk4IinJ19cMXx7GfrFzRt4YJdVar-DKQqn1ohV0J5qauP2lSEcI0OEkfJsufCvrfvKJMbAhvB-AeLrQmPFuFBxCgYdHHIje1SxCINmlJuqjTxNETyX_pf1d_CFfpN7j9a3S2hUyA5umAn8ezE7xQ4X33fu21KXWkSNKWEuYMaqzx71YXONAdpMQb0FXXdFS8moN-Adl4-eyJhbGciOiJSUzI1NiIsImtpZCI6IlU5OFJkVEQ3ZVV2T3puNjFheklxM3RUc2xSWGdDNFdHTjlfQWN4b1RGc3cifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJrM3MiXSwiZXhwIjoxNzM0NzA1MDk5LCJpYXQiOjE3MzQ3MDE0OTksImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwianRpIjoiMDMxZWI5ZGMtMGQ2MC00YjAzLWEwNWItMzQyZjI3Mzk0NDhjIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ0ZWt0b24tcGlwZWxpbmVzIiwic2VydmljZWFjY291bnQiOnsibmFtZSI6InRla3Rvbi1yZXN1bHRzLWRlYnVnIiwidWlkIjoiZTc5MGQwZTctZDJhYy00Njg3LWJiZjgtYjlkYmJhZTY5OTFkIn19LCJuYmYiOjE3MzQ3MDE0OTksInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDp0ZWt0b24tcGlwZWxpbmVzOnRla3Rvbi1yZXN1bHRzLWRlYnVnIn0.lVbJogflHSjZtrmC79dA9kKdEooLY4OGH2DVje5W9oXRlJHyihn-TD_P4qs1w9yYrRwgnzsvTl7Y0eT0CMcliIkQdvb3rva3ZkoTml809jzvSiA_bQVtfdAtlwWPPSpUO_f0AI8iMRL1YP8XgYC2qJvce0Z8A998hh-ma7SoxQWwrVNuVDKXI1nRbzQrZY4rupjonqtoOC8DuSt7zzWEAcVZESNDActLih5vs-muCZ3bgtAyNnMMcNTJr1_t9BIONyp8MKZ960K7JKriOvZBwTIzmiX4rJbZ_JMpko4_0me3zye3Wyh6d9UABUkj74rqM_9oVtJjVNsjmQAFRkaZiQ'
+          'Content-Type': 'application/json'
         }
-      });
+      }).then(response => checkStatus(response, false));
+
+      if (resp.records) {
+        resp.records = resp.records.map(record => {
+          return {
+            ...record,
+            data: {
+              type: record.data.type,
+              value: JSON.parse(atob(record.data.value))
+            }
+          };
+        });
+      }
+      return resp;
     },
     staleTime: 0,
     ...queryConfig
   });
-  if (query.data?.records) {
-    query.data.records.forEach(record => {
-      return {
-        ...record,
-        data: {
-          type: record.data.type,
-          value: JSON.parse(atob(record.data.value))
-        }
-      };
-    });
+  if (query.data) {
+    console.debug(
+      'records queried for TaskRuns, response: ',
+      JSON.parse(JSON.stringify(query.data))
+    );
   }
-  return query;
+  return {
+    ...query,
+    data: query.data?.records || []
+  };
 }

--- a/src/api/taskRunsByResultsAPI.test.js
+++ b/src/api/taskRunsByResultsAPI.test.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 import * as API from './taskRunsByResultsAPI';
 
+// TODO(xinnjie): add tests. Un-runnable test to block PR merge.
 it('useTaskRunsByResults', () => {
   expect(API.useTaskRunsByResultsAPI()).toEqual(null);
 });

--- a/src/api/taskRunsByResultsAPI.test.js
+++ b/src/api/taskRunsByResultsAPI.test.js
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as API from './taskRunsByResultsAPI';
+
+it('useTaskRunsByResults', () => {
+  expect(API.useTaskRunsByResultsAPI()).toEqual(null);
+});

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -21,6 +21,8 @@ export const apiRoot = getAPIRoot();
 export const tektonAPIGroup = 'tekton.dev';
 export const triggersAPIGroup = 'triggers.tekton.dev';
 export const dashboardAPIGroup = 'dashboard.tekton.dev';
+export const resultsAPIGroup = 'results.tekton.dev';
+export const ALL_RESULTS = '*';
 
 export function getQueryParams({
   filters,
@@ -80,6 +82,23 @@ export function getKubeAPI({
     Object.keys(queryParamsToUse).length > 0
       ? `?${new URLSearchParams(queryParamsToUse).toString()}`
       : ''
+  ].join('');
+}
+
+export function getRecordsAPI({
+  group = resultsAPIGroup,
+  version = 'v1alpha2',
+  namespace = ALL_NAMESPACES,
+  result = ALL_RESULTS,
+  filters
+}) {
+  const host = '127.0.0.1:8080';
+  return [
+    `https://${host}/apis/${group}/${version}`,
+    namespace === ALL_NAMESPACES ? `/parents/-` : `/parents/${namespace}`,
+    result === ALL_RESULTS ? `/results/-` : `/results/${result}`,
+    `/records`,
+    filters ? `?${filters}` : ''
   ].join('');
 }
 
@@ -194,9 +213,11 @@ export function useWebSocket({
     function handleClose() {
       setWebSocketConnected(false);
     }
+
     function handleOpen() {
       setWebSocketConnected(true);
     }
+
     function handleMessage(event) {
       if (event.type !== 'message') {
         return;

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -92,9 +92,8 @@ export function getRecordsAPI({
   result = ALL_RESULTS,
   filters
 }) {
-  const host = '127.0.0.1:8080';
   return [
-    `https://${host}/apis/${group}/${version}`,
+    `${apiRoot}/apis/${group}/${version}`,
     namespace === ALL_NAMESPACES ? `/parents/-` : `/parents/${namespace}`,
     result === ALL_RESULTS ? `/results/-` : `/results/${result}`,
     `/records`,

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -101,6 +101,21 @@ export function getRecordsAPI({
   ].join('');
 }
 
+export function getRecordAPI({
+  group = resultsAPIGroup,
+  version = 'v1alpha2',
+  namespace,
+  resultUID,
+  recordUID
+}) {
+  return [
+    `${apiRoot}/apis/${group}/${version}`,
+    `/parents/${namespace}`,
+    `/results/${resultUID}`,
+    `/records/${recordUID}`
+  ].join('');
+}
+
 export async function defaultQueryFn({ queryKey, signal }) {
   const [group, version, kind, params] = queryKey;
   const url = getKubeAPI({ group, kind, params, version });

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -85,6 +85,7 @@ export function getKubeAPI({
   ].join('');
 }
 
+// getRecordsAPI return URL for getting a list of records through the ResultsAPI
 export function getRecordsAPI({
   group = resultsAPIGroup,
   version = 'v1alpha2',
@@ -101,6 +102,7 @@ export function getRecordsAPI({
   ].join('');
 }
 
+// getRecordAPI return URL for getting a record through the ResultsAPI
 export function getRecordAPI({
   group = resultsAPIGroup,
   version = 'v1alpha2',
@@ -113,6 +115,22 @@ export function getRecordAPI({
     `/parents/${namespace}`,
     `/results/${resultUID}`,
     `/records/${recordUID}`
+  ].join('');
+}
+
+// getLogAPI return URL for getting a log through the ResultsAPI
+export function getLogAPI({
+  group = resultsAPIGroup,
+  version = 'v1alpha2',
+  namespace,
+  resultUID,
+  recordUID
+}) {
+  return [
+    `${apiRoot}/apis/${group}/${version}`,
+    `/parents/${namespace}`,
+    `/results/${resultUID}`,
+    `/logs/${recordUID}`
   ].join('');
 }
 

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -98,7 +98,7 @@ export function getRecordsAPI({
     namespace === ALL_NAMESPACES ? `/parents/-` : `/parents/${namespace}`,
     result === ALL_RESULTS ? `/results/-` : `/results/${result}`,
     `/records`,
-    filters ? `?${filters}` : ''
+    filters ? `?filter=${encodeURIComponent(filters)}` : ''
   ].join('');
 }
 

--- a/src/containers/SideNav/SideNav.jsx
+++ b/src/containers/SideNav/SideNav.jsx
@@ -127,6 +127,12 @@ function SideNav({ expanded, showKubernetesResources = false }) {
           <SideNavMenuItem {...getMenuItemProps(getPath(urls.taskRuns.all()))}>
             TaskRuns
           </SideNavMenuItem>
+          {/* TODO(xinnjie) appear by config */}
+          <SideNavMenuItem
+            {...getMenuItemProps(getPath(urls.results.taskRunsAll()))}
+          >
+            TaskRuns by Results
+          </SideNavMenuItem>
           <SideNavMenuItem
             {...getMenuItemProps(getPath(urls.customRuns.all()))}
           >

--- a/src/containers/SideNav/SideNav.jsx
+++ b/src/containers/SideNav/SideNav.jsx
@@ -129,7 +129,7 @@ function SideNav({ expanded, showKubernetesResources = false }) {
           </SideNavMenuItem>
           {/* TODO(xinnjie) appear by config */}
           <SideNavMenuItem
-            {...getMenuItemProps(getPath(urls.results.taskRunsAll()))}
+            {...getMenuItemProps(getPath(urls.taskRunsByResults.all()))}
           >
             TaskRuns by Results
           </SideNavMenuItem>

--- a/src/containers/TaskRunByResults/TaskRunByResults.jsx
+++ b/src/containers/TaskRunByResults/TaskRunByResults.jsx
@@ -1,0 +1,205 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Fragment, useRef, useState } from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { InlineNotification, SkeletonText } from '@carbon/react';
+import {
+  ActionableNotification,
+  Actions,
+  Log,
+  Portal,
+  RunHeader,
+  StepDetails,
+  TaskRunDetails,
+  TaskTree
+} from '@tektoncd/dashboard-components';
+import {
+  getStatus,
+  getStepDefinition,
+  getStepStatus,
+  isRunning,
+  labels as labelConstants,
+  queryParams as queryParamConstants,
+  urls,
+  useTitleSync
+} from '@tektoncd/dashboard-utils';
+import {
+  getLogsRetriever,
+  getLogsToolbar,
+  getViewChangeHandler
+} from '../../utils';
+import { useTaskRunByResultsAPI } from '../../api/taskRunsByResultsAPI';
+import { useSelectedNamespace } from '../../api';
+import NotFound from '../NotFound';
+
+const { STEP, RETRY, TASK_RUN_DETAILS, VIEW } = queryParamConstants;
+
+export function TaskRunContainerByResults() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const {
+    namespace: namespaceParam,
+    resultuid: resultUID,
+    recorduid: recordUID
+  } = params;
+  const queryParams = new URLSearchParams(location.search);
+  let currentRetry = queryParams.get(RETRY);
+  if (!currentRetry || !/^[0-9]+$/.test(currentRetry)) {
+    // if retry param is specified it should contain a positive integer (or 0) only
+    // otherwise we'll default to the latest attempt
+    currentRetry = '';
+  }
+  const selectedStepId = queryParams.get(STEP);
+  const view = queryParams.get(VIEW);
+  const showTaskRunDetails = queryParams.get(TASK_RUN_DETAILS);
+
+  const { selectedNamespace } = useSelectedNamespace();
+  const namespace = namespaceParam || selectedNamespace;
+
+  const maximizedLogsContainer = useRef();
+  const [isLogsMaximized, setIsLogsMaximized] = useState(false);
+  const [showNotification, setShowNotification] = useState(null);
+  const [isUsingExternalLogs, setIsUsingExternalLogs] = useState(false);
+
+  const {
+    data: record,
+    error,
+    isLoading
+  } = useTaskRunByResultsAPI(namespace, resultUID, recordUID, {
+    staleTime: 1000 // 1 second
+  });
+
+  const taskRun = record?.data?.value;
+
+  useTitleSync({
+    page: 'TaskRun by Results',
+    resourceName: taskRun?.metadata?.name
+  });
+
+  function handleRetryChange(retry) {
+    if (Number.isInteger(retry)) {
+      queryParams.set(RETRY, retry);
+    } else {
+      queryParams.delete(RETRY);
+    }
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
+    navigate(browserURL);
+  }
+
+  function handleTaskSelected({ selectedStepId: newSelectedStepId }) {
+    if (newSelectedStepId) {
+      queryParams.set(STEP, newSelectedStepId);
+      queryParams.delete(TASK_RUN_DETAILS);
+    } else {
+      queryParams.delete(STEP);
+      queryParams.set(TASK_RUN_DETAILS, true);
+    }
+
+    if (newSelectedStepId !== selectedStepId) {
+      queryParams.delete(VIEW);
+    }
+
+    const browserURL = location.pathname.concat(`?${queryParams.toString()}`);
+    if (showTaskRunDetails || selectedStepId) {
+      navigate(browserURL);
+    } else {
+      // auto-selecting step on first load
+      navigate(browserURL, { replace: true });
+    }
+  }
+
+  if (isLoading) {
+    return <SkeletonText heading width="60%" />;
+  }
+
+  if (error || !record || !taskRun) {
+    return (
+      <NotFound
+        suggestions={[
+          {
+            text: 'TaskRuns by Results',
+            to: urls.taskRunsByResults.byNamespace({ namespace })
+          }
+        ]}
+      />
+    );
+  }
+
+  const {
+    reason: taskRunStatusReason,
+    message: taskRunStatusMessage,
+    status: succeeded
+  } = getStatus(taskRun);
+
+  const definition = getStepDefinition({
+    selectedStepId,
+    task: null,
+    taskRun
+  });
+
+  const stepStatus = getStepStatus({
+    selectedStepId,
+    taskRun
+  });
+
+  const onViewChange = getViewChangeHandler({ location, navigate });
+
+
+  return (
+    <>
+      <RunHeader
+        lastTransitionTime={taskRun.status?.startTime}
+        message={taskRunStatusMessage}
+        reason={taskRunStatusReason}
+        runName={taskRun.metadata.name}
+        status={succeeded}
+      />
+      <div className="tkn--tasks">
+        <TaskTree
+          onRetryChange={handleRetryChange}
+          onSelect={handleTaskSelected}
+          selectedRetry={currentRetry}
+          selectedStepId={selectedStepId}
+          selectedTaskId={
+            taskRun.metadata.labels?.[labelConstants.PIPELINE_TASK]
+          }
+          taskRuns={[taskRun]}
+        />
+        {(selectedStepId && (
+          <StepDetails
+            definition={definition}
+            // logContainer={logContainer}
+            onViewChange={onViewChange}
+            stepName={selectedStepId}
+            stepStatus={stepStatus}
+            taskRun={taskRun}
+            view={view}
+          />
+        )) || (
+          <TaskRunDetails
+            onViewChange={onViewChange}
+            // pod={podDetails}
+            // task={task}
+            taskRun={taskRun}
+            view={view}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+export default TaskRunContainerByResults;

--- a/src/containers/TaskRunByResults/TaskRunByResults.jsx
+++ b/src/containers/TaskRunByResults/TaskRunByResults.jsx
@@ -64,8 +64,7 @@ export function TaskRunContainerByResults() {
 
   const maximizedLogsContainer = useRef();
   const [isLogsMaximized, setIsLogsMaximized] = useState(false);
-  const [showNotification, setShowNotification] = useState(null);
-  const [isUsingExternalLogs, setIsUsingExternalLogs] = useState(false);
+  const isUsingExternalLogs = false;
 
   const {
     data: record,
@@ -123,7 +122,7 @@ export function TaskRunContainerByResults() {
       return null;
     }
 
-    // TODO(xinnjie) supporting Step level log,log provided by ResultsAPI is currently TaskRun level instead of Step level
+    // TODO(xinnjie): supporting Step level log, log provided by ResultsAPI is currently TaskRun level instead of Step level
     const log = getLogByResultsAPI({
       namespace,
       resultUID,
@@ -139,6 +138,7 @@ export function TaskRunContainerByResults() {
           : null)}
       >
         <Log
+          // FIXME(xinnjie): log in toolbar is not from ResultsAPI yet
           toolbar={getLogsToolbar({
             isMaximized: isLogsMaximized,
             isUsingExternalLogs,

--- a/src/containers/TaskRunByResults/index.js
+++ b/src/containers/TaskRunByResults/index.js
@@ -1,0 +1,13 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export { default } from './TaskRunByResults';

--- a/src/containers/TaskRunsByResults/TaskRunsByResults.jsx
+++ b/src/containers/TaskRunsByResults/TaskRunsByResults.jsx
@@ -28,7 +28,9 @@ function TaskRunsByResults() {
     data: recordsForTaskRuns = [],
     error,
     isLoading
-  } = useTaskRunsByResultsAPI(namespace);
+  } = useTaskRunsByResultsAPI(namespace, {
+    staleTime: 1000 // 1 second
+  });
   if (isLoading) {
     return <div>Loading...</div>;
   }

--- a/src/containers/TaskRunsByResults/TaskRunsByResults.jsx
+++ b/src/containers/TaskRunsByResults/TaskRunsByResults.jsx
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { urls } from '@tektoncd/dashboard-utils';
+import { useParams } from 'react-router-dom';
+import NotFound from '../NotFound';
+import { useSelectedNamespace } from '../../api';
+import { useTaskRunsByResultsAPI } from '../../api/taskRunsByResultsAPI';
+
+
+function TaskRunsByResults() {
+  const params = useParams();
+  const { namespace: namespaceParam } = params;
+
+  const { selectedNamespace } = useSelectedNamespace();
+  const namespace = namespaceParam || selectedNamespace;
+
+  const {
+    data: recordsForTaskRuns = [],
+    error,
+    isLoading
+  } = useTaskRunsByResultsAPI({
+    namespace
+  });
+  console.log(recordsForTaskRuns);
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    console.log(error);
+    return (
+      <NotFound
+        suggestions={[
+          {
+            text: 'TaskRuns',
+            to: urls.results.taskRunsByNamespace({ namespace })
+          }
+        ]}
+      />
+    );
+  }
+
+  return <div>TaskRuns By Results</div>;
+}
+
+export default TaskRunsByResults;

--- a/src/containers/TaskRunsByResults/TaskRunsByResults.jsx
+++ b/src/containers/TaskRunsByResults/TaskRunsByResults.jsx
@@ -12,15 +12,15 @@ limitations under the License.
 */
 import { urls } from '@tektoncd/dashboard-utils';
 import { useParams } from 'react-router-dom';
+import { TaskRuns as TaskRunsList } from '@tektoncd/dashboard-components';
 import NotFound from '../NotFound';
 import { useSelectedNamespace } from '../../api';
 import { useTaskRunsByResultsAPI } from '../../api/taskRunsByResultsAPI';
-
+import ListPageLayout from '../ListPageLayout';
 
 function TaskRunsByResults() {
   const params = useParams();
   const { namespace: namespaceParam } = params;
-
   const { selectedNamespace } = useSelectedNamespace();
   const namespace = namespaceParam || selectedNamespace;
 
@@ -28,15 +28,12 @@ function TaskRunsByResults() {
     data: recordsForTaskRuns = [],
     error,
     isLoading
-  } = useTaskRunsByResultsAPI({
-    namespace
-  });
-  console.log(recordsForTaskRuns);
+  } = useTaskRunsByResultsAPI(namespace);
   if (isLoading) {
     return <div>Loading...</div>;
   }
   if (error) {
-    console.log(error);
+    console.error('Error querying TaskRuns by ResultsAPI', error);
     return (
       <NotFound
         suggestions={[
@@ -48,8 +45,25 @@ function TaskRunsByResults() {
       />
     );
   }
+  const taskRuns = recordsForTaskRuns.map(record => record.data.value);
+  console.debug('taskRuns', JSON.parse(JSON.stringify(taskRuns)));
 
-  return <div>TaskRuns By Results</div>;
+  return (
+    <ListPageLayout
+      error={error}
+      resources={taskRuns}
+      title="TaskRuns by Results"
+    >
+      {({ resources }) => (
+        <TaskRunsList
+          filters={[]}
+          loading={isLoading}
+          selectedNamespace={namespace}
+          taskRuns={resources}
+        />
+      )}
+    </ListPageLayout>
+  );
 }
 
 export default TaskRunsByResults;

--- a/src/containers/TaskRunsByResults/index.js
+++ b/src/containers/TaskRunsByResults/index.js
@@ -1,0 +1,15 @@
+/*
+Copyright 2019-2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+
+export { default } from './TaskRunsByResults';

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -45,6 +45,7 @@ export { default as Tasks } from './Tasks';
 export { default as TasksDropdown } from './TasksDropdown';
 export { default as TaskRun } from './TaskRun';
 export { default as TaskRuns } from './TaskRuns';
+export { default as TaskRunByResults } from './TaskRunByResults';
 export { default as TaskRunsByResults } from './TaskRunsByResults';
 export { default as TriggerBinding } from './TriggerBinding';
 export { default as Trigger } from './Trigger';

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -45,6 +45,7 @@ export { default as Tasks } from './Tasks';
 export { default as TasksDropdown } from './TasksDropdown';
 export { default as TaskRun } from './TaskRun';
 export { default as TaskRuns } from './TaskRuns';
+export { default as TaskRunsByResults } from './TaskRunsByResults';
 export { default as TriggerBinding } from './TriggerBinding';
 export { default as Trigger } from './Trigger';
 export { default as TriggerTemplate } from './TriggerTemplate';

--- a/src/routes/pipelines.jsx
+++ b/src/routes/pipelines.jsx
@@ -28,6 +28,7 @@ import {
   ResourceList,
   TaskRun,
   TaskRuns,
+  TaskRunsByResults,
   Tasks
 } from '../containers';
 import { getTektonPipelinesAPIVersion, tektonAPIGroup } from '../api/utils';
@@ -240,5 +241,9 @@ export default [
         <CreateTaskRun />
       </ReadWriteRoute>
     )
+  },
+  {
+    path: paths.results.taskRunsAll(),
+    element: <TaskRunsByResults />
   }
 ];

--- a/src/routes/pipelines.jsx
+++ b/src/routes/pipelines.jsx
@@ -243,7 +243,15 @@ export default [
     )
   },
   {
-    path: paths.results.taskRunsAll(),
+    path: paths.taskRunsByResults.all(),
     element: <TaskRunsByResults />
+  },
+  {
+    path: paths.taskRunsByResults.byNamespace(),
+    element: <TaskRunsByResults />,
+    handle: {
+      isNamespaced: true,
+      path: paths.taskRunsByResults.byNamespace()
+    }
   }
 ];

--- a/src/routes/pipelines.jsx
+++ b/src/routes/pipelines.jsx
@@ -27,6 +27,7 @@ import {
   ReadWriteRoute,
   ResourceList,
   TaskRun,
+  TaskRunByResults,
   TaskRuns,
   TaskRunsByResults,
   Tasks
@@ -252,6 +253,15 @@ export default [
     handle: {
       isNamespaced: true,
       path: paths.taskRunsByResults.byNamespace()
+    }
+  },
+  {
+    path: paths.taskRunsByResults.byUID(),
+    element: <TaskRunByResults />,
+    handle: {
+      isNamespaced: true,
+      isResourceDetails: true,
+      path: paths.taskRunsByResults.byUID()
     }
   }
 ];


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This is a demo for [Tekton Results](https://github.com/tektoncd/results) to integrate with Tekton Dashboard.
Related to https://github.com/tektoncd/results/issues/82

Please focus on front-end part.

I want to know if there are any unwanted decisions made here .I'd like to propose a TEP about the integration in a few days.

## Included functionality:
* Add `TaskRuns by Results` in side navigation bar. `TaskRuns by Results` display all TaskRuns provided by [Tekton Results](https://github.com/tektoncd/results) API
* TaskRun page data provideed by [Tekton Results](https://github.com/tektoncd/results) API, this page would be navigated to by clicking TaskRun in `TaskRuns by Results`
* Logs in steps in provided by [Tekton Results](https://github.com/tektoncd/results) API

I will call API provided by Tekton Results  ResultsAPI for short.

## Impletation details

### Resources URL mapping
There are about 3 types of resources in [Tekton Results](https://github.com/tektoncd/results): `Result`, `Record`, `Log`, read [Results Data Model](https://github.com/tektoncd/results?tab=readme-ov-file#data-model) for detail.

Here `Record` of `TaskRun` type and `Log` is involved.

|        | tekton Dashboard                                             | Tekton Results                                       |
| ------ | ------------------------------------------------------------ | ---------------------------------------------------- |
| Record | /apis/results.tekton.dev/v1alpha2/parents/{namespace}/results/{uid}/record/{uid} | /namespaces/{namespace}/results/taskruns/{uid}/{uid} |
| Log    | /apis/results.tekton.dev/v1alpha2/parents/{namespace}/results/{uid}/logs/{uid} | NA                                                   |

### Data accessing to ResultsAPI
Dashboard frontend sends requests to Dashboard backed, and Dashboard backend forwards all requests to Results backend. 

How dashboard frontend queries resources of ResultAPI remains unclear and needs to be discussed. Implemantation in demo is merely for convenience. One of the goal should be taking advange of existing kubernates access control mechanism.

Need a plan design for how this is going to be, as mentioned in https://github.com/tektoncd/dashboard/pull/3002#issuecomment-1647637166

### New `TaskRunsByResults` Component Instead of reusing `TaskRuns`
* Largely for implementation simplicity concern. Much easier than concerning Results resources and raw TaskRun recources at the same time.
* The ResultsAPI can return significantly more TaskRuns than the API server, allowing for different pagination methods in the future.
* TaskRuns from the ResultsAPI are immutable for end users, simplifying the `TaskRunsByResults` component compared to `TaskRuns`.
* Implementation could be more progressive, avoiding changing `TaskRuns` behavior directly.

Basicly, I think a little boilerplate code here is better than mixing Results resources with TaskRun resources.

## Snapshots:
![image](https://github.com/user-attachments/assets/d1fd6657-0875-4bfd-b12f-7873c7d0f66c)

![image](https://github.com/user-attachments/assets/e1114987-048b-40c7-add2-599d7f525fa7)

## Setup
In dashboard repo root directory: 
```
scripts/installer install --enable-result
```

To enable log feature, checkout [this branch](https://github.com/tektoncd/results/pull/910) in results repo root directory:
```
kubectl kustomize config/overlays/logs-local-db | ko apply -f -
```

## More decisions to make
* How dashboard front-end access ResultsAPI.
* How to implement step-level logs: Currently, ResultsAPI provides TaskRun-level logs with a step prefix at the beginning of each line.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
