### PR TITLE
Fix the release installer used in the nightly ppc64le tests

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -125,7 +125,7 @@ download() {
   debug "Downloading $url -> $TMP_FILE …"
 
   if type "curl" > /dev/null 2>&1; then
-    curl -s "$url" -o "$TMP_FILE"
+    curl -s -L "$url" -o "$TMP_FILE"
   elif type "wget" > /dev/null 2>&1; then
     wget -q -O "$TMP_FILE" "$url"
   fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Update usage of `curl` to follow redirects. This is required since the official download location at `infra.tekton.dev` issues a 302 redirect to the OCI bucket URL.

This was affecting nightly tests on ppc64le as the generated install manifest contained a HTML snippet for the redirect, causing the installation to fail.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
