### PR TITLE
Fix bleed-through for sticky header

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.jsx
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.jsx
@@ -38,27 +38,26 @@ export default function DetailsHeader({
         stepStatus.terminated || {});
     }
 
-    if (!startTime || !endTime || new Date(startTime).getTime() === 0) {
-      return null;
-    }
-
     return (
       <span className="tkn--run-details-time">
-        {intl.formatMessage(
-          {
-            id: 'dashboard.run.duration',
-            defaultMessage: 'Duration: {duration}'
-          },
-          {
-            duration: (
-              <FormattedDuration
-                milliseconds={
-                  new Date(endTime).getTime() - new Date(startTime).getTime()
-                }
-              />
+        {startTime && endTime && new Date(startTime).getTime() !== 0
+          ? intl.formatMessage(
+              {
+                id: 'dashboard.run.duration',
+                defaultMessage: 'Duration: {duration}'
+              },
+              {
+                duration: (
+                  <FormattedDuration
+                    milliseconds={
+                      new Date(endTime).getTime() -
+                      new Date(startTime).getTime()
+                    }
+                  />
+                )
+              }
             )
-          }
-        )}
+          : ' '}
       </span>
     );
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/4322
Related to https://github.com/tektoncd/dashboard/issues/2306

When a run is in progress we don't currently display the duration. As a result, there's a gap where the logs can bleed through between the 2 sticky headers on scroll.

Fix this by always rendering the duration row, defaulting to empty.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
