### PR TITLE
Replace js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
         "@tektoncd/dashboard-utils": "*",
         "@uiw/react-codemirror": "^4.25.2",
         "git-url-parse": "^16.1.0",
-        "js-yaml": "^4.1.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-intl": "^7.1.11",
         "react-is": "^18.3.1",
         "react-router-dom": "^6.30.1",
-        "reconnecting-websocket": "^4.4.0"
+        "reconnecting-websocket": "^4.4.0",
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "@formatjs/cli": "^6.7.2",
@@ -5076,7 +5076,8 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -8938,6 +8939,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -12726,6 +12728,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -12797,12 +12811,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tektoncd/dashboard-utils": "file:../utils",
-        "js-yaml": "^4.1.0",
         "linkify-it": "^5.0.0",
         "prop-types": "^15.7.2",
         "react-intl-formatted-duration": "^4.0.0",
         "react-window": "^1.8.11",
-        "tlds": "^1.260.0"
+        "tlds": "^1.260.0",
+        "yaml": "^2.8.1"
       },
       "engines": {
         "node": "^20.18.0",

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "@tektoncd/dashboard-utils": "*",
     "@uiw/react-codemirror": "^4.25.2",
     "git-url-parse": "^16.1.0",
-    "js-yaml": "^4.1.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^7.1.11",
     "react-is": "^18.3.1",
     "react-router-dom": "^6.30.1",
-    "reconnecting-websocket": "^4.4.0"
+    "reconnecting-websocket": "^4.4.0",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@formatjs/cli": "^6.7.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "@tektoncd/dashboard-utils": "file:../utils",
-    "js-yaml": "^4.1.0",
     "linkify-it": "^5.0.0",
     "prop-types": "^15.7.2",
     "react-intl-formatted-duration": "^4.0.0",
     "react-window": "^1.8.11",
-    "tlds": "^1.260.0"
+    "tlds": "^1.260.0",
+    "yaml": "^2.8.1"
   },
   "peerDependencies": {
     "@carbon/react": "^1.65.0",

--- a/packages/components/src/components/ViewYAML/SyntaxHighlighter.jsx
+++ b/packages/components/src/components/ViewYAML/SyntaxHighlighter.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2021-2024 The Tekton Authors
+Copyright 2021-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,7 +13,7 @@ limitations under the License.
 /* istanbul ignore file */
 
 import { usePrefix } from '@carbon/react';
-import jsYaml from 'js-yaml';
+import yaml from 'yaml';
 
 function addLine({ addBullet, key, level, lines, path, rawString, value }) {
   let valueNode;
@@ -44,7 +44,7 @@ function addLine({ addBullet, key, level, lines, path, rawString, value }) {
         <>
           <span> </span>
           <span className="hljs-string">
-            {jsYaml.dump(value, { lineWidth: -1 })}
+            {yaml.stringify(value, { lineWidth: 0, singleQuote: true })}
           </span>
         </>
       );
@@ -98,7 +98,7 @@ function addLine({ addBullet, key, level, lines, path, rawString, value }) {
         {typeof key === 'number' ? (
           bullet
         ) : (
-          <span className="hljs-attr">{`${jsYaml.dump(key).trim()}:`}</span>
+          <span className="hljs-attr">{`${yaml.stringify(key, { singleQuote: true }).trim()}:`}</span>
         )}
         {valueNode}
       </span>

--- a/packages/components/src/components/ViewYAML/ViewYAML.jsx
+++ b/packages/components/src/components/ViewYAML/ViewYAML.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import PropTypes from 'prop-types';
-import jsYaml from 'js-yaml';
+import YAML from 'yaml';
 import { classNames } from '@tektoncd/dashboard-utils';
 
 import { usePrefix } from '@carbon/react';
@@ -43,7 +43,7 @@ function ViewYAML({
     const clz = classNames(`${carbonPrefix}--snippet--multi`, className, {
       'tkn--view-yaml--dark': dark
     });
-    const yaml = jsYaml.dump(resource);
+    const yaml = YAML.stringify(resource, { singleQuote: true });
     yamlComponent = <YAMLRaw className={clz}>{yaml}</YAMLRaw>;
   }
 

--- a/packages/components/src/components/ViewYAML/ViewYAML.test.jsx
+++ b/packages/components/src/components/ViewYAML/ViewYAML.test.jsx
@@ -42,7 +42,7 @@ it('YAML renders correctly', () => {
   expect(getByText(/apiVersion: tekton.dev\/v1alpha1/i)).toBeTruthy();
   expect(getByText(/kind: Resource/i)).toBeTruthy();
   expect(getByText(/metadata:/i)).toBeTruthy();
-  expect(getByText(/creationTimestamp: '1995-11-08T00:00:00Z'/i)).toBeTruthy();
+  expect(getByText(/creationTimestamp: 1995-11-08T00:00:00Z/i)).toBeTruthy();
   expect(getByText(/generation:/i)).toBeTruthy();
   expect(getByText(/labels:/i)).toBeTruthy();
   expect(getByText(/foo: bar/i)).toBeTruthy();

--- a/src/api/pipelineRuns.test.js
+++ b/src/api/pipelineRuns.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import { http, HttpResponse } from 'msw';
 
 import * as API from './pipelineRuns';
@@ -318,7 +318,7 @@ spec:
     name: simple
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 
   it('rerun with all processed fields', () => {
@@ -372,7 +372,7 @@ spec:
     - name: param-2
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 
   it('edit with minimum possible fields', () => {
@@ -405,7 +405,7 @@ spec:
     name: simple
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 
   it('edit with all processed fields', () => {
@@ -459,6 +459,6 @@ spec:
     - name: param-2
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 });

--- a/src/api/taskRuns.test.js
+++ b/src/api/taskRuns.test.js
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import { http, HttpResponse } from 'msw';
 
 import * as API from './taskRuns';
@@ -293,7 +293,7 @@ spec:
     name: simple
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 
   it('rerun with all processed fields', () => {
@@ -347,7 +347,7 @@ spec:
     - name: param-2
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 
   it('edit with minimum possible fields', () => {
@@ -380,7 +380,7 @@ spec:
     name: simple
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 
   it('edit with all processed fields', () => {
@@ -434,6 +434,6 @@ spec:
     - name: param-2
 `;
     expect(namespace).toEqual('test-namespace');
-    expect(yaml.dump(payload)).toEqual(expected);
+    expect(yaml.stringify(payload)).toEqual(expected);
   });
 });

--- a/src/containers/CreateCustomRun/CreateCustomRun.jsx
+++ b/src/containers/CreateCustomRun/CreateCustomRun.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 The Tekton Authors
+Copyright 2023-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -14,7 +14,7 @@ limitations under the License.
 
 import { lazy, Suspense } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import { ALL_NAMESPACES, urls, useTitleSync } from '@tektoncd/dashboard-utils';
 import { Loading } from '@tektoncd/dashboard-components';
 import { useIntl } from 'react-intl';
@@ -87,7 +87,7 @@ function CreateCustomRun() {
         customRun: customRunObject,
         rerun: false
       });
-      payloadYaml = yaml.dump(payload);
+      payloadYaml = yaml.stringify(payload, { singleQuote: true });
     }
     const loadingMessage = intl.formatMessage(
       {
@@ -116,7 +116,7 @@ function CreateCustomRun() {
   return (
     <Suspense fallback={<Loading />}>
       <YAMLEditor
-        code={yaml.dump(customRun)}
+        code={yaml.stringify(customRun, { singleQuote: true })}
         handleClose={handleCloseYAMLEditor}
         handleCreate={handleCreate}
         kind="CustomRun"

--- a/src/containers/CreatePipelineRun/CreatePipelineRun.jsx
+++ b/src/containers/CreatePipelineRun/CreatePipelineRun.jsx
@@ -14,7 +14,7 @@ limitations under the License.
 
 import { lazy, Suspense, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import {
   Button,
   Form,
@@ -467,7 +467,7 @@ function CreatePipelineRun() {
           pipelineRun: pipelineRunObject,
           rerun: false
         });
-        payloadYaml = yaml.dump(payload);
+        payloadYaml = yaml.stringify(payload, { singleQuote: true });
       }
       const loadingMessage = intl.formatMessage(
         {
@@ -515,7 +515,7 @@ function CreatePipelineRun() {
     return (
       <Suspense fallback={<Loading />}>
         <YAMLEditor
-          code={yaml.dump(pipelineRun)}
+          code={yaml.stringify(pipelineRun, { singleQuote: true })}
           handleClose={handleCloseYAMLEditor}
           handleCreate={handleCreate}
           kind="PipelineRun"

--- a/src/containers/CreateTaskRun/CreateTaskRun.jsx
+++ b/src/containers/CreateTaskRun/CreateTaskRun.jsx
@@ -14,7 +14,7 @@ limitations under the License.
 
 import { lazy, Suspense, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import {
   Button,
   Form,
@@ -431,7 +431,7 @@ function CreateTaskRun() {
           taskRun: taskRunObject,
           rerun: false
         });
-        payloadYaml = yaml.dump(payload);
+        payloadYaml = yaml.stringify(payload, { singleQuote: true });
       }
       const loadingMessage = intl.formatMessage(
         {
@@ -477,7 +477,7 @@ function CreateTaskRun() {
     return (
       <Suspense fallback={<Loading />}>
         <YAMLEditor
-          code={yaml.dump(taskRun)}
+          code={yaml.stringify(taskRun, { singleQuote: true })}
           handleClose={handleCloseYAMLEditor}
           handleCreate={handleCreate}
           kind="TaskRun"

--- a/src/containers/YAMLEditor/YAMLEditor.jsx
+++ b/src/containers/YAMLEditor/YAMLEditor.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022-2024 The Tekton Authors
+Copyright 2022-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,7 +12,7 @@ limitations under the License.
 */
 import { useIntl } from 'react-intl';
 import { Button, Form, FormGroup, InlineNotification } from '@carbon/react';
-import yaml from 'js-yaml';
+import yaml from 'yaml';
 import { useEffect, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { StreamLanguage } from '@codemirror/language';
@@ -77,7 +77,7 @@ export default function YAMLEditor({
 
     let resource;
     try {
-      resource = yaml.load(code);
+      resource = yaml.parse(code);
     } catch (e) {
       setValidationErrorMessage(e.message);
       return;

--- a/src/containers/YAMLEditor/YAMLEditor.test.jsx
+++ b/src/containers/YAMLEditor/YAMLEditor.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022-2024 The Tekton Authors
+Copyright 2022-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -129,7 +129,9 @@ describe('YAMLEditor', () => {
 
     fireEvent.click(submitButton(queryAllByText));
     expect(getByText(/Please fix errors, then resubmit/)).toBeTruthy();
-    expect(getByText(/can not read a block mapping entry/)).toBeTruthy();
+    expect(
+      getByText(/Implicit map keys need to be followed by map values/)
+    ).toBeTruthy();
   });
 
   it('handle submit', async () => {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Related to https://github.com/tektoncd/dashboard/pull/4477

Use `yaml` instead, which is still maintained.

There are some differences in behaviour for the default config, so we need to enable `singleQuote` when dumping YAML using `stringify`.

Also the value to disable line wrapping changes from `-1` to `0`.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
