### PR TITLE
Fix image SHA used in release pipeline check-github-release step

### DIFF
--- a/tekton/prerelease-checks.yaml
+++ b/tekton/prerelease-checks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Tekton Authors
+# Copyright 2021-2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ spec:
           exit 1
         fi
     - name: check-github-release
-      image: docker.io/library/python:3.6-alpine3.9@sha256:368f69f11e002a63d587791bb9652009dbb19a85f015698eac40d687e6f4ab19
+      image: docker.io/library/python:3.6-alpine3.9@sha256:f0b2142d5280c4e14162dce011b173c161cd7ccd1f562b6d97f6d14036954e2f
       script: |
         echo "Checking GitHub release"
         PACKAGE=$(echo $(params.package) | cut -d/ -f2,3)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Somehow the python image used for this step ended up referencing the arm64 image instead of the multiarch manifest's SHA.

Use the correct SHA so the appropriate version is pulled to match the architecture of the node the pipeline is executed on.

This was causing issues testing the nightly releases on the new Azure cluster. Some investigation required into how this was working on dogfooding up to now.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
