### PR TITLE
Accessibility fix: avoid animation rotation

### DIFF
--- a/packages/components/src/components/Spinner/_Spinner.scss
+++ b/packages/components/src/components/Spinner/_Spinner.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -24,5 +24,11 @@ limitations under the License.
   }
   100% {
     transform: rotate(360deg) scaleX(-1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tkn--spinner {
+    animation: none;
   }
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
- Disables rotating spinner animation when users have reduced motion preference enabled in their OS/browser settings.
- This prevents discomfort for users with motion-triggered vestibular disorders.

Fixes https://github.com/tektoncd/dashboard/issues/4974

/kind misc

## Testing

Tested using Chrome DevTools → Command Palette → "Emulate CSS prefers-reduced-motion: reduce"

✅ Confirmed: Running status icon stops spinning when reduced motion is enabled
✅ Normal behavior: Spinner continues rotating when reduced motion is disabled

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
