### PR TITLE
PipelineRun details design enhancements: Add sidecar support, update styles, and improve testability

### DIFF
--- a/packages/components/src/components/Log/Log.jsx
+++ b/packages/components/src/components/Log/Log.jsx
@@ -447,7 +447,11 @@ export class LogContainer extends Component {
   };
 
   getTrailerMessage = ({ exitCode, reason, terminationReason }) => {
-    const { forcePolling, intl } = this.props;
+    const { forcePolling, intl, isSidecar } = this.props;
+
+    if (isSidecar) {
+      return null;
+    }
 
     if (terminationReason === 'Skipped') {
       return intl.formatMessage({

--- a/packages/components/src/components/Log/_Log.scss
+++ b/packages/components/src/components/Log/_Log.scss
@@ -150,6 +150,7 @@ pre.tkn--log {
   padding-inline: 1rem;
   font-family: 'IBM Plex Sans', sans-serif;
   color: $text-secondary;
+  background-color: $layer-02;
 
   hr {
     border: none;

--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -110,6 +110,7 @@ export default /* istanbul ignore next */ function PipelineRun({
 
   function getLogContainer({
     disableLogsToolbar,
+    isSidecar,
     stepName,
     stepStatus,
     taskRun
@@ -141,6 +142,7 @@ export default /* istanbul ignore next */ function PipelineRun({
           }
           fetchLogs={() => fetchLogs({ stepName, stepStatus, taskRun })}
           forcePolling={forceLogPolling}
+          isSidecar={isSidecar}
           key={`${selectedTaskId}:${stepName}:${selectedRetry}`}
           logLevels={logLevels}
           pollingInterval={pollingInterval}

--- a/packages/components/src/components/RunHeader/_RunHeader.scss
+++ b/packages/components/src/components/RunHeader/_RunHeader.scss
@@ -51,7 +51,7 @@ limitations under the License.
 header.tkn--pipeline-run-header {
   @include type-style('body-compact-01');
   line-height: 1;
-  margin-block-end: 2em;
+  margin-block-end: 1em;
   padding-block: 0.4em;
   padding-inline-end: 0;
 

--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -175,6 +175,13 @@ limitations under the License.
 
   .tkn--step-details {
     overflow: initial;
+
+    > .#{$prefix}--tabs {
+      position: sticky;
+      inset-block-start: 4.4rem;
+      z-index: 5996;
+      background-color: $layer;
+    }
   }
 
   header.tkn--step-details-header {

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
@@ -365,17 +365,15 @@ const TaskRunDetails = ({
             className="tkn--taskrun-retries-dropdown"
             hideLabel
             id={`${taskRun.metadata.uid}-retry`}
-            initialSelectedItem={
-              retryMenuItems[
-                selectedRetry || fullTaskRun.status.retriesStatus.length - 1
-              ]
-            }
             items={retryMenuItems}
             itemToString={itemToString}
             label={retryMenuTitle}
             onChange={({ selectedItem }) => {
               onRetryChange(selectedItem.id);
             }}
+            selectedItem={
+              retryMenuItems[selectedRetry || retryMenuItems.length - 1]
+            }
             size="sm"
             titleText={retryMenuTitle}
             translateWithId={getTranslateWithId(intl)}

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
@@ -197,7 +197,7 @@ const TaskRunDetails = ({
   /* istanbul ignore if */
   if (logs) {
     tabList.push(
-      <Tab key="logs">
+      <Tab data-tab="logs" key="logs">
         {intl.formatMessage({
           id: 'dashboard.taskRun.logs',
           defaultMessage: 'Logs'
@@ -214,7 +214,7 @@ const TaskRunDetails = ({
   }
   if (paramsTable) {
     tabList.push(
-      <Tab key="params">
+      <Tab data-tab="params" key="params">
         {intl.formatMessage({
           id: 'dashboard.taskRun.params',
           defaultMessage: 'Parameters'
@@ -231,7 +231,7 @@ const TaskRunDetails = ({
   }
   if (resultsTable) {
     tabList.push(
-      <Tab key="results">
+      <Tab data-tab="results" key="results">
         {intl.formatMessage({
           id: 'dashboard.taskRun.results',
           defaultMessage: 'Results'
@@ -247,7 +247,7 @@ const TaskRunDetails = ({
     );
   }
   tabList.push(
-    <Tab key="status">
+    <Tab data-tab="status" key="status">
       {intl.formatMessage({
         id: 'dashboard.taskRun.status',
         defaultMessage: 'Status'
@@ -275,7 +275,11 @@ const TaskRunDetails = ({
     </TabPanel>
   );
   if (!skippedTask && pod) {
-    tabList.push(<Tab key="pod">Pod</Tab>);
+    tabList.push(
+      <Tab data-tab="pod" key="pod">
+        Pod
+      </Tab>
+    );
     tabPanels.push(
       <TabPanel key="pod">
         {selectedTabIndex === tabPanels.length && (

--- a/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
+++ b/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
@@ -198,6 +198,10 @@ function Logs({
 
         return (
           <AccordionItem
+            className="tkn--step"
+            data-status={stepStatus}
+            data-reason={reason}
+            data-termination-reason={terminationReason}
             open={expandedSteps[step.name]}
             onHeadingClick={({ isOpen }) => {
               onStepSelected({

--- a/packages/components/src/scss/_Run.scss
+++ b/packages/components/src/scss/_Run.scss
@@ -60,11 +60,11 @@ limitations under the License.
 .tkn--task-logs {
   .#{$prefix}--accordion__heading {
     position: sticky;
-    inset-block-start: 4rem;
+    inset-block-start: 6.5rem;
     background-color: var(--cds-layer-01);
     // this needs to be lower than the run header to prevent it bleeding through
     // popovers or other menus such as the log settings
-    z-index: 5996;
+    z-index: 5995;
 
     &:focus, &:hover {
       // prevent Carbon from reverting to position: relative

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -123,23 +123,30 @@ export function applyStepTemplate({ step, stepTemplate }) {
   return definition;
 }
 
-export function getStepDefinition({ selectedStepId, task, taskRun }) {
+export function getStepDefinition({
+  isSidecar,
+  selectedStepId,
+  task,
+  taskRun
+}) {
   if (!selectedStepId) {
     return null;
   }
 
   const stepTemplate =
-    taskRun.status?.taskSpec?.stepTemplate ||
-    taskRun.spec?.taskSpec?.stepTemplate ||
-    task?.spec?.stepTemplate;
+    !isSidecar &&
+    (taskRun.status?.taskSpec?.stepTemplate ||
+      taskRun.spec?.taskSpec?.stepTemplate ||
+      task?.spec?.stepTemplate);
 
   let stepDefinitions = [];
-  if (taskRun.status?.taskSpec?.steps) {
-    stepDefinitions = taskRun.status.taskSpec.steps;
-  } else if (taskRun.spec?.taskSpec?.steps) {
-    stepDefinitions = taskRun.spec.taskSpec.steps;
-  } else if (task?.spec?.steps) {
-    stepDefinitions = task.spec.steps;
+  const field = isSidecar ? 'sidecars' : 'steps';
+  if (taskRun.status?.taskSpec?.[field]) {
+    stepDefinitions = taskRun.status.taskSpec[field];
+  } else if (taskRun.spec?.taskSpec?.[field]) {
+    stepDefinitions = taskRun.spec.taskSpec[field];
+  } else if (task?.spec?.[field]) {
+    stepDefinitions = task.spec[field];
   }
 
   const definition = stepDefinitions?.find(
@@ -159,7 +166,7 @@ export function getStepDefinition({ selectedStepId, task, taskRun }) {
   // ['unnamed-2', 'unnamed-4']
   // but the order will be consistent with unnamed steps in the definition
   const statusSteps =
-    taskRun.status.steps?.filter(({ name }) => name.startsWith('unnamed-')) ||
+    taskRun.status[field]?.filter(({ name }) => name.startsWith('unnamed-')) ||
     [];
   const unnamedSteps = stepDefinitions.filter(({ name }) => !name);
 

--- a/packages/utils/src/utils/index.test.js
+++ b/packages/utils/src/utils/index.test.js
@@ -469,6 +469,31 @@ describe('getStepDefinition', () => {
     const definition = getStepDefinition({ selectedStepId, task, taskRun });
     expect(definition).toEqual(step);
   });
+
+  it('handles sidecars', () => {
+    const selectedStepId = 'a-sidecar';
+    const sidecar = { name: selectedStepId };
+    const task = {};
+    const taskRun = {
+      spec: {
+        taskRef: {
+          name: 'dummy-task'
+        }
+      },
+      status: {
+        taskSpec: {
+          sidecars: [sidecar]
+        }
+      }
+    };
+    const definition = getStepDefinition({
+      isSidecar: true,
+      selectedStepId,
+      task,
+      taskRun
+    });
+    expect(definition).toEqual(sidecar);
+  });
 });
 
 it('getStepStatus', () => {

--- a/src/containers/Settings/Settings.jsx
+++ b/src/containers/Settings/Settings.jsx
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useTitleSync } from '@tektoncd/dashboard-utils';
 import { RadioTile, Stack, TileGroup, Toggle } from '@carbon/react';
@@ -37,6 +38,12 @@ export function Settings() {
     })
   });
 
+  const [theme, setThemeState] = useState(() => getTheme());
+  function onSelectTheme(selectedTheme) {
+    setThemeState(selectedTheme);
+    setTheme(selectedTheme);
+  }
+
   return (
     <div className="tkn--settings">
       <h1 id="main-content-header">
@@ -52,8 +59,8 @@ export function Settings() {
             defaultMessage: 'Theme'
           })}
           name="theme-group"
-          valueSelected={getTheme()}
-          onChange={theme => setTheme(theme)}
+          valueSelected={theme}
+          onChange={selectedTheme => onSelectTheme(selectedTheme)}
         >
           <RadioTile value="system" name="theme">
             <SystemIcon />

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "",
   "dashboard.taskRun.results": "",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "Status",
   "dashboard.taskRun.status.cancelled": "Abgebrochen",
   "dashboard.taskRun.status.failed": "Fehlgeschlagen",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "No logs are available. See status for more details.",
   "dashboard.taskRun.params": "Parameters",
   "dashboard.taskRun.results": "Results",
+  "dashboard.taskRun.sidecar": "Sidecar: {name}",
   "dashboard.taskRun.status": "Status",
   "dashboard.taskRun.status.cancelled": "Cancelled",
   "dashboard.taskRun.status.failed": "Failed",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "",
   "dashboard.taskRun.results": "",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "Estado",
   "dashboard.taskRun.status.cancelled": "Cancelado",
   "dashboard.taskRun.status.failed": "Fallidas",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "",
   "dashboard.taskRun.results": "",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "Statut",
   "dashboard.taskRun.status.cancelled": "Annulé",
   "dashboard.taskRun.status.failed": "Echec",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "",
   "dashboard.taskRun.results": "",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "Stato",
   "dashboard.taskRun.status.cancelled": "Annullato",
   "dashboard.taskRun.status.failed": "Non riuscito",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "パラメータ",
   "dashboard.taskRun.results": "結果",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "ステータス",
   "dashboard.taskRun.status.cancelled": "キャンセル済み",
   "dashboard.taskRun.status.failed": "失敗",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "매개변수",
   "dashboard.taskRun.results": "결과",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "상태",
   "dashboard.taskRun.status.cancelled": "취소됨",
   "dashboard.taskRun.status.failed": "실패",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "",
   "dashboard.taskRun.results": "",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "Status",
   "dashboard.taskRun.status.cancelled": "Cancelado",
   "dashboard.taskRun.status.failed": "Com falha",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "参数",
   "dashboard.taskRun.results": "结果",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "状态",
   "dashboard.taskRun.status.cancelled": "已取消",
   "dashboard.taskRun.status.failed": "失败",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -253,6 +253,7 @@
   "dashboard.taskRun.logs.unavailable": "",
   "dashboard.taskRun.params": "",
   "dashboard.taskRun.results": "",
+  "dashboard.taskRun.sidecar": "",
   "dashboard.taskRun.status": "狀態",
   "dashboard.taskRun.status.cancelled": "已取消",
   "dashboard.taskRun.status.failed": "已失敗",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2306
Resolves https://github.com/tektoncd/dashboard/issues/972

- Add data attributes to help with testing
- Fix theme selector not reflecting selected tile without page reload
- Fix background colour of log settings popover in gray100 theme
- Make tabs in TaskRun sticky
- Fix TaskRun retry dropdown
- Display sidecar logs and definitions
- Don't display duration for skipped steps
- Only show a single step at a time as running for each task

/kind misc
/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
