### PR TITLE
Fix: Add spacing between labels in resource details

### DIFF
--- a/src/scss/_Triggers.scss
+++ b/src/scss/_Triggers.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,7 +22,7 @@ limitations under the License.
 
     .tkn--actions-dropdown {
       margin-inline-start: auto;
-      margin-inline-end: 1rem;
+      margin-inline-end: $spacing-05;
     }
   }
   .tkn--details {
@@ -72,14 +72,15 @@ limitations under the License.
 
   .#{$prefix}--tag {
     margin-block-start: 0;
+    margin-inline-end: $spacing-02;
   }
 
   & + h4 {
-    margin-block-end: 0.5rem;
+    margin-block-end: $spacing-03;
   }
 
   svg {
     vertical-align: sub;
-    margin-inline-end: 0.5rem;
+    margin-inline-end: $spacing-03;
   }
 }


### PR DESCRIPTION
Also replace hardcoded spacing values with Carbon Design System tokens

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
- Added margin-inline-end to tag elements for proper label spacing
- Replaced hardcoded spacing values with Carbon Design System tokens

/kind bug

Fixes https://github.com/tektoncd/dashboard/issues/4973

After the fix, the spacing looks better:

<img width="622" height="482" alt="Screenshot 2026-05-20 at 1 08 26 PM" src="https://github.com/user-attachments/assets/20c9cf13-65f4-4aa3-900a-bcfe76532f43" />



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
