### PR TITLE
Remove dependency on setup-kind script from pipeline repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
           cache-dependency-path: "${{ github.workspace }}/src/github.com/tektoncd/dashboard/go.sum"
           go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/dashboard/go.mod"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          cache: npm
+          cache-dependency-path: src/github.com/tektoncd/dashboard/package-lock.json
+          node-version-file: src/github.com/tektoncd/dashboard/.nvmrc
+          registry-url: 'https://registry.npmjs.org/'
+
       - name: Install dependencies
         run: |
           echo "${GOPATH}/bin" >> "$GITHUB_PATH"
@@ -68,6 +76,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Run tests
         run: |
@@ -117,6 +132,14 @@ jobs:
         with:
           cache-dependency-path: "${{ github.workspace }}/src/github.com/tektoncd/dashboard/go.sum"
           go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/dashboard/go.mod"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          cache: npm
+          cache-dependency-path: src/github.com/tektoncd/dashboard/package-lock.json
+          node-version-file: src/github.com/tektoncd/dashboard/.nvmrc
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         working-directory: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,16 +91,15 @@ jobs:
         # protection config. Map name to corresponding version for use in steps
         include:
           - k8s-name: k8s-oldest
-            k8s-version: v1.29.x
+            k8s-version: v1.31.x
           - k8s-name: k8s-plus-one
-            k8s-version: v1.30.x
+            k8s-version: v1.32.x
 
     env:
+      ARTIFACTS: ${{ github.workspace }}/artifacts
       GOPATH: ${{ github.workspace }}
       GO111MODULE: on
-      KO_DOCKER_REPO: registry.local:5000/tekton
-      CLUSTER_DOMAIN: c${{ github.run_id }}.local
-      ARTIFACTS: ${{ github.workspace }}/artifacts
+      KO_DOCKER_REPO: kind.local
 
     steps:
       - name: Harden runner
@@ -113,16 +112,6 @@ jobs:
         with:
           path: ${{ github.workspace }}/src/github.com/tektoncd/dashboard
 
-      - name: Checkout setup-kind.sh
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: tektoncd/pipeline
-          ref: d306d649df2dbd2badaba6a90459efd05c753d2f
-          path: scripts
-          sparse-checkout: |
-            hack/setup-kind.sh
-          sparse-checkout-cone-mode: false
-
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
@@ -131,11 +120,17 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./
+        env:
+          GO111MODULE: "on"
         run: |
           echo '::group::install ko'
           curl -L https://github.com/ko-build/ko/releases/download/v0.15.4/ko_0.15.4_Linux_x86_64.tar.gz | tar xzf - ko
           chmod +x ./ko
           sudo mv ko /usr/local/bin
+          echo '::endgroup::'
+
+          echo '::group::install kind'
+          go install sigs.k8s.io/kind@v0.27.0
           echo '::endgroup::'
 
           echo '::group::create required folders'
@@ -148,14 +143,10 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/dashboard
         env:
           DASHBOARD_MODE: ${{ matrix.dashboard-mode }}
+          SKIP_INITIALIZE: true
         run: |
-          ${{ github.workspace }}/scripts/hack/setup-kind.sh \
-            --registry-url $(echo ${KO_DOCKER_REPO} | cut -d'/' -f 1) \
-            --cluster-suffix c${{ github.run_id }}.local \
-            --nodes 3 \
+          ./test/e2e-tests-prow.sh \
             --k8s-version ${{ matrix.k8s-version }} \
-            --e2e-script ./test/e2e-tests-prow.sh \
-            --e2e-env ./test/e2e-tests-kind-prow.env
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/test/e2e-tests-kind-prow.env
+++ b/test/e2e-tests-kind-prow.env
@@ -1,2 +1,0 @@
-KO_DOCKER_REPO=registry.local:5000
-SKIP_INITIALIZE=true

--- a/test/e2e-tests-prow.sh
+++ b/test/e2e-tests-prow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022 The Tekton Authors
+# Copyright 2022-2025 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,4 +13,70 @@
 
 set -e
 
+# Defaults
+K8S_VERSION="v1.32.x"
+
+while [[ $# -ne 0 ]]; do
+  parameter="$1"
+  case "${parameter}" in
+    --k8s-version)
+      shift
+      K8S_VERSION="$1"
+      ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+
+# The version map correlated with this version of kind
+case ${K8S_VERSION} in
+  v1.29.x)
+    K8S_VERSION="1.29.14"
+    KIND_IMAGE_SHA="sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.30.x)
+    K8S_VERSION="1.30.10"
+    KIND_IMAGE_SHA="sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.31.x)
+    K8S_VERSION="1.31.6"
+    KIND_IMAGE_SHA="sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.32.x)
+    K8S_VERSION="1.32.2"
+    KIND_IMAGE_SHA="sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  *) abort "Unsupported version: ${K8S_VERSION}" ;;
+esac
+
+# Create kind config with correct k8s version
+cat > kind-config.yaml <<EOF
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  image: "docker.io/${KIND_IMAGE}"
+EOF
+
+echo '::group::kind-config.yaml'
+cat kind-config.yaml
+echo '::endgroup::'
+
+echo '::group::kind version'
+kind --version
+echo '::endgroup::'
+
+echo '::group::check we can talk to docker'
+docker ps
+echo '::endgroup::'
+
+echo '::group::create cluster'
+kind create cluster --config kind-config.yaml
+echo '::endgroup::'
+
+# Run the tests
 $(git rev-parse --show-toplevel)/test/presubmit-tests.sh --integration-tests;

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -64,6 +64,11 @@ function post_build_tests() {
 }
 
 function get_node() {
+  if [ "$GITHUB_ACTIONS" == "true" ]; then
+    echo "Running in GitHub Actions, skipping nvm / Node.js install script"
+    return
+  fi
+
   echo "Installing Node.js"
   # nvm v0.40.1
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/179d45050be0a71fd57591b0ed8aedf9b177ba10/install.sh | bash


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
We don't need most of the functionality provided by the setup-kind script (e.g. local registry, metallb, etc.), and it creates overhead in managing the supported k8s versions for the tests.

Instead, use a simplified approach to creating the desired cluster and directly manage the supported k8s versions in this repo.

Also skip custom nvm installation when running tests in GitHub Actions, preferring the `setup-node` action in that scenario.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
