### PR TITLE
Switch npm publish to use trusted publishing instead of token auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      # required for npm package provenance
+      # required for OIDC
       id-token: write
     steps:
       - name: Check for publish commit
@@ -129,9 +129,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
       - name: Publish dry run
         if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-        run: npm publish --workspaces --provenance --access public --dry-run
+        # npm@11: You must specify a tag using --tag when publishing a prerelease version.
+        run: npm publish --workspaces --access public --tag latest --dry-run
       - name: Publish
         if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'push' }}
-        run: npm publish --workspaces --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: npm publish --workspaces --access public --tag latest


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Enable OpenID Connect (OIDC) trusted publishing. This is configured on npmjs.com for each of the packages to trust this workflow file from tektoncd/dashboard only.

Passing the `--provenance` flag to `npm publish` is no longer required as trusted publishing generates provenance by default.

It uses short-lived, workflow-specific credentials that are automatically managed by GitHub / npm, and do not require manual rotation like the previously used npm auth token.

npm v11.5.1 or later is required, included by default with Node.js v24.5.0.

See https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/ for further details.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
