### PR TITLE
ci: run zizmor on GitHub Actions and fix security findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ${{ github.workspace }}/src/github.com/tektoncd/dashboard
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -69,6 +70,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -119,6 +122,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ${{ github.workspace }}/src/github.com/tektoncd/dashboard
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,7 +23,10 @@ jobs:
           egress-policy: audit
 
       - name: 'Checkout Repository'
+
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/e2e-base-image.yml
+++ b/.github/workflows/e2e-base-image.yml
@@ -37,7 +37,10 @@ jobs:
         with:
           egress-policy: audit
 
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Log in to the Container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -71,6 +71,9 @@ jobs:
           kustomize build tekton | kubectl apply -f -
 
       - name: Start Tekton Build Pipeline
+        env:
+          LATEST_SHA: ${{ steps.version.outputs.latest_sha }}
+          VERSION_TAG: ${{ steps.version.outputs.version_tag }}
         run: |
           set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
 
@@ -78,15 +81,15 @@ jobs:
 
           PIPELINE_RUN=$(tkn pipeline start dashboard-release \
             --serviceaccount=release-right-meow \
-            --param gitRevision="${{ steps.version.outputs.latest_sha }}" \
-            --param versionTag="${{ steps.version.outputs.version_tag }}" \
-            --param releaseBucket="${{ env.BUCKET }}" \
-            --param imageRegistry=${{ env.REGISTRY }} \
-            --param imageRegistryPath="${{ env.IMAGE_REGISTRY_PATH }}" \
-            --param imageRegistryUser="${{ env.IMAGE_REGISTRY_USER }}" \
+            --param gitRevision="${LATEST_SHA}" \
+            --param versionTag="${VERSION_TAG}" \
+            --param releaseBucket="${BUCKET}" \
+            --param imageRegistry="${REGISTRY}" \
+            --param imageRegistryPath="${IMAGE_REGISTRY_PATH}" \
+            --param imageRegistryUser="${IMAGE_REGISTRY_USER}" \
             --param imageRegistryRegions="" \
             --param koExtraArgs="" \
-            --param repoName="${{ env.REPO_NAME }}" \
+            --param repoName="${REPO_NAME}" \
             --param serviceAccountImagesPath=credentials \
             --param releaseAsLatest="true" \
             --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,137 +1,136 @@
 name: Publish NPM packages
 
-  permissions:
-    contents: read
+permissions:
+  contents: read
 
-  on:
-    pull_request:
-      branches: ["main"]
-      paths-ignore:
-        - "**"
-        - "!**/package.json"
-        - "!**/package-lock.json"
-      types:
-        - opened
-        - reopened
-        - synchronize
-    push:
-      branches: ["main"]
-      paths-ignore:
-        - "**"
-        - "!**/package.json"
-        - "!**/package-lock.json"
+on:
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - "**"
+      - "!**/package.json"
+      - "!**/package-lock.json"
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "**"
+      - "!**/package.json"
+      - "!**/package-lock.json"
 
-  defaults:
-    run:
-      shell: bash
+defaults:
+  run:
+    shell: bash
 
-  jobs:
-    publish:
-      runs-on: ubuntu-24.04
-      permissions:
-        contents: read
-        # required for OIDC
-        id-token: write
-      steps:
-        - name: Check for publish commit
-          id: checkPublishCommit
-          if: >-
-            ${{
-              (
-                github.event_name == 'pull_request' &&
-                startsWith(github.event.pull_request.title, 'Publish v') &&
-                endsWith(github.event.pull_request.title, 'of the @tektoncd/dashboard-* packages')
-              ) ||
-              (
-                github.event_name == 'push' &&
-                startsWith(github.event.head_commit.message, 'Publish v') &&
-                endsWith(github.event.head_commit.message, 'of the @tektoncd/dashboard-* packages')
-              )
-            }}
-          run: |
-            echo "Confirmed it's a publish commit"
-        - name: Harden Runner
-          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-          uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-          with:
-            egress-policy: audit
-        - name: Checkout
-          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-          with:
-            # for PRs checkout the head rather than the merge commit so we can get the original commit message
-            ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        - name: Validate PR title and commit message match
-          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-          env:
-            PR_TITLE: ${{ github.event.pull_request.title }}
-          run: |
-            COMMIT_MESSAGE="$(git log --pretty=%s -n 1)"
-            if [ "$PR_TITLE" != "$COMMIT_MESSAGE" ]; then
-              echo "::error::PR title and commit message mismatch"
-              echo "Expected format: Publish <version> of the @tektoncd/dashboard-* packages"
-              echo "PR_TITLE:        $PR_TITLE"
-              echo "COMMIT_MESSAGE:  $COMMIT_MESSAGE"
-              exit 1
-            else
-              echo "PR title and commit message match, continuing…"
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      # required for OIDC
+      id-token: write
+    steps:
+      - name: Check for publish commit
+        id: checkPublishCommit
+        if: >-
+          ${{
+            (
+              github.event_name == 'pull_request' &&
+              startsWith(github.event.pull_request.title, 'Publish v') &&
+              endsWith(github.event.pull_request.title, 'of the @tektoncd/dashboard-* packages')
+            ) ||
+            (
+              github.event_name == 'push' &&
+              startsWith(github.event.head_commit.message, 'Publish v') &&
+              endsWith(github.event.head_commit.message, 'of the @tektoncd/dashboard-* packages')
+            )
+          }}
+        run: |
+          echo "Confirmed it's a publish commit"
+      - name: Harden Runner
+        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout
+        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # for PRs checkout the head rather than the merge commit so we can get the original commit message
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Validate PR title and commit message match
+        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          COMMIT_MESSAGE="$(git log --pretty=%s -n 1)"
+          if [ "$PR_TITLE" != "$COMMIT_MESSAGE" ]; then
+            echo "::error::PR title and commit message mismatch"
+            echo "Expected format: Publish <version> of the @tektoncd/dashboard-* packages"
+            echo "PR_TITLE:        $PR_TITLE"
+            echo "COMMIT_MESSAGE:  $COMMIT_MESSAGE"
+            exit 1
+          else
+            echo "PR title and commit message match, continuing…"
+          fi
+      - name: Get version
+        id: get-version
+        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+        env:
+          MESSAGE_WITH_VERSION: ${{ github.event.pull_request.title || github.event.head_commit.message }}
+        run: |
+          echo "Extracting version from commit message"
+          VERSION=$(echo "$MESSAGE_WITH_VERSION" | grep -Po '(v\d+\.\d+\.\d+(\S)*)')
+          echo "VERSION: $VERSION"
+          echo "newPackageVersion=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Check version matches package.json
+        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+        run: |
+          EXPECTED_VERSION="${{ steps.get-version.outputs.newPackageVersion }}"
+          mismatch=false
+          for packageJson in ./packages/*/package.json; do
+            VERSION="v$(jq -r .version $packageJson)"
+            PRIVATE="$(jq -r .private $packageJson)"
+            if [ "$PRIVATE" == "false" ] && [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+              echo "::error::Version mismatch found in $packageJson: ${VERSION}"
+              mismatch=true
             fi
-        - name: Get version
-          id: get-version
-          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-          env:
-            MESSAGE_WITH_VERSION: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-          run: |
-            echo "Extracting version from commit message"
-            VERSION=$(echo "$MESSAGE_WITH_VERSION" | grep -Po '(v\d+\.\d+\.\d+(\S)*)')
-            echo "VERSION: $VERSION"
-            echo "newPackageVersion=${VERSION}" >> $GITHUB_OUTPUT
-        - name: Check version matches package.json
-          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-          env:
-            NEW_PACKAGE_VERSION: ${{ steps.get-version.outputs.newPackageVersion }}
-          run: |
-            EXPECTED_VERSION="${NEW_PACKAGE_VERSION}"
-            mismatch=false
-            for packageJson in ./packages/*/package.json; do
-              VERSION="v$(jq -r .version $packageJson)"
-              PRIVATE="$(jq -r .private $packageJson)"
-              if [ "$PRIVATE" == "false" ] && [ "$VERSION" != "$EXPECTED_VERSION" ]; then
-                echo "::error::Version mismatch found in $packageJson: ${VERSION}"
-                mismatch=true
-              fi
-            done
-            if [ "$mismatch" == "true" ]; then
-              exit 1
-            fi
-        - name: Check PR is up-to-date
-          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-          env:
-            HEAD_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
-            GH_TOKEN: ${{ github.token }}
-          run: |
-            BASE_REF="${GITHUB_REPOSITORY_OWNER}:${GITHUB_BASE_REF}"
-            HEAD_REF="${HEAD_REPO_OWNER}:${GITHUB_HEAD_REF}"
-            STATUS=$(gh api \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                /repos/${GITHUB_REPOSITORY}/compare/${BASE_REF}...${HEAD_REF} | jq -r .status)
-            if [ "$STATUS" != "ahead" ]; then
-              echo "::error::Pull request not up-to-date with base branch, please rebase"
-              exit 1
-            else
-              echo "Pull request is up-to-date with base branch, continuing…"
-            fi
-        - name: Setup Node.js
-          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-          with:
-            node-version-file: .nvmrc
-            registry-url: 'https://registry.npmjs.org/'
-        - name: Publish dry run
-          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-          # npm@11: You must specify a tag using --tag when publishing a prerelease version.
-          run: npm publish --workspaces --access public --tag latest --dry-run
-        - name: Publish
-          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'push' }}
-          run: npm publish --workspaces --access public --tag latest
+          done
+          if [ "$mismatch" == "true" ]; then
+            exit 1
+          fi
+      - name: Check PR is up-to-date
+        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
+        env:
+          # user controls the head ref, use env var to avoid script injection similar to PR title / commit message handling above
+          PR_HEAD_REF: ${{github.event.pull_request.head.ref}}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BASE_REF="${{github.event.pull_request.base.repo.owner.login}}:${{github.event.pull_request.base.ref}}"
+          HEAD_REF="${{github.event.pull_request.head.repo.owner.login}}:${PR_HEAD_REF}"
+          STATUS=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/compare/${BASE_REF}...${HEAD_REF} | jq -r .status)
+          if [ "$STATUS" != "ahead" ]; then
+            echo "::error::Pull request not up-to-date with base branch, please rebase"
+            exit 1
+          else
+            echo "Pull request is up-to-date with base branch, continuing…"
+          fi
+      - name: Setup Node.js
+        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org/'
+      - name: Publish dry run
+        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
+        # npm@11: You must specify a tag using --tag when publishing a prerelease version.
+        run: npm publish --workspaces --access public --tag latest --dry-run
+      - name: Publish
+        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'push' }}
+        run: npm publish --workspaces --access public --tag latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,136 +1,137 @@
 name: Publish NPM packages
 
