### PR TITLE
Remove the deprecated displayname field from Dashboard extensions

### DIFF
--- a/src/api/extensions.js
+++ b/src/api/extensions.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -25,19 +25,14 @@ export function useExtensions(params, queryConfig) {
   return {
     ...query,
     data: (data || []).map(({ spec }) => {
-      const {
-        disableResourceDetailsLinks,
-        displayname, // keep for backwards compatibility for a few releases
-        displayName,
-        name,
-        namespaced
-      } = spec;
+      const { disableResourceDetailsLinks, displayName, name, namespaced } =
+        spec;
       const [apiGroup, apiVersion] = spec.apiVersion.split('/');
       return {
         apiGroup,
         apiVersion,
         disableResourceDetailsLinks,
-        displayName: displayName || displayname,
+        displayName,
         name,
         namespaced
       };

--- a/src/api/extensions.test.js
+++ b/src/api/extensions.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -23,40 +23,6 @@ it('useExtensions', () => {
   const namespaced = true;
   const query = {
     data: [{ spec: { apiVersion, displayName, name, namespaced } }]
-  };
-  const params = { fake: 'params' };
-  vi.spyOn(utils, 'useCollection').mockImplementation(() => query);
-  const extensions = API.useExtensions(params);
-  expect(utils.useCollection).toHaveBeenCalledWith(
-    expect.objectContaining({
-      group: utils.dashboardAPIGroup,
-      kind: 'extensions',
-      params,
-      version: 'v1alpha1'
-    })
-  );
-  expect(extensions).toEqual({
-    data: [
-      {
-        apiGroup: group,
-        apiVersion: version,
-        displayName,
-        name,
-        namespaced
-      }
-    ]
-  });
-});
-
-it('useExtensions displayname backwards compatibility', () => {
-  const name = 'fake_name';
-  const group = 'fake_group';
-  const version = 'fake_version';
-  const apiVersion = `${group}/${version}`;
-  const displayName = 'fake_displayName';
-  const namespaced = true;
-  const query = {
-    data: [{ spec: { apiVersion, displayname: displayName, name, namespaced } }]
   };
   const params = { fake: 'params' };
   vi.spyOn(utils, 'useCollection').mockImplementation(() => query);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The `displayname` field was deprecated in v0.49.0 LTS.

Remove the remaining code that was added for backwards compatibility.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Action required: The `displayname` field in Dashboard extensions is no longer supported, please rename to `displayName`. It was first deprecated in v0.49.0 LTS released in July 2024 and support is now removed.
```
