### PR TITLE
Update docs to reference OCI storage buckets instead of GCS

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -2,23 +2,23 @@
 
 This guide explains how to build, deploy and test the Tekton Dashboard. It covers the following topics:
 
-- [Pre-requisites](#pre-requisites)
-- [Checkout your fork](#checkout-your-fork)
-- [Build the frontend](#build-the-frontend)
-- [Build the backend](#build-the-backend)
-  - [Command line arguments](#command-line-arguments)
-- [Build and deploy with the installer script](#build-and-deploy-with-the-installer-script)
-- [Development server](#development-server)
-- [Quick setup for local cluster](#quick-setup-for-local-cluster)
-- [Run backend tests](#run-backend-tests)
-  - [Backend unit tests](#backend-unit-tests)
-- [Run frontend tests](#run-frontend-tests)
-  - [Frontend unit tests](#frontend-unit-tests)
-  - [Frontend E2E tests](#frontend-e2e-tests)
-  - [Linter](#linter)
-- [i18n](#i18n)
-- [Storybook](#storybook)
-- [Next steps](#next-steps)
+- [Tekton Dashboard - Dev docs](#tekton-dashboard---dev-docs)
+  - [Pre-requisites](#pre-requisites)
+  - [Checkout your fork](#checkout-your-fork)
+  - [Build the frontend](#build-the-frontend)
+    - [Command line arguments](#command-line-arguments)
+  - [Build and deploy with the installer script](#build-and-deploy-with-the-installer-script)
+  - [Development server](#development-server)
+  - [Quick setup for local cluster](#quick-setup-for-local-cluster)
+  - [Run backend tests](#run-backend-tests)
+    - [Backend unit tests](#backend-unit-tests)
+  - [Run frontend tests](#run-frontend-tests)
+    - [Frontend unit tests](#frontend-unit-tests)
+    - [Frontend E2E tests](#frontend-e2e-tests)
+    - [Linter](#linter)
+  - [i18n](#i18n)
+  - [Storybook](#storybook)
+  - [Next steps](#next-steps)
 
 ## Pre-requisites
 
@@ -110,8 +110,8 @@ Make sure that the backend service running in the cluster is proxied using `kube
 
 **Note:** If you've exposed the backend by some other means than port-forwarding port 9097 as described above, set the `API_DOMAIN` environment variable to provide the correct details.
 
-e.g. to connect your local dev frontend to the Dashboard deployed on the robocat cluster:
-`API_DOMAIN=https://dashboard.robocat.tekton.dev/ npm start`
+e.g. to connect your local dev frontend to the Dashboard deployed on the infra cluster:
+`API_DOMAIN=https://tekton.infra.tekton.dev/ npm start`
 
 ## Quick setup for local cluster
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,13 +9,19 @@ weight: 2
 
 This guide explains how to install Tekton Dashboard. It covers the following topics:
 
-- [Before you begin](#before-you-begin)
-- [Pre-requisites](#pre-requisites)
-- [Installing Tekton Dashboard on Kubernetes](#installing-tekton-dashboard-on-kubernetes)
-- [Installing with the installer script](#installing-with-the-installer-script)
-- [Accessing the Dashboard](#accessing-the-dashboard)
-- [Uninstalling the Dashboard on Kubernetes](#uninstalling-the-dashboard-on-kubernetes)
-- [Next steps](#next-steps)
+- [Installing Tekton Dashboard](#installing-tekton-dashboard)
+  - [Before you begin](#before-you-begin)
+  - [Pre-requisites](#pre-requisites)
+    - [Supported Tekton Pipelines and Tekton Triggers versions](#supported-tekton-pipelines-and-tekton-triggers-versions)
+  - [Installing Tekton Dashboard on Kubernetes](#installing-tekton-dashboard-on-kubernetes)
+  - [Installing with the installer script](#installing-with-the-installer-script)
+  - [Accessing the Dashboard](#accessing-the-dashboard)
+    - [Using kubectl proxy](#using-kubectl-proxy)
+    - [Using kubectl port-forward](#using-kubectl-port-forward)
+    - [Using an Ingress rule](#using-an-ingress-rule)
+    - [Access control](#access-control)
+  - [Uninstalling the Dashboard on Kubernetes](#uninstalling-the-dashboard-on-kubernetes)
+  - [Next steps](#next-steps)
 
 ## Before you begin
 
@@ -49,13 +55,13 @@ To install Tekton Dashboard on a Kubernetes cluster:
 1. Run the following command to install Tekton Dashboard:
 
    ```bash
-   kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
+   kubectl apply --filename https://infra.tekton.dev/tekton-releases/dashboard/latest/release.yaml
    ```
 
    This will install the Dashboard in read-only mode by default.
 
    Previous versions are available at `previous/$VERSION_NUMBER/*.yaml`, e.g.
-   https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.32.0/release.yaml
+   https://infra.tekton.dev/tekton-releases/dashboard/previous/v0.32.0/release.yaml
 
    To install in read/write mode, use release-full.yaml.
 
@@ -231,7 +237,7 @@ If you're using one of these proxies to provide authentication but still want to
 The Dashboard can be uninstalled by running the following command:
 
 ```bash
-kubectl delete --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
+kubectl delete --filename https://infra.tekton.dev/tekton-releases/dashboard/latest/release.yaml
 ```
 
 The above command assumes that the current latest version was installed, refer to [Installing Tekton Dashboard on Kubernetes](#installing-tekton-dashboard-on-kubernetes) to find the correct `--filename` argument if another version was installed.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -83,7 +83,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 
    ```bash
    kubectl apply --filename \
-   https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+   https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
    ```
 
 1. Monitor the installation:
@@ -103,7 +103,7 @@ Hit *Ctrl + C* to stop monitoring.
 
    ```bash
    kubectl apply --filename \
-   https://storage.googleapis.com/tekton-releases/dashboard/latest/release-full.yaml
+   https://infra.tekton.dev/tekton-releases/dashboard/latest/release-full.yaml
    ```
 
    **NOTE**: release-full.yaml [installs dashboard in READ-WRITE mode](/docs/install.md#installing-tekton-dashboard-on-kubernetes).

--- a/docs/walkthrough/walkthrough-kind.md
+++ b/docs/walkthrough/walkthrough-kind.md
@@ -2,16 +2,16 @@
 
 This guide walks you through installing a working Tekton Dashboard locally from scratch. It covers the following topics:
 
-* [Before you begin](#before-you-begin)
-* [Creating a local Kubernetes cluster](#creating-a-local-kubernetes-cluster)
-* [Installing NGINX ingress controller](#installing-nginx-ingress-controller)
-* [Installing Tekton Pipelines](#installing-tekton-pipelines)
-* [Installing Tekton Triggers (optional)](#installing-tekton-triggers-optional)
-* [Installing Tekton Dashboard](#installing-tekton-dashboard)
-* [Setting up an Ingress rule to access the Dashboard](#setting-up-an-ingress-rule-to-access-the-dashboard)
-* [Importing resources from a Github repository](#importing-resources-from-a-github-repository)
-* [Viewing and managing resources from the Dashboard](#viewing-and-managing-resources-from-the-dashboard)
-* [Cleaning up](#cleaning-up)
+- [Tekton Dashboard walk-through - Kind](#tekton-dashboard-walk-through---kind)
+  - [Before you begin](#before-you-begin)
+  - [Creating a local Kubernetes cluster](#creating-a-local-kubernetes-cluster)
+  - [Installing NGINX ingress controller](#installing-nginx-ingress-controller)
+  - [Installing Tekton Pipelines](#installing-tekton-pipelines)
+  - [Installing Tekton Dashboard](#installing-tekton-dashboard)
+  - [Setting up an Ingress rule to access the Dashboard](#setting-up-an-ingress-rule-to-access-the-dashboard)
+  - [Importing resources from a Github repository](#importing-resources-from-a-github-repository)
+  - [Viewing and managing resources from the Dashboard](#viewing-and-managing-resources-from-the-dashboard)
+  - [Cleaning up](#cleaning-up)
 
 ## Before you begin
 
@@ -111,7 +111,7 @@ Tekton Dashboard requires to have Tekton Pipelines installed.
 Installing the latest Tekton Pipelines release is done by running the following command:
 
 ```bash
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
 
 kubectl wait -n tekton-pipelines \
   --for=condition=ready pod \

--- a/packages/e2e/base-image/tekton/README.md
+++ b/packages/e2e/base-image/tekton/README.md
@@ -5,12 +5,12 @@
 To create a release:
 - verify the `CHROME_VERSION` and `NODE_VERSION` args in the [`Dockerfile`](../Dockerfile) on the main branch are correct
 - set a matching tag value in the `TAGS` environment variable in the [`CronJob`](./cronjob.yaml), e.g. `node20.11.0-chrome121`
-- apply the `CronJob` to the default namespace on the dogfooding cluster (`kubectl apply -k .`)
+- apply the `CronJob` to the default namespace on the infra cluster (`kubectl apply -k .`)
 - create a `Job` from the `CronJob` to trigger the release
   ```bash
   kubectl create job --from=cronjob/image-build-cron-trigger-dashboard-e2e-base dashboard-e2e-base-$(date +"%Y%m%d-%H%M")
   ```
-- check the status of the [resulting `PipelineRun`](https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns?labelSelector=plumbing.tekton.dev%2Fimage%3Ddashboard-e2e-base)
+- check the status of the [resulting `PipelineRun`](https://tekton.infra.tekton.dev/#/namespaces/default/pipelineruns?labelSelector=plumbing.tekton.dev%2Fimage%3Ddashboard-e2e-base)
 - confirm the image was [released and properly tagged](https://github.com/tektoncd/dashboard/pkgs/container/dashboard%2Fdashboard-e2e-base)
 - open a PR to update the [E2E test `Dockerfile`](../../Dockerfile) to reference the new image
 

--- a/releases.md
+++ b/releases.md
@@ -16,8 +16,8 @@ as follows:
       20th, depending on week-ends and readiness
 
 Tekton Dashboard produces nightly builds, publicly available at:
-- [read-only](https://storage.googleapis.com/tekton-releases-nightly/dashboard/latest/release.yaml)
-- [read/write](https://storage.googleapis.com/tekton-releases-nightly/dashboard/latest/release-full.yaml)
+- [read-only](https://infra.tekton.dev/tekton-nightly/dashboard/latest/release.yaml)
+- [read/write](https://infra.tekton.dev/tekton-nightly/dashboard/latest/release-full.yaml)
 
 The images for Dashboard releases are published to `ghcr.io/tektoncd/dashboard`.
 

--- a/scripts/installer
+++ b/scripts/installer
@@ -28,7 +28,7 @@ DEFAULT_NAMESPACE=""
 TENANT_NAMESPACES=""
 STREAM_LOGS="true"
 EXTERNAL_LOGS=""
-BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard"
+BASE_RELEASE_URL="https://infra.tekton.dev/tekton-releases/dashboard"
 
 # additional options passed to ko resolve
 KO_RESOLVE_OPTIONS="--image-label=org.opencontainers.image.source=https://github.com/tektoncd/dashboard"
@@ -531,7 +531,7 @@ while [[ $# -gt 0 ]]; do
       OVERRIDE_NAMESPACE="${1}"
       ;;
     '--nightly')
-      BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases-nightly/dashboard"
+      BASE_RELEASE_URL="https://infra.tekton.dev/tekton-nightly/dashboard"
       ;;
     '--output')
       shift

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -73,15 +73,15 @@ install_ingress_nginx() {
 
 install_pipelines() {
   header 'Installing Tekton Pipelines'
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+  kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
   sleep 10
   kubectl wait -n tekton-pipelines --for=condition=ready pod --selector=app.kubernetes.io/part-of=tekton-pipelines,app.kubernetes.io/component=controller --timeout=90s
 }
 
 install_triggers() {
   header 'Installing Tekton Triggers'
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+  kubectl apply --filename https://infra.tekton.dev/tekton-releases/triggers/latest/release.yaml
+  kubectl apply --filename https://infra.tekton.dev/tekton-releases/triggers/latest/interceptors.yaml
   sleep 10
   kubectl wait -n tekton-pipelines --for=condition=ready pod --selector=app.kubernetes.io/part-of=tekton-triggers,app.kubernetes.io/component=controller --timeout=90s
 }

--- a/scripts/release-installer
+++ b/scripts/release-installer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2023 The Tekton Authors
+# Copyright 2020-2025 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases/dashboard"
+BASE_RELEASE_URL="https://infra.tekton.dev/tekton-releases/dashboard"
 
 download() {
   if type "curl" > /dev/null 2>&1; then
@@ -74,7 +74,7 @@ case $1 in
     VERSION="${1}"
     if [ $VERSION == "--nightly" ]; then
       CHANNEL="--nightly"
-      BASE_RELEASE_URL="https://storage.googleapis.com/tekton-releases-nightly/dashboard"
+      BASE_RELEASE_URL="https://infra.tekton.dev/tekton-nightly/dashboard"
       shift
       VERSION="${1}"
     fi

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -42,8 +42,6 @@ the dashboard repo, a terminal window and a text editor.
 
    **If you are back-porting include this flag: `--param=releaseAsLatest="false"`**
 
-   **Note:** Change the context name in the following commands if using the GCP `dogfooding` cluster instead
-
     ```bash
     tkn --context tekton-ci-cd pipeline start dashboard-release \
       --serviceaccount=release-right-meow \
@@ -74,15 +72,15 @@ the dashboard repo, a terminal window and a text editor.
 
     NAME             VALUE
     ∙ commit-sha     41751e228930c03a1e310d548bc2c529747ca423
-    ∙ release-file   https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.61.0/release.yaml
-    ∙ release-file-full   https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.61.0/release-full.yaml
+    ∙ release-file   https://infra.tekton.dev/tekton-releases/dashboard/previous/v0.61.0/release.yaml
+    ∙ release-file-full   https://infra.tekton.dev/tekton-releases/dashboard/previous/v0.61.0/release-full.yaml
     (...)
     ```
 
     The `commit-sha` should match `$TEKTON_RELEASE_GIT_SHA`.
     The URLs can be opened in the browser or via `curl` to download the release manifests.
 
-1. The YAMLs are now released! Anyone installing Tekton Dashboard will now get the new version. Time to create a new GitHub release announcement
+4. The YAMLs are now released! Anyone installing Tekton Dashboard will now get the new version. Time to create a new GitHub release announcement
 
 ## Create a release announcement
 
@@ -132,12 +130,12 @@ Creating the release announcement is currently a manual process but will be auto
 
      ```bash
      # Test latest
-     kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/release-full.yaml
+     kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/dashboard/latest/release-full.yaml
      ```
 
      ```bash
      # Test backport
-     kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/dashboard/previous/v0.32.0/release-full.yaml
+     kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/dashboard/previous/v0.32.0/release-full.yaml
      ```
 
 1. Announce the release in Slack channels #general, #announcements, and #dashboard.
@@ -150,30 +148,12 @@ Congratulations, you're done!
 
 ## Setup context
 
-### GCP dogfooding cluster
-
-1. Configure `kubectl` to connect to
-   [the dogfooding cluster](https://github.com/tektoncd/plumbing/blob/main/docs/dogfooding.md):
-
-    ```bash
-    gcloud container clusters get-credentials dogfooding --zone us-central1-a --project tekton-releases
-    ```
-
-1. Give [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
-   a short memorable name such as `dogfooding`:
-
-   ```bash
-   kubectl config rename-context gke_tekton-releases_us-central1-a_dogfooding dogfooding
-   ```
-
-### OCI tekton-ci-cd cluster
-
 1. Configure `kubectl` to connect to the cluster:
     ```bash
     oci ce cluster create-kubeconfig --cluster-id $CLUSTER_OCID --file $HOME/.kube/config --region $CLUSTER_REGION --token-version 2.0.0 --kube-endpoint PUBLIC_ENDPOINT
     ```
 
-1. Give the context a short memorable name such as `tekton-ci-cd`:
+2. Give the context a short memorable name such as `tekton-ci-cd`:
 
    ```bash
    kubectl config rename-context cluster-c3h3zdippcq tekton-ci-cd


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Also remove references to the decommissioned dogfooding and robocat clusters, replacing them with the new infra cluster where appropriate.

/kind documentation

Update installer scripts to point at the new locations too.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
