### PR TITLE
Improve scroll behaviour in new PipelineRun layout

### DIFF
--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -58,7 +58,6 @@ export default /* istanbul ignore next */ function PipelineRun({
   loading,
   logLevels,
   maximizedLogsContainer,
-  maximizedTaskRunContainer,
   onRetryChange,
   onViewChange = /* istanbul ignore next */ () => {},
   pipeline,
@@ -431,12 +430,9 @@ export default /* istanbul ignore next */ function PipelineRun({
                 getLogContainer={getLogContainer}
                 getLogsToolbar={getLogsToolbar}
                 isMaximized={isTaskRunMaximized}
-                maximizedContainer={maximizedTaskRunContainer}
                 onRetryChange={onRetryChange}
                 onStepSelected={onStepSelected}
-                onToggleMaximized={
-                  !!maximizedTaskRunContainer && onToggleTaskRunMaximized
-                }
+                onToggleMaximized={onToggleTaskRunMaximized}
                 onViewChange={onViewChange}
                 pod={pod}
                 preTaskRun={preTaskRun}

--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -175,27 +175,29 @@ limitations under the License.
     padding-inline: 0;
   }
 
-  .tkn--step-details {
-    overflow: initial;
-
-    > .#{$prefix}--tabs {
-      position: sticky;
-      inset-block-start: 7.4rem;
-      z-index: 4996;
-      background-color: $layer;
-    }
-  }
-
   header.tkn--step-details-header {
     padding: 1rem 0 0 0;
     position: sticky;
-    inset-block-start: 3rem;
+    inset-block-start: var(--tkn-global-header-offset);
     z-index: 4997;
+  }
+
+  .tkn--step-details {
+    > .#{$prefix}--tabs {
+      position: sticky;
+      inset-block-start: calc(var(--tkn-global-header-offset) + 4.4rem);
+      z-index: 4996;
+      background-color: $layer;
+    }
+
+    &:not(.tkn--taskrun--maximized) {
+      overflow: initial;
+    }
   }
 }
 
 .#{$prefix}--tabs.tkn--task-list {
   position: sticky;
-  inset-block-start: 3rem;
-  max-block-size: calc(100vb - 3rem);
+  inset-block-start: var(--tkn-global-header-offset);
+  max-block-size: calc(100vb - var(--tkn-global-header-offset));
 }

--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -162,6 +162,8 @@ limitations under the License.
     max-inline-size: 100%;
 
     > .#{$prefix}--tab-content {
+      // we don't want 2 scrollbars, prefer the one on body
+      overflow-y: visible;
       // to stop log content bleeding through the sticky header
       padding-block-start: 0;
     }
@@ -178,7 +180,7 @@ limitations under the License.
 
     > .#{$prefix}--tabs {
       position: sticky;
-      inset-block-start: 4.4rem;
+      inset-block-start: 7.4rem;
       z-index: 4996;
       background-color: $layer;
     }
@@ -187,7 +189,13 @@ limitations under the License.
   header.tkn--step-details-header {
     padding: 1rem 0 0 0;
     position: sticky;
-    inset-block-start: 0;
+    inset-block-start: 3rem;
     z-index: 4997;
   }
+}
+
+.#{$prefix}--tabs.tkn--task-list {
+  position: sticky;
+  inset-block-start: 3rem;
+  max-block-size: calc(100vb - 3rem);
 }

