### PR TITLE
Add visx group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,9 @@ updates:
           - "eslint-plugin-storybook"
           - "storybook"
           - "@storybook/*"
+      visx:
+        patterns:
+          - "@visx/*"
       vitest:
         patterns:
           - "vitest"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Add a dependabot group for all visx packages so they're updated together.

This should prevent wasteful PRs / GitHub Actions workflow runs, for example:
- https://github.com/tektoncd/dashboard/pull/5032
- https://github.com/tektoncd/dashboard/pull/5034
- https://github.com/tektoncd/dashboard/pull/5037
- https://github.com/tektoncd/dashboard/pull/5038

The last 2 of these failed all GHA checks and could have been avoided entirely.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
