### PR TITLE
Fix log streaming when no external logs configured

### DIFF
--- a/packages/components/src/components/Log/Log.jsx
+++ b/packages/components/src/components/Log/Log.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2025 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -422,6 +422,8 @@ export class LogContainer extends Component {
   loadLog = async () => {
     // In development mode this request is duplicated due to usage of StrictMode component wrapper
     // It highlights a potential problem but only affects local dev and not production mode
+    this.cancelled = false;
+
     const { fetchLogs, forcePolling, intl, stepStatus, pollingInterval } =
       this.props;
     if (!fetchLogs) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -155,8 +155,8 @@ export function getLogsRetriever({
     return ({ stepName, stepStatus, taskRun }) =>
       fetchLogs({
         stepName,
-        stream: isLogStreamingEnabled,
         stepStatus,
+        stream: isLogStreamingEnabled,
         taskRun
       }).catch(() => {
         onFallback(true);
@@ -165,7 +165,8 @@ export function getLogsRetriever({
       });
   }
 
-  return fetchLogs;
+  return ({ stepName, stepStatus, taskRun }) =>
+    fetchLogs({ stepName, stepStatus, stream: isLogStreamingEnabled, taskRun });
 }
 
 // K8s label documentation comes from here:

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -266,6 +266,19 @@ describe('getLogsRetriever', () => {
     });
   });
 
+  it('should handle default logs retriever with streaming enabled', () => {
+    vi.spyOn(API, 'getPodLog').mockImplementation(() => {});
+    const logsRetriever = getLogsRetriever({ isLogStreamingEnabled: true });
+    expect(logsRetriever).toBeDefined();
+    logsRetriever({ stepName, stepStatus, taskRun });
+    expect(API.getPodLog).toHaveBeenCalledWith({
+      container: stepName,
+      name: podName,
+      namespace,
+      stream: true
+    });
+  });
+
   it('should handle default logs retriever with external fallback enabled', async () => {
     const externalLogsURL = 'fake_externalLogsURL';
     vi.spyOn(API, 'getPodLog').mockImplementation(() => {});


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Fix for bug introduced by https://github.com/tektoncd/dashboard/pull/3870

When no external logs fallback is configured, the log retriever does not capture the `streamLogs` config state. This means that the log retriever defaults to polling even when streaming is expected. If external logs are configured, streaming works as expected.

Update the log retriever to correctly capture and forward the `streamLogs` config so that log streaming works as expected in both modes.

Also fix issue preventing testing the streaming behaviour in local dev environment (dev mode only) due to React.StrictMode behaviour.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix log streaming when no external logs configured.
```
