### PR TITLE
Update E2E to use new base image with Node.js 20.19 and Chrome 138

### DIFF
--- a/packages/e2e/Dockerfile
+++ b/packages/e2e/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 The Tekton Authors
+# Copyright 2022-2025 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/tektoncd/dashboard/dashboard-e2e-base:node20.18.0-chrome130@sha256:d1f3068cfb5ec95eb6e3e732788bf70e4c88c43d491a031d953b0c312e66c23d
+FROM ghcr.io/tektoncd/dashboard/dashboard-e2e-base:node20.19.3-chrome138@sha256:6ca889424f0e60dd622d4bf54d04d3fc46606ef7bea68f1faf1d89d9ef943bd2
 
 ENTRYPOINT ["npm", "run", "test:ci"]
 CMD ["--", "--browser", "chrome"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/4264
Related to https://github.com/tektoncd/dashboard/issues/4262
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
