### PR TITLE
Increase vertical space available for viewing logs

### DIFF
--- a/packages/components/src/scss/_Run.scss
+++ b/packages/components/src/scss/_Run.scss
@@ -49,7 +49,8 @@ limitations under the License.
 
   > .#{$prefix}--css-grid {
     padding-inline: 0;
-    height: calc(100cqh - 350px);
+    min-block-size: calc(100cqb - 350px);
+    max-block-size: calc(100vb - 4rem);
   }
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Properly constrain height of vertical tab container so that the user can scroll down to give the logs more vertical space.

Replace `height` with `block-size` for consistency and update units accordingly.

The tabs should always expand to use the available space, but be no taller than the viewport (minus header) to ensure the sticky header behaviour can still be triggered.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
