### PR TITLE
Remove Storybook addon storysource

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2024 The Tekton Authors
+Copyright 2020-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,6 @@ const config = {
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-links',
-    '@storybook/addon-storysource',
     '@storybook/addon-themes',
     'storybook-addon-remix-react-router'
   ],

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2024 The Tekton Authors
+Copyright 2020-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -57,6 +57,7 @@ const decorators = [
 const preview = {
   decorators,
   parameters
+  // tags: ['autodocs'] // revisit with Storybook 9 and code panel
 };
 
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@storybook/addon-actions": "^8.6.12",
         "@storybook/addon-essentials": "^8.6.12",
         "@storybook/addon-links": "^8.6.12",
-        "@storybook/addon-storysource": "^8.6.12",
         "@storybook/addon-themes": "^8.6.12",
         "@storybook/manager-api": "^8.6.12",
         "@storybook/preview-api": "^8.6.12",
@@ -2753,25 +2752,6 @@
         "storybook": "^8.6.12"
       }
     },
-    "node_modules/@storybook/addon-storysource": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-8.6.12.tgz",
-      "integrity": "sha512-EAvf7DubbIw8OnTCp/blmgDaO4hzL8rROR+SpNMx6t3NwFgfJTP4VosiNOFIrtdGOaUeG0I815XSUphjNQ14lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/source-loader": "8.6.12",
-        "estraverse": "^5.2.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
     "node_modules/@storybook/addon-themes": {
       "version": "8.6.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-8.6.12.tgz",
@@ -3161,25 +3141,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@storybook/source-loader": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-8.6.12.tgz",
-      "integrity": "sha512-Yfq54Vh1RnsUXqda6yd79gUoqjOfvig9t6a2eZDkLSBlFiYIUqHYCfMBFXxQTJN2pn0BlZccZs5ho85q3ULWWQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-toolkit": "^1.22.0",
-        "estraverse": "^5.2.0",
-        "prettier": "^3.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
       }
     },
     "node_modules/@storybook/theming": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@storybook/addon-actions": "^8.6.12",
     "@storybook/addon-essentials": "^8.6.12",
     "@storybook/addon-links": "^8.6.12",
-    "@storybook/addon-storysource": "^8.6.12",
     "@storybook/addon-themes": "^8.6.12",
     "@storybook/manager-api": "^8.6.12",
     "@storybook/preview-api": "^8.6.12",

--- a/packages/components/src/components/Log/Log.stories.jsx
+++ b/packages/components/src/components/Log/Log.stories.jsx
@@ -42,6 +42,7 @@ export default {
       themeOverride: 'dark'
     }
   },
+  subcomponents: { LogsToolbar },
   title: 'Log'
 };
 

--- a/packages/components/src/components/PipelineRun/PipelineRun.stories.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.stories.jsx
@@ -231,6 +231,7 @@ export default {
   },
   component: PipelineRun,
   decorators: [Story => <Story />],
+  subcomponents: { LogsToolbar },
   title: 'PipelineRun'
 };
 

--- a/packages/components/src/components/StepDetails/StepDetails.stories.jsx
+++ b/packages/components/src/components/StepDetails/StepDetails.stories.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -43,6 +43,7 @@ export default {
     taskRun: {}
   },
   component: StepDetails,
+  subcomponents: { Log },
   title: 'StepDetails'
 };
 

--- a/src/containers/Header/Header.stories.jsx
+++ b/src/containers/Header/Header.stories.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -43,6 +43,7 @@ const namespaceContext = {
 
 export default {
   component: Header,
+  subcomponents: { HeaderBarContent },
   title: 'Header'
 };
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Storysource is deprecated and does not generate useful code snippets in most cases, largely due to our use of CSF to define the stories.

The docs addon can generate more useful content and will be getting a number of updates in the upcoming Storybook 9 release, including the ability to display its code content in an addon panel instead of just on the generated docs page.

Prepare for enabling the docs addon by adding subcomponent config where appropriate.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
