### PR TITLE
fix visualization for a selected task with highlighting

### DIFF
--- a/packages/components/src/components/Task/_Task.scss
+++ b/packages/components/src/components/Task/_Task.scss
@@ -15,6 +15,15 @@ limitations under the License.
 @use '@carbon/react/scss/theme' as *;
 
 .#{$prefix}--tabs__nav-item.tkn--task {
+  &.#{$prefix}--tabs__nav-item--selected {
+    background-color: var(--cds-layer-selected);
+    border-inline-end-color: var(--cds-layer-selected);
+    box-shadow:
+      inset 3px 0 0 0 var(--cds-border-interactive),
+      inset -1px 0 0 0 var(--cds-layer-selected),
+      inset 0 0 0 1px var(--cds-border-subtle);
+  }
+
   .#{$prefix}--tabs__nav-item-label-wrapper {
     display: block;
   }
@@ -59,6 +68,7 @@ limitations under the License.
 .tkn--tasks:has(> .#{$prefix}--tabs, .#{$prefix}--tabs.tkn--task-list, > .tkn--step-details:first-child) {
   > .#{$prefix}--css-grid {
     max-inline-size: 100%;
+    column-gap: 0;
 
     > .#{$prefix}--tab-content {
       // we don't want 2 scrollbars, prefer the one on body
@@ -80,7 +90,7 @@ limitations under the License.
     inset-block-start: var(--tkn-global-header-offset);
     z-index: 4997;
   }
-
+  
   .tkn--step-details {
     > .#{$prefix}--tabs {
       position: sticky;
@@ -103,4 +113,44 @@ limitations under the License.
   position: sticky;
   inset-block-start: var(--tkn-global-header-offset);
   max-block-size: calc(100vb - var(--tkn-global-header-offset));
+}
+
+.#{$prefix}--tabs__nav-item.tkn--task.#{$prefix}--tabs__nav-item--selected {
+  background-color: var(--cds-layer-selected);
+  border-inline-end-color: var(--cds-layer-selected);
+  box-shadow:
+    inset 3px 0 0 0 var(--cds-border-interactive),
+    inset -1px 0 0 0 var(--cds-layer-selected),
+    inset 0 0 0 1px var(--cds-border-subtle);
+}
+
+.tkn--tasks
+  > .#{$prefix}--css-grid
+  > .#{$prefix}--tab-content:not([hidden]) {
+  background-color: var(--cds-layer-selected);
+  margin-inline-start: 0;
+  padding-inline-start: 0;
+}
+
+.tkn--tasks
+  > .#{$prefix}--css-grid
+  > .#{$prefix}--tab-content:not([hidden])
+  .tkn--step-details {
+  background-color: var(--cds-layer-selected);
+
+  > header.tkn--step-details-header,
+  > .#{$prefix}--tabs,
+  > .#{$prefix}--tab-content {
+    background-color: var(--cds-layer-selected);
+  }
+
+  .tkn--step {
+    background-color: var(--cds-layer-selected);
+
+    .#{$prefix}--accordion__heading,
+    .#{$prefix}--accordion__wrapper,
+    .#{$prefix}--accordion__content {
+      background-color: var(--cds-layer-selected);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #5056


# Changes

Fix task selection styling so the selected task connects properly with its corresponding task details panel. Also fixes the background styling for the active step content.

<img width="1447" height="553" alt="Screenshot 2026-08-18 at 11 53 05 PM" src="https://github.com/user-attachments/assets/c9d261c2-e8f9-4ded-98c1-2244a911cad2" />
<img width="1452" height="575" alt="Screenshot 2026-08-18 at 11 53 19 PM" src="https://github.com/user-attachments/assets/a8301720-0e97-4902-8c7c-a7001dfa891d" />


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (new features, significant UI changes, API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix task selection and content panel styling.
```
