### PR TITLE
Fix keyBy implementation to support nested fields

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -21,6 +21,19 @@ const supportedLocales = import.meta.env.VITE_LOCALES_SUPPORTED.split(',');
 export const defaultLocale = import.meta.env.VITE_LOCALES_DEFAULT;
 export const I18N_DEV_KEY = 'tkn-locale-dev';
 
+function getByPath(object, key) {
+  const keyParts = key.split('.');
+  const length = keyParts.length;
+  let index = 0;
+
+  let value = object;
+  while (value !== undefined && index < length) {
+    value = value[keyParts[index++]];
+  }
+
+  return index === length ? value : undefined;
+}
+
 /**
  * Convert an array of objects to an object keyed by the field specified by `key`.
  * In case multiple elements have the same value for `key`, the last such element
@@ -36,12 +49,21 @@ export const I18N_DEV_KEY = 'tkn-locale-dev';
  *  xyz: { title: 'xyz', value: '456' }
  * }
  * ```
+ *
+ * Example using nested field:
+ * `keyBy([{ name: { first: 'John', last: 'Smith' } }], 'name.first')`
+ *
+ * Result:
+ * ```
+ * {
+ *   Bob: { name: { first: 'Bob', last: 'Smith' } }
+ * }
  */
 export function keyBy(array, key) {
   return (array || []).reduce(
     (acc, item) => ({
       ...acc,
-      [item[key]]: item
+      [getByPath(item, key)]: item
     }),
     {}
   );

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2025 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -370,6 +370,15 @@ describe('keyBy', () => {
     ];
     const key = 'name';
     expect(keyBy(array, key)).toEqual({ a: array[0], b: array[1] });
+  });
+
+  it('handles nested field', () => {
+    const array = [
+      { name: { first: 'John', last: 'Smith' } },
+      { name: { first: 'Jane', last: 'Doe' } }
+    ];
+    const key = 'name.first';
+    expect(keyBy(array, key)).toEqual({ John: array[0], Jane: array[1] });
   });
 });
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The [previous implementation](https://github.com/tektoncd/dashboard/pull/4479) only supported top-level fields by name. Update the implementation to support using dot notation to reference nested fields, as was previously supported by `lodash`.

This omission caused problems with the batch delete option.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
