### PR TITLE
feat(logs): pass preferences to external providers. Fixes #4981

### DIFF
--- a/docs/logs.md
+++ b/docs/logs.md
@@ -90,7 +90,7 @@ It can be enabled by providing the `--external-logs` flag to the installer scrip
 When configured, the Dashboard will first attempt to load pod logs normally, and if they're unavailable will fallback to the provided external logs service by making a `GET` request to the provided endpoint with the following format:
 
 ```
-GET <external-logs>/<namespace>/<podName>/<container>?startTime=<stepStartTime>&completionTime=<stepCompletionTime>
+GET <external-logs>/<namespace>/<podName>/<container>?startTime=<stepStartTime>&completionTime=<stepCompletionTime>&timestamps=<true|false>&logLevel=<selectedLogLevel>&logLevel=<selectedLogLevel>
 ```
 
 - `namespace`: the namespace containing the run
@@ -98,8 +98,10 @@ GET <external-logs>/<namespace>/<podName>/<container>?startTime=<stepStartTime>&
 - `container`: the name of the container associated with the selected `step`
 - `stepStartTime`: the start time of the step container
 - `stepCompletionTime`: the completion time of the step container
+- `timestamps`: the user's timestamp preference
+- `logLevel`: repeated for each user-selected log level
 
-If the start / completion times are unavailable their respective query parameters will be omitted from the request.
+If the start / completion times are unavailable their respective query parameters will be omitted from the request. External log providers may ignore the `timestamps` and `logLevel` parameters.
 
 ---
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -124,9 +124,11 @@ export function getExternalLogURL({
   completionTime,
   container,
   externalLogsURL,
+  logLevels,
   namespace,
   podName,
-  startTime
+  startTime,
+  timestamps
 }) {
   const queryParams = new URLSearchParams();
   if (startTime) {
@@ -135,6 +137,14 @@ export function getExternalLogURL({
   if (completionTime) {
     queryParams.set('completionTime', completionTime);
   }
+  if (timestamps !== undefined) {
+    queryParams.set('timestamps', timestamps);
+  }
+  Object.entries(logLevels || {}).forEach(([logLevel, enabled]) => {
+    if (enabled) {
+      queryParams.append('logLevel', logLevel);
+    }
+  });
   let queryString = queryParams.toString(); // returns the properly encoded string, or '' if no params
   if (queryString) {
     queryString = `?${queryString}`;

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -138,6 +138,30 @@ it('getExternalLogURL', () => {
     )}&completionTime=${completionTime.replaceAll(':', '%3A')}`
   );
 });
+it('getExternalLogURL includes log preferences', () => {
+  const container = 'fake_container';
+  const externalLogsURL = '/fake_externalLogsURL';
+  const logLevels = {
+    error: true,
+    info: true,
+    warning: false
+  };
+  const namespace = 'fake_namespace';
+  const podName = 'fake_podName';
+  const timestamps = false;
+  expect(
+    API.getExternalLogURL({
+      container,
+      externalLogsURL,
+      logLevels,
+      namespace,
+      podName,
+      timestamps
+    })
+  ).toEqual(
+    `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}?timestamps=false&logLevel=error&logLevel=info`
+  );
+});
 
 it('getExternalLogURL with empty completionTime', () => {
   const container = 'fake_container';

--- a/src/containers/PipelineRun/PipelineRun.jsx
+++ b/src/containers/PipelineRun/PipelineRun.jsx
@@ -521,7 +521,9 @@ export /* istanbul ignore next */ function PipelineRunContainer({
         fetchLogs={getLogsRetriever({
           externalLogsURL,
           isLogStreamingEnabled,
-          onFallback: setIsUsingExternalLogs
+          logLevels,
+          onFallback: setIsUsingExternalLogs,
+          timestamps: showTimestamps
         })}
         handleTaskSelected={handleTaskSelected}
         loading={isLoading}
@@ -537,7 +539,15 @@ export /* istanbul ignore next */ function PipelineRunContainer({
             showTimestamps={showTimestamps}
           />
         )}
-        getStepLogToolbar={toolbarProps => <StepLogToolbar {...toolbarProps} />}
+        getStepLogToolbar={toolbarProps => (
+          <StepLogToolbar
+            {...toolbarProps}
+            externalLogsURL={externalLogsURL}
+            isUsingExternalLogs={isUsingExternalLogs}
+            logLevels={logLevels}
+            showTimestamps={showTimestamps}
+          />
+        )}
         onRetryChange={retry => {
           if (Number.isInteger(retry)) {
             queryParams.set(RETRY, retry);

--- a/src/containers/StepLogToolbar/StepLogToolbar.jsx
+++ b/src/containers/StepLogToolbar/StepLogToolbar.jsx
@@ -18,6 +18,8 @@ import { getExternalLogURL, getPodLogURL } from '../../api';
 export default function StepLogToolbarContainer({
   externalLogsURL,
   isUsingExternalLogs,
+  logLevels,
+  showTimestamps,
   stepStatus,
   taskRun
 }) {
@@ -28,7 +30,14 @@ export default function StepLogToolbarContainer({
   let logURL;
   if (container && podName) {
     logURL = isUsingExternalLogs
-      ? getExternalLogURL({ container, externalLogsURL, namespace, podName })
+      ? getExternalLogURL({
+          container,
+          externalLogsURL,
+          logLevels,
+          namespace,
+          podName,
+          timestamps: showTimestamps
+        })
       : getPodLogURL({
           container,
           name: podName,

--- a/src/containers/StepLogToolbar/StepLogToolbar.test.jsx
+++ b/src/containers/StepLogToolbar/StepLogToolbar.test.jsx
@@ -39,6 +39,8 @@ describe('getLogsToolbar', () => {
   it('should handle external logs', () => {
     const container = 'fake_container';
     const externalLogsURL = 'fake_externalLogsURL';
+    const logLevels = { error: true };
+    const showTimestamps = false;
     const namespace = 'fake_namespace';
     const podName = 'fake_podname';
     const stepStatus = { container };
@@ -50,6 +52,8 @@ describe('getLogsToolbar', () => {
       <LogsToolbarContainer
         externalLogsURL={externalLogsURL}
         isUsingExternalLogs
+        logLevels={logLevels}
+        showTimestamps={showTimestamps}
         stepStatus={stepStatus}
         taskRun={taskRun}
       />
@@ -59,8 +63,10 @@ describe('getLogsToolbar', () => {
     expect(API.getExternalLogURL).toHaveBeenCalledWith({
       container,
       externalLogsURL,
+      logLevels,
       namespace,
-      podName
+      podName,
+      timestamps: showTimestamps
     });
   });
 

--- a/src/containers/TaskRun/TaskRun.jsx
+++ b/src/containers/TaskRun/TaskRun.jsx
@@ -169,7 +169,9 @@ export function TaskRunContainer({
     const logsRetriever = getLogsRetriever({
       externalLogsURL,
       isLogStreamingEnabled,
-      onFallback: setIsUsingExternalLogs
+      logLevels,
+      onFallback: setIsUsingExternalLogs,
+      timestamps: showTimestamps
     });
 
     return (
@@ -184,6 +186,8 @@ export function TaskRunContainer({
           <StepLogToolbar
             externalLogsURL={externalLogsURL}
             isUsingExternalLogs={isUsingExternalLogs}
+            logLevels={logLevels}
+            showTimestamps={showTimestamps}
             stepStatus={stepStatus}
             taskRun={run}
           />

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -119,7 +119,10 @@ export async function fetchLogs({ _stepName, stream, stepStatus, taskRun }) {
   return logs;
 }
 
-export function fetchLogsFallback(externalLogsURL) {
+export function fetchLogsFallback(
+  externalLogsURL,
+  { logLevels, timestamps } = {}
+) {
   if (!externalLogsURL) {
     return undefined;
   }
@@ -132,9 +135,11 @@ export function fetchLogsFallback(externalLogsURL) {
       getExternalLogURL({
         container,
         externalLogsURL,
+        logLevels,
         namespace,
         podName,
         startTime,
+        timestamps,
         completionTime
       }),
       {
@@ -147,9 +152,14 @@ export function fetchLogsFallback(externalLogsURL) {
 export function getLogsRetriever({
   externalLogsURL,
   isLogStreamingEnabled,
-  onFallback
+  logLevels,
+  onFallback,
+  timestamps
 }) {
-  const fallback = fetchLogsFallback(externalLogsURL);
+  const fallback = fetchLogsFallback(externalLogsURL, {
+    logLevels,
+    timestamps
+  });
 
   if (fallback) {
     return ({ stepName, stepStatus, taskRun }) =>

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -202,6 +202,32 @@ describe('fetchLogsFallback', () => {
     expect(fetchLogsFallback()).toBeUndefined();
   });
 
+  it('should pass preferences to the external log provider', () => {
+    const container = 'fake_container';
+    const externalLogsURL = '/fake_url';
+    const logLevels = {
+      error: true,
+      info: false
+    };
+    const namespace = 'fake_namespace';
+    const podName = 'fake_podName';
+    const stepName = 'fake_stepName';
+    const timestamps = true;
+    const stepStatus = { container };
+    const taskRun = { metadata: { namespace }, status: { podName } };
+    vi.spyOn(comms, 'get').mockImplementation(() => {});
+
+    const fallback = fetchLogsFallback(externalLogsURL, {
+      logLevels,
+      timestamps
+    });
+    fallback({ stepName, stepStatus, taskRun });
+    expect(comms.get).toHaveBeenCalledWith(
+      `http://localhost:3000${externalLogsURL}/${namespace}/${podName}/${container}?timestamps=true&logLevel=error`,
+      { Accept: 'text/plain' }
+    );
+  });
+
   it('should return a function to retrieve logs from the external provider', () => {
     const container = 'fake_container';
     const externalLogsURL = '/fake_url';
@@ -296,13 +322,20 @@ describe('getLogsRetriever', () => {
 
   it('should handle external logs fallback', async () => {
     const externalLogsURL = 'fake_externalLogsURL';
+    const logLevels = { error: true };
+    const timestamps = false;
     vi.spyOn(API, 'getExternalLogURL');
     vi.spyOn(API, 'getPodLog').mockImplementation(() => {
       throw new Error();
     });
     vi.spyOn(comms, 'get').mockImplementation(() => {});
     const onFallback = vi.fn();
-    const logsRetriever = getLogsRetriever({ externalLogsURL, onFallback });
+    const logsRetriever = getLogsRetriever({
+      externalLogsURL,
+      logLevels,
+      onFallback,
+      timestamps
+    });
     expect(logsRetriever).toBeDefined();
     await logsRetriever({ stepName, stepStatus, taskRun });
     expect(API.getPodLog).toHaveBeenCalledWith({
@@ -310,7 +343,9 @@ describe('getLogsRetriever', () => {
       name: podName,
       namespace
     });
-    expect(API.getExternalLogURL).toHaveBeenCalled();
+    expect(API.getExternalLogURL).toHaveBeenCalledWith(
+      expect.objectContaining({ logLevels, timestamps })
+    );
     expect(onFallback).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Passes the user's timestamp and selected log-level preferences to external log providers.

- Adds `timestamps=<true|false>` and repeated `logLevel` parameters to external log URLs.
- Propagates the preferences through PipelineRun and TaskRun fallback requests and external raw-log links.
- Documents the optional parameters for external providers.
- Adds URL, fallback, and toolbar coverage.

Fixes #4981

Validation: targeted tests (137), the full test suite (614 passing, 1 skipped), lint, and production build pass. A live UI check requires an authenticated Tekton cluster and configured external log provider; neither is available on the remote host, so no cluster state or credentials were changed.

# Submitter Checklist

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included for this user-facing change
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included for changed functionality
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label
- [x] Release notes block below has been updated for this user-facing change
- [x] Release notes do not require action from users switching to the new release

# Release Notes

```release-note
External log providers can now receive the user's timestamp and log-level preferences.
```
