### PR TITLE
Update label checker workflow to use correct format for action reference

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: docker://agilepathway/pull-request-label-checker:v1.6.65@sha256:65e57fd98ba3ab6ca4fcbc5a0aef288dd984ee4ab988f124d83424d19b55b801
+      - uses: docker://agilepathway/pull-request-label-checker@sha256:65e57fd98ba3ab6ca4fcbc5a0aef288dd984ee4ab988f124d83424d19b55b801 # v1.6.65
         with:
           prefix_mode: true
           one_of: "kind/"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The action was being blocked as it didn't match the expected reference format:

```
The action docker://agilepathway/pull-request-label-checker:v1.6.65@sha256:65e57
fd98ba3ab6ca4fcbc5a0aef288dd984ee4ab988f124d83424d19b55b801 is not allowed in
tektoncd/dashboard because all actions must … match one of the patterns: …
docker://agilepathway/pull-request-label-checker@* …
```

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
