### PR TITLE
Add support for multiline strings in create TaskRun / PipelineRun form

### DIFF
--- a/src/containers/CreatePipelineRun/CreatePipelineRun.jsx
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.jsx
@@ -21,6 +21,7 @@ import {
   Form,
   FormGroup,
   InlineNotification,
+  TextArea,
   TextInput,
   Toggle
 } from '@carbon/react';
@@ -686,12 +687,9 @@ function CreatePipelineRun() {
         {paramSpecs && paramSpecs.length !== 0 && (
           <FormGroup legendText="Params">
             {paramSpecs.map(paramSpec => (
-              <TextInput
-                id={`create-pipelinerun--param-${paramSpec.name}`}
-                key={`create-pipelinerun--param-${paramSpec.name}`}
-                labelText={paramSpec.name}
+              <TextArea
                 helperText={paramSpec.description}
-                placeholder={paramSpec.default || paramSpec.name}
+                id={`create-pipelinerun--param-${paramSpec.name}`}
                 invalid={
                   validationError &&
                   !params[paramSpec.name] &&
@@ -701,10 +699,13 @@ function CreatePipelineRun() {
                   id: 'dashboard.createRun.invalidParams',
                   defaultMessage: 'Params cannot be empty'
                 })}
-                value={params[paramSpec.name] || ''}
+                key={`create-pipelinerun--param-${paramSpec.name}`}
+                labelText={paramSpec.name}
                 onChange={({ target: { value } }) =>
                   handleParamChange(paramSpec.name, value)
                 }
+                placeholder={paramSpec.default || paramSpec.name}
+                value={params[paramSpec.name] || ''}
               />
             ))}
           </FormGroup>

--- a/src/containers/CreateTaskRun/CreateTaskRun.jsx
+++ b/src/containers/CreateTaskRun/CreateTaskRun.jsx
@@ -21,6 +21,7 @@ import {
   Form,
   FormGroup,
   InlineNotification,
+  TextArea,
   TextInput
 } from '@carbon/react';
 import {
@@ -648,12 +649,9 @@ function CreateTaskRun() {
         {paramSpecs && paramSpecs.length !== 0 && (
           <FormGroup legendText="Params">
             {paramSpecs.map(paramSpec => (
-              <TextInput
-                id={`create-taskrun--param-${paramSpec.name}`}
-                key={`create-taskrun--param-${paramSpec.name}`}
-                labelText={paramSpec.name}
+              <TextArea
                 helperText={paramSpec.description}
-                placeholder={paramSpec.default || paramSpec.name}
+                id={`create-taskrun--param-${paramSpec.name}`}
                 invalid={
                   validationError &&
                   !params[paramSpec.name] &&
@@ -663,10 +661,13 @@ function CreateTaskRun() {
                   id: 'dashboard.createRun.invalidParams',
                   defaultMessage: 'Params cannot be empty'
                 })}
-                value={params[paramSpec.name] || ''}
+                key={`create-taskrun--param-${paramSpec.name}`}
+                labelText={paramSpec.name}
                 onChange={({ target: { value } }) =>
                   handleParamChange(paramSpec.name, value)
                 }
+                placeholder={paramSpec.default || paramSpec.name}
+                value={params[paramSpec.name] || ''}
               />
             ))}
           </FormGroup>

--- a/src/scss/_carbon.scss
+++ b/src/scss/_carbon.scss
@@ -66,6 +66,7 @@ limitations under the License.
 @use '@carbon/react/scss/components/stack';
 @use '@carbon/react/scss/components/tabs';
 @use '@carbon/react/scss/components/tag';
+@use '@carbon/react/scss/components/text-area';
 @use '@carbon/react/scss/components/text-input';
 @use '@carbon/react/scss/components/tile';
 @use '@carbon/react/scss/components/toggle';


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Resolves https://github.com/tektoncd/dashboard/issues/4071

Replace the Carbon `TextInput` with a `TextArea` for the string params to provide support for rendering multiline default value placeholders as well as allowing the user to enter multiline values.

Previously newlines from the default values were stripped and the entire value was rendered on a single line. Now they're preserved and the user can easily include them in their provided value if desired.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
