### PR TITLE
Fix table action button alignment

### DIFF
--- a/packages/components/src/components/Table/_Table.scss
+++ b/packages/components/src/components/Table/_Table.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -95,14 +95,8 @@ limitations under the License.
       }
 
       .#{$prefix}--link.#{$prefix}--btn--icon-only {
+        display: inline-flex;
         vertical-align: top;
-        // from Carbon v11 button styles
-        padding-block-start: min(
-          calc(
-            (layout.size('height') - convert.to-rem(16px)) / 2 - convert.to-rem(1px)
-          ),
-          var(--temp-padding-block-max)
-        );
       }
     }
   }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Add `display: inline-flex` to icon-only buttons in tables to fix misalignment caused by recent Carbon updates. Remove complex padding calculations in favor of a simpler flexbox layout.

/kind bug


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
