### PR TITLE
Don't attempt to list namespaces when tenant namespaces configured

### DIFF
--- a/src/containers/CreateTaskRun/CreateTaskRun.test.jsx
+++ b/src/containers/CreateTaskRun/CreateTaskRun.test.jsx
@@ -75,6 +75,9 @@ describe('CreateTaskRun', () => {
     );
     vi.spyOn(TasksAPI, 'useTasks').mockImplementation(() => ({ data: tasks }));
 
+    vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+      isFetching: false
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [
         { metadata: { name: 'namespace-1' } },

--- a/src/containers/HeaderBarContent/HeaderBarContent.test.jsx
+++ b/src/containers/HeaderBarContent/HeaderBarContent.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022-2024 The Tekton Authors
+Copyright 2022-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -38,6 +38,9 @@ describe('HeaderBarContent', () => {
   it('adds namespace to URL when selected', async () => {
     const otherNamespace = 'foo';
     const path = '/fake/path';
+    vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+      isFetching: false
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [{ metadata: { name: otherNamespace } }]
     }));
@@ -60,6 +63,9 @@ describe('HeaderBarContent', () => {
     const namespace = 'default';
     const otherNamespace = 'foo';
     const path = '/namespaces/:namespace/fake/path';
+    vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+      isFetching: false
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [
         { metadata: { name: namespace } },
@@ -91,6 +97,9 @@ describe('HeaderBarContent', () => {
     const namespace = 'default';
     const path = '/namespaces/:namespace/fake/path';
     const selectNamespace = vi.fn();
+    vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+      isFetching: false
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [{ metadata: { name: namespace } }]
     }));
@@ -116,6 +125,9 @@ describe('HeaderBarContent', () => {
     const namespace = 'default';
     const path = '/namespaces/:namespace/fake/path';
     const selectNamespace = vi.fn();
+    vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+      isFetching: false
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [{ metadata: { name: namespace } }]
     }));

--- a/src/containers/ImportResources/ImportResources.test.jsx
+++ b/src/containers/ImportResources/ImportResources.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,6 +21,9 @@ import * as APIUtils from '../../api/utils';
 
 describe('ImportResources component', () => {
   beforeEach(() => {
+    vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+      isFetching: false
+    }));
     vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
       data: [
         { metadata: { name: 'default' } },

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.jsx
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import { useIntl } from 'react-intl';
 import { ALL_NAMESPACES } from '@tektoncd/dashboard-utils';
 import { TooltipDropdown } from '@tektoncd/dashboard-components';
 
-import { useNamespaces, useTenantNamespaces } from '../../api';
+import { useNamespaces, useProperties, useTenantNamespaces } from '../../api';
 
 const NamespacesDropdown = ({
   allNamespacesLabel,
@@ -51,10 +51,15 @@ const NamespacesDropdown = ({
       defaultMessage: 'All Namespaces'
     });
 
+  const { isFetching: isFetchingProperties } = useProperties();
   const tenantNamespaces = useTenantNamespaces();
-  const { data: namespaces = [], isFetching } = useNamespaces({
-    disableWebSocket: true
-  });
+  const { data: namespaces = [], isFetching: isFetchingNamespaces } =
+    useNamespaces({
+      disableWebSocket: true,
+      enabled: !isFetchingProperties && !tenantNamespaces.length
+    });
+
+  const isFetching = isFetchingProperties || isFetchingNamespaces;
 
   const selectedItem = useMemo(() => {
     const newSelectedItem = { ...originalSelectedItem };

--- a/src/containers/NamespacesDropdown/NamespacesDropdown.test.jsx
+++ b/src/containers/NamespacesDropdown/NamespacesDropdown.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -30,6 +30,9 @@ const namespaceResources = namespaces.map(namespace => ({
 const initialTextRegExp = /select namespace/i;
 
 it('NamespacesDropdown renders items', () => {
+  vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+    isFetching: false
+  }));
   vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
     data: namespaceResources
   }));
@@ -49,6 +52,9 @@ it('NamespacesDropdown renders items', () => {
 it('NamespacesDropdown renders controlled selection', () => {
   const namespace1 = 'namespace-1';
   const namespace2 = 'namespace-2';
+  vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+    isFetching: false
+  }));
   vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
     data: namespaceResources
   }));
@@ -75,6 +81,9 @@ it('NamespacesDropdown renders controlled selection', () => {
 });
 
 it('NamespacesDropdown renders empty', () => {
+  vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+    isFetching: false
+  }));
   vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({ data: [] }));
   const { queryByPlaceholderText } = render(<NamespacesDropdown {...props} />);
   expect(queryByPlaceholderText(/no namespaces found/i)).toBeTruthy();
@@ -89,6 +98,9 @@ it('NamespacesDropdown renders loading skeleton', () => {
 });
 
 it('NamespacesDropdown handles onChange event', () => {
+  vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+    isFetching: false
+  }));
   vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({
     data: namespaceResources
   }));
@@ -102,6 +114,9 @@ it('NamespacesDropdown handles onChange event', () => {
 });
 
 it('NamespacesDropdown renders tenant namespace in tenant namespace mode', () => {
+  vi.spyOn(API, 'useProperties').mockImplementation(() => ({
+    isFetching: false
+  }));
   vi.spyOn(API, 'useTenantNamespaces').mockImplementation(() => ['fake']);
   vi.spyOn(API, 'useNamespaces').mockImplementation(() => ({ data: [] }));
   const { getByPlaceholderText, getByText } = render(


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The namespaces dropdown was unconditionally making a request to list namespaces, however this is not required when tenant namespaces are configured. Check whether properties have been loaded, and disable the namespaces query if tenant namespaces are configured.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
