### PR TITLE
Fix location of 'latest' release manifests

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -224,6 +224,8 @@ spec:
           value: $(params.versionTag)
         - name: serviceAccountPath
           value: $(params.serviceAccountPath)
+        - name: deleteExtraFiles
+          value: "true" # Uses rsync to copy content into latest
     - name: report-bucket
       runAfter: [publish-to-bucket]
       params:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Instead of outputting the release manifests directly in the `latest` folder the release pipeline is currently creating a nested folder with the version tag and placing the files inside that.

As a result, the `latest` versions are actually pointing at releases from March 2025.

Update the config to be consistent with other projects which should resolve the issue and ensure the manifests are placed in the correct location.

See for example, currently nightly releases:
<img width="794" height="456" alt="image" src="https://github.com/user-attachments/assets/22c86312-f59a-4693-b7a4-ea70a959424a" />

The `previous` versions are in the correct location / structure, it's only `latest` that's affected.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
