### PR TITLE
Adopt standard OCI image labels on published images

### DIFF
--- a/packages/e2e/base-image/Dockerfile
+++ b/packages/e2e/base-image/Dockerfile
@@ -19,7 +19,9 @@ ARG NODE_VERSION='24.14.0'
 FROM cypress/factory@sha256:6fc007867f2b7bcf17dd3a74989da2ffdaa772f4f9c447e1184a1656452308c3
 
 LABEL maintainer="Tekton Authors <tekton-dev@googlegroups.com>"
-LABEL org.opencontainers.image.source=https://github.com/tektoncd/dashboard
+LABEL org.opencontainers.image.source=https://github.com/tektoncd/dashboard/tree/main/packages/e2e/base-image
+LABEL org.opencontainers.image.url=https://github.com/tektoncd/dashboard/tree/main/packages/e2e/base-image \
+LABEL org.opencontainers.image.title=dashboard-e2e-base \
 LABEL org.opencontainers.image.description="Base image for Tekton Dashboard E2E tests"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 

--- a/scripts/installer
+++ b/scripts/installer
@@ -31,7 +31,8 @@ EXTERNAL_LOGS=""
 BASE_RELEASE_URL="https://infra.tekton.dev/tekton-releases/dashboard"
 
 # additional options passed to ko resolve
-KO_RESOLVE_OPTIONS="--image-label=org.opencontainers.image.source=https://github.com/tektoncd/dashboard"
+KO_RESOLVE_OPTIONS=""
+
 PLATFORM=""
 
 # Display a box banner.
@@ -110,7 +111,13 @@ bootstrapFromInstallerManifest() {
 
 compile() {
   debug "Building config …"
-  kustomize build --load-restrictor LoadRestrictionsNone config | ko resolve $KO_RESOLVE_OPTIONS $PLATFORM -f - > "$TMP_FILE"
+  kustomize build --load-restrictor LoadRestrictionsNone config | ko resolve \
+    --image-label=org.opencontainers.image.source=https://github.com/tektoncd/dashboard \
+    --image-label=org.opencontainers.image.url=https://github.com/tektoncd/dashboard \
+    --image-label=org.opencontainers.image.title=dashboard \
+    --image-label=org.opencontainers.image.description="Tekton Dashboard" \
+    $KO_RESOLVE_OPTIONS \
+    $PLATFORM -f - > "$TMP_FILE"
 }
 
 download() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/plumbing/issues/3435
Primarily to avoid inheriting incorrect / misleading labels from base image when using `ko resolve` but also adding to E2E base image for consistency.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
