### PR TITLE
Fix styling of date and duration on resource details pages

### DIFF
--- a/src/scss/_Triggers.scss
+++ b/src/scss/_Triggers.scss
@@ -29,7 +29,7 @@ limitations under the License.
     li:not(:empty), p:not(:empty) {
       @include type-style('body-compact-02');
       margin-block-start: $spacing-03;
-      span:first-child {
+      > span:first-child {
         font-weight: bold;
         margin-inline-end: $spacing-02;
       }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/dashboard/pull/5019

Recent changes to the DOM structure for the FormattedDate and FormattedDuration components had an unintended impact on the style of their output specifically on the resource detail pages.

Since we've introduced a new span that is a first child of its parent it inherits the heavier font weight intendend for the field labels.

Update the selector to target only the immediate child of the parent, and not all descendants.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
