### PR TITLE
AVT enhance date and duration format

### DIFF
--- a/packages/components/src/components/DetailsHeader/DetailsHeader.test.jsx
+++ b/packages/components/src/components/DetailsHeader/DetailsHeader.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -165,10 +165,10 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = render(
+    const { getAllByText, queryByText } = render(
       <DetailsHeader {...props} stepStatus={stepStatus} />
     );
-    expect(queryByText(/duration/i)).toBeTruthy();
+    expect(getAllByText(/duration/i).length).toBeGreaterThan(0);
     expect(queryByText(/0s/i)).toBeTruthy();
   });
 
@@ -199,9 +199,9 @@ describe('DetailsHeader', () => {
       }
     };
 
-    const { queryByText } = render(
+    const { getAllByText } = render(
       <DetailsHeader {...props} taskRun={taskRun} type="taskRun" />
     );
-    expect(queryByText(/duration/i)).toBeTruthy();
+    expect(getAllByText(/duration/i).length).toBeGreaterThan(0);
   });
 });

--- a/packages/components/src/components/FormattedDate/FormattedDate.jsx
+++ b/packages/components/src/components/FormattedDate/FormattedDate.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -62,7 +62,12 @@ const FormattedDateWrapper = ({
     ...(includeSeconds ? { second: 'numeric' } : null)
   });
   formattedDate = formatTooltip(formattedDate);
-  return <span title={formattedDate}>{content}</span>;
+  return (
+    <span title={formattedDate}>
+      <span aria-hidden="true">{content}</span>
+      <span className="cds--assistive-text">{formattedDate}</span>
+    </span>
+  );
 };
 
 export default FormattedDateWrapper;

--- a/packages/components/src/components/FormattedDuration/FormattedDuration.jsx
+++ b/packages/components/src/components/FormattedDuration/FormattedDuration.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2024 The Tekton Authors
+Copyright 2019-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -42,33 +42,14 @@ class FormattedDurationWrapper extends Component {
   state = { tooltip: '' };
 
   componentDidMount() {
-    const { intl } = this.props;
-    const tooltip = intl.formatMessage(
-      {
-        id: 'dashboard.run.duration',
-        defaultMessage: 'Duration: {duration}'
-      },
-      {
-        duration: this.durationNode?.textContent
-      }
-    );
+    const tooltip = this.durationNode?.textContent;
     this.setState({
       tooltip
     });
   }
 
   componentDidUpdate() {
-    const { intl } = this.props;
-    const duration = this.durationNode.textContent;
-    const tooltip = intl.formatMessage(
-      {
-        id: 'dashboard.run.duration',
-        defaultMessage: 'Duration: {duration}'
-      },
-      {
-        duration
-      }
-    );
+    const tooltip = this.durationNode?.textContent;
     if (this.state.tooltip !== tooltip) {
       this.setState({ // eslint-disable-line
         tooltip
@@ -77,19 +58,38 @@ class FormattedDurationWrapper extends Component {
   }
 
   render() {
-    const { milliseconds } = this.props;
+    const { intl, milliseconds } = this.props;
     return (
-      <span
-        ref={ref => {
-          this.durationNode = ref;
-        }}
-        title={this.state.tooltip}
-      >
-        <FormattedDuration
-          format="{days} {hours} {minutes} {seconds}"
-          seconds={milliseconds / 1000}
-          unitDisplay="narrow"
-        />
+      <span title={this.state.tooltip}>
+        <span aria-hidden="true">
+          <FormattedDuration
+            format="{days} {hours} {minutes} {seconds}"
+            seconds={milliseconds / 1000}
+            unitDisplay="narrow"
+          />
+        </span>
+        <span
+          className="cds--assistive-text"
+          ref={ref => {
+            this.durationNode = ref;
+          }}
+        >
+          {intl.formatMessage(
+            {
+              id: 'dashboard.run.duration',
+              defaultMessage: 'Duration: {duration}'
+            },
+            {
+              duration: (
+                <FormattedDuration
+                  format="{days} {hours} {minutes} {seconds}"
+                  seconds={milliseconds / 1000}
+                  unitDisplay="long"
+                />
+              )
+            }
+          )}
+        </span>
       </span>
     );
   }

--- a/packages/components/src/components/FormattedDuration/FormattedDuration.test.jsx
+++ b/packages/components/src/components/FormattedDuration/FormattedDuration.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2024 The Tekton Authors
+Copyright 2020-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -20,10 +20,10 @@ describe('FormattedDuration', () => {
       <FormattedDuration milliseconds={1000} />
     );
     expect(getByText(/1s/i)).toBeTruthy();
-    expect(getByTitle(/1s/i)).toBeTruthy();
+    expect(getByTitle(/Duration: 1 second/i)).toBeTruthy();
 
     render(<FormattedDuration milliseconds={2000} />, { rerender });
     expect(getByText(/2s/i)).toBeTruthy();
-    expect(getByTitle(/2s/i)).toBeTruthy();
+    expect(getByTitle(/Duration: 2 seconds/i)).toBeTruthy();
   });
 });

--- a/packages/components/src/components/LogFormat/LogFormat.test.jsx
+++ b/packages/components/src/components/LogFormat/LogFormat.test.jsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2025 The Tekton Authors
+Copyright 2020-2026 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -361,7 +361,7 @@ describe('LogFormat', () => {
       // accept anything (`.*`) for test purposes as it may be localised
       // and we're more concerned with the structure here
       new RegExp(
-        `<div class="tkn--log-line"><span class="tkn--log-line--timestamp"><span title="${timestamp}">.*</span> </span><span class="tkn--log-line--content">Hello</span></div>`
+        `<div class="tkn--log-line"><span class="tkn--log-line--timestamp"><span title="${timestamp}"><span aria-hidden="true">.*</span><span class="cds--assistive-text">${timestamp}</span></span> </span><span class="tkn--log-line--content">Hello</span></div>`
       )
     );
   });


### PR DESCRIPTION
# Changes
This PR improves accessibility for screen readers by updating date and duration components in the Tekton Dashboard. The changes use two separate span elements:
- One with `aria-hidden="true"` for sighted users (displays narrow/abbreviated format)
- One with `cds--assistive-text` class for screen readers (provides long format with context)

Visual users continue to see abbreviated formats (e.g., "Apr 7, 4:35 PM" and "2m 55s"), while screen readers announce full, descriptive formats (e.g., "April 7, 2024, 4:35 PM" and "Duration: 2 minutes 55 seconds"). The tooltip (title attribute) displays the same full format that screen readers announce, ensuring consistency.

**Example for duration:**
- Visual display: `2m 55s`
- Screen reader: `Duration: 2 minutes 55 seconds`
- Tooltip: `Duration: 2 minutes 55 seconds`

Fixes #5018

/kind bug

## Testing

### Test Coverage
- ✅ All 617 tests passing
- ✅ 100% code coverage maintained for modified components

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

None