### PR TITLE
Update npm release instructions to omit PRs from release notes

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -132,6 +132,7 @@ To release a new version of the npm packages, e.g. `@tektoncd/dashboard-componen
 
      e.g. `Publish v0.24.1-alpha.0 of the @tektoncd/dashboard-* packages`
    - Use the commit message as the PR title
+   - Add the label `release-note-none` to omit it from the generated release notes
 1. The packages are automatically published once the PR is merged
    - Verify there were no issues with the [publish workflow](https://github.com/tektoncd/dashboard/actions/workflows/publish.yml?query=event%3Apush+branch%3Amain)
 1. Once the packages are published, build and publish the Storybook:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Publication of the npm packages is irrelevant to most users of the Dashboard application and should not be included in the release notes published with each Dashboard release.

PRs with the label `release-note-none` are already excluded from the GH generated release notes, configured at https://github.com/tektoncd/dashboard/blob/456c45f79057bb50c3ace88815799b8a8086e05e/.github/release.yml#L2-L4.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
