### PR TITLE
Update layer used for sticky headers

### DIFF
--- a/packages/components/src/components/DetailsHeader/_DetailsHeader.scss
+++ b/packages/components/src/components/DetailsHeader/_DetailsHeader.scss
@@ -31,7 +31,7 @@ header.tkn--step-details-header {
 
     .tkn--taskrun-retries-dropdown {
       margin-inline-start: 0.5rem;
-      z-index: 5998;
+      z-index: 4998;
 
       .#{$prefix}--dropdown--sm {
         block-size: 1.75rem;

--- a/packages/components/src/components/Log/_Log.scss
+++ b/packages/components/src/components/Log/_Log.scss
@@ -141,7 +141,7 @@ pre.tkn--log {
 
 .tkn--log-settings-menu {
   // needs to appear over sticky headers
-  z-index: 5998;
+  z-index: 4998;
 }
 
 .#{$prefix}--popover-content.tkn--log-settings-menu-content {

--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -179,7 +179,7 @@ limitations under the License.
     > .#{$prefix}--tabs {
       position: sticky;
       inset-block-start: 4.4rem;
-      z-index: 5996;
+      z-index: 4996;
       background-color: $layer;
     }
   }
@@ -188,6 +188,6 @@ limitations under the License.
     padding: 1rem 0 0 0;
     position: sticky;
     inset-block-start: 0;
-    z-index: 5997;
+    z-index: 4997;
   }
 }

--- a/packages/components/src/scss/_Run.scss
+++ b/packages/components/src/scss/_Run.scss
@@ -64,7 +64,7 @@ limitations under the License.
     background-color: var(--cds-layer-01);
     // this needs to be lower than the run header to prevent it bleeding through
     // popovers or other menus such as the log settings
-    z-index: 5995;
+    z-index: 4995;
 
     &:focus, &:hover {
       // prevent Carbon from reverting to position: relative


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2306

CPC uses a custom z-index value of 5100 instead of Carbon's standard 6000. Reduce Dashboard's z-index values to account for this.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
