### PR TITLE
Always display duration on task run and step header

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.jsx
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.jsx
@@ -37,10 +37,13 @@ export default function DetailsHeader({
       ({ finishedAt: endTime, startedAt: startTime } =
         stepStatus.terminated || {});
     }
+    if (!endTime) {
+      endTime = new Date();
+    }
 
     return (
       <span className="tkn--run-details-time">
-        {startTime && endTime && new Date(startTime).getTime() !== 0
+        {startTime && new Date(startTime).getTime() !== 0
           ? intl.formatMessage(
               {
                 id: 'dashboard.run.duration',


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/4322
Related to https://github.com/tektoncd/dashboard/issues/2306

This is a best-effort display since it only updates when there's a change to the underlying resource (status) or when the user otherwise triggers a re-render.

Once the run is complete, it will show the correct duration based on the resource metadata.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