-permissions:
-  contents: read
+  permissions:
+    contents: read
 
-on:
-  pull_request:
-    branches: ["main"]
-    paths-ignore:
-      - "**"
-      - "!**/package.json"
-      - "!**/package-lock.json"
-    types:
-      - opened
-      - reopened
-      - synchronize
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - "**"
-      - "!**/package.json"
-      - "!**/package-lock.json"
+  on:
+    pull_request:
+      branches: ["main"]
+      paths-ignore:
+        - "**"
+        - "!**/package.json"
+        - "!**/package-lock.json"
+      types:
+        - opened
+        - reopened
+        - synchronize
+    push:
+      branches: ["main"]
+      paths-ignore:
+        - "**"
+        - "!**/package.json"
+        - "!**/package-lock.json"
 
-defaults:
-  run:
-    shell: bash
+  defaults:
+    run:
+      shell: bash
 
-jobs:
-  publish:
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      # required for OIDC
-      id-token: write
-    steps:
-      - name: Check for publish commit
-        id: checkPublishCommit
-        if: >-
-          ${{
-            (
-              github.event_name == 'pull_request' &&
-              startsWith(github.event.pull_request.title, 'Publish v') &&
-              endsWith(github.event.pull_request.title, 'of the @tektoncd/dashboard-* packages')
-            ) ||
-            (
-              github.event_name == 'push' &&
-              startsWith(github.event.head_commit.message, 'Publish v') &&
-              endsWith(github.event.head_commit.message, 'of the @tektoncd/dashboard-* packages')
-            )
-          }}
-        run: |
-          echo "Confirmed it's a publish commit"
-      - name: Harden Runner
-        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Checkout
-        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # for PRs checkout the head rather than the merge commit so we can get the original commit message
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Validate PR title and commit message match
-        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          COMMIT_MESSAGE="$(git log --pretty=%s -n 1)"
-          if [ "$PR_TITLE" != "$COMMIT_MESSAGE" ]; then
-            echo "::error::PR title and commit message mismatch"
-            echo "Expected format: Publish <version> of the @tektoncd/dashboard-* packages"
-            echo "PR_TITLE:        $PR_TITLE"
-            echo "COMMIT_MESSAGE:  $COMMIT_MESSAGE"
-            exit 1
-          else
-            echo "PR title and commit message match, continuing…"
-          fi
-      - name: Get version
-        id: get-version
-        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-        env:
-          MESSAGE_WITH_VERSION: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-        run: |
-          echo "Extracting version from commit message"
-          VERSION=$(echo "$MESSAGE_WITH_VERSION" | grep -Po '(v\d+\.\d+\.\d+(\S)*)')
-          echo "VERSION: $VERSION"
-          echo "newPackageVersion=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Check version matches package.json
-        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-        run: |
-          EXPECTED_VERSION="${{ steps.get-version.outputs.newPackageVersion }}"
-          mismatch=false
-          for packageJson in ./packages/*/package.json; do
-            VERSION="v$(jq -r .version $packageJson)"
-            PRIVATE="$(jq -r .private $packageJson)"
-            if [ "$PRIVATE" == "false" ] && [ "$VERSION" != "$EXPECTED_VERSION" ]; then
-              echo "::error::Version mismatch found in $packageJson: ${VERSION}"
-              mismatch=true
+  jobs:
+    publish:
+      runs-on: ubuntu-24.04
+      permissions:
+        contents: read
+        # required for OIDC
+        id-token: write
+      steps:
+        - name: Check for publish commit
+          id: checkPublishCommit
+          if: >-
+            ${{
+              (
+                github.event_name == 'pull_request' &&
+                startsWith(github.event.pull_request.title, 'Publish v') &&
+                endsWith(github.event.pull_request.title, 'of the @tektoncd/dashboard-* packages')
+              ) ||
+              (
+                github.event_name == 'push' &&
+                startsWith(github.event.head_commit.message, 'Publish v') &&
+                endsWith(github.event.head_commit.message, 'of the @tektoncd/dashboard-* packages')
+              )
+            }}
+          run: |
+            echo "Confirmed it's a publish commit"
+        - name: Harden Runner
+          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+          uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+          with:
+            egress-policy: audit
+        - name: Checkout
+          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+          with:
+            # for PRs checkout the head rather than the merge commit so we can get the original commit message
+            ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        - name: Validate PR title and commit message match
+          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
+          env:
+            PR_TITLE: ${{ github.event.pull_request.title }}
+          run: |
+            COMMIT_MESSAGE="$(git log --pretty=%s -n 1)"
+            if [ "$PR_TITLE" != "$COMMIT_MESSAGE" ]; then
+              echo "::error::PR title and commit message mismatch"
+              echo "Expected format: Publish <version> of the @tektoncd/dashboard-* packages"
+              echo "PR_TITLE:        $PR_TITLE"
+              echo "COMMIT_MESSAGE:  $COMMIT_MESSAGE"
+              exit 1
+            else
+              echo "PR title and commit message match, continuing…"
             fi
-          done
-          if [ "$mismatch" == "true" ]; then
-            exit 1
-          fi
-      - name: Check PR is up-to-date
-        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-        env:
-          # user controls the head ref, use env var to avoid script injection similar to PR title / commit message handling above
-          PR_HEAD_REF: ${{github.event.pull_request.head.ref}}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BASE_REF="${{github.event.pull_request.base.repo.owner.login}}:${{github.event.pull_request.base.ref}}"
-          HEAD_REF="${{github.event.pull_request.head.repo.owner.login}}:${PR_HEAD_REF}"
-          STATUS=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/compare/${BASE_REF}...${HEAD_REF} | jq -r .status)
-          if [ "$STATUS" != "ahead" ]; then
-            echo "::error::Pull request not up-to-date with base branch, please rebase"
-            exit 1
-          else
-            echo "Pull request is up-to-date with base branch, continuing…"
-          fi
-      - name: Setup Node.js
-        if: ${{ steps.checkPublishCommit.outcome == 'success' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .nvmrc
-          registry-url: 'https://registry.npmjs.org/'
-      - name: Publish dry run
-        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
-        # npm@11: You must specify a tag using --tag when publishing a prerelease version.
-        run: npm publish --workspaces --access public --tag latest --dry-run
-      - name: Publish
-        if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'push' }}
-        run: npm publish --workspaces --access public --tag latest
+        - name: Get version
+          id: get-version
+          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+          env:
+            MESSAGE_WITH_VERSION: ${{ github.event.pull_request.title || github.event.head_commit.message }}
+          run: |
+            echo "Extracting version from commit message"
+            VERSION=$(echo "$MESSAGE_WITH_VERSION" | grep -Po '(v\d+\.\d+\.\d+(\S)*)')
+            echo "VERSION: $VERSION"
+            echo "newPackageVersion=${VERSION}" >> $GITHUB_OUTPUT
+        - name: Check version matches package.json
+          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+          env:
+            NEW_PACKAGE_VERSION: ${{ steps.get-version.outputs.newPackageVersion }}
+          run: |
+            EXPECTED_VERSION="${NEW_PACKAGE_VERSION}"
+            mismatch=false
+            for packageJson in ./packages/*/package.json; do
+              VERSION="v$(jq -r .version $packageJson)"
+              PRIVATE="$(jq -r .private $packageJson)"
+              if [ "$PRIVATE" == "false" ] && [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+                echo "::error::Version mismatch found in $packageJson: ${VERSION}"
+                mismatch=true
+              fi
+            done
+            if [ "$mismatch" == "true" ]; then
+              exit 1
+            fi
+        - name: Check PR is up-to-date
+          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
+          env:
+            HEAD_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+            GH_TOKEN: ${{ github.token }}
+          run: |
+            BASE_REF="${GITHUB_REPOSITORY_OWNER}:${GITHUB_BASE_REF}"
+            HEAD_REF="${HEAD_REPO_OWNER}:${GITHUB_HEAD_REF}"
+            STATUS=$(gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/${GITHUB_REPOSITORY}/compare/${BASE_REF}...${HEAD_REF} | jq -r .status)
+            if [ "$STATUS" != "ahead" ]; then
+              echo "::error::Pull request not up-to-date with base branch, please rebase"
+              exit 1
+            else
+              echo "Pull request is up-to-date with base branch, continuing…"
+            fi
+        - name: Setup Node.js
+          if: ${{ steps.checkPublishCommit.outcome == 'success' }}
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          with:
+            node-version-file: .nvmrc
+            registry-url: 'https://registry.npmjs.org/'
+        - name: Publish dry run
+          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'pull_request' }}
+          # npm@11: You must specify a tag using --tag when publishing a prerelease version.
+          run: npm publish --workspaces --access public --tag latest --dry-run
+        - name: Publish
+          if: ${{ steps.checkPublishCommit.outcome == 'success' && github.event_name == 'push' }}
+          run: npm publish --workspaces --access public --tag latest


### PR DESCRIPTION
Fixes #4844

# Changes

This PR integrates the `zizmor` static analyzer as a CI check to harden our GitHub Actions workflows and resolves the immediate security vulnerabilities flagged by the tool.

Specifically, it:
* Sets up the `.github/workflows/zizmor.yaml` CI workflow to continuously scan and upload SARIF results to GitHub Advanced Security.
* Resolves all auto-fixable findings (e.g., injecting `persist-credentials: false` into `actions/checkout` steps across multiple workflows).
* Manually patches high-severity template injection risks in `publish.yml` by moving context variables safely out of the `run:` execution block and into the step's `env:` mapping.

**Note:** As requested in the original issue description, I have intentionally left the `secrets-inherit` warnings in `chatops-retest.yml` and `slash.yml` untouched. I will file a separate follow-up issue to handle those broader architectural changes once this baseline is merged.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE