### PR TITLE
Output k8s version info to debug ppc64le nightly test failure

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -356,6 +356,8 @@ install() {
   echo "Installing …"
   kubectl create ns $INSTALL_NAMESPACE > /dev/null 2>&1 || true
   if [ "$DEBUG" == "true" ]; then
+    echo "k8s version:"
+    kubectl version
     echo "Output $TMP_FILE"
     echo "====="
     cat $TMP_FILE


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/5015
Add k8s version info to debug log to help narrow down the issues with the ppc64le nightly tests since they cannot be reproduced locally on x86 or arm based clusters. It's not clear from the logs what k8s version is being deployed so it's possible a client/server version mismatch is contributing and kubectl isn't reporting the issue properly.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
