### PR TITLE
Update release pipeline to use remote resolution

### DIFF
--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Tekton Authors
+# Copyright 2021-2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - prerelease-checks.yaml
-  - build.yaml
-  - publish.yaml
   - release-pipeline.yaml

--- a/tekton/prerelease-checks.yaml
+++ b/tekton/prerelease-checks.yaml
@@ -29,16 +29,24 @@ spec:
   workspaces:
     - name: source-to-release
       description: The workspace where the repo has been cloned
+  stepTemplate:
+    env:
+      - name: PACKAGE
+        value: $(params.package)
+      - name: VERSION_TAG
+        value: $(params.versionTag)
+      - name: RELEASE_BUCKET
+        value: $(params.releaseBucket)
   steps:
     - name: check-git-tag
       image: ghcr.io/wolfi-dev/git:alpine@sha256:fed7036736d40fe460aa51f4df25b8862c6a5b137cdcceef80fc26a9bbb0386a
       script: |
         echo "Checking git tag"
         # Look for the tag in the list of tags
-        git ls-remote --tags https://$(params.package) | \
-          grep "$(params.versionTag)$" || exit 0
+        git ls-remote --tags https://${PACKAGE} | \
+          grep "${VERSION_TAG}$" || exit 0
         # If the version was found fail
-        echo "Version $(params.versionTag) already tagged for $(params.package)"
+        echo "Version ${VERSION_TAG} already tagged for ${PACKAGE}"
         exit 1
     - name: check-release-file
       image: gcr.io/google.com/cloudsdktool/cloud-sdk:515.0.0@sha256:c9052ef7d508207268fcf93a75f9ae0637f40559d1e373518494ec3acd16c4c2
@@ -46,8 +54,8 @@ spec:
         echo "Checking release file"
         # Check if the release file already exists
         # gsutil retuns 1 if the object was not found
-        if gsutil stat $(params.releaseBucket)/previous/$(params.versionTag)/release.yaml; then
-          echo "Release file already exists for $(params.versionTag) in the release bucket,"
+        if gsutil stat ${RELEASE_BUCKET}/previous/${VERSION_TAG}/release.yaml; then
+          echo "Release file already exists for ${VERSION_TAG} in the release bucket,"
           echo "but no git tag was found. To continue remove the release file first."
           exit 1
         fi
@@ -55,16 +63,16 @@ spec:
       image: docker.io/library/python:3.6-alpine3.9@sha256:f0b2142d5280c4e14162dce011b173c161cd7ccd1f562b6d97f6d14036954e2f
       script: |
         echo "Checking GitHub release"
-        PACKAGE=$(echo $(params.package) | cut -d/ -f2,3)
+        PACKAGE=$(echo ${PACKAGE} | cut -d/ -f2,3)
         # Check if the release exists on GitHub
         wget -q -O- --header 'Accept: application/vnd.github.v3+json' \
           https://api.github.com/repos/${PACKAGE}/releases | \
           python -c 'import sys; import json; print("\n".join([x["tag_name"] for x in json.load(sys.stdin)]))' | \
-          grep "$(params.versionTag)$" || exit 0
-        echo "Release $(params.versionTag) already exists for $(params.package)"
+          grep "${VERSION_TAG}$" || exit 0
+        echo "Release ${VERSION_TAG} already exists for ${PACKAGE}"
         exit 1
     - name: success-confirmation
       image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
       script: |
-        echo "All pre-release checks for $(params.package) @ $(params.versionTag) were successful"
+        echo "All pre-release checks for ${PACKAGE} @ ${VERSION_TAG} were successful"
         echo "Happy releasing 😺"

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Tekton Authors
+# Copyright 2019-2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,7 +73,12 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
+        resolver: hub
+        params:
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.7"
       workspaces:
         - name: output
           workspace: workarea
@@ -86,7 +91,16 @@ spec:
     - name: precheck
       runAfter: [git-clone]
       taskRef:
-        name: dashboard-prerelease-checks
+        resolver: git
+        params:
+          - name: org
+            value: tektoncd
+          - name: repo
+            value: dashboard
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: tekton/prerelease-checks.yaml
       params:
         - name: package
           value: $(params.package)
@@ -101,7 +115,16 @@ spec:
     - name: build
       runAfter: [precheck]
       taskRef:
-        name: build-dashboard
+        resolver: git
+        params:
+          - name: org
+            value: tektoncd
+          - name: repo
+            value: dashboard
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: tekton/build.yaml
       workspaces:
         - name: source
           workspace: workarea
@@ -109,7 +132,16 @@ spec:
     - name: publish-images
       runAfter: [build]
       taskRef:
-        name: publish-dashboard-release
+        resolver: git
+        params:
+          - name: org
+            value: tektoncd
+          - name: repo
+            value: dashboard
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: tekton/publish.yaml
       params:
         - name: package
           value: $(params.package)
@@ -143,7 +175,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -164,7 +203,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -199,8 +245,13 @@ spec:
         steps:
           - name: create-results
             image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+            env:
+              - name: RELEASE_BUCKET
+                value: $(params.releaseBucket)
+              - name: VERSION_TAG
+                value: $(params.versionTag)
             script: |
-              BASE_URL=$(echo "$(params.releaseBucket)/previous/$(params.versionTag)")
+              BASE_URL=$(echo "${RELEASE_BUCKET}/previous/${VERSION_TAG}")
               # If the bucket is in the gs:// return the corresponding public https URL
               BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
               echo "${BASE_URL}/release.yaml" > $(results.release.path)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Use resolvers to fetch the tasks used by the release pipeline instead of relying on the tasks being applied to the cluster in advance / separately.

Common tasks such as git-clone and gcs-upload are loaded from the catalog, while Dashboard-specific tasks are loaded from the Dashboard repo itself.

This has a number of benefits:
- simpler deployment of pipeline changes (only the pipelin definition needs to be synced)
- consistent versioning of pipeline and tasks, eliminates risk of drift / incompatibility
- easier patch releases on older release branches as it will always use the task definitions corresponding to the target release branch

Also replace direct use of params in scripts with env vars.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
