### PR TITLE
Fix nightly build issue caused by failed Pipelines install

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -55,7 +55,7 @@ jobs:
           echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Tekton Nightly Infra
-        uses: tektoncd/plumbing/.github/actions/setup-nightly-infra@c4d1d3e6b8e8ac398636f75aef0faf50784a5ca7 # main
+        uses: tektoncd/plumbing/.github/actions/setup-nightly-infra@48541a866223140c82bc5c7994ad89ffabb6ff1f # main
         with:
           kubernetes_version: ${{ env.KUBERNETES_VERSION }}
           image_registry_user: ${{ env.IMAGE_REGISTRY_USER }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Update setup-nightly-infra to latest to fix failed Pipelines install.

Related:

- https://github.com/tektoncd/plumbing/pull/3478
- https://github.com/tektoncd/actions/pull/16

The underlying setup-tektoncd action was updated to improve retrieval of release information, to resolve an issue where the required release didn't appear in the first page of results. Instead of requesting the list of releases and filtering for a matching tag name it now retrieves the required release by tag name directly.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
