### PR TITLE
Limit the maximum length of a single log line

### DIFF
--- a/packages/components/src/components/Log/Log.jsx
+++ b/packages/components/src/components/Log/Log.jsx
@@ -176,17 +176,33 @@ export class LogContainer extends Component {
   };
 
   getLogList = () => {
+    const { intl } = this.props;
+    const truncatedLineWarning = intl.formatMessage({
+      id: 'dashboard.logs.lineTruncated',
+      defaultMessage:
+        'This log line has been truncated. To view the full content, download the raw logs.'
+    });
+
     const {
-      intl,
       logLevels,
+      maxLineLength,
       parseLogLine = line => {
         if (!line?.length) {
           return { message: line };
         }
 
+        let truncatedLine = line;
+        if (line.length > maxLineLength) {
+          // Truncate extraordinarily long log lines to prevent performance
+          // issues in the browser. We have encountered some users outputting
+          // >2MB on a single log line which crashes even VS Code.
+          truncatedLine =
+            line.substring(0, maxLineLength) + ' … ' + truncatedLineWarning;
+        }
+
         const {
           groups: { command, message, timestamp }
-        } = logFormatRegex.exec(line);
+        } = logFormatRegex.exec(truncatedLine);
         let level;
         if (!['group', 'endgroup'].includes(command)) {
           level = command;
@@ -498,6 +514,7 @@ export class LogContainer extends Component {
 }
 LogContainer.contextType = PrefixContext;
 LogContainer.defaultProps = {
+  maxLineLength: 64 * 1024,
   pollingInterval: 4000
 };
 

--- a/packages/components/src/components/Log/Log.stories.jsx
+++ b/packages/components/src/components/Log/Log.stories.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2025 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -126,6 +126,7 @@ export const Toolbar = {
       debug: false,
       trace: false
     },
+    maxLineLength: 250,
     showLevels: true,
     showTimestamps: false,
     stepStatus: { terminated: { reason: 'Completed', exitCode: 0 } }

--- a/packages/components/src/components/Log/Log.test.jsx
+++ b/packages/components/src/components/Log/Log.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2025 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -29,6 +29,19 @@ describe('Log', () => {
       />
     );
     await waitFor(() => getByText(/testing/i));
+  });
+
+  it('renders truncated lines', async () => {
+    const { getByText, queryByText } = render(
+      <Log
+        stepStatus={{ terminated: { reason: 'Completed' } }}
+        fetchLogs={() => 'testing'}
+        maxLineLength={4}
+      />
+    );
+    await waitFor(() => getByText(/This log line has been truncated./i));
+    expect(queryByText(/testing/)).toBeFalsy();
+    expect(getByText(/test/)).toBeTruthy();
   });
 
   it('renders trailer', async () => {

--- a/src/nls/messages_de.json
+++ b/src/nls/messages_de.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_en.json
+++ b/src/nls/messages_en.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "All lines hidden due to selected log levels or collapsed groups",
   "dashboard.logs.hidden.one": "1 line hidden due to selected log levels or collapsed groups",
   "dashboard.logs.launchButtonTooltip": "Open logs in a new window",
+  "dashboard.logs.lineTruncated": "This log line has been truncated. To view the full content, download the raw logs.",
   "dashboard.logs.logLevels.debug": "Debug",
   "dashboard.logs.logLevels.error": "Error",
   "dashboard.logs.logLevels.info": "Info (default)",

--- a/src/nls/messages_es.json
+++ b/src/nls/messages_es.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_fr.json
+++ b/src/nls/messages_fr.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_it.json
+++ b/src/nls/messages_it.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_ja.json
+++ b/src/nls/messages_ja.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "新しいウィンドウでログを開く",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_ko.json
+++ b/src/nls/messages_ko.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "새 창에서 로그 열기",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_pt.json
+++ b/src/nls/messages_pt.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_zh-Hans.json
+++ b/src/nls/messages_zh-Hans.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "在新窗口中打开日志",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",

--- a/src/nls/messages_zh-Hant.json
+++ b/src/nls/messages_zh-Hant.json
@@ -149,6 +149,7 @@
   "dashboard.logs.hidden.all": "",
   "dashboard.logs.hidden.one": "",
   "dashboard.logs.launchButtonTooltip": "",
+  "dashboard.logs.lineTruncated": "",
   "dashboard.logs.logLevels.debug": "",
   "dashboard.logs.logLevels.error": "",
   "dashboard.logs.logLevels.info": "",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
To prevent performance issues in the browser, limit the length of a single line to 256k. This should be plenty for most log lines. For any longer than this, include text at the end of the line advising the user to download the raw logs for review outside the browser.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Limit the maximum length of a single log line that will be displayed on the PipelineRun or TaskRun details page to 256k.
```
