### PR TITLE
Fix dashboard-utils import issue

### DIFF
--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,14 +10,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* eslint-disable import/extensions */
 
-import { labels as labelConstants } from './constants';
-import { getStatus } from './status';
+// Include .js extension in imports/exports to solve ES Modules and CommonJS
+// problem when importing dashboard-utils
+import { labels as labelConstants } from './constants.js';
+import { getStatus } from './status.js';
 
-export * from './constants';
-export * from './hooks';
-export { paths, urls } from './router';
-export { getStatus } from './status';
+export * from './constants.js';
+export * from './hooks.js';
+export { paths, urls } from './router.js';
+export { getStatus } from './status.js';
 
 export const ALL_NAMESPACES = '*';
 

--- a/packages/utils/src/utils/router.js
+++ b/packages/utils/src/utils/router.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,8 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+/* eslint-disable import/extensions */
 import { generatePath } from 'react-router-dom';
-import { labels } from './constants';
+// Include .js extension in import to solve ES-modules and CommonJS
+// problem when importing dashboard-utils
+import { labels } from './constants.js';
 
 function byNamespace({ path = '' } = {}) {
   return `/namespaces/:namespace${path}`;


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When importing dashboard-utils into a commonjs file using webpack, a compiler error occurs due to an ESM vs CJS conflict. Using a dynamic import as a workaround for this results in a different error, as files imported in `packages/utils/src/index.js` cant be found. Adding the extension to the imports/exports in that file resolves this problem. Though this requires ignoring the eslint rule for file extensions in the affected files

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
