### PR TITLE
Restore the buildx install for ppc64le and s390x nightly tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,7 +32,12 @@ else
   END=50
 fi
 
-# install_buildx
+if [ "${GITHUB_ACTIONS}" != "true"]; then
+  # needed for ppc64le and s390x nightly tests which are still run in Tekton
+  # on infra.tekton.dev
+  install_buildx
+fi
+
 if [ "${USE_NIGHTLY_RELEASE}" != "true" ]; then
   install_kustomize
 fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/4758

ppc64le nightly tests are failing with the following:
```
Started at Tue Apr 14 07:17:06 UTC 2026
ERROR: BuildKit is enabled but the buildx component is missing or broken.
       Install the buildx component to build images with BuildKit:
       https://docs.docker.com/go/buildx/
ERROR: Failed building browser E2E image
```

s390x tests are failing much earlier as they're unable to access the cluster. That is an unrelated issue, but will likely encounter similar to the above once that's resolved.

Restore the `install_buildx` step when running outside GitHub Actions.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
