### PR TITLE
Remove legacy Cypress config

### DIFF
--- a/packages/e2e/cypress.config.js
+++ b/packages/e2e/cypress.config.js
@@ -21,7 +21,6 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8000',
     experimentalRunAllSpecs: true,
-    experimentalStudio: true,
     setupNodeEvents(on, config) {
       config.expose.carbonPrefix = 'cds';
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The `experimentalStudio` option was removed in Cypress version 15.4.0.

This is producing a warning in CI runs and when running tests locally.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
