### PR TITLE
fix: preserve steps execution order on task run details

### DIFF
--- a/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
+++ b/packages/components/src/components/TaskRunTabPanels/TaskRunTabPanels.jsx
@@ -24,6 +24,7 @@ import {
   getStatus,
   getStepDefinition,
   getStepStatusReason,
+  orderStepsFromTaskRun,
   updateUnexecutedSteps
 } from '@tektoncd/dashboard-utils';
 
@@ -288,9 +289,11 @@ function Logs({
     );
   }
 
+  const orderedSteps = orderStepsFromTaskRun(steps, taskRun);
+
   return (
     <Accordion align="end" className="tkn--task-logs" ordered size="md">
-      {steps.map(step => (
+      {orderedSteps.map(step => (
         <Step
           expandedSteps={{
             ...expandedSteps,
@@ -304,7 +307,7 @@ function Logs({
           selectedTaskId={selectedTaskId}
           taskRunReason={reason}
           step={step}
-          steps={steps}
+          steps={orderedSteps}
           task={task}
           taskRun={taskRun}
         />

--- a/packages/components/src/components/TaskTree/TaskTree.jsx
+++ b/packages/components/src/components/TaskTree/TaskTree.jsx
@@ -14,7 +14,8 @@ limitations under the License.
 import {
   dashboardReasonSkipped,
   getStatus,
-  labels as labelConstants
+  labels as labelConstants,
+  orderStepsFromTaskRun
 } from '@tektoncd/dashboard-utils';
 import Task from '../Task';
 
@@ -113,7 +114,7 @@ const TaskTree = ({
             selectDefaultStep={selectDefaultStep}
             selectedRetry={expanded && selectedRetry}
             selectedStepId={selectedStepId}
-            steps={steps}
+            steps={orderStepsFromTaskRun(steps, taskRunToUse)}
             succeeded={status}
             taskRun={taskRun}
           />

--- a/packages/components/src/components/TaskTree/TaskTree.test.jsx
+++ b/packages/components/src/components/TaskTree/TaskTree.test.jsx
@@ -173,3 +173,35 @@ it('TaskTree handles click event on Step', () => {
   fireEvent.click(getByText(/build/i));
   expect(onSelect).toHaveBeenCalledTimes(1);
 });
+
+it('TaskTree with steps order in taskSpec', () => {
+  const props = getProps();
+  props.taskRuns[0].status.taskSpec = {
+    steps: [{ name: 'test' }, { name: 'build' }]
+  };
+
+  const { container } = render(<TaskTree {...props} />);
+  const stepElements = container.querySelectorAll('.tkn--step-list li');
+  expect(stepElements[0].textContent).toContain('test');
+  expect(stepElements[1].textContent).toContain('build');
+});
+
+it('TaskTree handles invalid step names in taskSpec', () => {
+  const props = getProps();
+  props.taskRuns[0].status.taskSpec = {
+    steps: [
+      { name: 'test' },
+      {
+        /* missing name */
+      },
+      { name: null },
+      { name: 'build' }
+    ]
+  };
+
+  const { container } = render(<TaskTree {...props} />);
+  const stepElements = container.querySelectorAll('.tkn--step-list li');
+  expect(stepElements.length).toBe(2);
+  expect(stepElements[0].textContent).toContain('test');
+  expect(stepElements[1].textContent).toContain('build');
+});

--- a/packages/utils/src/utils/index.js
+++ b/packages/utils/src/utils/index.js
@@ -197,6 +197,32 @@ export function getStepStatusReason(step) {
   return { exitCode, reason, status };
 }
 
+export function orderStepsFromTaskRun(steps, taskRun) {
+  const stepsOrder = (taskRun.status?.taskSpec?.steps || [])
+    .map(step => step?.name)
+    .filter(stepName => typeof stepName === 'string');
+
+  if (!stepsOrder || stepsOrder.length === 0) {
+    return steps;
+  }
+
+  const orderedSteps = [];
+  const stepsMap = new Map(steps.map(step => [step.name, step]));
+
+  stepsOrder.forEach(stepName => {
+    if (stepsMap.has(stepName)) {
+      orderedSteps.push(stepsMap.get(stepName));
+      stepsMap.delete(stepName);
+    }
+  });
+
+  stepsMap.forEach(step => {
+    orderedSteps.push(step);
+  });
+
+  return orderedSteps;
+}
+
 export function isPending(reason, status) {
   return (
     !status ||


### PR DESCRIPTION
This PR adds a new utility function `orderStepsFromTaskRun` that reorders steps according to their definition order in the TaskRun's `taskSpec`. This ensures that steps are displayed in the correct execution order in the Tekton Dashboard UI.

### The problem

When a TaskRun has steps referring to StepAction, we encounter two issues that impact user experience in the Tekton Dashboard:
1. **Incorrect step ordering**: Steps referring to StepAction are always displayed at the top of the TaskRun steps list, regardless of their actual execution order defined in the TaskSpec. This creates confusion about the actual flow of execution.
2. **Misplaced step status**: When a step fails, the status information is sometimes misplaced, leading to poor visibility on which steps actually failed. This makes debugging and troubleshooting difficult for users trying to understand TaskRun execution failures.

These issues stem from the fact that steps are being displayed in an order that doesn't match their logical execution sequence as defined in the TaskRun's specification.

<img width="282" height="200" alt="taskrunpanel--before" src="https://github.com/user-attachments/assets/ec177ede-66d1-484f-9f47-8084f514cd58" />
<img width="408" height="200" alt="tasktree--before" src="https://github.com/user-attachments/assets/78744c3c-208c-4f61-abbe-dc61ca00ed97" />

### The changes

This PR introduces a new utility function `orderStepsFromTaskRun` that addresses both problems by ensuring steps are displayed in their correct execution order:
- Extract step order from `taskRun.status.taskSpec.steps` 
- Reorder steps array to match taskSpec definition order
- Preserve steps not found in taskSpec by appending at end
- Handle edge cases: missing taskSpec, empty arrays, invalid step names

This change should ensures that:
- Steps referring to StepAction are displayed in their correct position within the execution flow
- Step status information is properly aligned with the corresponding steps, improving failure visibility and debugging experience

<img width="299" height="200" alt="taskrunpanel--after" src="https://github.com/user-attachments/assets/b91c1b4d-273b-4ade-8960-a7333e46ec85" />
<img width="410" height="200" alt="tasktree--after" src="https://github.com/user-attachments/assets/d0faf496-3a2c-462a-8107-ed59aa80713e" />


/kind misc

# Release Notes

```release-note
Add `orderStepsFromTaskRun` utility function to reorder steps according to TaskRun taskSpec definition, ensuring steps are displayed in correct execution order in the dashboard UI.
```