--- a/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
+++ b/packages/components/src/components/TaskRunDetails/TaskRunDetails.jsx
@@ -15,6 +15,7 @@ import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import {
+  classNames,
   dashboardReasonSkipped,
   getParams,
   getTranslateWithId,
@@ -353,7 +354,11 @@ const TaskRunDetails = ({
       });
 
   return (
-    <div className="tkn--step-details">
+    <div
+      className={classNames('tkn--step-details', {
+        'tkn--taskrun--maximized': isMaximized
+      })}
+    >
       <DetailsHeader
         displayName={displayName}
         hasWarning={taskRunHasWarning(taskRun)}

--- a/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
+++ b/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
@@ -12,7 +12,6 @@ limitations under the License.
 */
 /* istanbul ignore file */
 
-import { Fragment } from 'react';
 import { useIntl } from 'react-intl';
 import {
   Accordion,
@@ -28,7 +27,6 @@ import {
   updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
-import Portal from '../Portal';
 import TaskRunDetails from '../TaskRunDetails';
 import StatusIcon from '../StatusIcon';
 import FormattedDuration from '../FormattedDuration';
@@ -332,7 +330,6 @@ const TaskRunTabPanels = ({
   getLogContainer,
   getLogsToolbar,
   isMaximized,
-  maximizedContainer,
   onRetryChange,
   onStepSelected,
   onToggleMaximized,
@@ -363,8 +360,6 @@ const TaskRunTabPanels = ({
     />
   );
 
-  const TaskRunRoot = isMaximized && maximizedContainer ? Portal : Fragment;
-
   return (
     <TabPanels>
       {/* only render panel content when active */}
@@ -374,26 +369,22 @@ const TaskRunTabPanels = ({
       {taskRuns.map((taskRun, index) => (
         <TabPanel key={taskRun.metadata?.uid || index}>
           {selectedIndex === index + 1 ? (
-            <TaskRunRoot
-              {...(isMaximized ? { container: maximizedContainer } : null)}
-            >
-              <TaskRunDetails
-                fullTaskRun={taskRun}
-                getLogsToolbar={getLogsToolbar}
-                isMaximized={isMaximized}
-                logs={logs}
-                onRetryChange={onRetryChange}
-                onToggleMaximized={onToggleMaximized}
-                onViewChange={onViewChange}
-                pod={pod}
-                selectedRetry={selectedRetry}
-                selectedStepId={selectedStepId}
-                skippedTask={skippedTask}
-                task={task}
-                taskRun={taskRunToUse} // may include additional matrix / retry data
-                view={view}
-              />
-            </TaskRunRoot>
+            <TaskRunDetails
+              fullTaskRun={taskRun}
+              getLogsToolbar={getLogsToolbar}
+              isMaximized={isMaximized}
+              logs={logs}
+              onRetryChange={onRetryChange}
+              onToggleMaximized={onToggleMaximized}
+              onViewChange={onViewChange}
+              pod={pod}
+              selectedRetry={selectedRetry}
+              selectedStepId={selectedStepId}
+              skippedTask={skippedTask}
+              task={task}
+              taskRun={taskRunToUse} // may include additional matrix / retry data
+              view={view}
+            />
           ) : null}
         </TabPanel>
       ))}

--- a/packages/components/src/scss/_Run.scss
+++ b/packages/components/src/scss/_Run.scss
@@ -59,8 +59,8 @@ limitations under the License.
 .tkn--task-logs {
   .#{$prefix}--accordion__heading {
     position: sticky;
-    inset-block-start: 9.9rem;
-    background-color: var(--cds-layer-01);
+    inset-block-start: calc(6.9rem + var(--tkn-global-header-offset));
+    background-color: $layer-01;
     // this needs to be lower than the run header to prevent it bleeding through
     // popovers or other menus such as the log settings
     z-index: 4995;
@@ -104,4 +104,15 @@ limitations under the License.
       }
     }
   }
+}
+
+.tkn--step-details.tkn--taskrun--maximized {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  block-size: 100vb;
+  overflow: auto;
+
+  // need to include units here otherwise breaks calc()
+  --tkn-global-header-offset: 0rem;
 }

--- a/packages/components/src/scss/_Run.scss
+++ b/packages/components/src/scss/_Run.scss
@@ -49,9 +49,6 @@ limitations under the License.
 
   > .#{$prefix}--css-grid {
     padding-inline: 0;
-    min-block-size: calc(100cqb - 350px);
-    // allow some overscroll so step header can be sticky to top of content
-    max-block-size: calc(100vb + 4rem);
   }
 }
 
@@ -62,7 +59,7 @@ limitations under the License.
 .tkn--task-logs {
   .#{$prefix}--accordion__heading {
     position: sticky;
-    inset-block-start: 6.9rem;
+    inset-block-start: 9.9rem;
     background-color: var(--cds-layer-01);
     // this needs to be lower than the run header to prevent it bleeding through
     // popovers or other menus such as the log settings

--- a/src/containers/PipelineRun/PipelineRun.jsx
+++ b/src/containers/PipelineRun/PipelineRun.jsx
@@ -107,7 +107,6 @@ export /* istanbul ignore next */ function PipelineRunContainer({
   const view = queryParams.get(VIEW);
 
   const maximizedLogsContainer = useRef();
-  const maximizedTaskRunContainer = useRef();
   const [showRunActionNotification, setShowRunActionNotification] =
     useState(null);
 
@@ -532,10 +531,6 @@ export /* istanbul ignore next */ function PipelineRunContainer({
   return (
     <>
       <div id="tkn--maximized-logs-container" ref={maximizedLogsContainer} />
-      <div
-        id="tkn--maximized-taskrun-container"
-        ref={maximizedTaskRunContainer}
-      />
       {showRunActionNotification?.logsURL && (
         <ActionableNotification
           inline
@@ -584,7 +579,6 @@ export /* istanbul ignore next */ function PipelineRunContainer({
           />
         )}
         maximizedLogsContainer={maximizedLogsContainer.current}
-        maximizedTaskRunContainer={maximizedTaskRunContainer.current}
         onRetryChange={retry => {
           if (Number.isInteger(retry)) {
             queryParams.set(RETRY, retry);

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -53,6 +53,11 @@ limitations under the License.
 @use '@tektoncd/dashboard-components/src/components/Trigger/Trigger';
 @use '@tektoncd/dashboard-components/src/components/ViewYAML/ViewYAML';
 
+:root {
+  // used to control position of sticky headers on run details page
+  --tkn-global-header-offset: 3rem;
+}
+
 html,
 #root,
 .tkn--main-content {
@@ -61,12 +66,16 @@ html,
 
 body {
   // to prevent unwanted scroll when content doesn't fill full height
-  block-size: calc(100% - 3rem);
+  block-size: calc(100% - var(--tkn-global-header-offset));
+}
+
+body:has(.tkn--taskrun--maximized) {
+  overflow: hidden;
 }
 
 #main-content {
   // height of the main header, added for accessibility of skip to main content link
-  scroll-margin-block-start: 3rem;
+  scroll-margin-block-start: var(--tkn-global-header-offset);
 }
 
 .#{$prefix}--btn.link-btn.#{$prefix}--btn--ghost {
@@ -112,7 +121,7 @@ body {
   margin-block-start: 1rem;
 }
 
-#tkn--maximized-logs-container, #tkn--maximized-taskrun-container {
+#tkn--maximized-logs-container {
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
@@ -120,42 +129,13 @@ body {
   block-size: 100vb;
   z-index: -1;
 
+  .tkn--log {
+    min-block-size: 100%;
+  }
+
   &:not(:empty) {
     background-color: $layer;
     z-index: 9999;
-  }
-}
-
-#tkn--maximized-taskrun-container {
-  // full screen instead of just content area
-  position: fixed;
-}
-
-#tkn--maximized-logs-container .tkn--log {
-  min-block-size: 100%;
-}
-
-#tkn--maximized-taskrun-container .tkn--step-details {
-  block-size: 100%;
-  overflow: auto;
-
-  > .#{$prefix}--tabs {
-    background-color: $layer;
-  }
-
-  > .#{$prefix}--tab-content {
-    padding: 0;
-  }
-
-  header.tkn--step-details-header {
-    padding: 1rem 0 0 1rem;
-    position: sticky;
-    inset-block-start: 0;
-    z-index: 4997;
-  }
-
-  .tkn--task-logs .cds--accordion__heading {
-    inset-block-start: 4.4rem;
   }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/tektoncd/dashboard/pull/4364 and https://github.com/tektoncd/dashboard/pull/4369
https://github.com/tektoncd/dashboard/issues/2306

Summary:
- Remove extra scrollbar on tab / log content
- Allow task run header and tabs to remain sticky

Details:

There were a number of issues with the previous styling which resulted in a negative user experience.

Double scrollbars were present in a number of cases, which resulted in confusion over which section was being / should be scrolled. In some cases, the top of the inner scrollbar became inaccessible, requiring the user to first scroll back up in the outer container.

Allowing the step header to become sticky at the top of the screen meant that the other tabs and log toolbar were inaccessible without first scrolling back to top.

Update the styling so the task run header and toolbar remain sticky, with the step header sticky below them.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
