### PR TITLE
Ensure code snippets are always full width

### DIFF
--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -193,6 +193,10 @@ limitations under the License.
     &:not(.tkn--taskrun--maximized) {
       overflow: initial;
     }
+
+    .#{$prefix}--snippet--multi {
+      max-inline-size: none;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/4385
https://github.com/tektoncd/dashboard/issues/2306

For some consumers, a more specific selector is used to limit the inline size of the multiline code snippet. Ensure the Dashboard styles are specific enough so that all use of this component under its control can expand to make full use of the available horizontal space as expected.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
