### PR TITLE
pipelineRun details page header changes

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -232,7 +232,7 @@ export default /* istanbul ignore next */ function PipelineRun({
   if (pipelineRun) {
     handlePipelineRunInfo({
       message: pipelineRunStatusMessage,
-      pipelineRunName,
+      name: pipelineRunName,
       reason: pipelineRunReason,
       status: pipelineRunStatus
     });

--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -42,6 +42,7 @@ function getPipelineTask({ pipeline, pipelineRun, selectedTaskId, taskRun }) {
 
 export default /* istanbul ignore next */ function PipelineRun({
   customNotification,
+  displayRunHeader,
   enableLogAutoScroll,
   enableLogScrollButtons,
   error,
@@ -49,6 +50,7 @@ export default /* istanbul ignore next */ function PipelineRun({
   forceLogPolling,
   getLogsToolbar,
   handleTaskSelected = /* istanbul ignore next */ () => {},
+  handlePipelineRunInfo = () => {},
   loading,
   logLevels,
   maximizedLogsContainer,
@@ -59,6 +61,7 @@ export default /* istanbul ignore next */ function PipelineRun({
   pod,
   pollingInterval,
   runActions,
+  runStatus,
   selectedRetry,
   selectedStepId = null,
   selectedTaskId = null,
@@ -227,10 +230,21 @@ export default /* istanbul ignore next */ function PipelineRun({
     status: pipelineRunStatus
   } = getStatus(pipelineRun);
 
+  if (pipelineRun) {
+    handlePipelineRunInfo({
+      message: pipelineRunStatusMessage,
+      pipelineRunName,
+      reason: pipelineRunReason,
+      runStatus,
+      status: pipelineRunStatus
+    });
+  }
+
   if (pipelineRunError) {
     return (
       <>
         <RunHeader
+          displayRunHeader={displayRunHeader}
           lastTransitionTime={lastTransitionTime}
           loading={loading}
           pipelineRun={pipelineRun}
@@ -313,6 +327,7 @@ export default /* istanbul ignore next */ function PipelineRun({
   return (
     <>
       <RunHeader
+        displayRunHeader={displayRunHeader}
         lastTransitionTime={lastTransitionTime}
         loading={loading}
         message={pipelineRunStatusMessage}

--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -61,7 +61,6 @@ export default /* istanbul ignore next */ function PipelineRun({
   pod,
   pollingInterval,
   runActions,
-  runStatus,
   selectedRetry,
   selectedStepId = null,
   selectedTaskId = null,
@@ -235,7 +234,6 @@ export default /* istanbul ignore next */ function PipelineRun({
       message: pipelineRunStatusMessage,
       pipelineRunName,
       reason: pipelineRunReason,
-      runStatus,
       status: pipelineRunStatus
     });
   }

--- a/packages/components/src/components/RunHeader/RunHeader.jsx
+++ b/packages/components/src/components/RunHeader/RunHeader.jsx
@@ -19,11 +19,12 @@ import FormattedDate from '../FormattedDate';
 
 export default function RunHeader({
   children,
+  displayRunHeader = true,
   lastTransitionTime,
   loading,
   message,
-  runName,
   reason,
+  runName,
   status,
   triggerHeader
 }) {
@@ -55,48 +56,55 @@ export default function RunHeader({
         return (
           runName && (
             <>
-              <h1 className="tkn--run-header--heading">
-                <div className="tkn--run-name" title={runName}>
-                  {runName}
-                </div>
-                <span className="tkn--time">
-                  {lastTransitionTime
-                    ? intl.formatMessage(
-                        {
-                          id: 'dashboard.lastUpdated',
-                          defaultMessage: 'Last updated {time}'
-                        },
-                        {
-                          time: (
-                            <FormattedDate date={lastTransitionTime} relative />
+              {displayRunHeader && (
+                <>
+                  <h1 className="tkn--run-header--heading">
+                    <div className="tkn--run-name" title={runName}>
+                      {runName}
+                    </div>
+                    <span className="tkn--time">
+                      {lastTransitionTime
+                        ? intl.formatMessage(
+                            {
+                              id: 'dashboard.lastUpdated',
+                              defaultMessage: 'Last updated {time}'
+                            },
+                            {
+                              time: (
+                                <FormattedDate
+                                  date={lastTransitionTime}
+                                  relative
+                                />
+                              )
+                            }
                           )
-                        }
-                      )
-                    : null}
-                </span>
-                {children}
-              </h1>
-              <div className="tkn--status">
-                <span className="tkn--status-label">{reason}</span>
-                {message && (
-                  <>
-                    <span className="tkn--status-message" title={message}>
-                      {message}
+                        : null}
                     </span>
-                    <CopyButton
-                      feedback={intl.formatMessage({
-                        id: 'dashboard.clipboard.copied',
-                        defaultMessage: 'Copied!'
-                      })}
-                      iconDescription={intl.formatMessage({
-                        id: 'dashboard.clipboard.copyStatusMessage',
-                        defaultMessage: 'Copy status message to clipboard'
-                      })}
-                      onClick={copyStatusMessage}
-                    />
-                  </>
-                )}
-              </div>
+                    {children}
+                  </h1>
+                  <div className="tkn--status">
+                    <span className="tkn--status-label">{reason}</span>
+                    {message && (
+                      <>
+                        <span className="tkn--status-message" title={message}>
+                          {message}
+                        </span>
+                        <CopyButton
+                          feedback={intl.formatMessage({
+                            id: 'dashboard.clipboard.copied',
+                            defaultMessage: 'Copied!'
+                          })}
+                          iconDescription={intl.formatMessage({
+                            id: 'dashboard.clipboard.copyStatusMessage',
+                            defaultMessage: 'Copy status message to clipboard'
+                          })}
+                          onClick={copyStatusMessage}
+                        />
+                      </>
+                    )}
+                  </div>
+                </>
+              )}
               {triggerHeader}
             </>
           )

--- a/packages/components/src/components/RunHeader/_RunHeader.scss
+++ b/packages/components/src/components/RunHeader/_RunHeader.scss
@@ -13,7 +13,9 @@ limitations under the License.
 
 @use '@carbon/react/scss/theme' as *;
 @use '@carbon/react/scss/type' as *;
-
+header.tkn--pipeline-run-header:empty{
+ padding-block: 0;
+}
 header.tkn--pipeline-run-header {
   @include type-style('body-compact-01');
   line-height: 1;

--- a/packages/components/src/components/RunHeader/_RunHeader.scss
+++ b/packages/components/src/components/RunHeader/_RunHeader.scss
@@ -13,9 +13,7 @@ limitations under the License.
 
 @use '@carbon/react/scss/theme' as *;
 @use '@carbon/react/scss/type' as *;
-header.tkn--pipeline-run-header:empty{
- padding-block: 0;
-}
+
 header.tkn--pipeline-run-header {
   @include type-style('body-compact-01');
   line-height: 1;

--- a/packages/components/src/components/RunTimeMetadata/RunTimeMetadata.jsx
+++ b/packages/components/src/components/RunTimeMetadata/RunTimeMetadata.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2025 The Tekton Authors
+Copyright 2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import FormattedDuration from '../FormattedDuration';
 export default function RunTimeMetadata({ lastTransitionTime, duration }) {
   const intl = useIntl();
   return (
-    <>
+    <div className="tkn--run-metadata-time">
       <div className="tkn--time">
         {lastTransitionTime
           ? intl.formatMessage(
@@ -32,7 +32,7 @@ export default function RunTimeMetadata({ lastTransitionTime, duration }) {
             )
           : null}
       </div>
-      <div className="tkn--run-details-time tkn--run-metadata-time">
+      <div className="tkn--run-details-time">
         {duration
           ? intl.formatMessage(
               {
@@ -45,6 +45,6 @@ export default function RunTimeMetadata({ lastTransitionTime, duration }) {
             )
           : null}
       </div>
-    </>
+    </div>
   );
 }

--- a/packages/components/src/components/RunTimeMetadata/RunTimeMetadata.jsx
+++ b/packages/components/src/components/RunTimeMetadata/RunTimeMetadata.jsx
@@ -1,0 +1,50 @@
+/*
+Copyright 2020-2025 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useIntl } from 'react-intl';
+import FormattedDate from '../FormattedDate';
+import FormattedDuration from '../FormattedDuration';
+
+export default function RunTimeMetadata({ lastTransitionTime, duration }) {
+  const intl = useIntl();
+  return (
+    <>
+      <div className="tkn--time">
+        {lastTransitionTime
+          ? intl.formatMessage(
+              {
+                id: 'dashboard.lastUpdated',
+                defaultMessage: 'Last updated {time}'
+              },
+              {
+                time: <FormattedDate date={lastTransitionTime} relative />
+              }
+            )
+          : null}
+      </div>
+      <div className="tkn--run-details-time tkn--run-metadata-time">
+        {duration
+          ? intl.formatMessage(
+              {
+                id: 'dashboard.run.duration',
+                defaultMessage: 'Duration: {duration}'
+              },
+              {
+                duration: <FormattedDuration milliseconds={duration} />
+              }
+            )
+          : null}
+      </div>
+    </>
+  );
+}

--- a/packages/components/src/components/RunTimeMetadata/index.js
+++ b/packages/components/src/components/RunTimeMetadata/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2025 The Tekton Authors
+Copyright 2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/packages/components/src/components/RunTimeMetadata/index.js
+++ b/packages/components/src/components/RunTimeMetadata/index.js
@@ -1,0 +1,14 @@
+/*
+Copyright 2019-2025 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* istanbul ignore file */
+export { default } from './RunTimeMetadata';

--- a/packages/components/src/components/index.js
+++ b/packages/components/src/components/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -36,6 +36,7 @@ export { default as PipelineRuns } from './PipelineRuns';
 export { default as Portal } from './Portal';
 export { default as ResourceDetails } from './ResourceDetails';
 export { default as RunHeader } from './RunHeader';
+export { default as RunTimeMetadata } from './RunTimeMetadata';
 export { default as Spinner } from './Spinner';
 export { default as StatusFilterDropdown } from './StatusFilterDropdown';
 export { default as StatusIcon } from './StatusIcon';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related to https://github.com/tektoncd/dashboard/issues/2306

part 1 of the UI changes for RunHeader - 
Option to hide the Run Header information, without hiding the the triggerHeader
Adding `handlePipelineRunInfo` to return pipeline run specific information
Adding new component `RunTimeMetadata`, it will handle the time related pipelinerun metadata eg `last updated` and `duration` and will be utilised in the next part of the runHeader redesign.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
