### PR TITLE
Improve layout and styling of run details tabs in horizontal mode

### DIFF
--- a/packages/components/src/components/DetailsHeader/_DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/_DetailsHeader.scss
@@ -40,7 +40,7 @@ header.tkn--step-details-header {
     }
 
     .#{$prefix}--btn-set {
-      margin-inline-start: 0.5rem;
+      margin-inline: 0.5rem;
       align-self: center;
     }
 

--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -145,7 +145,19 @@ limitations under the License.
   }
 }
 
-.tkn--tasks:has(.#{$prefix}--tabs.tkn--task-list) {
+.tkn--tasks > .#{$prefix}--tabs {
+  .tkn--task-title {
+    margin-block-start: 0.25rem;
+    margin-block-end: 0;
+    line-height: 1.75;
+  }
+
+  .tkn--task-duration {
+    margin-block-end: 0.25rem;
+  }
+}
+
+.tkn--tasks:has(> .#{$prefix}--tabs, .#{$prefix}--tabs.tkn--task-list) {
   > .#{$prefix}--css-grid {
     max-inline-size: 100%;
 
@@ -153,6 +165,12 @@ limitations under the License.
       // to stop log content bleeding through the sticky header
       padding-block-start: 0;
     }
+  }
+
+  > .#{$prefix}--tab-content {
+    // to stop log content bleeding through the sticky header
+    padding-block-start: 0;
+    padding-inline: 0;
   }
 
   .tkn--step-details {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/4322
Related to https://github.com/tektoncd/dashboard/issues/2306

When rendered in a small window, the task tabs are rendered horizontally across the top of the tab panels.

Improve the layout of the task title, as well as removing unwanted padding around the panel content.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
