### PR TITLE
Preserve sidecar status

### DIFF
--- a/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
+++ b/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
@@ -32,8 +32,9 @@ import StatusIcon from '../StatusIcon';
 import FormattedDuration from '../FormattedDuration';
 import StepDefinition from '../StepDefinition';
 
-function getStepData({ reason, selectedStepId, steps }) {
-  const stepsToUse = updateUnexecutedSteps(steps);
+function getStepData({ isSidecar, reason, selectedStepId, steps }) {
+  // sidecars run in parallel to the regular steps, so keep their actual status
+  const stepsToUse = isSidecar ? steps : updateUnexecutedSteps(steps);
   const step = stepsToUse.find(
     stepToCheck => stepToCheck.name === selectedStepId
   );
@@ -106,6 +107,7 @@ function Step({
   }
 
   const stepData = getStepData({
+    isSidecar,
     reason: taskRunReason,
     selectedStepId: step.name,
     steps


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2306

Sidecar containers run in parallel to the regular step containers and typically live for the duration of the TaskRun. They are not subject to the Tekton entrypoint signalling for ensuring only a single step is actually executing at a time.

Ensure we don't modify the reported status of sidecar containers when displayed in the UI. A completed sidecar displayed after an errored / running sidecar should still be displayed as completed.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
