### PR TITLE
Update log timestamp detection to support more formats

### DIFF
--- a/packages/components/src/components/Log/Log.jsx
+++ b/packages/components/src/components/Log/Log.jsx
@@ -31,8 +31,8 @@ import LogFormat from '../LogFormat';
 const itemSize = 16; // This should be kept in sync with the line-height in SCSS
 const defaultHeight = itemSize * 100 + itemSize / 2;
 
-const logFormatRegex =
-  /^((?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3,9}Z)\s?)?(::(?<command>group|endgroup|error|warning|info|notice|debug)::)?(?<message>.*)?$/s;
+export const logFormatRegex =
+  /^((?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(.\d{3,9})?(Z|[+-]\d{2}:\d{2}))\s?)?(::(?<command>group|endgroup|error|warning|info|notice|debug)::)?(?<message>.*)?$/s;
 
 function LogsFilteredNotification({ displayedLogLines, totalLogLines }) {
   const intl = useIntl();

--- a/packages/components/src/components/Log/Log.test.jsx
+++ b/packages/components/src/components/Log/Log.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import { fireEvent, waitFor } from '@testing-library/react';
-import Log from './Log';
+import Log, { logFormatRegex } from './Log';
 import { render } from '../../utils/test';
 
 describe('Log', () => {
@@ -348,4 +348,32 @@ describe('Log', () => {
     );
     await waitFor(() => getByText(/step failed/i));
   });
+
+  it.each([
+    {
+      label: 'UTC with second fractions',
+      line: '2025-02-14T15:07:17.123456789Z'
+    },
+    {
+      label: 'with timezone offset',
+      line: '2025-02-14T15:07:17.123456789-05:00'
+    },
+    { label: 'without second fractions', line: '2025-02-14T15:07:17Z' },
+    {
+      label: 'without second fractions and with timezone offset',
+      line: '2025-02-14T15:07:17+01:00'
+    },
+    {
+      label: 'without seconds',
+      line: '2025-02-14T15:07Z'
+    }
+  ])(
+    'logFormatRegex detects supported timestamp formats - $line',
+    ({ line }) => {
+      const {
+        groups: { timestamp }
+      } = logFormatRegex.exec(line);
+      expect(timestamp).toEqual(line);
+    }
+  );
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Update the regex to support detection of:
- timestamps with no fractional seconds
- timestamps with no seconds
- timezone offsets (+/-hh:mm)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
