### PR TITLE
Fix LABEL instructions in E2E base image

### DIFF
--- a/packages/e2e/base-image/Dockerfile
+++ b/packages/e2e/base-image/Dockerfile
@@ -20,8 +20,8 @@ FROM cypress/factory@sha256:4d7cea25c059c3f153dcf03ace3aa737be59d0be42b769c7dd4c
 
 LABEL maintainer="Tekton Authors <tekton-dev@googlegroups.com>"
 LABEL org.opencontainers.image.source=https://github.com/tektoncd/dashboard/tree/main/packages/e2e/base-image
-LABEL org.opencontainers.image.url=https://github.com/tektoncd/dashboard/tree/main/packages/e2e/base-image \
-LABEL org.opencontainers.image.title=dashboard-e2e-base \
+LABEL org.opencontainers.image.url=https://github.com/tektoncd/dashboard/tree/main/packages/e2e/base-image
+LABEL org.opencontainers.image.title=dashboard-e2e-base
 LABEL org.opencontainers.image.description="Base image for Tekton Dashboard E2E tests"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Remove trailing `\` copied over from shell script which is invalid in the Dockerfile and prevented the base image from building.
Follow-up to https://github.com/tektoncd/dashboard/pull/5066
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
