### PR TITLE
Remove `followLogs` function

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -120,7 +120,7 @@ export default /* istanbul ignore next */ function PipelineRun({
               taskRun
             })
           }
-          fetchLogs={() => fetchLogs(stepName, stepStatus, taskRun)}
+          fetchLogs={() => fetchLogs({ stepName, stepStatus, taskRun })}
           forcePolling={forceLogPolling}
           key={`${selectedTaskId}:${selectedStepId}:${selectedRetry}`}
           logLevels={logLevels}

--- a/src/containers/TaskRun/TaskRun.jsx
+++ b/src/containers/TaskRun/TaskRun.jsx
@@ -182,10 +182,12 @@ export function TaskRunContainer({
           : null)}
       >
         <Log
-          fetchLogs={() => logsRetriever(stepName, stepStatus, run)}
-          isLogsMaximized={isLogsMaximized}
           enableLogAutoScroll
           enableLogScrollButtons
+          fetchLogs={() =>
+            logsRetriever({ stepName, stepStatus, taskRun: run })
+          }
+          isLogsMaximized={isLogsMaximized}
           key={`${stepName}:${currentRetry}`}
           logLevels={logLevels}
           showLevels={showLogLevels}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Remove the `followLogs` function and update `fetchLogs` to support the `stream` parameter. There's no need to maintain 2 separate functions for this. Update tests and usage accordingly.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
