### PR TITLE
Remove redundant category in generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,10 +3,7 @@ changelog:
     labels:
       - release-note-none
   categories:
-    - title: 🚨 Breaking changes
-      labels:
-        - release-note-action-required
-    - title: 🚨 Deprecation notices
+    - title: 🚨 Breaking changes / deprecation notices
       labels:
         - release-note-action-required
     - title: ✨ Features


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The release notes generator only outputs an issue in the first matching category. This means the 'Deprecation notices' category is redundant and will never be produced.

Instead, combine 'Breaking changes' and 'Deprecation notices' into a single category.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
