### PR TITLE
Enable new PipelineRun and TaskRun details UI by default

### DIFF
--- a/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
+++ b/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
@@ -292,7 +292,11 @@ function Logs({
     <Accordion align="end" className="tkn--task-logs" ordered size="md">
       {steps.map(step => (
         <Step
-          expandedSteps={expandedSteps}
+          expandedSteps={{
+            ...expandedSteps,
+            // automatically expand the step when there's only one
+            ...(steps.length === 1 ? { [step.name]: true } : null)
+          }}
           getLogContainer={getLogContainer}
           key={step.name}
           onStepSelected={onStepSelected}

--- a/packages/e2e/cypress/e2e/run/pipelinerun-create.cy.js
+++ b/packages/e2e/cypress/e2e/run/pipelinerun-create.cy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022-2024 The Tekton Authors
+Copyright 2022-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -66,8 +66,6 @@ spec:
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
 
-    cy.contains('[role=button]', 'echo').click();
-
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
   });
@@ -129,8 +127,6 @@ spec:
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
 
-    cy.contains('[role=button]', 'echo').click();
-
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
   });
@@ -174,8 +170,6 @@ spec:
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
 
-    cy.contains('[role=button]', 'echo').click();
-
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
   });
@@ -214,8 +208,6 @@ spec:
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
-
-    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');

--- a/packages/e2e/cypress/e2e/run/taskrun-create.cy.js
+++ b/packages/e2e/cypress/e2e/run/taskrun-create.cy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 The Tekton Authors
+Copyright 2023-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -61,8 +61,6 @@ spec:
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
 
-    cy.contains('[role=button]', 'echo').click();
-
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
   });
@@ -118,8 +116,6 @@ spec:
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
 
-    cy.contains('[role=button]', 'echo').click();
-
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
   });
@@ -160,8 +156,6 @@ spec:
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
 
-    cy.contains('[role=button]', 'echo').click();
-
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');
   });
@@ -198,8 +192,6 @@ spec:
     cy.get('header[class="tkn--pipeline-run-header"]')
       .find('span[class="tkn--status-label"]', { timeout: 15000 })
       .should('have.text', 'Succeeded');
-
-    cy.contains('[role=button]', 'echo').click();
 
     cy.contains('.tkn--log', 'Hello World!');
     cy.contains('.tkn--log', 'Step completed successfully');

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -106,7 +106,7 @@ export function getTektonPipelinesAPIVersion() {
 }
 
 export function isPipelineRunTabLayoutEnabled() {
-  return localStorage.getItem('tkn-pipelinerun-tab-layout') === 'true';
+  return localStorage.getItem('tkn-pipelinerun-tab-layout') !== 'false';
 }
 
 export function setPipelineRunTabLayoutEnabled(enabled) {

--- a/src/containers/Settings/Settings.jsx
+++ b/src/containers/Settings/Settings.jsx
@@ -109,7 +109,7 @@ export function Settings() {
             labelText={intl.formatMessage({
               id: 'dashboard.pipelineRun.tabLayout.label',
               defaultMessage:
-                'Enable new PipelineRun and TaskRun details layout (preview)'
+                'Enable new PipelineRun and TaskRun details layout'
             })}
             labelA={intl.formatMessage({
               id: 'dashboard.toggle.off',

--- a/src/containers/TaskRun/TaskRun.jsx
+++ b/src/containers/TaskRun/TaskRun.jsx
@@ -174,7 +174,7 @@ export function TaskRunContainer({
   }
 
   function getLogContainer({ stepName, stepStatus, taskRun: run }) {
-    if (!selectedStepId || !stepStatus) {
+    if ((!selectedStepId && !stepName) || !stepStatus) {
       return null;
     }
 

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -195,7 +195,7 @@
   "dashboard.pipelineRun.stepCompleted.exitCode": "Step completed with exit code {exitCode}",
   "dashboard.pipelineRun.stepFailed": "Step failed",
   "dashboard.pipelineRun.stepSkipped": "Step skipped",
-  "dashboard.pipelineRun.tabLayout.label": "Enable new PipelineRun and TaskRun details layout (preview)",
+  "dashboard.pipelineRun.tabLayout.label": "Enable new PipelineRun and TaskRun details layout",
   "dashboard.pipelineRuns.error": "Error loading PipelineRuns",
   "dashboard.pipelines.errorLoading": "Error loading Pipelines",
   "dashboard.pipelines.v1Resources.label": "Use Tekton Pipelines API version v1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/issues/2306

Users can still opt out by disabling the toggle on the settings page.

The old UI (and the toggle) will be removed in a future release.

As part of this change, the step is automatically expanded if it's the only one. This reduces the number of clicks required to view the logs / definition in the simple case, without sacrificing the glanceable overview of step status for more complex tasks.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
