### PR TITLE
Fix label links on PipelineRun and TaskRun detail pages

### DIFF
--- a/packages/components/src/components/LabelsWithOverflow/LabelsWithOverflow.jsx
+++ b/packages/components/src/components/LabelsWithOverflow/LabelsWithOverflow.jsx
@@ -25,6 +25,7 @@ import { urls } from '@tektoncd/dashboard-utils';
 import Link from '../Link';
 
 export default function LabelsWithOverflow({
+  kind,
   namespace,
   resource,
   LinkComponent = Link
@@ -46,7 +47,10 @@ export default function LabelsWithOverflow({
     maxVisibleLabels + maxOverflowLabels
   );
   const totalHiddenLabels = labelEntries.length - maxVisibleLabels;
-  const resourceType = resource.kind;
+  // Kubernetes typed API responses typically do not populate `kind` on the
+  // resource body, so we rely on an explicit prop from the caller rather than
+  // reading `resource.kind` — see tektoncd/dashboard#4905.
+  const resourceType = kind;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [open, setOpen] = useState(false);

--- a/packages/components/src/components/LabelsWithOverflow/LabelsWithOverflow.stories.jsx
+++ b/packages/components/src/components/LabelsWithOverflow/LabelsWithOverflow.stories.jsx
@@ -22,6 +22,7 @@ export default {
 
 export const Default = args => <LabelsWithOverflow {...args} />;
 Default.args = {
+  kind: 'PipelineRun',
   resource: {
     metadata: {
       labels: {
@@ -43,8 +44,7 @@ Default.args = {
         'triggers.tekton.dev/triggers-eventid3':
           'e9742d5b-00e4-4124-9aa1-da2fd670f2da5'
       }
-    },
-    kind: 'PipelineRun'
+    }
   },
   namespace: 'default'
 };

--- a/packages/components/src/components/LabelsWithOverflow/LabelsWithOverflow.test.jsx
+++ b/packages/components/src/components/LabelsWithOverflow/LabelsWithOverflow.test.jsx
@@ -34,8 +34,7 @@ const resource = {
       label14: 'value14',
       label15: 'value15'
     }
-  },
-  kind: 'PipelineRun'
+  }
 };
 
 const namespace = 'default';
@@ -43,7 +42,11 @@ const namespace = 'default';
 describe('LabelsWithOverflow with overflow', () => {
   it('renders visible labels', () => {
     const { getByText } = renderWithRouter(
-      <LabelsWithOverflow resource={resource} namespace={namespace} />
+      <LabelsWithOverflow
+        kind="PipelineRun"
+        resource={resource}
+        namespace={namespace}
+      />
     );
     expect(getByText('label1: value1')).toBeTruthy();
     expect(getByText('label2: value2')).toBeTruthy();
@@ -53,7 +56,11 @@ describe('LabelsWithOverflow with overflow', () => {
 
   it('renders overflow labels with popover', () => {
     const { getByText } = renderWithRouter(
-      <LabelsWithOverflow resource={resource} namespace={namespace} />
+      <LabelsWithOverflow
+        kind="PipelineRun"
+        resource={resource}
+        namespace={namespace}
+      />
     );
     fireEvent.click(getByText('+11'));
     expect(getByText('label5: value5')).toBeTruthy();
@@ -65,7 +72,11 @@ describe('LabelsWithOverflow with overflow', () => {
 
   it('open modal with remaining labels', () => {
     const { getByText, getByPlaceholderText, queryByRole } = renderWithRouter(
-      <LabelsWithOverflow resource={resource} namespace={namespace} />
+      <LabelsWithOverflow
+        kind="PipelineRun"
+        resource={resource}
+        namespace={namespace}
+      />
     );
     fireEvent.click(getByText('+11'));
     fireEvent.click(getByText('+6'));
@@ -78,7 +89,11 @@ describe('LabelsWithOverflow with overflow', () => {
 
   it('filter labels in modal', () => {
     const { getByText, getByPlaceholderText, queryByRole } = renderWithRouter(
-      <LabelsWithOverflow resource={resource} namespace={namespace} />
+      <LabelsWithOverflow
+        kind="PipelineRun"
+        resource={resource}
+        namespace={namespace}
+      />
     );
     fireEvent.click(getByText('+11'));
     fireEvent.click(getByText('+6'));
@@ -91,5 +106,29 @@ describe('LabelsWithOverflow with overflow', () => {
     expect(filteredTags.length).toBe(1);
     expect(filteredTags[0]).toBeTruthy();
     expect(within(dialog).queryByText('label10: value10')).not.toBeTruthy();
+  });
+
+  it('builds label links pointing to the list page for the given kind', () => {
+    const { getByTitle, rerender } = renderWithRouter(
+      <LabelsWithOverflow
+        kind="PipelineRun"
+        resource={resource}
+        namespace={namespace}
+      />
+    );
+    expect(getByTitle('label1: value1').getAttribute('href')).toBe(
+      '/namespaces/default/pipelineruns?labelSelector=label1%3Dvalue1'
+    );
+
+    rerender(
+      <LabelsWithOverflow
+        kind="TaskRun"
+        resource={resource}
+        namespace={namespace}
+      />
+    );
+    expect(getByTitle('label1: value1').getAttribute('href')).toBe(
+      '/namespaces/default/taskruns?labelSelector=label1%3Dvalue1'
+    );
   });
 });

--- a/packages/components/src/components/PipelineRun/PipelineRun.jsx
+++ b/packages/components/src/components/PipelineRun/PipelineRun.jsx
@@ -384,6 +384,7 @@ export default /* istanbul ignore next */ function PipelineRun({
         showFailureMessage={showFailureMessage}
         displayRunHeader={displayRunHeader}
         duration={duration}
+        kind="PipelineRun"
         lastTransitionTime={lastTransitionTime}
         triggerInfo={triggerInfo}
         resource={pipelineRun}

--- a/packages/components/src/components/RunHeader/RunHeader.jsx
+++ b/packages/components/src/components/RunHeader/RunHeader.jsx
@@ -23,6 +23,7 @@ export default function RunHeader({
   description,
   displayRunHeader = true,
   duration = null,
+  kind,
   lastTransitionTime,
   loading,
   message,
@@ -114,6 +115,7 @@ export default function RunHeader({
                       })}
                       columnContent={
                         <LabelsWithOverflow
+                          kind={kind}
                           resource={resource}
                           namespace={namespace}
                         />

--- a/src/containers/TaskRun/TaskRun.jsx
+++ b/src/containers/TaskRun/TaskRun.jsx
@@ -555,6 +555,7 @@ export function TaskRunContainer({
       )}
       <RunHeader
         duration={duration}
+        kind="TaskRun"
         namespace={namespace}
         resource={taskRun}
         lastTransitionTime={taskRun.status?.startTime}


### PR DESCRIPTION
## Changes

Fixes #4905.

`LabelsWithOverflow` read the resource kind from `resource.kind` when building the list page link for each label chip. Kubernetes does not populate `TypeMeta` (`kind` / `apiVersion`) on typed get/list responses, so `resource.kind` was `undefined` at runtime, and `urls.pipelineRuns.labels` returned the literal string `"undefined?labelSelector=…"`. The hash router resolved that relative to the current URL, producing links like `/namespaces/<ns>/pipelineruns/<name>/undefined?labelSelector=…` and surfacing an `Error loading undefined` notification when users clicked a label.

This PR stops depending on `resource.kind` and instead passes an explicit `kind` prop from the `PipelineRun` and `TaskRun` containers through `RunHeader` to `LabelsWithOverflow`. The callers already know which kind they are rendering.

The existing `LabelsWithOverflow` test masked the bug by hardcoding `kind: 'PipelineRun'` on the resource fixture; that has been removed, and a new test asserts the generated label-link URL for both kinds so the regression cannot return silently.

## Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been filled in, or marked NONE

## Release Notes

```release-note
Fix label links on the PipelineRun and TaskRun detail pages, which previously pointed to `/namespaces/<ns>/<kind>/<name>/undefined?labelSelector=…` and produced an "Error loading undefined" notification when clicked.
```