### PR TITLE
Always show TaskRun duration on PipelineRun tab layout

### DIFF
--- a/packages/components/src/components/TaskRunTabs/TaskRunTabs.jsx
+++ b/packages/components/src/components/TaskRunTabs/TaskRunTabs.jsx
@@ -69,7 +69,12 @@ export default function TaskRunTabs({
             // use the resource creation to include total time for all retries
             taskRun.metadata.creationTimestamp
           ).getTime();
-          const endTime = new Date(taskRun.status.completionTime).getTime();
+          // default to current time for end, will only update when there's a
+          // change to the task run resource so may not be 100% accurate but
+          // users have requested this so it's displayed as best-effort
+          const endTime = taskRun.status.completionTime
+            ? new Date(taskRun.status.completionTime).getTime()
+            : Date.now();
           duration = endTime - createdTime;
         }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Follow-up to https://github.com/tektoncd/dashboard/pull/4322
Related to https://github.com/tektoncd/dashboard/issues/2306
Resolves https://github.com/tektoncd/dashboard/issues/3767

While this may not be 100% accurate (since it's only updated when there's a change to the run or user triggers a re-render), this has been a commonly requested enhancement from many users.

Default to current time for 'end' of in-progress runs, display as best-effort representation of duration. Once the run is complete it will show the final value based on the actual resource metadata.

/kind feature

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
