### PR TITLE
nightly build workflow with gha

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,178 @@
+name: Tekton Dashboard Nightly Build
+
+on:
+  schedule:
+    # Run at 03:00 UTC daily
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      kubernetes_version:
+        description: 'Kubernetes version to test with'
+        required: false
+        default: 'v1.33.x'
+      nightly_bucket:
+        description: 'Nightly bucket for builds'
+        required: false
+        default: 'gs://tekton-releases-nightly/dashboard'
+        type: string
+
+env:
+  KUBERNETES_VERSION: ${{ inputs.kubernetes_version || 'v1.33.x' }}
+  REGISTRY: ghcr.io
+  PACKAGE: github.com/${{ github.repository }}
+  BUCKET: ${{ inputs.nightly_bucket || 'gs://tekton-releases-nightly/dashboard' }}
+  IMAGE_REGISTRY_PATH: ${{ github.repository }}
+  IMAGE_REGISTRY_USER: tekton-robot
+
+jobs:
+  build:
+    name: Nightly Build (K8s ${{ inputs.kubernetes_version || 'v1.33.x' }})
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Generate version info
+        id: version
+        run: |
+          latest_sha=${{ github.sha }}
+          date_tag=$(date +v%Y%m%d-${latest_sha:0:7})
+          echo "version_tag=${date_tag}" >> "$GITHUB_OUTPUT"
+          echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Kind cluster
+        uses: chainguard-dev/actions/setup-kind@v1.4.12
+        with:
+          k8s-version: ${{ env.KUBERNETES_VERSION }}
+
+      - name: Set up Tekton
+        uses: tektoncd/actions/setup-tektoncd@main
+        with:
+          pipeline_version: latest
+          setup_registry: "true"
+          patch_etc_hosts: "true"
+
+      - name: Configure Tekton Git Resolver
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
+        run: |
+          # Create Git authentication secret with proper Tekton annotations
+          kubectl create secret generic git-resolver-secret \
+            --from-literal=token="${GITHUB_TOKEN}" \
+            -n tekton-pipelines-resolvers || true
+
+          kubectl annotate secret git-resolver-secret \
+            tekton.dev/git-0=github.com \
+            -n tekton-pipelines-resolvers || true
+
+          kubectl create secret generic git-resolver-secret \
+            --from-literal=token="${GITHUB_TOKEN}" \
+            -n default || true
+
+          kubectl annotate secret git-resolver-secret \
+            tekton.dev/git-0=github.com \
+            -n default || true
+
+          kubectl patch configmap git-resolver-config -n tekton-pipelines-resolvers --patch='
+          data:
+            api-token-secret-name: "git-resolver-secret"
+            api-token-secret-key: "token"
+          ' || true
+
+          kubectl patch configmap feature-flags -n tekton-pipelines --patch='
+          data:
+            enable-cel-in-whenexpression: "true"
+          ' || true
+
+      - name: Install tkn CLI
+        uses: tektoncd/actions/setup-tektoncd-cli@main
+        with:
+          version: latest
+
+      - name: Apply Build Pipeline Definition
+        run: |
+          kustomize build tekton | kubectl apply -f -
+
+      - name: Create secrets, service account and PVC template
+        env:
+          GCS_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
+          IMAGE_REGISTRY_USER: ${{ env.IMAGE_REGISTRY_USER }}
+        run: |
+          # Create GCS service account secret for release bucket access
+          echo "${GCS_SERVICE_ACCOUNT_KEY}" > /tmp/gcs-key.json
+          kubectl create secret generic release-secret \
+            --from-file=release.json=/tmp/gcs-key.json
+          rm -f /tmp/gcs-key.json
+
+          # Create a Kubernetes secret for GHCR authentication.
+          # This version creates the secret with a custom key name `docker-config.json`
+          # (instead of the default `.dockerconfigjson`) to match what the publish task expects.
+          echo "${GHCR_TOKEN}" > /tmp/docker-config.json
+          kubectl create secret generic release-images-secret \
+            --from-file=docker-config.json=/tmp/docker-config.json
+          rm -f /tmp/docker-config.json
+
+          # Apply service account configuration with proper RBAC
+          kubectl apply -f tekton/account.yaml
+
+          cat > workspace-template.yaml << EOF
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+          EOF
+
+      - name: Start Tekton Build Pipeline
+        run: |
+          set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
+
+          echo "Starting Tekton pipeline..."
+
+          PIPELINE_RUN=$(tkn pipeline start dashboard-release \
+            --serviceaccount=release-right-meow \
+            --param package="${{ env.PACKAGE }}" \
+            --param gitRevision="${{ steps.version.outputs.latest_sha }}" \
+            --param versionTag="${{ steps.version.outputs.version_tag }}" \
+            --param releaseBucket="${{ env.BUCKET }}" \
+            --param imageRegistry=${{ env.REGISTRY }} \
+            --param imageRegistryPath="${{ env.IMAGE_REGISTRY_PATH }}" \
+            --param imageRegistryUser="${{ env.IMAGE_REGISTRY_USER }}" \
+            --param imageRegistryRegions="" \
+            --param platforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le" \
+            --param koExtraArgs="" \
+            --param serviceAccountPath=release.json \
+            --param serviceAccountImagesPath=docker-config.json \
+            --param releaseAsLatest="true" \
+            --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \
+            --workspace name=release-secret,secret=release-secret \
+            --workspace name=release-images-secret,secret=release-images-secret \
+            --tasks-timeout 2h \
+            --pipeline-timeout 3h \
+            --output name) || {
+            echo "Failed to start Tekton pipeline!"
+            exit 1
+          }
+
+          echo "Pipeline started: ${PIPELINE_RUN}"
+          tkn pipelinerun logs "${PIPELINE_RUN}" -f
+
+          # Check if pipeline succeeded
+          tkn pipelinerun describe "${PIPELINE_RUN}" --output jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' | grep -q "True" || {
+            echo "Pipeline failed!"
+            tkn pipelinerun describe "${PIPELINE_RUN}"
+            exit 1
+          }
+
+          echo "✅ Pipeline Run completed successfully!"

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -145,6 +145,16 @@ kubectl patch serviceaccount $ACCOUNT \
   -p "{\"secrets\": [{\"name\": \"$GENERIC_SECRET\"}]}"
 ```
 
+## Automated Nightly builds with github action workflow
+
+The GitHub Actions workflow provides an alternative approach for automated nightly builds with GitHub infrastructure.
+
+[The nightly release workflow](../.github/workflows/nightly-release.yaml) is triggered daily at 03:00 UTC via cron schedule
+The workflow is configured to reuses the same pipelines used for standard releases with varied param values.
+
+- [release-pipeline.yaml](release-pipeline.yaml)
+- [publish.yaml](publish.yaml)
+
 ## Update dogfooding
 
 To update the Dashboard release on the [`dogfooding` cluster](https://dashboard.dogfooding.tekton.dev/):

--- a/tekton/account.yaml
+++ b/tekton/account.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-right-meow
+secrets:
+- name: release-secret
+- name: git-resolver-secret
+- name: release-images-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-api-secret
+  annotations:
+    kubernetes.io/service-account.name: release-right-meow
+type: kubernetes.io/service-account-token
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-role
+rules:
+- apiGroups: [""]
+  resources: ["services", "configmaps", "secrets"]
+  verbs: ["get", "create", "update", "patch", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "create", "update", "patch", "list"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelines", "pipelineruns", "tasks", "taskruns"]
+  verbs: ["get", "create", "update", "patch", "list"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-role
+subjects:
+- kind: ServiceAccount
+  name: release-right-meow

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -30,10 +30,10 @@ spec:
       description: Extra args to be passed to ko
       default: "--preserve-import-paths"
     - name: versionTag
-      description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
+      description: The version, vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly that the artifacts should be tagged with (including `v`).
     - name: imageRegistry
       description: The target image registry
-      default: gcr.io
+      default: ghcr.io
     - name: imageRegistryPath
       description: The path (project) in the image registry
     - name: imageRegistryRegions

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: dashboard-release
@@ -25,23 +25,23 @@ spec:
       description: the git revision to release
     - name: imageRegistry
       description: The target image registry
-      default: gcr.io
+      default: ghcr.io
     - name: imageRegistryPath
       description: The path (project) in the image registry
-      default: tekton-releases
+      default: tekton-releases # Will be overridden based on releaseMode
     - name: imageRegistryRegions
       description: The target image registry regions
-      default: "us eu asia"
+      default: ""  # Empty for GHCR, "us eu asia" for GCR
     - name: imageRegistryUser
       description: The user for the image registry credentials
       default: "_json_key"
     - name: versionTag
-      description: The X.Y.Z version that the artifacts should be tagged with
+      description: Version tag (vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly)
     - name: releaseBucket
       description: bucket where the release is stored. The bucket must be project specific.
       default: gs://tekton-releases-nightly/dashboard
     - name: releaseAsLatest
-      description: Whether to tag and publish this release as Pipelines' latest
+      description: Whether to tag and publish this release as Dashboard's latest
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)


### PR DESCRIPTION
# Changes

This pull request introduces a new automated nightly build workflow for the Tekton Dashboard using GitHub Actions.

**Nightly Build Automation**
* Added a new GitHub Actions workflow (`.github/workflows/nightly-builds.yml`) to automate nightly builds of the Tekton Dashboard.
* Updated documentation (`tekton/README.md`) to describe the new nightly build workflow, its schedule, and mentions reuse of existing pipelines.

**Pipeline and Publish Definition Updates**
* Updated `tekton/release-pipeline.yaml` and `tekton/publish.yaml` to use `ghcr.io` as the default image registry, clarified version tag descriptions to support nightly builds, and modernized Tekton API versions and parameter defaults for nightly/stable releases.

**Kubernetes Resource Improvements**
* Added `tekton/account.yaml` to define service accounts, secrets, RBAC roles, and bindings necessary for secure pipeline execution and resource access during nightly builds.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
