### PR TITLE
Fix image path for GHA nightly builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -70,6 +70,7 @@ jobs:
             --param imageRegistryPath="${{ env.IMAGE_REGISTRY_PATH }}" \
             --param imageRegistryUser="${{ env.IMAGE_REGISTRY_USER }}" \
             --param imageRegistryRegions="" \
+            --param koExtraArgs="" \
             --param serviceAccountPath=release.json \
             --param serviceAccountImagesPath=credentials \
             --param releaseAsLatest="true" \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Add the missing `koExtraArgs` param so the images are published to the correct location, i.e.
`ghcr.io/tektoncd/dashboard/dashboard-9623576a202fe86c8b7d1bc489905f86` instead of
`ghcr.io/tektoncd/dashboard/github.com/tektoncd/dashboard/cmd/dashboard`

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
