### PR TITLE
Update E2E base image workflow to specify default value on input

### DIFF
--- a/.github/workflows/e2e-base-image.yml
+++ b/.github/workflows/e2e-base-image.yml
@@ -7,8 +7,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag containing the Node.js and browser versions, e.g. node24.14.0-chrome140'
-        required: false
+        description: 'Image tag, typically containing the Node.js and browser versions'
+        required: true
+        default: 'node24.14.0-chrome147'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -20,7 +22,7 @@ defaults:
 
 env:
   REGISTRY: ghcr.io
-  TAG: ${{ inputs.tag || 'node24.14.0-chrome147' }}
+  TAG: ${{ inputs.tag }}
 
 jobs:
   build:

--- a/packages/e2e/base-image/README.md
+++ b/packages/e2e/base-image/README.md
@@ -5,7 +5,7 @@
 To create a release:
 
 - verify the `CHROME_VERSION` and `NODE_VERSION` args in the [`Dockerfile`](./Dockerfile) on the main branch are correct
-- set a matching tag value in the `TAG` environment variable in the [workflow](../../../.github/workflows/e2e-base-image.yml), e.g. `node20.11.0-chrome121`
+- set a matching tag value for the `on.workflow_dispatch.inputs.tag.default` input in the [workflow](../../../.github/workflows/e2e-base-image.yml), e.g. `node20.11.0-chrome121`
 - manually trigger the [workflow](https://github.com/tektoncd/dashboard/actions/workflows/e2e-base-image.yml)
 - check the status of the resulting run
 - confirm the image was [released and properly tagged](https://github.com/tektoncd/dashboard/pkgs/container/dashboard%2Fdashboard-e2e-base)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/dashboard/pull/4892#pullrequestreview-4127306799

Instead of defaulting the value when declaring the env var, do it in the input. This means the value is displayed to the user before they proceed and can be modified or overridden in the GitHub Actions UI more easily if needed.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
