### PR TITLE
chore: print tool versions while installing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,12 @@ jobs:
           curl -L https://github.com/ko-build/ko/releases/download/v0.15.4/ko_0.15.4_Linux_x86_64.tar.gz | tar xzf - ko
           chmod +x ./ko
           sudo mv ko /usr/local/bin
+          ko version
           echo '::endgroup::'
 
           echo '::group::install kind'
           go install sigs.k8s.io/kind@v0.31.0
+          kind version
           echo '::endgroup::'
 
           echo '::group::create required folders'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
- Output `ko version` and `kind version` after installation in CI logs
- Improves debugging when E2E tests fail due to tool version mismatches or installation issues
- Version info now visible in the install log groups for quick verification

Fixes https://github.com/tektoncd/dashboard/issues/4976

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
