### PR TITLE
Update kind and k8s versions for E2E tests and dev scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         k8s-name:
           - k8s-oldest
-          - k8s-plus-one
+          - k8s-latest
 
         dashboard-mode:
           - read-only
@@ -100,8 +100,8 @@ jobs:
         include:
           - k8s-name: k8s-oldest
             k8s-version: v1.31.x
-          - k8s-name: k8s-plus-one
-            k8s-version: v1.32.x
+          - k8s-name: k8s-latest
+            k8s-version: v1.35.x
 
     env:
       ARTIFACTS: ${{ github.workspace }}/artifacts
@@ -146,7 +146,7 @@ jobs:
           echo '::endgroup::'
 
           echo '::group::install kind'
-          go install sigs.k8s.io/kind@v0.27.0
+          go install sigs.k8s.io/kind@v0.31.0
           echo '::endgroup::'
 
           echo '::group::create required folders'

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,7 @@ Choose the version of Tekton Dashboard you want to install. You have the followi
 ## Pre-requisites
 
 In order to install the Tekton Dashboard, please make sure the following requirements are met:
-- You must have a Kubernetes cluster running version 1.28.0 or later. Tekton Pipelines or other projects may require a newer version. The Dashboard may work on older Kubernetes versions but this is untested and not officially supported.
+- You must have a Kubernetes cluster running version 1.31.0 or later. Tekton Pipelines or other projects may require a newer version. The Dashboard may work on older Kubernetes versions but this is untested and not officially supported.
 
   If you don't already have a cluster, you can create one for testing with `kind`.
   [Install `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and create a cluster by running [`kind create cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). This

--- a/scripts/prepare-kind-cluster
+++ b/scripts/prepare-kind-cluster
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2024 The Tekton Authors
+# Copyright 2020-2026 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,7 +16,7 @@ set -e
 CLUSTERNAME=tekton-dashboard
 DEFAULT_OPTIONS="--log-format console --read-write"
 ENABLE_INGRESS="false"
-KUBERNETES_NODE_IMAGE="docker.io/kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
+KUBERNETES_NODE_IMAGE="docker.io/kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
 
 create_cluster() {
 if [ "$ENABLE_INGRESS" == "false" ]; then

--- a/test/e2e-tests-prow.sh
+++ b/test/e2e-tests-prow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022-2025 The Tekton Authors
+# Copyright 2022-2026 The Tekton Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 set -e
 
 # Defaults
-K8S_VERSION="v1.32.x"
+K8S_VERSION="v1.35.x"
 
 while [[ $# -ne 0 ]]; do
   parameter="$1"
@@ -29,29 +29,33 @@ while [[ $# -ne 0 ]]; do
 done
 
 # The version map correlated with this version of kind
+# Image versions and SHAs can be found in the kind release notes
+# https://github.com/kubernetes-sigs/kind/releases
 case ${K8S_VERSION} in
-  v1.29.x)
-    K8S_VERSION="1.29.14"
-    KIND_IMAGE_SHA="sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.30.x)
-    K8S_VERSION="1.30.10"
-    KIND_IMAGE_SHA="sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
   v1.31.x)
-    K8S_VERSION="1.31.6"
-    KIND_IMAGE_SHA="sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    K8S_VERSION="1.31.14"
+    KIND_IMAGE_SHA="sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b"
     ;;
   v1.32.x)
-    K8S_VERSION="1.32.2"
-    KIND_IMAGE_SHA="sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    K8S_VERSION="1.32.11"
+    KIND_IMAGE_SHA="sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8"
+    ;;
+  v1.33.x)
+    K8S_VERSION="1.33.7"
+    KIND_IMAGE_SHA="sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040"
+    ;;
+  v1.34.x)
+    K8S_VERSION="1.34.3"
+    KIND_IMAGE_SHA="sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48"
+    ;;
+  v1.35.x)
+    K8S_VERSION="1.35.0"
+    KIND_IMAGE_SHA="sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
     ;;
   *) abort "Unsupported version: ${K8S_VERSION}" ;;
 esac
+
+KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
 
 # Create kind config with correct k8s version
 cat > kind-config.yaml <<EOF


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Update to the latest `kind` release and update the k8s node images used for E2E and the dev `prepare-kind-cluster` script. The latest released node image for kind is currently 1.35.x, there is no release for 1.36 yet.

For the E2E jobs, rename `k8s-plus-one` to `k8s-latest` to better reflect its purpose.

Node images pulled from the corresponding kind release notes, see "Images pre-built for this release": https://github.com/kubernetes-sigs/kind/releases/tag/v0.31.0

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
