### PR TITLE
Remove linux/arm from supported platforms

### DIFF
--- a/docs/dev/installer.md
+++ b/docs/dev/installer.md
@@ -170,9 +170,8 @@ The `build` command is useful when you want to ensure everything builds correctl
 
 ## Platform support
 
-Official Dashboard releases since v0.12.0 provide multi-platform images supporting the following:
+Official Dashboard releases provide multi-platform images supporting the following:
 - `linux/amd64`
-- `linux/arm`
 - `linux/arm64`
 - `linux/ppc64le`
 - `linux/s390x`
@@ -180,7 +179,7 @@ Official Dashboard releases since v0.12.0 provide multi-platform images supporti
 The `installer` script's `build` and `install` commands will build an image for `linux/amd64` by default.
 To override the platform in cases where the target cluster is running on a different architecture, add `--platform <platform>` where `<platform>` is a value from the list of supported values, for example:
 ```bash
-./scripts/installer install --platform linux/arm
+./scripts/installer install --platform linux/arm64
 ```
 or build a multi-platform image by specifying `all` or a comma-separated list of supported platforms:
 ```bash

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -47,7 +47,7 @@ spec:
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-      default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
     - name: serviceAccountPath
       description: The name of the service account path within the release-secret workspace
   workspaces:

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -45,7 +45,7 @@ spec:
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-      default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
     - name: koExtraArgs
       description: Extra args to be passed to ko
       default: "--preserve-import-paths"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Remove `linux/arm` from the list of platforms for which we build and publish images. This only affects arm5, arm6, and arm7. We still build, publish, and support `linux/arm64` (also known as `aarch64`) images.

See the [announcement on the tekton-users mailing list](https://groups.google.com/g/tekton-users/c/3VJcEJT4XYg) for more details.

/kind cleanup
/kind misc
/hold

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
