### PR TITLE
Reduce manual steps required to publish npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tektoncd/dashboard",
-  "version": "0.1.0",
+  "version": "0.55.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tektoncd/dashboard",
-      "version": "0.1.0",
+      "version": "0.55.0-alpha.0",
       "workspaces": [
         "packages/utils",
         "packages/components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tektoncd/dashboard",
-  "version": "0.1.0",
+  "version": "0.55.0-alpha.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -21,7 +21,9 @@
     "storybook": "storybook dev -p 5000",
     "storybook:build": "storybook build -o storybook-static && touch storybook-static/.nojekyll",
     "storybook:deploy": "npx gh-pages --dist ./storybook-static --dotfiles --no-history --message \"Deploy Storybook to GitHub Pages\"",
-    "test": "vitest"
+    "test": "vitest",
+    "version": "npm --workspaces version --preid alpha $npm_new_version && git add packages/",
+    "version:packages": "npm version --preid alpha -m \"Publish v%s of the @tektoncd/dashboard-* packages\""
   },
   "dependencies": {
     "@carbon/react": "^1.77.0",

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -162,15 +162,25 @@ To update the Dashboard release on the [`dogfooding` cluster](https://dashboard.
 
 To release a new version of the npm packages, e.g. `@tektoncd/dashboard-components`:
 
-1. ensure you have checked out the latest change and that you're at the root of the project
-1. `npm --workspaces version <version>` where version is a valid semver string, e.g. `0.24.1-alpha.0`
-    - Note: On Windows set the npm script-shell to git-bash, e.g.: `npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"`
-1. commit the change and open a PR
-   - Note: both the PR title and commit message should use the following format:
+1. Prereqs:
+    1. Ensure you are at the root of the project
+    1. Check out the HEAD of the branch you wish to publish from, typically `main`
+    1. Verify that your working directory is clean
+    - Note: This process will intentionally exit early if your git working directory is not clean
+1. `npm run version:packages -- <type>` where type is one of `prerelease` or `preminor`
+    - `prerelease` will bump `0.24.1-alpha.0` to `0.24.1-alpha.1`
+    - `preminor` will bump `0.24.1-alpha.2` to `0.25.0-alpha.0` and should be used for the first publish after a new Dashboard release
+    - Note: On Windows you may need to set the npm script-shell to git-bash, e.g.: `npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"`
+1. Push the change to your fork and open a PR
+   - The command above should have created a commit with the correct message format and version
      > `Publish v<version> of the @tektoncd/dashboard-* packages`
- 
+
      e.g. `Publish v0.24.1-alpha.0 of the @tektoncd/dashboard-* packages`
-1. once the packages are published, build and publish the Storybook:
-   1. `npm run storybook:build` - optional, deploys to your fork (origin)
-   1. `npm run storybook:deploy -- --remote upstream`
-   1. verify that the updated version is available at https://tektoncd.github.io/dashboard/
+   - Use the commit message as the PR title
+1. The packages are automatically published once the PR is merged
+   - Verify there were no issues with the [publish workflow](https://github.com/tektoncd/dashboard/actions/workflows/publish.yml?query=event%3Apush+branch%3Amain)
+1. Once the packages are published, build and publish the Storybook:
+   1. `npm run storybook:build`
+   1. `npm run storybook:deploy` - optional, deploys to your fork's (origin) pages
+   1. `npm run storybook:deploy -- --remote upstream` - deploys to the `tektoncd/dashboard` repo's pages
+   1. Verify that the updated version is available at https://tektoncd.github.io/dashboard/


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Add new `version:packages` script which takes care of providing the correct parameters to the `npm version` command to ensure appropriate version string, and produces a commit with the standard formatted message required for the publish automation.

When the `version:packages` script is executed, the following things happen in order:
1. Check the working directory is clean, exit if not
2. Bump version in package.json
3. Run the `version` script which bumps the same version in each packages/* package.json file and stages the changes
4. Commit the changes with a correctly formatted commit message containing the updated version

See https://docs.npmjs.com/cli/v10/commands/npm-version#:~:text=The%20exact%20order%20of%20execution%20is%20as%20follows%3A for more details

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
