### PR TITLE
Define custom categories for the auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - release-note-none
+  categories:
+    - title: 🚨 Breaking changes
+      labels:
+        - release-note-action-required
+    - title: 🚨 Deprecation notices
+      labels:
+        - release-note-action-required
+    - title: ✨ Features
+      labels:
+        - kind/feature
+    - title: 🐛 Fixes
+      labels:
+        - kind/bug
+    - title: 🔨 Misc
+      labels:
+        - kind/misc
+    - title: 📖 Docs
+      labels:
+        - kind/documentation
+    - title: Other changes to review
+      labels:
+        - "*"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Define custom categories matching the existing release note sections so that the auto-generated release notes more closely match the desired format.

Any items appearing in the 'Other changes to review' category should be reviewed to determine if they should be included, and if so should be manually moved to the appropriate category.

Unfortunately it's not possible to include custom header / footer content, e.g. our attestation or thanks sections, in the auto-generated release notes so we can't use this approach to produce the complete document. However, there is an API we can call to generate these release notes and use the returned content as part of another automation. This will be based on the [`release-draft` Pipeline from the plumbing repo](https://github.com/tektoncd/plumbing/blob/f1b2461323b4e2db8050627272d97657c63390f6/tekton/resources/release/base/github_release.yaml) and delivered in a separate change.

In the meantime, this change still reduces the amount of manual effort required to create a new release.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
